### PR TITLE
Add auth actor boundary

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -20,7 +20,10 @@ target_metadata = Base.metadata
 
 
 def get_database_url() -> str:
-    return str(get_settings().database_url)
+    database_url = get_settings().database_url
+    if not database_url:
+        raise RuntimeError("WORKSTREAM_DATABASE_URL must be set before running migrations")
+    return database_url
 
 
 def run_migrations_offline() -> None:
@@ -65,4 +68,3 @@ if context.is_offline_mode():
     run_migrations_offline()
 else:
     run_migrations_online()
-

--- a/backend/app/adapters/auth/__init__.py
+++ b/backend/app/adapters/auth/__init__.py
@@ -1,0 +1,2 @@
+"""Authentication adapter implementations."""
+

--- a/backend/app/adapters/auth/dev.py
+++ b/backend/app/adapters/auth/dev.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from uuid import NAMESPACE_URL, uuid5
+
+from app.core.config import Settings
+from app.interfaces.auth import AuthVerificationError
+from app.schemas.auth import ActorContext
+
+DEVELOPMENT_ENVIRONMENTS = {"local", "dev", "development", "test"}
+
+
+def parse_roles(raw_roles: str) -> tuple[str, ...]:
+    return tuple(role.strip() for role in raw_roles.split(",") if role.strip())
+
+
+def actor_id_from_external_identity(external_issuer: str, external_subject: str) -> str:
+    return str(uuid5(NAMESPACE_URL, f"{external_issuer}:{external_subject}"))
+
+
+class DevelopmentAuthVerifier:
+    """Local development verifier. It must never be enabled in production."""
+
+    def __init__(self, settings: Settings) -> None:
+        if settings.environment.strip().lower() not in DEVELOPMENT_ENVIRONMENTS:
+            raise RuntimeError("development auth cannot run in production")
+        if not settings.dev_auth_token:
+            raise RuntimeError("WORKSTREAM_DEV_AUTH_TOKEN must be set for development auth")
+        if not settings.dev_auth_subject:
+            raise RuntimeError("WORKSTREAM_DEV_AUTH_SUBJECT must be set for development auth")
+        if not settings.dev_auth_issuer:
+            raise RuntimeError("WORKSTREAM_DEV_AUTH_ISSUER must be set for development auth")
+        self._settings = settings
+
+    async def verify(self, token: str) -> ActorContext:
+        if token != self._settings.dev_auth_token:
+            raise AuthVerificationError("invalid development auth token")
+
+        roles = parse_roles(self._settings.dev_auth_roles)
+        actor_id = actor_id_from_external_identity(
+            self._settings.dev_auth_issuer,
+            self._settings.dev_auth_subject,
+        )
+        claim_snapshot = {
+            "roles": roles,
+            "claim_source": "workstream_dev_settings",
+        }
+
+        return ActorContext(
+            actor_id=actor_id,
+            external_subject=self._settings.dev_auth_subject,
+            external_issuer=self._settings.dev_auth_issuer,
+            email=self._settings.dev_auth_email,
+            display_name=self._settings.dev_auth_display_name,
+            roles=roles,
+            claim_snapshot=claim_snapshot,
+            auth_source="dev_mock",
+            is_dev_auth=True,
+        )

--- a/backend/app/adapters/auth/flow.py
+++ b/backend/app/adapters/auth/flow.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from app.core.config import Settings
+from app.interfaces.auth import AuthVerificationError
+from app.schemas.auth import ActorContext
+
+
+class FlowAuthVerifier:
+    """Production Flow token verifier boundary.
+
+    Chunk 2 defines the adapter boundary without adding network verification. The
+    concrete Flow verification client is added when Flow auth details are wired.
+    """
+
+    def __init__(self, settings: Settings) -> None:
+        self._issuer = settings.flow_auth_issuer
+
+    async def verify(self, token: str) -> ActorContext:
+        raise AuthVerificationError(
+            f"Flow token verification is not configured for issuer {self._issuer}"
+        )

--- a/backend/app/api/deps/__init__.py
+++ b/backend/app/api/deps/__init__.py
@@ -1,0 +1,2 @@
+"""FastAPI dependencies."""
+

--- a/backend/app/api/deps/auth.py
+++ b/backend/app/api/deps/auth.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from app.core.auth import get_auth_verifier
+from app.interfaces.auth import AuthVerificationError, AuthVerifier
+from app.schemas.auth import ActorContext
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def unauthorized(detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+async def get_current_actor(
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(bearer_scheme)],
+    verifier: Annotated[AuthVerifier, Depends(get_auth_verifier)],
+) -> ActorContext:
+    if credentials is None:
+        raise unauthorized("Missing bearer token")
+
+    try:
+        return await verifier.verify(credentials.credentials)
+    except AuthVerificationError as exc:
+        raise unauthorized("Invalid bearer token") from exc

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from app.api.routes.auth import router as auth_router
 from app.api.routes.health import router as health_router
 
 api_router = APIRouter()
 api_router.include_router(health_router)
 api_router.include_router(health_router, prefix="/api/v1")
+api_router.include_router(auth_router, prefix="/api/v1")

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+
+from app.api.deps.auth import get_current_actor
+from app.schemas.auth import ActorContext, ActorResponse
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.get("/me", response_model=ActorResponse)
+async def read_current_actor(
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+) -> ActorResponse:
+    return ActorResponse.from_actor(actor)

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from app.adapters.auth.dev import DevelopmentAuthVerifier
+from app.adapters.auth.flow import FlowAuthVerifier
+from app.core.config import Settings, get_settings
+from app.interfaces.auth import AuthVerifier
+
+
+def build_auth_verifier(settings: Settings) -> AuthVerifier:
+    if settings.auth_provider == "dev":
+        return DevelopmentAuthVerifier(settings)
+    return FlowAuthVerifier(settings)
+
+
+def get_auth_verifier() -> AuthVerifier:
+    return build_auth_verifier(get_settings())

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from functools import lru_cache
+from typing import Literal
 
-from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -10,10 +10,25 @@ class Settings(BaseSettings):
     app_name: str = "Workstream API"
     app_version: str = "0.1.0"
     debug: bool = False
-    environment: str = "local"
-    database_url: str = Field(
-        default="postgresql+asyncpg://workstream:workstream@localhost:5432/workstream"
-    )
+    environment: Literal[
+        "local",
+        "dev",
+        "development",
+        "test",
+        "staging",
+        "preview",
+        "prod",
+        "production",
+    ] = "production"
+    auth_provider: Literal["dev", "flow"] = "flow"
+    database_url: str | None = None
+    dev_auth_token: str | None = None
+    dev_auth_subject: str | None = None
+    dev_auth_issuer: str | None = None
+    dev_auth_email: str | None = None
+    dev_auth_display_name: str | None = None
+    dev_auth_roles: str = ""
+    flow_auth_issuer: str = "https://auth.flow.local"
 
     model_config = SettingsConfigDict(
         env_prefix="WORKSTREAM_",
@@ -25,4 +40,3 @@ class Settings(BaseSettings):
 @lru_cache
 def get_settings() -> Settings:
     return Settings()
-

--- a/backend/app/core/permissions.py
+++ b/backend/app/core/permissions.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from app.schemas.auth import ActorContext
+
+
+class PermissionDenied(Exception):
+    """Raised when the current actor lacks required permissions."""
+
+
+def require_any_role(actor: ActorContext, allowed_roles: set[str]) -> None:
+    if not set(actor.roles).intersection(allowed_roles):
+        raise PermissionDenied(
+            f"actor lacks required role: has {actor.roles}, needs one of {sorted(allowed_roles)}"
+        )

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -2,15 +2,43 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import get_settings
 
-engine = create_async_engine(str(get_settings().database_url), pool_pre_ping=True)
-AsyncSessionFactory = async_sessionmaker(engine, expire_on_commit=False)
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def get_database_url() -> str:
+    database_url = get_settings().database_url
+    if not database_url:
+        raise RuntimeError("WORKSTREAM_DATABASE_URL must be set before database access")
+    return database_url
+
+
+def get_engine() -> AsyncEngine:
+    global _engine
+    if _engine is None:
+        _engine = create_async_engine(get_database_url(), pool_pre_ping=True)
+    return _engine
+
+
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    global _session_factory
+    if _session_factory is None:
+        _session_factory = async_sessionmaker(get_engine(), expire_on_commit=False)
+    return _session_factory
 
 
 async def get_db_session() -> AsyncIterator[AsyncSession]:
-    async with AsyncSessionFactory() as session:
+    async with get_session_factory()() as session:
         yield session
 
+
+async def dispose_engine() -> None:
+    global _engine, _session_factory
+    if _engine is not None:
+        await _engine.dispose()
+    _engine = None
+    _session_factory = None

--- a/backend/app/interfaces/auth.py
+++ b/backend/app/interfaces/auth.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from app.schemas.auth import ActorContext
+
+
+class AuthVerificationError(Exception):
+    """Raised when a bearer token cannot be verified."""
+
+
+class AuthVerifier(Protocol):
+    async def verify(self, token: str) -> ActorContext:
+        """Verify a bearer token and return the trusted actor context."""

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ActorAuditContext(BaseModel):
+    actor_id: str
+    external_subject: str
+    external_issuer: str
+    actor_roles: tuple[str, ...]
+    claim_snapshot: dict[str, Any]
+    auth_source: Literal["flow", "dev_mock"]
+    is_dev_auth: bool
+
+
+class ActorContext(BaseModel):
+    actor_id: str
+    external_subject: str
+    external_issuer: str
+    email: str | None = None
+    display_name: str | None = None
+    roles: tuple[str, ...] = ()
+    claim_snapshot: dict[str, Any] = Field(default_factory=dict)
+    auth_source: Literal["flow", "dev_mock"]
+    is_dev_auth: bool = False
+
+    def audit_context(self) -> ActorAuditContext:
+        return ActorAuditContext(
+            actor_id=self.actor_id,
+            external_subject=self.external_subject,
+            external_issuer=self.external_issuer,
+            actor_roles=self.roles,
+            claim_snapshot=self.claim_snapshot,
+            auth_source=self.auth_source,
+            is_dev_auth=self.is_dev_auth,
+        )
+
+
+class ActorResponse(BaseModel):
+    actor_id: str
+    external_subject: str
+    external_issuer: str
+    email: str | None = None
+    display_name: str | None = None
+    roles: tuple[str, ...]
+    auth_source: Literal["flow", "dev_mock"]
+    is_dev_auth: bool
+    audit_context: ActorAuditContext
+
+    @classmethod
+    def from_actor(cls, actor: ActorContext) -> "ActorResponse":
+        return cls(
+            actor_id=actor.actor_id,
+            external_subject=actor.external_subject,
+            external_issuer=actor.external_issuer,
+            email=actor.email,
+            display_name=actor.display_name,
+            roles=actor.roles,
+            auth_source=actor.auth_source,
+            is_dev_auth=actor.is_dev_auth,
+            audit_context=actor.audit_context(),
+        )

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -40,7 +40,7 @@ async def test_versioned_health_endpoint() -> None:
 async def test_no_local_auth_routes() -> None:
     app = create_app()
     paths = {route.path for route in app.routes}
-    forbidden_segments = {"login", "signup", "register", "password", "password-reset", "auth"}
+    forbidden_segments = {"login", "signup", "register", "password", "password-reset"}
 
     assert not any(
         segment in forbidden_segments

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.adapters.auth.dev import DevelopmentAuthVerifier
+from app.adapters.auth.flow import FlowAuthVerifier
+from app.core.config import Settings, get_settings
+from app.core.permissions import PermissionDenied, require_any_role
+from app.interfaces.auth import AuthVerificationError
+from app.main import create_app
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache() -> None:
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def test_missing_bearer_token_is_rejected() -> None:
+    app = create_app()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get("/api/v1/auth/me")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing bearer token"
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+async def test_invalid_bearer_token_is_rejected() -> None:
+    app = create_app()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get(
+            "/api/v1/auth/me",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid bearer token"
+
+
+async def test_valid_dev_token_resolves_actor_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WORKSTREAM_AUTH_PROVIDER", "dev")
+    monkeypatch.setenv("WORKSTREAM_ENVIRONMENT", "local")
+    monkeypatch.setenv("WORKSTREAM_DEV_AUTH_TOKEN", "local-token")
+    monkeypatch.setenv("WORKSTREAM_DEV_AUTH_SUBJECT", "flow-subject-1")
+    monkeypatch.setenv("WORKSTREAM_DEV_AUTH_ISSUER", "flow-dev-issuer")
+    monkeypatch.setenv("WORKSTREAM_DEV_AUTH_EMAIL", "worker@example.test")
+    monkeypatch.setenv("WORKSTREAM_DEV_AUTH_DISPLAY_NAME", "Worker One")
+    monkeypatch.setenv("WORKSTREAM_DEV_AUTH_ROLES", "worker,reviewer")
+    get_settings.cache_clear()
+    app = create_app()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.get(
+            "/api/v1/auth/me",
+            headers={"Authorization": "Bearer local-token"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["actor_id"]
+    assert body["external_subject"] == "flow-subject-1"
+    assert body["external_issuer"] == "flow-dev-issuer"
+    assert body["email"] == "worker@example.test"
+    assert body["display_name"] == "Worker One"
+    assert body["roles"] == ["worker", "reviewer"]
+    assert body["auth_source"] == "dev_mock"
+    assert body["is_dev_auth"] is True
+    assert body["audit_context"]["actor_id"] == body["actor_id"]
+    assert body["audit_context"]["external_subject"] == "flow-subject-1"
+    assert body["audit_context"]["external_issuer"] == "flow-dev-issuer"
+    assert body["audit_context"]["auth_source"] == "dev_mock"
+    assert body["audit_context"]["is_dev_auth"] is True
+
+
+async def test_actor_id_uses_subject_and_issuer_not_email() -> None:
+    first = Settings(
+        environment="local",
+        auth_provider="dev",
+        dev_auth_token="local-token",
+        dev_auth_subject="same-subject",
+        dev_auth_issuer="same-issuer",
+        dev_auth_email="first@example.test",
+    )
+    second = Settings(
+        environment="local",
+        auth_provider="dev",
+        dev_auth_token="local-token",
+        dev_auth_subject="same-subject",
+        dev_auth_issuer="same-issuer",
+        dev_auth_email="second@example.test",
+    )
+
+    first_actor = await DevelopmentAuthVerifier(first).verify(first.dev_auth_token)
+    second_actor = await DevelopmentAuthVerifier(second).verify(second.dev_auth_token)
+
+    assert first_actor.actor_id == second_actor.actor_id
+    assert first_actor.email != second_actor.email
+
+
+@pytest.mark.parametrize("environment", ["production", "prod", "staging", "preview"])
+def test_dev_auth_requires_explicit_development_environment(environment: str) -> None:
+    settings = Settings(
+        environment=environment,
+        auth_provider="dev",
+        dev_auth_token="local-token",
+        dev_auth_subject="subject",
+        dev_auth_issuer="issuer",
+    )
+
+    with pytest.raises(RuntimeError, match="development auth cannot run in production"):
+        DevelopmentAuthVerifier(settings)
+
+
+@pytest.mark.parametrize("environment", ["local", "dev", "development", "test"])
+def test_dev_auth_allows_only_development_environments(environment: str) -> None:
+    verifier = DevelopmentAuthVerifier(
+        Settings(
+            environment=environment,
+            auth_provider="dev",
+            dev_auth_token="local-token",
+            dev_auth_subject="subject",
+            dev_auth_issuer="issuer",
+        )
+    )
+
+    assert verifier
+
+
+@pytest.mark.parametrize(
+    ("field_name", "error_message"),
+    [
+        ("dev_auth_token", "WORKSTREAM_DEV_AUTH_TOKEN must be set"),
+        ("dev_auth_subject", "WORKSTREAM_DEV_AUTH_SUBJECT must be set"),
+        ("dev_auth_issuer", "WORKSTREAM_DEV_AUTH_ISSUER must be set"),
+    ],
+)
+def test_dev_auth_requires_explicit_identity_fields(
+    field_name: str,
+    error_message: str,
+) -> None:
+    values = {
+        "environment": "local",
+        "auth_provider": "dev",
+        "dev_auth_token": "local-token",
+        "dev_auth_subject": "subject",
+        "dev_auth_issuer": "issuer",
+    }
+    values[field_name] = None
+    settings = Settings(**values)
+
+    with pytest.raises(RuntimeError, match=error_message):
+        DevelopmentAuthVerifier(settings)
+
+
+async def test_flow_auth_verifier_boundary_rejects_unconfigured_verification() -> None:
+    verifier = FlowAuthVerifier(Settings(auth_provider="flow"))
+
+    with pytest.raises(AuthVerificationError, match="Flow token verification is not configured"):
+        await verifier.verify("flow-token")
+
+
+async def test_permission_policy_allows_required_role() -> None:
+    actor = await DevelopmentAuthVerifier(
+        Settings(
+            environment="local",
+            auth_provider="dev",
+            dev_auth_token="local-token",
+            dev_auth_subject="subject",
+            dev_auth_issuer="issuer",
+            dev_auth_roles="worker,reviewer",
+        )
+    ).verify("local-token")
+
+    require_any_role(actor, {"reviewer"})
+
+
+async def test_permission_policy_rejects_missing_role() -> None:
+    actor = await DevelopmentAuthVerifier(
+        Settings(
+            environment="local",
+            auth_provider="dev",
+            dev_auth_token="local-token",
+            dev_auth_subject="subject",
+            dev_auth_issuer="issuer",
+            dev_auth_roles="worker",
+        )
+    ).verify("local-token")
+
+    with pytest.raises(PermissionDenied, match="needs one of"):
+        require_any_role(actor, {"finance"})
+
+
+async def test_no_local_login_password_or_session_routes() -> None:
+    app = create_app()
+    paths = {route.path.lower() for route in app.routes}
+    forbidden_segments = {
+        "login",
+        "signup",
+        "register",
+        "password",
+        "password-reset",
+        "session",
+        "sessions",
+    }
+
+    assert "/api/v1/auth/me" in paths
+    assert not any(
+        segment in forbidden_segments
+        for path in paths
+        for segment in path.strip("/").split("/")
+    )

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+import pytest
+from pydantic import ValidationError
+
 from app.core.config import Settings
 
 
-def test_default_settings_target_postgres() -> None:
+def test_default_settings_are_fail_closed() -> None:
     settings = Settings()
 
     assert settings.app_name == "Workstream API"
-    assert settings.database_url.startswith("postgresql+asyncpg://")
+    assert settings.environment == "production"
+    assert settings.auth_provider == "flow"
+    assert settings.database_url is None
+    assert settings.dev_auth_token is None
 
+
+def test_settings_reject_unknown_environment() -> None:
+    with pytest.raises(ValidationError):
+        Settings(environment="unknown")

--- a/backend/tests/test_db_session.py
+++ b/backend/tests/test_db_session.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
 from sqlalchemy import text
 
 from app.core.config import get_settings
@@ -21,5 +22,31 @@ async def test_async_database_session_executes_simple_query(
         assert result.scalar_one() == 1
     finally:
         await session_iterator.aclose()
-        await db_session.engine.dispose()
+        await db_session.dispose_engine()
+        get_settings.cache_clear()
+
+
+async def test_get_database_url_requires_workstream_database_url(monkeypatch) -> None:
+    monkeypatch.delenv("WORKSTREAM_DATABASE_URL", raising=False)
+    get_settings.cache_clear()
+    db_session = importlib.reload(importlib.import_module("app.db.session"))
+
+    try:
+        with pytest.raises(RuntimeError, match="WORKSTREAM_DATABASE_URL must be set"):
+            db_session.get_database_url()
+    finally:
+        await db_session.dispose_engine()
+        get_settings.cache_clear()
+
+
+async def test_get_engine_requires_workstream_database_url(monkeypatch) -> None:
+    monkeypatch.delenv("WORKSTREAM_DATABASE_URL", raising=False)
+    get_settings.cache_clear()
+    db_session = importlib.reload(importlib.import_module("app.db.session"))
+
+    try:
+        with pytest.raises(RuntimeError, match="WORKSTREAM_DATABASE_URL must be set"):
+            db_session.get_engine()
+    finally:
+        await db_session.dispose_engine()
         get_settings.cache_clear()

--- a/docs/spec_chunk_2_auth_actor_boundary.md
+++ b/docs/spec_chunk_2_auth_actor_boundary.md
@@ -1,0 +1,116 @@
+# Chunk 2 Auth And Actor Boundary Spec
+
+## Scope
+
+Build the Workstream v0.1 authentication boundary.
+
+This chunk defines how FastAPI routes resolve the current actor from an external Flow-issued token without Workstream owning login, signup, password reset, password storage, or primary auth sessions.
+
+## Non-Scope
+
+- password authentication
+- user registration
+- password reset
+- local session ownership
+- production Flow network verification
+- actor persistence tables
+- project/task/submission business logic
+- frontend work
+
+## Expected Files And Modules
+
+- `backend/app/interfaces/auth.py`
+- `backend/app/adapters/auth/`
+- `backend/app/api/deps/auth.py`
+- `backend/app/api/routes/auth.py`
+- `backend/app/core/permissions.py`
+- `backend/app/schemas/auth.py`
+- `backend/tests/test_auth.py`
+
+## Architecture Requirements
+
+- Auth verifier behavior is defined by an interface.
+- Production Flow verification is represented by an adapter boundary.
+- Local development auth is a separate adapter.
+- The current actor is resolved by one FastAPI dependency.
+- Routers do not own permission logic.
+- Permission checks live in service/policy code.
+- Actor identity uses stable Flow `subject + issuer`, not email.
+- Actor context includes role/claim context for later audit writes.
+- Dev/mock auth cannot run in production.
+- Dev/mock auth is explicit opt-in only for local, dev, development, or test environments.
+- Dev/mock auth has no built-in token default.
+- Runtime database configuration comes from environment and does not expose embedded credentials in source defaults.
+- Dev/mock auth is visible through actor context and audit context fields.
+
+## Data Model Impact
+
+No database tables are introduced in this chunk.
+
+The in-request actor context must expose:
+
+- `actor_id`
+- `external_subject`
+- `external_issuer`
+- `roles`
+- `claim_snapshot`
+- `auth_source`
+- `is_dev_auth`
+
+## API Impact
+
+Adds:
+
+- `GET /api/v1/auth/me`
+
+This is a protected smoke endpoint used to prove actor resolution. It does not replace Flow login and does not create a session.
+
+## Lifecycle Impact
+
+No Workstream task lifecycle transitions are implemented.
+
+The actor context created here becomes the input later services use for audit attribution and permission checks.
+
+## Security/Auth Impact
+
+- Missing token returns unauthorized.
+- Invalid token returns unauthorized.
+- Valid dev token resolves an actor only outside production.
+- Flow verifier adapter boundary exists but does not fake production verification.
+- Workstream does not add local login, signup, registration, password reset, password storage, or session routes.
+
+## Tests Required
+
+- missing bearer token is rejected
+- invalid bearer token is rejected
+- valid dev token resolves actor id, external subject, external issuer, roles, auth source, and audit context
+- actor id is derived from `external_subject + external_issuer`, not email
+- dev verifier cannot be created in production
+- Flow verifier adapter boundary rejects unsupported local verification
+- permission policy allows required roles
+- permission policy rejects missing roles
+- no local auth/password/session routes exist
+
+## Conditions Of Satisfaction
+
+- protected endpoint resolves current actor
+- invalid or missing token is rejected
+- actor id is available for audit writes
+- actor identity uses stable Flow subject and issuer, not email
+- role/claim source is documented in code and tested
+- no password table or login route exists
+- dev verifier is separate from production Flow verifier
+- dev/mock auth cannot run in production and is visible in audit context
+- permission checks live outside routers
+- backend tests pass
+- stale wording scan passes
+- markdown link check passes
+- senior engineering verifier passes
+- QA/test verifier passes
+- security/auth verifier passes
+
+## Reviewer Agents Required
+
+- security/auth
+- senior engineering
+- QA/test


### PR DESCRIPTION
## Summary
- add Chunk 2 auth and actor boundary spec
- define AuthVerifier interface
- add separate development and Flow auth verifier adapters
- add current actor dependency using bearer token verification
- add protected /api/v1/auth/me smoke endpoint
- add ActorContext, ActorResponse, and audit context schemas
- add role permission policy outside routers
- keep auth ownership external to Flow; no local login/signup/password/session behavior

## Security hardening after review
- auth defaults fail closed: provider defaults to Flow, environment defaults to production
- removed hardcoded Postgres credential default; WORKSTREAM_DATABASE_URL is required before DB access
- removed built-in dev token/default dev identity values
- dev auth is explicit opt-in only for local/dev/development/test environments
- config rejects unknown environment values
- dev auth requires explicit token, subject, and issuer
- permission errors now include diagnostic role context

## Tests
- backend pytest: 29 passed
- compileall app/tests passed
- protected auth smoke with explicit dev env passed
- Uvicorn startup smoke passed with timeout shutdown
- Alembic smoke passed: upgrade head and downgrade base against isolated SQLite URL
- hardcoded credential/default scan passed
- stale wording scan passed
- markdown link check passed across 71 markdown files

## Verifier Review
- Security/auth: pass after CodeRabbit hardening, no blockers
- QA/test: pass after config-level unknown environment rejection, no blockers
- Senior engineering: pass after config/session hardening, no blockers

## Notes
- no domain tables added
- no product/business routes added beyond auth smoke endpoint
- no frontend work added