### PR TITLE
Lock Week 1 backend roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ Workstream is how Flow measures, certifies, and coordinates useful human-agent w
 - Frontend is locked as React + Vite + TypeScript.
 - Backend API is locked as Python with FastAPI.
 - ORM, migrations, and API schemas are locked as SQLAlchemy 2.x async + Alembic + Pydantic schemas.
+- Workstream verifies external Flow authentication tokens; do not add Workstream-owned login, signup, password reset, password storage, or primary auth sessions.
+- Week 1 implementation is backend-first; do not start frontend work until backend contracts and lifecycle guards are stable.
 - Execution is async-first; do not document synchronous-first checkers or jobs.
 - FastAPI background tasks are acceptable for simple local v0.1 jobs; use Celery or equivalent durable workers when retries, scheduling, isolation, or distributed execution are needed.
 - Postgres is the record database.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Workstream turns that operating knowledge into reusable infrastructure.
 
 - [30-Day Master Plan](docs/roadmap_30_day_master_plan.md)
 - [Roadmap Status](docs/roadmap_status.md)
+- [Week 1 Backend Plan](docs/roadmap_week1_backend_plan.md)
 - [Day-by-Day Execution Plan](docs/roadmap_day_by_day_execution_plan.md)
 - [Implementation Backlog](docs/roadmap_implementation_backlog.md)
 - [Product Principles](docs/product_principles.md)

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -7,7 +7,7 @@ The v0.1 persistence layer uses SQLAlchemy 2.x async models, Alembic migrations,
 ## Entity Overview
 
 ```text
-User
+Actor
   WorkerProfile
   ReviewerProfile
 
@@ -34,16 +34,25 @@ Task
   AuditEvent
 ```
 
-## User
+## Actor
 
 Fields:
 
 - `id`
-- `name`
+- `external_subject`
+- `external_issuer`
 - `email`
+- `display_name`
 - `role`
+- `claim_snapshot`
+- `auth_source`
 - `created_at`
+- `last_seen_at`
 - `status`
+
+Actor identity comes from external Flow authentication. `external_subject` plus `external_issuer` is the stable identity binding. Email is profile metadata and must not be treated as the primary identity.
+
+Workstream can keep actor/profile records for permissions, assignments, reputation, and audit display, but it does not own password authentication or primary login sessions.
 
 Roles:
 
@@ -60,7 +69,7 @@ Roles:
 
 Fields:
 
-- `user_id`
+- `actor_id`
 - `display_name`
 - `skill_tags`
 - `accepted_count`
@@ -75,7 +84,7 @@ Fields:
 
 Fields:
 
-- `user_id`
+- `actor_id`
 - `skill_tags`
 - `reviews_completed`
 - `accept_count`
@@ -620,7 +629,7 @@ Payment adjustments are append-only. Accepted amount changes must use this recor
 Fields:
 
 - `id`
-- `user_id`
+- `actor_id`
 - `task_id`
 - `submission_id`
 - `contribution_record_id`
@@ -650,6 +659,11 @@ Fields:
 - `entity_type`
 - `entity_id`
 - `actor_id`
+- `external_subject`
+- `external_issuer`
+- `actor_role`
+- `claim_snapshot`
+- `auth_source`
 - `event_type`
 - `before`
 - `after`

--- a/docs/architecture_system_architecture.md
+++ b/docs/architecture_system_architecture.md
@@ -56,7 +56,7 @@ Approved stack:
 - ORM, migrations, and API schemas: SQLAlchemy 2.x async + Alembic + Pydantic schemas
 - Database: Postgres
 - File storage: local development can use filesystem-backed storage, but it must sit behind an object-storage abstraction compatible with R2/S3-style storage
-- Auth: role-based accounts
+- Auth: external Flow authentication token verification through an auth interface/adapter; Workstream does not own login, signup, password reset, password storage, or primary auth sessions
 - Jobs: async-first background execution; FastAPI background tasks are acceptable for simple local v0.1 jobs, with Celery or an equivalent durable queue when jobs need retries, scheduling, isolation, or distributed workers
 
 Async policy:
@@ -78,6 +78,17 @@ Frontend policy:
 - Next.js is deferred unless server rendering, public pages, or full-stack React routing becomes a real requirement.
 
 The architecture avoids framework coupling in the domain model. Project, task, submission, checker, review, revision, contribution, payment, reputation, and audit behavior remain portable.
+
+Auth policy:
+
+- Workstream verifies Flow-issued tokens through an `AuthVerifier` interface.
+- Production auth uses a Flow token verifier adapter.
+- Local development may use a mock verifier only outside production.
+- Actor identity is based on stable token subject and issuer, not email.
+- Workstream may keep local actor/profile records for workflow state, permissions, audit display, and reputation, but those records do not replace Flow as the auth source.
+- Role and permission checks use trusted Flow claims, local Workstream role mappings, or a documented combination of both.
+- Routers depend on a single current-actor dependency; permission checks live in service or policy code so workflow rules do not scatter across HTTP handlers.
+- Audit records preserve actor id, external subject, issuer, role/claim context, and whether dev/mock auth was used when relevant.
 
 ## Component Responsibilities
 

--- a/docs/operations_roles_permissions.md
+++ b/docs/operations_roles_permissions.md
@@ -6,6 +6,8 @@ Workstream needs explicit permissions from the first version because review, pay
 
 ## Roles
 
+Roles come from trusted Flow token claims, local Workstream role mappings, or an explicitly documented combination of both. The backend resolves those into a current actor context before protected workflow actions run.
+
 | Role | Purpose |
 | --- | --- |
 | Admin | Controls project setup, policies, overrides, and user access. |
@@ -45,4 +47,6 @@ Workstream needs explicit permissions from the first version because review, pay
 
 ## First-Version Enforcement
 
-The first version can enforce permissions in application code. The database records actor IDs for every important event so later role enforcement can be audited.
+The first version enforces permissions in application service or policy code, not directly inside routers. The database records actor IDs, external subject, issuer, role/claim context, and auth source for important events so later role enforcement can be audited.
+
+Development auth, if enabled, must be impossible to use in production and must be visible in audit context.

--- a/docs/review_final_architecture_review.md
+++ b/docs/review_final_architecture_review.md
@@ -34,11 +34,11 @@ Status: documented in `docs/architecture_data_model.md` and `docs/architecture_l
 
 Finding:
 
-The plan now chooses Next.js/TypeScript/Postgres for v0.1. This avoids wasting the first month debating stack.
+The plan now chooses Python/FastAPI, SQLAlchemy 2.x async, Alembic, Pydantic schemas, Postgres, and React/Vite/TypeScript for v0.1. This avoids wasting the first month debating stack.
 
 Suggested change:
 
-Only introduce Go services later for checker runners or high-throughput workers.
+Only introduce Rust, TypeScript, or another language later for a specific layer when there is a clear justification.
 
 Status: addressed in `docs/architecture_system_architecture.md`.
 
@@ -53,4 +53,3 @@ Suggested change:
 Implement hash manifests and prevent in-place artifact mutation.
 
 Status: documented in `docs/architecture_data_model.md`, `docs/architecture_lifecycle_state_machine.md`, and `docs/architecture_checker_framework.md`.
-

--- a/docs/review_product_strategy_review.md
+++ b/docs/review_product_strategy_review.md
@@ -10,11 +10,13 @@ The plan defines the full 30-day loop, but it does not explicitly name the small
 
 Suggested change: add a "Day 7 Thin Slice" that proves `Project -> Task -> Submission -> Checker Result -> Review Decision` with one project, one task, one checker, and one reviewer.
 
-### High: Recommended stack is still undecided
+### High: Recommended stack needed to be locked
 
-`docs/architecture_system_architecture.md` says backend can be Node/TypeScript or Go. For a 30-day execution plan, this leaves too much room for debate.
+The architecture needed one v0.1 stack so the first build cycle would not keep reopening framework decisions.
 
 Suggested change: pick one v0.1 stack and treat alternatives as future decisions.
+
+Status: fixed in `docs/architecture_system_architecture.md`. Backend is Python/FastAPI with SQLAlchemy 2.x async, Alembic, Pydantic schemas, and Postgres. Frontend is React/Vite/TypeScript.
 
 ### Medium: First customer/operator value needs sharper wording
 
@@ -33,4 +35,3 @@ Suggested change: add manual intake as the only v0.1 task source.
 The metrics mix system deliverables with pilot outcomes.
 
 Suggested change: separate "Build Success" and "Pilot Success" in the roadmap.
-

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -52,7 +52,7 @@ If a feature does not improve lifecycle correctness, review quality, evidence, p
 
 ## Week 1: Foundation
 
-Objective: define the product contract and implement the core records.
+Objective: define the product contract and implement the backend foundation for the core records.
 
 Deliverables:
 
@@ -68,8 +68,10 @@ Deliverables:
 - evidence record
 - payment record
 - reputation record
-- basic task list and task detail pages
+- backend API smoke paths for project, task, assignment, and submission records
 - workspace/packet convention for the first project
+- modular monolith structure with clean router, service, repository, interface, and adapter boundaries
+- external Flow authentication verification boundary
 
 Day 1:
 
@@ -78,18 +80,20 @@ Day 1:
 - finalize first database schema
 - create first internal project template
 - define default queue lanes and packet convention
+- lock the per-chunk specification and conditions-of-satisfaction protocol
 
 Day 2:
 
 - build project and guide records
 - create project guide editor or markdown-backed guide import
 - define base amount and payout policy fields
+- use backend records/API first; frontend editor is deferred until the backend contract is stable
 
 Day 3:
 
 - build task creation
 - build queue states
-- build task detail page
+- build task detail API response
 - enforce task belongs to project
 
 Day 4:
@@ -110,6 +114,9 @@ Week 1 acceptance bar:
 - a task can be created, screened, claimed, submitted, and tracked
 - every task status transition is recorded
 - no task exists outside a project
+- the backend runs as a modular monolith with clear boundaries
+- Flow authentication is represented as token verification, not Workstream-owned login
+- frontend implementation is not required for Week 1 acceptance
 
 ## Day-7 Thin Slice
 

--- a/docs/roadmap_day_by_day_execution_plan.md
+++ b/docs/roadmap_day_by_day_execution_plan.md
@@ -14,7 +14,13 @@ The plan assumes a small team:
 
 If the team is smaller, keep the sequence and reduce scope, not the quality gates.
 
-## Week 1: Core Control Plane
+## Week 1: Backend Foundation
+
+Week 1 is backend-first. The frontend starts after the backend contract, lifecycle guards, and first workflow are stable.
+
+The backend is a modular monolith. Routers stay thin, services own workflow rules, repositories own database queries, interfaces define external boundaries, and adapters implement those boundaries.
+
+Each implementation chunk must have a specification and conditions of satisfaction before code starts. Senior engineering, QA/test, and security/auth verification are required before operator final review.
 
 ### Day 1: Freeze Product Contract
 
@@ -25,12 +31,16 @@ Deliver:
 - entity list accepted
 - first three project templates named
 - initial operating principles frozen
+- Week 1 backend chunk plan accepted
+- modular monolith boundaries accepted
+- external Flow auth verification boundary accepted
 
 Exit criteria:
 
 - no task can exist without a project
 - no project can exist without a guide
 - no accepted task can exist without payment and evidence concepts
+- no backend implementation starts without chunk specification and conditions of satisfaction
 
 ### Day 2: Project And Guide Records
 
@@ -44,6 +54,8 @@ Deliver:
 - evidence policy fields
 - dispute policy fields
 - active/inactive project status
+- SQLAlchemy 2.x async model shape
+- Pydantic request/response schemas
 
 Exit criteria:
 
@@ -51,6 +63,7 @@ Exit criteria:
 - retrieve the active guide version for a task
 - edit a draft guide without changing historical task guide versions
 - block activation of a guide with missing payment or evidence policy
+- migrations and model tests define the expected invariants
 
 ### Day 3: Task Queue
 
@@ -62,6 +75,7 @@ Deliver:
 - screening/readiness gate
 - task status transition table
 - audit event for each status change
+- task-owned locked guide and policy context
 
 Exit criteria:
 
@@ -69,6 +83,7 @@ Exit criteria:
 - move task to `SCREENING` only when required fields exist
 - move task to `READY` only after screening passes
 - view queues by status
+- every transition writes an actor-attributed audit event
 
 ### Day 4: People And Assignment
 
@@ -79,12 +94,14 @@ Deliver:
 - `AdminRole`
 - assignment/claim flow
 - skill tags
+- external Flow actor identity mapped into Workstream actor context
 
 Exit criteria:
 
 - assign task to worker
 - move `READY -> CLAIMED -> IN_PROGRESS`
 - prevent two workers owning the same task unless project policy allows it
+- Workstream verifies Flow-issued tokens and does not own passwords or login
 
 ### Day 5: Submission Packet
 
@@ -97,10 +114,12 @@ Deliver:
 - artifact hash manifest
 - worker attestation
 - submission versioning
+- server-stamped locked guide and policy context from the task
 
 Exit criteria:
 
 - submit v1 packet
+- worker does not provide guide, checker policy, review policy, or payment policy versions
 - task moves to `SUBMITTED`
 - package/evidence records are immutable after checker run starts
 - replacing any artifact creates v2 instead of mutating v1

--- a/docs/roadmap_implementation_backlog.md
+++ b/docs/roadmap_implementation_backlog.md
@@ -2,6 +2,32 @@
 
 ## P0: Must Exist For v0.1
 
+### Backend Foundation
+
+- FastAPI backend scaffold
+- modular monolith module layout
+- thin routers
+- service layer for workflow rules
+- repository layer for database access
+- interfaces for external boundaries
+- adapters for external implementations
+- SQLAlchemy 2.x async setup
+- Alembic migrations
+- Pydantic request and response schemas
+- Postgres configuration
+- async-first request and database boundaries
+- test setup
+- health endpoint
+
+### Authentication Boundary
+
+- verify external Flow authentication tokens
+- map trusted token claims into Workstream actor context
+- provide current actor dependency for protected routes
+- attach actor id to audit events
+- keep login, signup, password reset, and password storage out of Workstream
+- keep local development auth separate from production Flow token verification
+
 ### Project And Guide
 
 - create project
@@ -9,7 +35,7 @@
 - version project guide
 - mark one guide version active
 - require guide approval before activation
-- lock guide version on every task
+- lock guide and policy versions on every task
 - configure base amount and currency
 - configure checker policy
 - configure review policy

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -41,11 +41,14 @@ Current phase: reviewed planning baseline.
 
 ## Pending Before Build Starts
 
-- Choose the actual repository/app scaffold for implementation.
+- Review and accept the Week 1 backend chunk plan.
+- Review and accept the external Flow auth verifier contract before backend scaffold implementation.
+- Review and accept the Week 1 backend test gates before implementation.
 - Create the first pilot project guide from the template.
 - Create the first 5 pilot task records.
 - Confirm who owns product, engineering, review, operations, and payment reconciliation during the first build cycle.
 - Confirm the first v0.1 project guide uses the locked guide fields, task contract fields, evidence IDs, and contribution record flow.
+- Confirm each implementation chunk will start with a specification and conditions of satisfaction.
 
 ## Operating Rule
 

--- a/docs/roadmap_week1_backend_plan.md
+++ b/docs/roadmap_week1_backend_plan.md
@@ -1,0 +1,305 @@
+# Week 1 Backend Plan
+
+## Purpose
+
+This is the implementation plan for the June 2-5 foundation work.
+
+The week is backend-first. Frontend work starts after the backend contract, state guards, and first workflow are stable enough to support an internal operations UI.
+
+## Architecture Rule
+
+Workstream v0.1 is a modular monolith.
+
+The backend must keep clear boundaries:
+
+- routers handle HTTP only
+- Pydantic schemas define API input and output contracts
+- services own workflow and business rules
+- repositories own database queries
+- interfaces define external boundaries
+- adapters implement external boundaries
+- domain/state helpers own lifecycle rules
+- audit writes happen through one audit path
+
+The stack is:
+
+- Python
+- FastAPI
+- SQLAlchemy 2.x async
+- Alembic
+- Pydantic schemas
+- Postgres
+- local filesystem storage behind an object-storage interface
+- external Flow authentication token verification behind an auth interface
+
+Workstream does not own login, signup, password reset, or password storage. It verifies Flow-issued authentication tokens and derives the current actor from trusted token claims.
+
+## Chunk Review Rule
+
+Each implementation chunk needs a short specification before code starts.
+
+Each chunk specification must include:
+
+- scope
+- non-scope
+- files or modules expected to change
+- data model impact
+- API impact
+- lifecycle/state impact
+- security/auth impact
+- tests required
+- conditions of satisfaction
+- reviewer agents required
+
+The implementation chunk is not done until:
+
+- local tests for that chunk pass
+- stale wording scan passes when docs changed
+- markdown links pass when docs changed
+- at least senior engineering, QA, and security/auth verification are complete or explicitly cancelled and retried
+- unresolved verifier concerns are either fixed or recorded for the operator review
+- the operator gives final review
+
+Every backend chunk must be judged against Workstream workflow correctness, not generic CRUD completion.
+
+Required test gates across the Week 1 chunks:
+
+- migration tests prove Alembic can create the schema from an empty database and run at least one upgrade/downgrade path during early chunks
+- model invariant tests prove project, guide, task, submission, payment, and audit ownership rules
+- API smoke tests prove health, project, guide, task, claim, and submission paths
+- transition guard tests prove allowed lifecycle moves and block invalid shortcuts
+- submission immutability tests prove locked packets cannot be edited in place and replacements create new versions
+- auth dependency tests prove missing/invalid tokens fail and valid Flow actor context reaches protected services
+- storage abstraction tests prove services use the storage interface and hash validation catches mismatches
+- repository hygiene checks prove markdown links and stale wording scans pass when docs change
+
+## Chunk 0: Roadmap And Specification Lock
+
+Scope:
+
+- update the Week 1 roadmap to backend-first
+- define modular monolith boundaries
+- define per-chunk specification and conditions of satisfaction
+- confirm external Flow auth boundary
+- keep this as planning only; no backend code
+
+Non-scope:
+
+- FastAPI scaffold
+- database migrations
+- frontend
+- checker implementation
+- external source adapters
+- marketplace, blockchain, or agent workspace
+
+Conditions of satisfaction:
+
+- roadmap no longer implies frontend is part of the first backend foundation chunk
+- roadmap names the backend stack and modular monolith boundaries
+- roadmap says Workstream verifies Flow auth tokens instead of managing auth directly
+- roadmap defines the review protocol for each implementation chunk
+- roadmap defines the required test gates for backend implementation chunks
+- stale wording and markdown link checks pass
+
+Verifier agents:
+
+- senior engineering
+- security/auth
+- QA/test
+
+## Chunk 1: Backend Scaffold
+
+Scope:
+
+- create the FastAPI backend application structure
+- add settings/config
+- add health endpoint
+- add async database session setup
+- add SQLAlchemy base conventions
+- add Alembic initialization
+- add test setup
+
+Non-scope:
+
+- project/task/submission business logic
+- checker runner
+- frontend
+- external Flow auth network integration beyond interface shape if needed
+
+Expected modules:
+
+- `backend/app/main.py`
+- `backend/app/core/`
+- `backend/app/api/`
+- `backend/app/db/`
+- `backend/tests/`
+- Alembic config and migration directory
+
+Conditions of satisfaction:
+
+- app starts locally
+- health endpoint returns success
+- async database session can connect in a test path
+- Alembic can create an initial migration path
+- Alembic upgrade/downgrade path is covered once the first migration exists
+- router/service/repository boundaries are present in structure, even before all modules are implemented
+- tests pass
+
+Verifier agents:
+
+- senior engineering
+- QA/test
+- security/auth
+
+## Chunk 2: Auth And Actor Boundary
+
+Scope:
+
+- define auth verifier interface
+- implement Flow token verifier adapter boundary
+- add development verifier for local testing
+- create current actor dependency
+- map trusted token claims into Workstream actor identity and role context
+
+Non-scope:
+
+- password authentication
+- user registration
+- password reset
+- direct ownership of Flow identity
+
+Conditions of satisfaction:
+
+- protected endpoint can resolve current actor
+- invalid or missing token is rejected
+- actor id is available for audit writes
+- actor identity uses stable Flow subject and issuer, not email
+- roles/claims source is documented and tested
+- no password table or login route exists
+- dev verifier is clearly separated from production Flow token verification
+- dev/mock auth cannot run in production and is visible in audit context
+- permission checks live in service or policy code, not scattered in routers
+
+Verifier agents:
+
+- security/auth
+- senior engineering
+- QA/test
+
+## Chunk 3: Project And Guide Foundation
+
+Scope:
+
+- project model
+- project guide model
+- checker policy model
+- review policy model
+- payment policy model
+- guide versioning fields
+- active guide lock behavior
+- base payout and evidence policy fields
+
+Non-scope:
+
+- full guide editor UI
+- external source adapters
+- checker execution
+
+Conditions of satisfaction:
+
+- project can be created
+- guide version can be created as draft
+- guide version can be activated only when required policy fields exist
+- active guide can be retrieved for task creation
+- editing a draft guide does not mutate historical task context
+- migrations and model tests pass
+
+Verifier agents:
+
+- senior engineering
+- QA/test
+- security/auth
+
+## Chunk 4: Task Queue And Assignment
+
+Scope:
+
+- task model with locked guide and policy context
+- worker profile
+- reviewer profile
+- assignment model
+- status transition rules through `IN_PROGRESS`
+- audit events for status changes
+- skill tags
+
+Non-scope:
+
+- submission artifacts
+- checker runs
+- human review workflow
+- payment execution
+
+Conditions of satisfaction:
+
+- task can be created in `DRAFT`
+- task cannot move to `SCREENING` without required fields
+- task cannot move to `READY` without locked guide/policy context
+- task can move `READY -> CLAIMED -> IN_PROGRESS`
+- two workers cannot own the same task unless policy explicitly allows it
+- every status change writes an audit event
+- audit events include actor id, external subject, issuer, role/claim context, and auth source where relevant
+- transition guard tests pass
+
+Verifier agents:
+
+- senior engineering
+- QA/test
+- security/auth
+
+## Chunk 5: Submission Packet Foundation
+
+Scope:
+
+- submission model
+- evidence item model
+- artifact/package metadata
+- artifact hash manifest
+- worker attestation
+- submission versioning
+- task transition to `SUBMITTED`
+
+Non-scope:
+
+- checker execution
+- review decisions
+- payment/reputation creation
+
+Conditions of satisfaction:
+
+- worker submits v1 packet against `task_id`
+- worker does not provide guide or policy versions
+- worker-provided guide or policy version fields are rejected or ignored and cannot mutate task context
+- Workstream stamps locked guide and policy versions from task context
+- task moves to `SUBMITTED`
+- submitted packet can be locked before checker execution
+- replacing an artifact creates a new submission version instead of mutating v1
+- submission and immutability tests pass
+
+Verifier agents:
+
+- senior engineering
+- QA/test
+- security/auth
+
+## Week 1 Acceptance Bar
+
+By the end of the week:
+
+- backend scaffold exists and runs
+- external Flow auth boundary is designed and enforced at dependency level
+- project/guide/task/assignment/submission records exist
+- core lifecycle works through `SUBMITTED`
+- every status transition is audit-recorded
+- submitter packet is simple and task-owned policy context is server-stamped
+- tests cover model invariants and transition guards
+- no frontend work is required for this acceptance bar


### PR DESCRIPTION
## Summary
- add a dedicated Week 1 backend plan for June 2-5 foundation work
- lock modular monolith boundaries before implementation starts
- define per-chunk specification and conditions of satisfaction
- clarify external Flow auth token verification and Actor identity model
- add Week 1 backend test gates for migrations, model invariants, API smoke paths, transitions, submissions, auth, storage, and repo hygiene
- remove stale stack wording from review docs

## Verifier Review
- Senior engineering: pass, no blockers
- Security/auth: pass, no blockers
- QA/test: pass, no blockers after stale stack references were fixed

## Checks
- broad stale wording scan passed
- old decision/name scan passed
- local markdown link check passed across 54 markdown files
- no local sheet exports are present to update