### PR TITLE
Strengthen Workstream ADR coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Workstream is how Flow measures, certifies, and coordinates useful human-agent w
 - Do not import XLSX into Google Sheets with "replace spreadsheet"; use a temporary sheet and copy only the roadmap tab.
 - Prefer evidence-backed docs over vague product claims.
 - Keep v0.1 focused on project guide -> task -> submission -> checks -> review -> revision -> contribution/payment/reputation records.
-- Review decisions are only accept, needs revision, or reject.
+- Review decision stored values are only accept, needs_revision, or reject.
 - Frontend is locked as React + Vite + TypeScript.
 - Backend API is locked as Python with FastAPI.
 - ORM, migrations, and API schemas are locked as SQLAlchemy 2.x async + Alembic + Pydantic schemas.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Assign task
 Submit packet
 Run checks
 Review packet
-Record review decision: accept, needs revision, or reject
+Record review decision: accept, needs_revision, or reject
 Create contribution record for accepted work
 Record payment status separately for accepted work
 Update reputation from review outcome

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Different projects speak different domain languages, but serious task evaluation
 
 - every project has a guide
 - every task belongs to a project
-- every project has a base amount or payout policy
+- every project has a base amount or payment policy
 - every task has acceptance criteria
 - every submission has evidence
 - every submission passes automated checks before human review
@@ -95,6 +95,12 @@ Workstream turns that operating knowledge into reusable infrastructure.
 - [ADR 0001: Core Scope](docs/decision_0001_core_scope.md)
 - [ADR 0002: Database Ledger Before Blockchain Settlement](docs/decision_0002_db_first_not_blockchain_first.md)
 - [ADR 0003: Project Guides Are First-Class](docs/decision_0003_project_guides_are_first_class.md)
+- [ADR 0004: v0.1 Implementation Stack Is Locked](docs/decision_0004_v0_1_stack_is_locked.md)
+- [ADR 0005: Postgres Is The Record Database](docs/decision_0005_postgres_is_the_record_database.md)
+- [ADR 0006: Workstream Verifies External Flow Auth](docs/decision_0006_external_flow_auth_boundary.md)
+- [ADR 0007: Execution Is Async-First](docs/decision_0007_async_first_execution.md)
+- [ADR 0008: Files Use An Object-Storage Abstraction](docs/decision_0008_object_storage_abstraction.md)
+- [ADR 0009: Review Decisions Are Canonical](docs/decision_0009_review_decisions_are_canonical.md)
 
 ## Local Backend Database
 
@@ -121,10 +127,10 @@ Assign task
 Submit packet
 Run checks
 Review packet
-Request revision or accept
-Create contribution record
-Record payment status separately
-Update reputation
+Record review decision: accept, needs revision, or reject
+Create contribution record for accepted work
+Record payment status separately for accepted work
+Update reputation from review outcome
 Review lessons learned
 ```
 

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -298,7 +298,7 @@ Look for:
 - evidence that passed structurally but did not prove the claim
 - generated or copied artifacts that evade forbidden-file rules
 
-Each blind spot becomes a guide update, checker update, or reviewer policy update.
+Each blind spot becomes a guide update, checker update, reviewer policy update, revision policy update, or payment policy update.
 
 ## First Implementation
 

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -82,9 +82,9 @@ Validates task record fields required by the project guide.
 
 Ensures the task has a guide version attached.
 
-### check_payment_policy_present
+### check_policy_context_present
 
-Ensures the task has base amount and currency.
+Ensures the task has locked checker, review, revision, and payment policy context, including base amount and currency where required.
 
 ### check_submission_packet
 
@@ -154,7 +154,7 @@ This is optional by project policy, but recommended for high-value work.
 Project activation gate:
 
 - `check_project_guide_attached`
-- `check_payment_policy_present`
+- `check_policy_context_present`
 - project-specific guide completeness checks
 
 Task screening gate:

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -15,6 +15,7 @@ Project
   ProjectGuide
   CheckerPolicy
   ReviewPolicy
+  RevisionPolicy
   PaymentPolicy
   ProjectLesson
 
@@ -239,6 +240,7 @@ Lesson types:
 - guide_update
 - checker_update
 - reviewer_policy_update
+- revision_policy_update
 - queue_policy_update
 - payment_policy_update
 - risk_note

--- a/docs/architecture_lifecycle_state_machine.md
+++ b/docs/architecture_lifecycle_state_machine.md
@@ -49,13 +49,13 @@ Required before leaving:
 
 ### SCREENING
 
-The task is structurally prepared but not yet released. This is the pre-release quality gate used to catch weak guides, vague acceptance criteria, missing evidence requirements, bad payout policy, or missing checker policy before workers see the task.
+The task is structurally prepared but not yet released. This is the pre-release quality gate used to catch weak guides, vague acceptance criteria, missing evidence requirements, bad payment policy, missing checker policy, missing review policy, or missing revision policy before workers see the task.
 
 Required before entering:
 
 - draft task has required fields
 - project guide version is attached
-- base payout policy is present
+- payment policy is present
 - task creator believes the task is ready for independent screening
 
 Required before leaving:
@@ -73,7 +73,10 @@ Required before entering:
 
 - task schema valid
 - project guide active
-- payout policy present
+- checker policy present
+- review policy present
+- revision policy present
+- payment policy present
 - guide version locked for this task
 - source reference recorded when imported
 - acceptance criteria frozen unless an admin records a guide-correction event

--- a/docs/architecture_lockdown.md
+++ b/docs/architecture_lockdown.md
@@ -19,7 +19,7 @@ Project guide
 -> pre-review gate
 -> human review
 -> revision replay
--> review decision: accept / needs revision / reject
+-> review decision: accept / needs_revision / reject
 -> contribution record
 -> payment record
 -> reputation event
@@ -69,7 +69,6 @@ Every project guide must define:
 - checker policy
 - review policy
 - revision policy
-- payment policy
 - common rejection reasons
 
 Tasks lock to the active guide version at creation or screening time before entering `READY`. Material guide changes require a new guide version.

--- a/docs/architecture_lockdown.md
+++ b/docs/architecture_lockdown.md
@@ -1,10 +1,12 @@
 # Architecture Lockdown
 
-Last updated: 2026-06-03
+Last updated: 2026-06-06
 
 ## Purpose
 
 This note locks the Workstream v0.1 architecture around source-agnostic intake, project guide discipline, task contracts, human accountability for agent-assisted work, contribution records, payment records, and reputation consequences.
+
+The ADR files under `docs/decision_*.md` are the decision record for this lockdown. When a locked rule changes, update or add an ADR before changing implementation specs.
 
 The canonical v0.1 scope remains narrower:
 
@@ -17,7 +19,7 @@ Project guide
 -> pre-review gate
 -> human review
 -> revision replay
--> accepted/rejected outcome
+-> review decision: accept / needs revision / reject
 -> contribution record
 -> payment record
 -> reputation event
@@ -63,7 +65,7 @@ Every project guide must define:
 - required skills
 - difficulty scale
 - estimated time policy
-- base payout policy
+- payment policy
 - checker policy
 - review policy
 - revision policy

--- a/docs/architecture_system_architecture.md
+++ b/docs/architecture_system_architecture.md
@@ -101,6 +101,7 @@ Owns:
 - base payout
 - checker policy
 - review policy
+- revision policy
 - payment policy
 - skill taxonomy
 

--- a/docs/decision_0001_core_scope.md
+++ b/docs/decision_0001_core_scope.md
@@ -19,8 +19,9 @@ Project Guide
 -> Platform Checker
 -> Human Review
 -> Needs Revision / Accepted / Rejected
--> Payment
--> Reputation
+-> Contribution Record
+-> Payment Record
+-> Reputation Event
 ```
 
 The same evaluation and contribution infrastructure can support many project domains if project-specific rules are configurable.
@@ -36,6 +37,7 @@ The first version prioritizes:
 - reviews
 - revisions
 - evidence
+- contribution records
 - payment ledger
 - reputation ledger
 

--- a/docs/decision_0002_db_first_not_blockchain_first.md
+++ b/docs/decision_0002_db_first_not_blockchain_first.md
@@ -12,7 +12,7 @@ The first risk is not settlement. The first risk is whether the evaluation and c
 
 ## Decision
 
-Use a normal database-backed payment and reputation ledger for the first version.
+Use Postgres-backed contribution, payment, and reputation records for v0.1.
 
 Blockchain settlement comes later as an adapter behind the payment ledger.
 

--- a/docs/decision_0003_project_guides_are_first_class.md
+++ b/docs/decision_0003_project_guides_are_first_class.md
@@ -23,6 +23,17 @@ The guide drives:
 - payment policy
 - common rejection reasons
 
+The checker, review, revision, and payment policies are guide-version policies. They must be tied to the project guide version they govern, not only to the project.
+
+Project guide activation requires the guide plus its required policy context before work can lock against it:
+
+- checker policy
+- review policy
+- revision policy
+- payment policy
+
+Revision policy is not optional. It defines the revision loop contract, including revision limits, revision deadlines, allowed resubmission states, and automatic rejection behavior after the limit.
+
 ## Consequences
 
 Positive:
@@ -30,10 +41,11 @@ Positive:
 - rules become inspectable
 - checkers can be mapped to guide requirements
 - reviewers have a consistent source of truth
+- revision loops have explicit limits and deadlines
 - project templates become reusable
 
 Tradeoff:
 
 - project setup takes more discipline
 - guide changes need versioning
-
+- policies must be versioned and validated with the guide

--- a/docs/decision_0004_v0_1_stack_is_locked.md
+++ b/docs/decision_0004_v0_1_stack_is_locked.md
@@ -1,0 +1,39 @@
+# ADR 0004: v0.1 Implementation Stack Is Locked
+
+## Status
+
+Accepted
+
+## Context
+
+Workstream needs to move quickly through the first internal loop without reopening stack debates every chunk.
+
+The stack still needs clean boundaries so a later specialized runtime can be added when there is a clear reason.
+
+## Decision
+
+The v0.1 implementation stack is:
+
+- Backend API: Python with FastAPI
+- ORM and migrations: SQLAlchemy 2.x async with Alembic
+- API schemas: Pydantic schemas
+- Frontend: React + Vite + TypeScript
+- Database: Postgres
+
+Workstream is a modular monolith for v0.1. Routers handle HTTP, services own business rules, repositories own database access, interfaces define external boundaries, and adapters implement those boundaries.
+
+Rust, TypeScript backend services, or another language can be introduced later only for a specific layer with a documented reason.
+
+## Consequences
+
+Positive:
+
+- implementation chunks have a stable default
+- review can focus on workflow correctness instead of stack selection
+- API and database contracts stay explicit
+- later specialized runtimes remain possible behind interfaces
+
+Tradeoff:
+
+- some future optimizations wait until the internal loop proves them necessary
+- stack changes require a new ADR or an amendment to this one

--- a/docs/decision_0005_postgres_is_the_record_database.md
+++ b/docs/decision_0005_postgres_is_the_record_database.md
@@ -1,0 +1,35 @@
+# ADR 0005: Postgres Is The Record Database
+
+## Status
+
+Accepted
+
+## Context
+
+Workstream depends on database-enforced lifecycle and policy invariants.
+
+The project guide foundation already relies on Postgres behavior such as partial unique indexes and composite foreign keys tying guide policies to guide versions.
+
+Using a different local or CI database can hide production failures or create false confidence.
+
+## Decision
+
+Postgres is the record database for local development, CI, and production.
+
+SQLite is not a supported test target for Workstream backend behavior.
+
+Local development uses the repository Docker Compose Postgres service. CI uses a Postgres service container. Production uses managed or operator-provided Postgres.
+
+## Consequences
+
+Positive:
+
+- local, CI, and production validate the same database family
+- database constraints can be trusted as part of the product contract
+- migration smoke tests exercise Postgres DDL directly
+- review findings about Postgres-specific behavior are not hidden by a fallback database
+
+Tradeoff:
+
+- local backend tests require a running Postgres service
+- CI must provision a Postgres service container

--- a/docs/decision_0006_external_flow_auth_boundary.md
+++ b/docs/decision_0006_external_flow_auth_boundary.md
@@ -1,0 +1,43 @@
+# ADR 0006: Workstream Verifies External Flow Auth
+
+## Status
+
+Accepted
+
+## Context
+
+Workstream needs trusted actor context for project setup, task work, review, audit, reputation, and payment records.
+
+It does not need to become Flow's primary authentication product.
+
+Owning login flows would add password, session, reset, and account-security scope that distracts from the evaluation loop.
+
+## Decision
+
+Workstream verifies external Flow-issued authentication tokens through an auth interface.
+
+Workstream does not implement or own:
+
+- login
+- signup
+- password reset
+- password storage
+- primary auth sessions
+
+Actor identity is derived from stable external issuer and subject claims. Email and display name are profile metadata, not primary identity.
+
+Local development may use a development verifier only in explicitly allowed local/test environments, and it must fail closed outside those environments.
+
+## Consequences
+
+Positive:
+
+- Workstream keeps auth scope narrow
+- audit records can bind actions to stable Flow identity claims
+- production auth can be swapped behind the verifier interface
+- weak local development auth cannot silently become production auth
+
+Tradeoff:
+
+- production deployment depends on a configured Flow token verifier
+- local actor simulation must remain clearly separated from production auth

--- a/docs/decision_0007_async_first_execution.md
+++ b/docs/decision_0007_async_first_execution.md
@@ -1,0 +1,35 @@
+# ADR 0007: Execution Is Async-First
+
+## Status
+
+Accepted
+
+## Context
+
+Workstream will run checks, submissions, reviews, revision loops, payment reconciliation, notifications, and audit writes.
+
+Some of these operations are quick request/response work. Others are long-running jobs that must not block API requests.
+
+## Decision
+
+Workstream is async-first.
+
+FastAPI route handlers, service calls, database access, storage access, checker orchestration, and audit writes use async boundaries where I/O is involved.
+
+Long-running checker and background work must not block request/response paths.
+
+FastAPI background tasks are acceptable only for simple early v0.1 local jobs. Celery or an equivalent durable worker is required when work needs retries, scheduling, progress tracking, isolation, distributed execution, or operational durability.
+
+## Consequences
+
+Positive:
+
+- API responsiveness does not depend on checker duration
+- checker runs can produce durable running/completed state
+- the system has a clear upgrade path from simple background work to durable workers
+- synchronous-first shortcuts are rejected by architecture, not debated per chunk
+
+Tradeoff:
+
+- services must be designed around async database and I/O APIs from the start
+- durable job infrastructure is introduced only when the workflow needs it

--- a/docs/decision_0008_object_storage_abstraction.md
+++ b/docs/decision_0008_object_storage_abstraction.md
@@ -1,0 +1,35 @@
+# ADR 0008: Files Use An Object-Storage Abstraction
+
+## Status
+
+Accepted
+
+## Context
+
+Workstream needs to store submission packages, evidence, checker logs, reports, and other artifacts.
+
+Those artifacts must be hash-bound and auditable. Local development may need simple filesystem storage, but production should be able to use R2, S3, or another compatible object store.
+
+If services write directly to local paths, storage semantics will drift when object storage is introduced.
+
+## Decision
+
+All file and evidence storage goes through a storage interface that behaves like object storage.
+
+Local filesystem storage is allowed only as an adapter behind that interface.
+
+Callers use stable object keys, content hashes, metadata, and immutable artifact references. Services must not depend on local filesystem paths as the business contract.
+
+## Consequences
+
+Positive:
+
+- local development remains simple
+- production object storage can replace the local adapter without changing submission semantics
+- artifacts can be hash-bound and audited consistently
+- checker and review records can cite stable artifact identifiers
+
+Tradeoff:
+
+- direct file-path shortcuts are not allowed in domain services
+- the storage interface must be designed before artifact-heavy workflows are implemented

--- a/docs/decision_0009_review_decisions_are_canonical.md
+++ b/docs/decision_0009_review_decisions_are_canonical.md
@@ -12,13 +12,15 @@ If projects invent their own review outcome labels, downstream lifecycle rules b
 
 ## Decision
 
-The only review decisions are:
+The only canonical stored review decision values are:
 
 - accept
-- needs revision
+- needs_revision
 - reject
 
-`Escalated` is not a review decision.
+Display labels may render these as "Accept", "Needs revision", and "Reject", but persisted records, audit events, API payloads, and analytics must use the canonical stored values.
+
+`Escalated` is not a review decision value.
 
 Disputes, second review, suspected fraud, payment holds, or admin overrides may create separate workflow records and audit events, but they do not replace the reviewer decision contract.
 

--- a/docs/decision_0009_review_decisions_are_canonical.md
+++ b/docs/decision_0009_review_decisions_are_canonical.md
@@ -1,0 +1,36 @@
+# ADR 0009: Review Decisions Are Canonical
+
+## Status
+
+Accepted
+
+## Context
+
+Workstream review results drive task state, revision loops, contribution records, payment records, and reputation signals.
+
+If projects invent their own review outcome labels, downstream lifecycle rules become ambiguous.
+
+## Decision
+
+The only review decisions are:
+
+- accept
+- needs revision
+- reject
+
+`Escalated` is not a review decision.
+
+Disputes, second review, suspected fraud, payment holds, or admin overrides may create separate workflow records and audit events, but they do not replace the reviewer decision contract.
+
+## Consequences
+
+Positive:
+
+- task state transitions remain simple
+- review analytics can compare decisions across projects
+- revision policy has one clear entry point
+- payment and reputation logic can depend on a stable decision set
+
+Tradeoff:
+
+- special handling must be modeled as workflow, audit, dispute, or override records instead of extra review decisions

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -6,7 +6,7 @@ Flow's task evaluation and contribution infrastructure: the system for project g
 
 ## Project
 
-A configured work program with its own guide, rules, checker policy, review policy, payout policy, and queue.
+A configured work program with its own guide, rules, checker policy, review policy, revision policy, payment policy, and queue.
 
 ## Source
 
@@ -18,7 +18,7 @@ A future external task source that can submit tasks into Workstream through an a
 
 ## Project Guide
 
-The operating law of a project. Defines quality standards, submission format, reviewer expectations, payment policy, and common rejection reasons.
+The operating law of a project. Defines quality standards, submission format, reviewer expectations, revision policy, payment policy, and common rejection reasons.
 
 ## Task
 

--- a/docs/operations_operator_workflow.md
+++ b/docs/operations_operator_workflow.md
@@ -91,6 +91,8 @@ Every project maintains lessons learned:
 - new checker needed
 - guide update needed
 - reviewer policy update needed
+- revision policy update needed
+- payment policy update needed
 
 This is how Workstream compounds operational knowledge.
 
@@ -109,5 +111,6 @@ Lessons are not just notes. They become one of:
 - checker update
 - reviewer workflow update
 - queue policy update
+- revision policy update
 - payment policy update
 - risk register update

--- a/docs/operations_operator_workflow.md
+++ b/docs/operations_operator_workflow.md
@@ -12,7 +12,7 @@ Claims or receives tasks, completes work, submits packet, handles revisions.
 
 ### Reviewer
 
-Reviews checker-passed submissions and issues accept, needs revision, or reject decisions.
+Reviews checker-passed submissions and issues accept, needs_revision, or reject decisions.
 
 ### Admin
 

--- a/docs/operations_project_operating_manual.md
+++ b/docs/operations_project_operating_manual.md
@@ -11,6 +11,7 @@ Every project has:
 - reviewer owner
 - checker policy
 - review policy
+- revision policy
 - payment policy
 - review guard
 - preflight evidence requirements
@@ -30,6 +31,7 @@ Before releasing tasks:
 - required submission fields listed
 - checker policy attached
 - review policy attached
+- revision policy attached
 - payment policy attached
 - reviewer pool assigned
 - review guard created from the project guide
@@ -39,11 +41,11 @@ Before releasing tasks:
 
 ### Project Activation Gate
 
-A project cannot become active unless guide, checker policy, review policy, evidence policy, and payment policy are present.
+A project cannot become active unless guide, checker policy, review policy, revision policy, evidence policy, and payment policy are present.
 
 ### Task Screening Gate
 
-A task cannot move to `READY` until the task contract is complete, the guide version is locked, evidence requirements are clear, payout policy is present, and a release decision is recorded.
+A task cannot move to `READY` until the task contract is complete, the guide version is locked, evidence requirements are clear, checker/review/revision/payment policy versions are locked, and a release decision is recorded.
 
 ### Submission Quality Gate
 
@@ -141,6 +143,7 @@ Every repeated failure becomes one of:
 - template update
 - reviewer training note
 - payment policy update
+- revision policy update
 - task creator checklist update
 
 Do not let repeated mistakes remain tribal knowledge.
@@ -151,6 +154,8 @@ Each lesson must have an action owner and one target:
 - checker update
 - template update
 - reviewer policy update
+- revision policy update
+- payment policy update
 - operator training note
 
 ## Weekly Project Review
@@ -172,4 +177,6 @@ Output:
 - policy changes
 - checker backlog
 - guide amendments
+- revision policy amendments
+- payment policy amendments
 - operator training notes

--- a/docs/operations_queue_policy.md
+++ b/docs/operations_queue_policy.md
@@ -21,7 +21,7 @@ Exit requirement:
 
 - project guide attached
 - acceptance criteria present
-- payout policy present
+- payment policy present
 - required output defined
 
 ### Screening
@@ -40,6 +40,8 @@ Exit requirement:
 - acceptance criteria are concrete
 - evidence requirements are explicit
 - checker policy is attached
+- review policy is attached
+- revision policy is attached
 - payment policy is attached
 - no open high-severity readiness finding
 
@@ -202,16 +204,16 @@ Every operating day starts with:
 
 | Transition | Required Records |
 | --- | --- |
-| `DRAFT -> SCREENING` | project id, locked guide candidate, required task fields, payout policy |
-| `SCREENING -> READY` | screening decision, guide version lock, acceptance criteria, evidence requirements, checker policy |
+| `DRAFT -> SCREENING` | project id, locked guide candidate, required task fields, payment policy |
+| `SCREENING -> READY` | screening decision, guide version lock, acceptance criteria, evidence requirements, checker policy, review policy, revision policy, payment policy |
 | `IN_PROGRESS -> SUBMITTED` | submission packet, evidence ids, artifact hash manifest, worker attestation |
 | `SUBMITTED -> AUTO_CHECKING` | immutable submission version, checker policy version derived from the locked task context |
 | `AUTO_CHECKING -> REVIEW_PENDING` | checker run for exact submission version, readiness certificate, no blocking failures |
 | `AUTO_CHECKING -> NEEDS_REVISION` | checker failures with severity, message, suggested fix |
-| `REVIEW_PENDING -> NEEDS_REVISION` | review decision, at least one structured finding |
+| `REVIEW_PENDING -> NEEDS_REVISION` | review decision, at least one structured finding, revision policy still permits revision |
 | `REVIEW_PENDING -> ACCEPTED` | accepted review, acceptance evidence refs, contribution record, payment record |
-| `NEEDS_REVISION -> IN_PROGRESS` | prior findings visible to worker |
-| resubmission after `NEEDS_REVISION` | revision replay covering every high and medium prior finding |
+| `NEEDS_REVISION -> IN_PROGRESS` | prior findings visible to worker, revision deadline active |
+| resubmission after `NEEDS_REVISION` | revision replay covering every high and medium prior finding, revision count under policy limit |
 | payment `PENDING -> PAID` | payment reference and payment audit event |
 
 ## Lane Capacity

--- a/docs/operations_roles_permissions.md
+++ b/docs/operations_roles_permissions.md
@@ -11,7 +11,7 @@ Roles come from trusted Flow token claims, local Workstream role mappings, or an
 | Role | Purpose |
 | --- | --- |
 | Admin | Controls project setup, policies, overrides, and user access. |
-| Project Manager | Creates project guides, task batches, checker policies, and review policies. |
+| Project Manager | Creates project guides, task batches, checker policies, review policies, revision policies, and payment policies. |
 | Worker | Claims tasks, submits packets, and handles revisions. |
 | Reviewer | Reviews checker-passed submissions and records decisions. |
 | Finance | Updates payout status and payment references. |

--- a/docs/operations_subagent_review_protocol.md
+++ b/docs/operations_subagent_review_protocol.md
@@ -77,7 +77,7 @@ No major plan is marked ready without at least product, architecture, and operat
 
 Before a task moves from `SCREENING` to `READY`, run the same review pattern at task scale:
 
-- product/ops pass: task is worth doing and payout policy is clear
+- product/ops pass: task is worth doing and payment policy is clear
 - guide pass: task follows the active project guide
 - checker pass: required automated checks exist for the task type
 - reviewer pass: acceptance criteria are reviewable

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -31,7 +31,7 @@ Each project has a guide that defines the rules for that project. A guide specif
 - payment policy
 - common rejection reasons
 
-If a rule matters, it belongs in the guide, a checker, or a template.
+If a rule matters, it belongs in the guide, checker policy, review policy, revision policy, payment policy, or task template.
 
 ## 3. Automated Checks Protect Human Time
 

--- a/docs/product_brief.md
+++ b/docs/product_brief.md
@@ -140,7 +140,7 @@ By day 30:
 - 3 project templates configured
 - 20 tasks entered
 - 10 submissions created
-- 5 accepted or rejected by review
+- 5 review decisions recorded across accept, needs revision, and reject
 - 3 needs-revision loops completed
 - 100 percent of submissions have checker results
 - 100 percent of accepted tasks have evidence, contribution record, and payment record

--- a/docs/product_brief.md
+++ b/docs/product_brief.md
@@ -140,7 +140,7 @@ By day 30:
 - 3 project templates configured
 - 20 tasks entered
 - 10 submissions created
-- 5 review decisions recorded across accept, needs revision, and reject
+- 5 review decisions recorded across accept, needs_revision, and reject
 - 3 needs-revision loops completed
 - 100 percent of submissions have checker results
 - 100 percent of accepted tasks have evidence, contribution record, and payment record

--- a/docs/product_first_user_flows.md
+++ b/docs/product_first_user_flows.md
@@ -10,12 +10,14 @@ The first user flows prove that Workstream can run real work from intake to acce
 4. Admin selects required submission fields.
 5. Admin enables checker policy.
 6. Admin enables review policy.
-7. Project becomes active.
+7. Admin enables revision policy.
+8. Admin enables payment policy.
+9. Project becomes active.
 
 Acceptance:
 
-- Project cannot become active without guide, base amount, and status policy.
-- Checker and review policies are visible on the project page.
+- Project cannot become active without guide, base amount, checker policy, review policy, revision policy, and payment policy.
+- Checker, review, revision, and payment policies are visible on the project page.
 
 ## Flow 2: Operator Creates A Task
 
@@ -23,14 +25,14 @@ Acceptance:
 2. Operator creates task with title, description, expected output, acceptance criteria, base amount, deadline, and difficulty.
 3. Workstream validates task against project guide.
 4. Task enters `SCREENING`.
-5. Screening confirms guide version, task contract, evidence requirements, payout policy, and reviewability.
+5. Screening confirms guide version, task contract, evidence requirements, checker policy, review policy, revision policy, payment policy, and reviewability.
 6. Task enters `READY`.
 
 Acceptance:
 
 - Missing required fields block `SCREENING`.
 - Missing required fields block `READY`.
-- Task shows project guide, required files, and checker policy.
+- Task shows project guide, required files, checker policy, review policy, revision policy, and payment policy.
 
 ## Flow 3: Worker Submits Work
 
@@ -87,7 +89,8 @@ Acceptance:
 
 - Prior review remains visible.
 - Each required finding has a closure state.
-- Revision count is tracked.
+- Revision count is tracked against the locked revision policy.
+- Resubmission is blocked or rejected when the revision policy limit or deadline says so.
 
 ## Flow 7: Accepted Work Creates Contribution Record
 

--- a/docs/product_first_user_flows.md
+++ b/docs/product_first_user_flows.md
@@ -68,7 +68,7 @@ Acceptance:
 2. Reviewer selects `REVIEW_PENDING` task.
 3. Reviewer reads guide, task, submission, evidence, and checker results.
 4. Reviewer enters structured findings.
-5. Reviewer selects accept, needs revision, or reject.
+5. Reviewer selects accept, needs_revision, or reject.
 
 Acceptance:
 

--- a/docs/product_first_user_flows.md
+++ b/docs/product_first_user_flows.md
@@ -73,8 +73,8 @@ Acceptance:
 Acceptance:
 
 - Review cannot be submitted without a decision.
-- Needs revision and reject require at least one finding.
-- Accept requires no unresolved high-severity checker failure.
+- needs_revision and reject require at least one finding.
+- accept requires no unresolved high-severity checker failure.
 
 ## Flow 6: Revision Replay
 

--- a/docs/product_principles.md
+++ b/docs/product_principles.md
@@ -19,9 +19,9 @@ Workstream is source-agnostic, but v0.1 stays manual-first. External origin adap
 
 ## 2. Project Rules Are First-Class
 
-Every project has its own guide, quality bar, checker policy, review policy, payout policy, and revision policy.
+Every project has its own guide, quality bar, checker policy, review policy, revision policy, and payment policy.
 
-The platform does not rely on memory or chat messages to enforce rules. If a rule matters, it belongs in the project guide or checker policy.
+The platform does not rely on memory or chat messages to enforce rules. If a rule matters, it belongs in the project guide, checker policy, review policy, revision policy, payment policy, or task template.
 
 ## 3. Same Lifecycle, Different Domain Language
 

--- a/docs/proposal_workstream_arch_today_source.md
+++ b/docs/proposal_workstream_arch_today_source.md
@@ -1,3 +1,7 @@
+// Historical source, non-canonical.
+// This file preserves the original React proposal for reference only.
+// Canonical Workstream architecture lives in README.md, AGENTS.md, docs/architecture_lockdown.md, and docs/decision_*.md.
+
 import { useState } from "react";
 
 const c = {

--- a/docs/review_adversarial_quality_review.md
+++ b/docs/review_adversarial_quality_review.md
@@ -68,7 +68,7 @@ Files: `docs/architecture_checker_framework.md`
 
 Finding: Checkers will initially miss real issues and produce false positives. Without a blind-spot review, the system will rely on memory and repeated manual corrections.
 
-Suggested change: Weekly compare checker output against reviewer findings and convert repeated misses into guide, checker, template, or reviewer-policy updates. This has been added.
+Suggested change: Weekly compare checker output against reviewer findings and convert repeated misses into guide, checker, template, reviewer-policy, revision-policy, or payment-policy updates. This has been added.
 
 ## Remaining Implementation Requirements
 

--- a/docs/review_closure.md
+++ b/docs/review_closure.md
@@ -40,7 +40,7 @@ Project Guide
 - require evidence citation before acceptance
 - keep payment status separate from task status
 - require second review for high-value, disputed, override-backed, or suspected fraud/confidentiality cases
-- treat repeated misses as guide, checker, template, or reviewer-policy updates
+- treat repeated misses as guide, checker, template, reviewer-policy, revision-policy, or payment-policy updates
 
 ## Open Follow-Up
 

--- a/docs/risk_register.md
+++ b/docs/risk_register.md
@@ -16,7 +16,7 @@ Project rules scattered across chat, memory, screenshots, or informal notes will
 
 Mitigation:
 
-- every rule belongs in project guide, checker policy, review policy, or payment policy
+- every rule belongs in project guide, checker policy, review policy, revision policy, or payment policy
 - daily lessons learned become document updates
 
 ### R2: Weak Submissions Reach Review

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -86,7 +86,7 @@ Day 2:
 
 - build project and guide records
 - create project guide editor or markdown-backed guide import
-- define base amount and payout policy fields
+- define checker, review, revision, and payment policy fields, including base amount and payout fields
 - use backend records/API first; frontend editor is deferred until the backend contract is stable
 
 Day 3:
@@ -110,7 +110,7 @@ Day 5:
 
 Week 1 acceptance bar:
 
-- a project can be created with a guide and base payout policy
+- a project can be created with a versioned guide plus checker, review, revision, and payment policy context
 - a task can be created, screened, claimed, submitted, and tracked
 - every task status transition is recorded
 - no task exists outside a project
@@ -251,7 +251,7 @@ Week 3 acceptance bar:
 - reviewers cannot issue vague decisions without findings
 - every NEEDS_REVISION has concrete fix requirements
 - every resubmission must close prior feedback
-- accepted/rejected decisions are auditable
+- accept, needs revision, and reject decisions are auditable
 
 ## Week 4: Payment, Reputation, Pilot
 
@@ -403,7 +403,7 @@ Mitigation: keep the first 30 days internal.
 
 Risk: project rules living in chat instead of system policy.
 
-Mitigation: every project guide must define checker and review policy.
+Mitigation: every project guide must define checker, review, revision, and payment policy.
 
 Risk: reviewers giving vague feedback.
 

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -251,7 +251,7 @@ Week 3 acceptance bar:
 - reviewers cannot issue vague decisions without findings
 - every NEEDS_REVISION has concrete fix requirements
 - every resubmission must close prior feedback
-- accept, needs revision, and reject decisions are auditable
+- accept, needs_revision, and reject decisions are auditable
 
 ## Week 4: Payment, Reputation, Pilot
 

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -86,7 +86,7 @@ Day 2:
 
 - build project and guide records
 - create project guide editor or markdown-backed guide import
-- define checker, review, revision, and payment policy fields, including base amount and payout fields
+- define checker, review, revision, and payment policy fields, including base amount, currency, and payment rule fields
 - use backend records/API first; frontend editor is deferred until the backend contract is stable
 
 Day 3:
@@ -161,7 +161,7 @@ Required first checkers:
 - `check_acceptance_criteria_present`
 - `check_status_transition`
 - `check_prior_revision_closed`
-- `check_payment_policy_present`
+- `check_policy_context_present`
 - `check_forbidden_files`
 
 Day 6:
@@ -207,7 +207,7 @@ Deliverables:
 - review packet
 - finding model
 - severity model
-- accept / needs revision / reject decisions
+- accept / needs_revision / reject decisions
 - revision replay
 - reviewer metrics
 - second-review flag

--- a/docs/roadmap_day_by_day_execution_plan.md
+++ b/docs/roadmap_day_by_day_execution_plan.md
@@ -168,7 +168,7 @@ Deliver:
 - `check_evidence_present`
 - `check_evidence_integrity`
 - `check_acceptance_criteria_present`
-- `check_payment_policy_present`
+- `check_policy_context_present`
 - `check_forbidden_files`
 - `check_confidentiality_attestation`
 - first version of `check_low_quality_generated_artifacts`

--- a/docs/roadmap_day_by_day_execution_plan.md
+++ b/docs/roadmap_day_by_day_execution_plan.md
@@ -50,9 +50,13 @@ Deliver:
 - `ProjectGuide`
 - guide versioning
 - guide approval and active-version locking
+- checker policy fields
+- review policy fields
+- revision policy fields
+- payment policy fields
 - base amount fields
 - evidence policy fields
-- dispute policy fields
+- payment dispute policy fields
 - active/inactive project status
 - SQLAlchemy 2.x async model shape
 - Pydantic request/response schemas
@@ -62,7 +66,7 @@ Exit criteria:
 - create a project from a markdown guide
 - retrieve the active guide version for a task
 - edit a draft guide without changing historical task guide versions
-- block activation of a guide with missing payment or evidence policy
+- block activation of a guide missing checker, review, revision, payment, or evidence policy
 - migrations and model tests define the expected invariants
 
 ### Day 3: Task Queue

--- a/docs/roadmap_implementation_backlog.md
+++ b/docs/roadmap_implementation_backlog.md
@@ -39,9 +39,10 @@
 - configure base amount and currency
 - configure checker policy
 - configure review policy
-- configure review guard policy
+- configure revision policy
+- configure pre-review gate policy
 - configure evidence policy
-- configure payment dispute policy
+- configure payment policy, including payment dispute policy
 - configure lessons-learned promotion rule
 
 ### Task Queue

--- a/docs/roadmap_pilot_plan.md
+++ b/docs/roadmap_pilot_plan.md
@@ -51,7 +51,7 @@ Seed negative or edge-case packets during the pilot:
 - fake or irrelevant evidence
 - missing revision replay row
 - high-severity checker failure with admin override request
-- reviewer disagreement on accepted or rejected decision
+- reviewer disagreement on review decision
 - imported task rejected during screening
 - payment amount mismatch
 - accepted task missing evidence citation

--- a/docs/roadmap_week1_backend_plan.md
+++ b/docs/roadmap_week1_backend_plan.md
@@ -194,6 +194,7 @@ Scope:
 - project guide model
 - checker policy model
 - review policy model
+- revision policy model
 - payment policy model
 - guide versioning fields
 - active guide lock behavior

--- a/docs/roles_permissions.md
+++ b/docs/roles_permissions.md
@@ -46,7 +46,7 @@ Can:
 
 - review submissions assigned to them
 - create structured findings
-- accept, needs revision, or reject
+- accept, needs_revision, or reject
 - close or reopen revision findings
 
 Cannot:

--- a/docs/roles_permissions.md
+++ b/docs/roles_permissions.md
@@ -14,6 +14,7 @@ Can:
 - edit project guides
 - configure checker policies
 - configure review policies
+- configure revision policies
 - configure payment policies
 - override task status with audit reason
 - assign reviewers
@@ -25,7 +26,6 @@ Can:
 
 Can:
 
-- create tasks under active projects
 - claim or assign tasks if project policy allows
 - create submissions
 - attach evidence
@@ -46,7 +46,7 @@ Can:
 
 - review submissions assigned to them
 - create structured findings
-- accept, reject, or request revision
+- accept, needs revision, or reject
 - close or reopen revision findings
 
 Cannot:

--- a/docs/template_checker_policy.md
+++ b/docs/template_checker_policy.md
@@ -22,7 +22,7 @@ Medium and low severities are visible to reviewers unless this policy overrides 
 | `check_task_schema` | high | yes | Task must include required project fields. |
 | `check_acceptance_criteria_present` | high | yes | Task must include reviewable acceptance criteria. |
 | `check_ready_gate` | high | yes | Task must pass screening before release. |
-| `check_payment_policy_present` | high | yes | Task must have base amount and currency. |
+| `check_policy_context_present` | high | yes | Task must have locked checker, review, revision, and payment policy context. |
 | `check_submission_packet` | high | yes | Submission must include required packet fields. |
 | `check_evidence_present` | high | yes | Submission must include audit evidence. |
 | `check_evidence_integrity` | high | yes | Evidence and checker runs must bind to submitted artifacts. |

--- a/docs/template_project_guide.md
+++ b/docs/template_project_guide.md
@@ -108,7 +108,7 @@ Required checkers:
 
 - check_task_schema
 - check_project_guide_attached
-- check_payment_policy_present
+- check_policy_context_present
 - check_submission_packet
 - check_evidence_present
 - check_evidence_integrity
@@ -159,6 +159,18 @@ Mandatory second review:
 - reviewer conflict of interest:
 - admin override used:
 
+## Revision Policy
+
+Define:
+
+- maximum revision rounds:
+- revision deadline hours:
+- allowed resubmission states:
+- auto-reject after revision limit:
+- missed deadline behavior:
+- reviewer reassignment rule:
+- payment effect during revision:
+
 ## Acceptance Policy
 
 Accepted work must:
@@ -206,4 +218,4 @@ Define:
 
 Keep this section updated as the project runs.
 
-Each repeated issue becomes a guide update, checker update, template update, or reviewer training note.
+Each repeated issue becomes a guide update, checker update, review policy update, revision policy update, payment policy update, template update, or reviewer training note.


### PR DESCRIPTION
## Summary
- add ADRs for locked stack, Postgres-only record DB, external Flow auth boundary, async-first execution, object-storage abstraction, and canonical review decisions
- strengthen project-guide ADR around guide-version policy context and first-class revision policy
- align roadmap, operating docs, templates, glossary, and user flows with checker/review/revision/payment policy context
- mark the old React proposal source as historical and non-canonical

## Validation
- stale wording scan completed; only expected guardrail references remain
- Markdown links checked: 48
- git diff --check passed
- no local sheets directory present, so XLSX checks were not applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced “payout” with unified “payment” terminology across docs and UX flows.
  * Added ADRs formalizing v0.1 decisions (implementation stack, Postgres as record DB, external auth verification, async-first execution, object-storage abstraction, canonical review decisions).
  * Introduced and surfaced a formal revision policy (rounds, deadlines, limits, resubmission behavior) and made revision/review/payment/checker policies required and visible for project activation and screening.
  * Specified auditable review outcomes (accept / needs_revision / reject) and explicit recording of contribution, payment, and reputation events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->