### PR TITLE
Add backend scaffold

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,41 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+path_separator = os
+timezone = UTC
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/README
+++ b/backend/alembic/README
@@ -1,0 +1,2 @@
+Alembic migration environment for the Workstream backend.
+

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from app.core.config import get_settings
+from app.db.base import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def get_database_url() -> str:
+    return str(get_settings().database_url)
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=get_database_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    section = config.get_section(config.config_ini_section, {})
+    section["sqlalchemy.url"] = get_database_url()
+    connectable = async_engine_from_config(
+        section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()
+

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}
+

--- a/backend/alembic/versions/0001_initial_baseline.py
+++ b/backend/alembic/versions/0001_initial_baseline.py
@@ -1,0 +1,22 @@
+"""initial baseline
+
+Revision ID: 0001_initial_baseline
+Revises:
+Create Date: 2026-06-04
+"""
+
+from __future__ import annotations
+
+revision = "0001_initial_baseline"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass
+

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,2 @@
+"""Workstream backend application package."""
+

--- a/backend/app/adapters/README.md
+++ b/backend/app/adapters/README.md
@@ -1,0 +1,4 @@
+# Adapters
+
+Adapters implement interfaces for concrete providers such as Flow auth, local storage, object storage, and checker runners.
+

--- a/backend/app/adapters/__init__.py
+++ b/backend/app/adapters/__init__.py
@@ -1,0 +1,2 @@
+"""External boundary implementations."""
+

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,2 @@
+"""HTTP API package."""
+

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.api.routes.health import router as health_router
+
+api_router = APIRouter()
+api_router.include_router(health_router)
+api_router.include_router(health_router, prefix="/api/v1")

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -1,0 +1,2 @@
+"""Route modules."""
+

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.schemas.health import HealthResponse
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    return HealthResponse(status="ok")
+

--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,0 +1,2 @@
+"""Core application configuration and shared behavior."""
+

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    app_name: str = "Workstream API"
+    app_version: str = "0.1.0"
+    debug: bool = False
+    environment: str = "local"
+    database_url: str = Field(
+        default="postgresql+asyncpg://workstream:workstream@localhost:5432/workstream"
+    )
+
+    model_config = SettingsConfigDict(
+        env_prefix="WORKSTREAM_",
+        env_file=".env",
+        extra="ignore",
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+

--- a/backend/app/db/__init__.py
+++ b/backend/app/db/__init__.py
@@ -1,0 +1,2 @@
+"""Database setup."""
+

--- a/backend/app/db/base.py
+++ b/backend/app/db/base.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase
+
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class Base(DeclarativeBase):
+    metadata = MetaData(naming_convention=NAMING_CONVENTION)
+

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.config import get_settings
+
+engine = create_async_engine(str(get_settings().database_url), pool_pre_ping=True)
+AsyncSessionFactory = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_db_session() -> AsyncIterator[AsyncSession]:
+    async with AsyncSessionFactory() as session:
+        yield session
+

--- a/backend/app/interfaces/README.md
+++ b/backend/app/interfaces/README.md
@@ -1,0 +1,4 @@
+# Interfaces
+
+Interfaces define external boundaries for auth, storage, checker execution, and later integrations.
+

--- a/backend/app/interfaces/__init__.py
+++ b/backend/app/interfaces/__init__.py
@@ -1,0 +1,2 @@
+"""External boundary interfaces."""
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.api.router import api_router
+from app.core.config import Settings, get_settings
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    settings = settings or get_settings()
+    app = FastAPI(
+        title=settings.app_name,
+        version=settings.app_version,
+        debug=settings.debug,
+    )
+    app.include_router(api_router)
+    return app
+
+
+app = create_app()
+

--- a/backend/app/modules/README.md
+++ b/backend/app/modules/README.md
@@ -1,0 +1,6 @@
+# Modules
+
+Domain modules live here.
+
+Each module keeps its own router, service, repository, schemas, and models when those pieces exist. Routers stay thin. Services own workflow rules. Repositories own database access.
+

--- a/backend/app/modules/__init__.py
+++ b/backend/app/modules/__init__.py
@@ -1,0 +1,2 @@
+"""Domain modules live here as the modular monolith grows."""
+

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -1,0 +1,2 @@
+"""Shared API schemas."""
+

--- a/backend/app/schemas/health.py
+++ b/backend/app/schemas/health.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    status: str
+

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "workstream-backend"
+version = "0.1.0"
+description = "Workstream backend API"
+requires-python = ">=3.11"
+dependencies = [
+  "alembic>=1.13,<2.0",
+  "asyncpg>=0.29,<1.0",
+  "fastapi>=0.115,<1.0",
+  "pydantic-settings>=2.6,<3.0",
+  "sqlalchemy[asyncio]>=2.0,<3.0",
+  "uvicorn[standard]>=0.30,<1.0",
+]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["app*"]
+
+[project.optional-dependencies]
+dev = [
+  "aiosqlite>=0.20,<1.0",
+  "httpx>=0.27,<1.0",
+  "pytest>=8.0,<9.0",
+  "pytest-asyncio>=0.24,<1.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["."]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from app.core.config import get_settings
+
+
+@pytest.fixture
+def sqlite_database_url(tmp_path: Path) -> str:
+    return f"sqlite+aiosqlite:///{tmp_path / 'workstream_test.db'}"
+
+
+@pytest.fixture
+def isolated_database_env(monkeypatch: pytest.MonkeyPatch, sqlite_database_url: str) -> str:
+    monkeypatch.setenv("WORKSTREAM_DATABASE_URL", sqlite_database_url)
+    get_settings.cache_clear()
+    yield sqlite_database_url
+    get_settings.cache_clear()

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+
+def test_alembic_upgrade_and_downgrade(isolated_database_env: str) -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    config = Config(str(project_root / "alembic.ini"))
+    config.set_main_option("script_location", str(project_root / "alembic"))
+
+    command.upgrade(config, "head")
+    command.downgrade(config, "base")
+

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+
+
+async def test_create_app() -> None:
+    app = create_app()
+
+    assert app.title == "Workstream API"
+
+
+async def test_health_endpoint() -> None:
+    app = create_app()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+async def test_versioned_health_endpoint() -> None:
+    app = create_app()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/v1/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+async def test_no_local_auth_routes() -> None:
+    app = create_app()
+    paths = {route.path for route in app.routes}
+    forbidden_segments = {"login", "signup", "register", "password", "password-reset", "auth"}
+
+    assert not any(
+        segment in forbidden_segments
+        for path in paths
+        for segment in path.lower().strip("/").split("/")
+    )

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from app.core.config import Settings
+
+
+def test_default_settings_target_postgres() -> None:
+    settings = Settings()
+
+    assert settings.app_name == "Workstream API"
+    assert settings.database_url.startswith("postgresql+asyncpg://")
+

--- a/backend/tests/test_db_session.py
+++ b/backend/tests/test_db_session.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib
+
+from sqlalchemy import text
+
+from app.core.config import get_settings
+
+
+async def test_async_database_session_executes_simple_query(
+    isolated_database_env: str,
+) -> None:
+    get_settings.cache_clear()
+    db_session = importlib.reload(importlib.import_module("app.db.session"))
+    session_iterator = db_session.get_db_session()
+
+    try:
+        session = await anext(session_iterator)
+        result = await session.execute(text("SELECT 1"))
+
+        assert result.scalar_one() == 1
+    finally:
+        await session_iterator.aclose()
+        await db_session.engine.dispose()
+        get_settings.cache_clear()

--- a/docs/spec_chunk_1_backend_scaffold.md
+++ b/docs/spec_chunk_1_backend_scaffold.md
@@ -1,0 +1,108 @@
+# Chunk 1 Backend Scaffold Spec
+
+## Scope
+
+Build the first backend scaffold for Workstream v0.1.
+
+This chunk creates the FastAPI application shell, async database wiring, Alembic migration path, test setup, and clean modular monolith boundaries. It does not implement project, guide, task, assignment, submission, checker, review, payment, or reputation business logic.
+
+## Non-Scope
+
+- frontend work
+- local password, login, signup, password reset, or session ownership
+- production Flow token verification
+- project/task/submission CRUD
+- checker runner
+- storage implementation beyond interface placement if needed
+- external source adapters
+- blockchain, marketplace, or agent workspace
+
+## Expected Files And Modules
+
+- `backend/pyproject.toml`
+- `backend/alembic.ini`
+- `backend/alembic/`
+- `backend/app/main.py`
+- `backend/app/api/`
+- `backend/app/core/`
+- `backend/app/db/`
+- `backend/app/modules/`
+- `backend/app/interfaces/`
+- `backend/app/adapters/`
+- `backend/tests/`
+
+## Architecture Requirements
+
+- Routers handle HTTP only.
+- Services will own workflow rules in later chunks.
+- Repositories will own database access in later chunks.
+- Interfaces define external boundaries.
+- Adapters implement external boundaries.
+- Database access uses SQLAlchemy 2.x async.
+- Migrations use Alembic.
+- API schemas use Pydantic.
+- Runtime database configuration targets Postgres.
+- Tests may override database configuration for isolated scaffold checks.
+
+## Data Model Impact
+
+No domain tables are introduced in this chunk.
+
+This chunk may define:
+
+- SQLAlchemy declarative base
+- shared metadata naming convention
+- async engine/session factory
+- empty Alembic baseline revision
+
+## API Impact
+
+Adds:
+
+- `GET /health`
+- versioned API router mount, currently empty beyond health routing
+
+No protected routes are added in this chunk.
+
+## Lifecycle Impact
+
+No lifecycle transitions are implemented.
+
+The scaffold must leave a clear place for lifecycle/state guard code in later chunks.
+
+## Security/Auth Impact
+
+No authentication behavior is implemented in this chunk.
+
+The scaffold must not add local login, signup, password reset, password storage, or primary session ownership.
+
+Auth interfaces/adapters can be added in Chunk 2.
+
+## Tests Required
+
+- health endpoint returns success
+- application object can be created
+- settings load with default values
+- async database session can execute a simple query through an override test URL
+- Alembic upgrade/downgrade path works against an isolated test database URL
+- no local login/password route exists
+
+## Conditions Of Satisfaction
+
+- app imports successfully
+- app starts through FastAPI application factory
+- health endpoint works
+- async database session works in a test path
+- Alembic has an initial migration path
+- tests pass locally
+- stale wording scan passes
+- markdown link check passes
+- senior engineering verifier passes
+- QA/test verifier passes
+- security/auth verifier passes
+
+## Reviewer Agents Required
+
+- senior engineering
+- QA/test
+- security/auth


### PR DESCRIPTION
## Summary
- add Chunk 1 backend scaffold spec
- create FastAPI app factory with root and versioned health endpoints
- add SQLAlchemy 2.x async base/session wiring
- add Alembic environment with initial baseline revision
- add modular monolith package boundaries for api/core/db/modules/interfaces/adapters/schemas
- add backend pytest setup and scaffold tests

## Tests
- backend pytest: 7 passed
- Uvicorn startup smoke passed with timeout shutdown
- Alembic smoke passed: upgrade head and downgrade base against isolated SQLite URL
- stale wording scan passed
- old project/name scan passed
- markdown link check passed across 70 markdown files

## Verifier Review
- Senior engineering: pass, no blockers
- QA/test: pass, no blockers after DB session test was updated to exercise app.db.session.get_db_session
- Security/auth: pass, no blockers

## Notes
- no frontend work added
- no local auth/login/signup/password/session behavior added
- no domain business logic added before later chunks