### PR TITLE
Add submission packet foundation

### DIFF
--- a/backend/alembic/versions/0004_submission_packet_foundation.py
+++ b/backend/alembic/versions/0004_submission_packet_foundation.py
@@ -101,6 +101,12 @@ def upgrade() -> None:
     op.create_index(op.f("ix_submissions_task_id"), "submissions", ["task_id"], unique=False)
     op.create_index(op.f("ix_submissions_worker_id"), "submissions", ["worker_id"], unique=False)
     op.create_index(op.f("ix_submissions_status"), "submissions", ["status"], unique=False)
+    op.create_index(
+        op.f("ix_submissions_supersedes_submission_id"),
+        "submissions",
+        ["supersedes_submission_id"],
+        unique=False,
+    )
 
     op.create_table(
         "evidence_items",
@@ -130,6 +136,7 @@ def downgrade() -> None:
     op.drop_index(op.f("ix_evidence_items_type"), table_name="evidence_items")
     op.drop_index(op.f("ix_evidence_items_submission_id"), table_name="evidence_items")
     op.drop_table("evidence_items")
+    op.drop_index(op.f("ix_submissions_supersedes_submission_id"), table_name="submissions")
     op.drop_index(op.f("ix_submissions_status"), table_name="submissions")
     op.drop_index(op.f("ix_submissions_worker_id"), table_name="submissions")
     op.drop_index(op.f("ix_submissions_task_id"), table_name="submissions")

--- a/backend/alembic/versions/0004_submission_packet_foundation.py
+++ b/backend/alembic/versions/0004_submission_packet_foundation.py
@@ -1,0 +1,157 @@
+"""submission packet foundation
+
+Revision ID: 0004_submission_packets
+Revises: 0003_task_queue_assignment
+Create Date: 2026-06-07
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0004_submission_packets"
+down_revision = "0003_task_queue_assignment"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create submission packet and evidence tables."""
+    op.create_unique_constraint(
+        "uq_workstream_tasks_id_locked_guide",
+        "workstream_tasks",
+        ["id", "locked_guide_version"],
+    )
+    op.create_unique_constraint(
+        "uq_workstream_tasks_id_locked_checker_policy",
+        "workstream_tasks",
+        ["id", "locked_checker_policy_version"],
+    )
+    op.create_unique_constraint(
+        "uq_workstream_tasks_id_locked_review_policy",
+        "workstream_tasks",
+        ["id", "locked_review_policy_version"],
+    )
+    op.create_unique_constraint(
+        "uq_workstream_tasks_id_locked_revision_policy",
+        "workstream_tasks",
+        ["id", "locked_revision_policy_version"],
+    )
+    op.create_unique_constraint(
+        "uq_workstream_tasks_id_locked_payment_policy",
+        "workstream_tasks",
+        ["id", "locked_payment_policy_version"],
+    )
+
+    op.create_table(
+        "submissions",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("worker_id", sa.String(length=100), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=30), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("package_uri", sa.String(length=1000), nullable=True),
+        sa.Column("package_hash", sa.String(length=128), nullable=False),
+        sa.Column("artifact_hash_manifest", sa.JSON(), nullable=False),
+        sa.Column("worker_attestation", sa.Text(), nullable=False),
+        sa.Column("locked_guide_version", sa.String(length=50), nullable=False),
+        sa.Column("locked_checker_policy_version", sa.String(length=50), nullable=False),
+        sa.Column("locked_review_policy_version", sa.String(length=50), nullable=False),
+        sa.Column("locked_revision_policy_version", sa.String(length=50), nullable=False),
+        sa.Column("locked_payment_policy_version", sa.String(length=50), nullable=False),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("locked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("supersedes_submission_id", sa.String(length=36), nullable=True),
+        sa.ForeignKeyConstraint(["task_id"], ["workstream_tasks.id"], name=op.f("fk_submissions_task_id_workstream_tasks")),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_guide_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_guide_version"],
+            name="fk_submissions_task_locked_guide",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_checker_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_checker_policy_version"],
+            name="fk_submissions_task_locked_checker_policy",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_review_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_review_policy_version"],
+            name="fk_submissions_task_locked_review_policy",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_revision_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_revision_policy_version"],
+            name="fk_submissions_task_locked_revision_policy",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_payment_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_payment_policy_version"],
+            name="fk_submissions_task_locked_payment_policy",
+        ),
+        sa.ForeignKeyConstraint(
+            ["supersedes_submission_id"],
+            ["submissions.id"],
+            name=op.f("fk_submissions_supersedes_submission_id_submissions"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_submissions")),
+        sa.UniqueConstraint("task_id", "version", name="uq_submissions_task_version"),
+    )
+    op.create_index(op.f("ix_submissions_task_id"), "submissions", ["task_id"], unique=False)
+    op.create_index(op.f("ix_submissions_worker_id"), "submissions", ["worker_id"], unique=False)
+    op.create_index(op.f("ix_submissions_status"), "submissions", ["status"], unique=False)
+
+    op.create_table(
+        "evidence_items",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("submission_id", sa.String(length=36), nullable=False),
+        sa.Column("type", sa.String(length=50), nullable=False),
+        sa.Column("label", sa.String(length=200), nullable=False),
+        sa.Column("uri", sa.String(length=1000), nullable=True),
+        sa.Column("hash", sa.String(length=128), nullable=True),
+        sa.Column("size_bytes", sa.Integer(), nullable=True),
+        sa.Column("locked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["submission_id"],
+            ["submissions.id"],
+            name=op.f("fk_evidence_items_submission_id_submissions"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_evidence_items")),
+    )
+    op.create_index(op.f("ix_evidence_items_submission_id"), "evidence_items", ["submission_id"], unique=False)
+    op.create_index(op.f("ix_evidence_items_type"), "evidence_items", ["type"], unique=False)
+
+
+def downgrade() -> None:
+    """Drop submission packet and evidence tables."""
+    op.drop_index(op.f("ix_evidence_items_type"), table_name="evidence_items")
+    op.drop_index(op.f("ix_evidence_items_submission_id"), table_name="evidence_items")
+    op.drop_table("evidence_items")
+    op.drop_index(op.f("ix_submissions_status"), table_name="submissions")
+    op.drop_index(op.f("ix_submissions_worker_id"), table_name="submissions")
+    op.drop_index(op.f("ix_submissions_task_id"), table_name="submissions")
+    op.drop_table("submissions")
+    op.drop_constraint(
+        "uq_workstream_tasks_id_locked_payment_policy",
+        "workstream_tasks",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_workstream_tasks_id_locked_revision_policy",
+        "workstream_tasks",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_workstream_tasks_id_locked_review_policy",
+        "workstream_tasks",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "uq_workstream_tasks_id_locked_checker_policy",
+        "workstream_tasks",
+        type_="unique",
+    )
+    op.drop_constraint("uq_workstream_tasks_id_locked_guide", "workstream_tasks", type_="unique")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -10,7 +10,9 @@ from app.modules.projects.models import (  # noqa: F401
 )
 from app.modules.tasks.models import (  # noqa: F401
     AuditEvent,
+    EvidenceItem,
     ReviewerProfile,
+    Submission,
     TaskAssignment,
     WorkerProfile,
     WorkstreamTask,

--- a/backend/app/modules/projects/repository.py
+++ b/backend/app/modules/projects/repository.py
@@ -108,6 +108,24 @@ class ProjectRepository:
             raise ProjectRepositoryIntegrityError("multiple active guides found for project")
         return active_guides[0]
 
+    async def get_guide_by_version(self, project_id: str, version: str) -> ProjectGuide | None:
+        """Load one project guide by project id and version.
+
+        Args:
+            project_id: Project that owns the guide.
+            version: Guide version to load.
+
+        Returns:
+            Project guide when found; otherwise ``None``.
+        """
+        result = await self._session.execute(
+            select(ProjectGuide).where(
+                ProjectGuide.project_id == project_id,
+                ProjectGuide.version == version,
+            )
+        )
+        return result.scalar_one_or_none()
+
     async def list_active_guides(self, project_id: str) -> Sequence[ProjectGuide]:
         """List active guides for a project.
 

--- a/backend/app/modules/tasks/lifecycle.py
+++ b/backend/app/modules/tasks/lifecycle.py
@@ -7,12 +7,14 @@ TASK_STATUS_SCREENING = "screening"
 TASK_STATUS_READY = "ready"
 TASK_STATUS_CLAIMED = "claimed"
 TASK_STATUS_IN_PROGRESS = "in_progress"
+TASK_STATUS_SUBMITTED = "submitted"
 
-ALLOWED_CHUNK4_TRANSITIONS = {
+ALLOWED_TASK_TRANSITIONS = {
     (TASK_STATUS_DRAFT, TASK_STATUS_SCREENING),
     (TASK_STATUS_SCREENING, TASK_STATUS_READY),
     (TASK_STATUS_READY, TASK_STATUS_CLAIMED),
     (TASK_STATUS_CLAIMED, TASK_STATUS_IN_PROGRESS),
+    (TASK_STATUS_IN_PROGRESS, TASK_STATUS_SUBMITTED),
 }
 
 
@@ -21,7 +23,7 @@ class InvalidTaskTransition(ValueError):
 
 
 def ensure_allowed_transition(from_status: str, to_status: str) -> None:
-    """Validate a task status transition implemented by Chunk 4.
+    """Validate a task status transition implemented by the current backend.
 
     Args:
         from_status: Current task status.
@@ -30,5 +32,5 @@ def ensure_allowed_transition(from_status: str, to_status: str) -> None:
     Raises:
         InvalidTaskTransition: If the transition is not supported.
     """
-    if (from_status, to_status) not in ALLOWED_CHUNK4_TRANSITIONS:
+    if (from_status, to_status) not in ALLOWED_TASK_TRANSITIONS:
         raise InvalidTaskTransition(f"invalid task transition: {from_status} -> {to_status}")

--- a/backend/app/modules/tasks/models.py
+++ b/backend/app/modules/tasks/models.py
@@ -249,6 +249,7 @@ class Submission(Base):
     supersedes_submission_id: Mapped[str | None] = mapped_column(
         ForeignKey("submissions.id"),
         nullable=True,
+        index=True,
     )
 
     task: Mapped[WorkstreamTask] = relationship(

--- a/backend/app/modules/tasks/models.py
+++ b/backend/app/modules/tasks/models.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
     text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -96,6 +97,27 @@ class WorkstreamTask(Base):
             ["payment_policies.project_id", "payment_policies.guide_version"],
             name="fk_workstream_tasks_locked_payment_policy",
         ),
+        UniqueConstraint("id", "locked_guide_version", name="uq_workstream_tasks_id_locked_guide"),
+        UniqueConstraint(
+            "id",
+            "locked_checker_policy_version",
+            name="uq_workstream_tasks_id_locked_checker_policy",
+        ),
+        UniqueConstraint(
+            "id",
+            "locked_review_policy_version",
+            name="uq_workstream_tasks_id_locked_review_policy",
+        ),
+        UniqueConstraint(
+            "id",
+            "locked_revision_policy_version",
+            name="uq_workstream_tasks_id_locked_revision_policy",
+        ),
+        UniqueConstraint(
+            "id",
+            "locked_payment_policy_version",
+            name="uq_workstream_tasks_id_locked_payment_policy",
+        ),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
@@ -138,6 +160,11 @@ class WorkstreamTask(Base):
         back_populates="task",
         cascade="all, delete-orphan",
     )
+    submissions: Mapped[list[Submission]] = relationship(
+        back_populates="task",
+        cascade="all, delete-orphan",
+        foreign_keys="Submission.task_id",
+    )
 
 
 class TaskAssignment(Base):
@@ -167,6 +194,94 @@ class TaskAssignment(Base):
     status: Mapped[str] = mapped_column(String(30), nullable=False, default="active", index=True)
 
     task: Mapped[WorkstreamTask] = relationship(back_populates="assignments")
+
+
+class Submission(Base):
+    """Immutable worker submission packet version for a task."""
+
+    __tablename__ = "submissions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["task_id", "locked_guide_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_guide_version"],
+            name="fk_submissions_task_locked_guide",
+        ),
+        ForeignKeyConstraint(
+            ["task_id", "locked_checker_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_checker_policy_version"],
+            name="fk_submissions_task_locked_checker_policy",
+        ),
+        ForeignKeyConstraint(
+            ["task_id", "locked_review_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_review_policy_version"],
+            name="fk_submissions_task_locked_review_policy",
+        ),
+        ForeignKeyConstraint(
+            ["task_id", "locked_revision_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_revision_policy_version"],
+            name="fk_submissions_task_locked_revision_policy",
+        ),
+        ForeignKeyConstraint(
+            ["task_id", "locked_payment_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_payment_policy_version"],
+            name="fk_submissions_task_locked_payment_policy",
+        ),
+        UniqueConstraint("task_id", "version", name="uq_submissions_task_version"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    task_id: Mapped[str] = mapped_column(ForeignKey("workstream_tasks.id"), nullable=False, index=True)
+    worker_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, default="submitted", index=True)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    package_uri: Mapped[str | None] = mapped_column(String(1000))
+    package_hash: Mapped[str] = mapped_column(String(128), nullable=False)
+    artifact_hash_manifest: Mapped[list[dict]] = mapped_column(JSON, nullable=False, default=list)
+    worker_attestation: Mapped[str] = mapped_column(Text, nullable=False)
+    locked_guide_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_checker_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_review_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_revision_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_payment_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    locked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    supersedes_submission_id: Mapped[str | None] = mapped_column(
+        ForeignKey("submissions.id"),
+        nullable=True,
+    )
+
+    task: Mapped[WorkstreamTask] = relationship(
+        back_populates="submissions",
+        foreign_keys=[task_id],
+    )
+    evidence_items: Mapped[list[EvidenceItem]] = relationship(
+        back_populates="submission",
+        cascade="all, delete-orphan",
+    )
+
+
+class EvidenceItem(Base):
+    """Evidence reference bound to one submission version."""
+
+    __tablename__ = "evidence_items"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    submission_id: Mapped[str] = mapped_column(
+        ForeignKey("submissions.id"),
+        nullable=False,
+        index=True,
+    )
+    type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    label: Mapped[str] = mapped_column(String(200), nullable=False)
+    uri: Mapped[str | None] = mapped_column(String(1000))
+    hash: Mapped[str | None] = mapped_column(String(128))
+    size_bytes: Mapped[int | None] = mapped_column(Integer)
+    locked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    metadata_json: Mapped[dict] = mapped_column("metadata", JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    submission: Mapped[Submission] = relationship(back_populates="evidence_items")
 
 
 class AuditEvent(Base):

--- a/backend/app/modules/tasks/repository.py
+++ b/backend/app/modules/tasks/repository.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from datetime import datetime
 
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.modules.tasks.models import (
     AuditEvent,
+    EvidenceItem,
     ReviewerProfile,
+    Submission,
     TaskAssignment,
     WorkerProfile,
     WorkstreamTask,
@@ -83,6 +87,83 @@ class TaskRepository:
             )
         )
         return result.scalar_one_or_none()
+
+    async def add_submission(self, submission: Submission) -> Submission:
+        """Persist a submission packet and its evidence items.
+
+        Args:
+            submission: Submission model to persist.
+
+        Returns:
+            Persisted submission with generated database fields refreshed.
+        """
+        self._session.add(submission)
+        await self._session.flush()
+        await self._session.refresh(submission)
+        return submission
+
+    async def get_submission(self, submission_id: str) -> Submission | None:
+        """Load one submission by id with evidence items.
+
+        Args:
+            submission_id: Submission id to load.
+
+        Returns:
+            Submission when found; otherwise ``None``.
+        """
+        result = await self._session.execute(
+            select(Submission)
+            .options(selectinload(Submission.evidence_items))
+            .where(Submission.id == submission_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_latest_submission_for_task(self, task_id: str) -> Submission | None:
+        """Load the latest submission version for a task.
+
+        Args:
+            task_id: Task whose latest submission should be loaded.
+
+        Returns:
+            Latest submission by version when present; otherwise ``None``.
+        """
+        result = await self._session.execute(
+            select(Submission)
+            .where(Submission.task_id == task_id)
+            .order_by(Submission.version.desc(), Submission.submitted_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_submissions_for_task(self, task_id: str) -> Sequence[Submission]:
+        """List submission versions for one task.
+
+        Args:
+            task_id: Task whose submissions should be listed.
+
+        Returns:
+            Submission versions ordered from oldest to newest.
+        """
+        result = await self._session.execute(
+            select(Submission)
+            .options(selectinload(Submission.evidence_items))
+            .where(Submission.task_id == task_id)
+            .order_by(Submission.version.asc(), Submission.submitted_at.asc())
+        )
+        return result.scalars().all()
+
+    async def lock_submission_evidence(self, submission_id: str, locked_at: datetime) -> None:
+        """Stamp evidence rows with the submission lock timestamp.
+
+        Args:
+            submission_id: Submission whose evidence rows should be locked.
+            locked_at: Timestamp applied to each evidence item.
+        """
+        result = await self._session.execute(
+            select(EvidenceItem).where(EvidenceItem.submission_id == submission_id)
+        )
+        for evidence in result.scalars():
+            evidence.locked_at = locked_at
 
     async def get_worker_profile(self, actor_id: str) -> WorkerProfile | None:
         """Load a worker profile by actor id.

--- a/backend/app/modules/tasks/router.py
+++ b/backend/app/modules/tasks/router.py
@@ -12,6 +12,8 @@ from app.core.permissions import PermissionDenied
 from app.db.session import get_db_session
 from app.modules.tasks.schemas import (
     AuditEventResponse,
+    SubmissionCreate,
+    SubmissionResponse,
     TaskCreate,
     TaskResponse,
     TaskTransitionRequest,
@@ -152,6 +154,67 @@ async def start_task(
             task_id,
             None if payload is None else payload.reason,
         )
+    except PermissionDenied as exc:
+        raise permission_http_error(exc) from exc
+    except TaskServiceError as exc:
+        raise task_http_error(exc) from exc
+
+
+@router.post("/tasks/{task_id}/submissions", response_model=SubmissionResponse, status_code=201)
+async def create_submission(
+    task_id: str,
+    payload: SubmissionCreate,
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SubmissionResponse:
+    """Create a submission packet version for a task."""
+    try:
+        return await TaskService(session).create_submission(actor, task_id, payload)
+    except PermissionDenied as exc:
+        raise permission_http_error(exc) from exc
+    except TaskServiceError as exc:
+        raise task_http_error(exc) from exc
+
+
+@router.get("/tasks/{task_id}/submissions", response_model=list[SubmissionResponse])
+async def list_task_submissions(
+    task_id: str,
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> list[SubmissionResponse]:
+    """Return submission packet versions for one task."""
+    try:
+        return await TaskService(session).list_task_submissions(actor, task_id)
+    except PermissionDenied as exc:
+        raise permission_http_error(exc) from exc
+    except TaskServiceError as exc:
+        raise task_http_error(exc) from exc
+
+
+@router.get("/submissions/{submission_id}", response_model=SubmissionResponse)
+async def get_submission(
+    submission_id: str,
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SubmissionResponse:
+    """Return one submission packet version."""
+    try:
+        return await TaskService(session).get_submission(actor, submission_id)
+    except PermissionDenied as exc:
+        raise permission_http_error(exc) from exc
+    except TaskServiceError as exc:
+        raise task_http_error(exc) from exc
+
+
+@router.post("/submissions/{submission_id}/lock", response_model=SubmissionResponse)
+async def lock_submission(
+    submission_id: str,
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> SubmissionResponse:
+    """Lock a submission packet before checker execution."""
+    try:
+        return await TaskService(session).lock_submission(actor, submission_id)
     except PermissionDenied as exc:
         raise permission_http_error(exc) from exc
     except TaskServiceError as exc:

--- a/backend/app/modules/tasks/schemas.py
+++ b/backend/app/modules/tasks/schemas.py
@@ -36,6 +36,51 @@ class TaskTransitionRequest(BaseModel):
     reason: str | None = None
 
 
+class EvidenceItemCreate(BaseModel):
+    """Request schema for one evidence item in a submission packet."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal[
+        "log",
+        "screenshot",
+        "test_result",
+        "package",
+        "diff",
+        "note",
+        "external_reference",
+    ]
+    label: str = Field(min_length=1, max_length=200)
+    uri: str | None = Field(default=None, max_length=1000)
+    hash: str | None = Field(default=None, max_length=128)
+    size_bytes: int | None = Field(default=None, ge=0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ArtifactHashEntry(BaseModel):
+    """Structured artifact hash entry supplied by a worker."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    artifact: str = Field(min_length=1, max_length=1000)
+    hash: str = Field(min_length=1, max_length=128)
+    size_bytes: int | None = Field(default=None, ge=0)
+    notes: str | None = None
+
+
+class SubmissionCreate(BaseModel):
+    """Request schema for creating a submission packet version."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    summary: str = Field(min_length=1)
+    package_uri: str | None = Field(default=None, max_length=1000)
+    package_hash: str = Field(min_length=1, max_length=128)
+    artifact_hash_manifest: list[ArtifactHashEntry] = Field(min_length=1)
+    worker_attestation: str = Field(min_length=1)
+    evidence_items: list[EvidenceItemCreate] = Field(default_factory=list)
+
+
 class TaskResponse(BaseModel):
     """Response schema for task records."""
 
@@ -94,6 +139,53 @@ class TaskWithAssignmentResponse(BaseModel):
 
     task: TaskResponse
     assignment: AssignmentResponse
+
+
+class EvidenceItemResponse(BaseModel):
+    """Response schema for evidence items."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    submission_id: str
+    type: str
+    label: str
+    uri: str | None
+    hash: str | None
+    size_bytes: int | None
+    locked_at: datetime | None
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        validation_alias="metadata_json",
+        serialization_alias="metadata",
+    )
+    created_at: datetime
+
+
+class SubmissionResponse(BaseModel):
+    """Response schema for submission packet versions."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    task_id: str
+    worker_id: str
+    version: int
+    status: str
+    summary: str
+    package_uri: str | None
+    package_hash: str
+    artifact_hash_manifest: list[dict[str, Any]]
+    worker_attestation: str
+    locked_guide_version: str
+    locked_checker_policy_version: str
+    locked_review_policy_version: str
+    locked_revision_policy_version: str
+    locked_payment_policy_version: str
+    submitted_at: datetime
+    locked_at: datetime | None
+    supersedes_submission_id: str | None
+    evidence_items: list[EvidenceItemResponse] = Field(default_factory=list)
 
 
 class AuditEventResponse(BaseModel):

--- a/backend/app/modules/tasks/service.py
+++ b/backend/app/modules/tasks/service.py
@@ -23,12 +23,15 @@ from app.modules.tasks.lifecycle import (
     TASK_STATUS_IN_PROGRESS,
     TASK_STATUS_READY,
     TASK_STATUS_SCREENING,
+    TASK_STATUS_SUBMITTED,
     InvalidTaskTransition,
     ensure_allowed_transition,
 )
 from app.modules.tasks.models import (
     AuditEvent,
+    EvidenceItem,
     ReviewerProfile,
+    Submission,
     TaskAssignment,
     WorkerProfile,
     WorkstreamTask,
@@ -37,6 +40,8 @@ from app.modules.tasks.repository import TaskRepository
 from app.modules.tasks.schemas import (
     AssignmentResponse,
     AuditEventResponse,
+    SubmissionCreate,
+    SubmissionResponse,
     TaskCreate,
     TaskResponse,
     TaskWithAssignmentResponse,
@@ -46,8 +51,10 @@ from app.schemas.auth import ActorContext
 PROJECT_OPERATOR_ROLES = {"admin", "project_manager"}
 TASK_VIEW_ROLES = {"admin", "project_manager", "worker"}
 TASK_CLAIM_ROLES = {"worker"}
+TASK_SUBMIT_ROLES = {"worker"}
 TASK_START_ROLES = {"admin", "project_manager", "worker"}
 TASK_START_OPERATOR_ROLES = {"admin", "project_manager"}
+SUBMISSION_LOCK_ROLES = {"admin", "project_manager"}
 
 
 class TaskServiceError(Exception):
@@ -90,6 +97,18 @@ class WorkerProfileRequired(TaskServiceError):
     """Raised when a worker tries to claim without an active worker profile."""
 
     status_code = 403
+
+
+class SubmissionNotFound(TaskServiceError):
+    """Raised when a submission id does not match a stored packet."""
+
+    status_code = 404
+
+
+class SubmissionVersionConflict(TaskServiceError):
+    """Raised when concurrent submission version allocation conflicts."""
+
+    status_code = 409
 
 
 class TaskService:
@@ -364,6 +383,194 @@ class TaskService:
         await self._session.refresh(task)
         return TaskResponse.model_validate(task)
 
+    async def create_submission(
+        self,
+        actor: ActorContext,
+        task_id: str,
+        payload: SubmissionCreate,
+    ) -> SubmissionResponse:
+        """Create a task-owned submission packet version.
+
+        Args:
+            actor: Verified Flow actor context for the current request.
+            task_id: Task receiving the submission packet.
+            payload: Submission packet fields supplied by the worker.
+
+        Returns:
+            Created submission response with evidence items.
+
+        Raises:
+            PermissionDenied: If the actor cannot create worker submissions.
+            TaskTransitionBlocked: If task state or assignment does not allow submission.
+            TaskValidationError: If required submission fields are missing.
+            SubmissionVersionConflict: If concurrent version allocation conflicts.
+        """
+        require_any_role(actor, TASK_SUBMIT_ROLES)
+        task = await self._get_task(task_id)
+        await self._require_active_worker_profile(actor)
+        assignment = await self._repo.get_active_assignment(task_id)
+        if assignment is None:
+            raise TaskTransitionBlocked("task has no active assignment")
+        if assignment.worker_id != actor.actor_id or task.assigned_to != actor.actor_id:
+            raise TaskTransitionBlocked("actor is not assigned to this task")
+        if task.status not in {TASK_STATUS_IN_PROGRESS, TASK_STATUS_SUBMITTED}:
+            raise TaskTransitionBlocked("task must be in progress before first submission")
+        self._ensure_locked_context(task)
+        await self._validate_required_submission_fields(task, payload)
+
+        latest_submission = await self._repo.get_latest_submission_for_task(task.id)
+        next_version = 1 if latest_submission is None else latest_submission.version + 1
+        submission = Submission(
+            id=str(uuid4()),
+            task_id=task.id,
+            worker_id=actor.actor_id,
+            version=next_version,
+            status="submitted",
+            summary=payload.summary,
+            package_uri=payload.package_uri,
+            package_hash=payload.package_hash,
+            artifact_hash_manifest=[
+                entry.model_dump(mode="json") for entry in payload.artifact_hash_manifest
+            ],
+            worker_attestation=payload.worker_attestation,
+            locked_guide_version=task.locked_guide_version,
+            locked_checker_policy_version=task.locked_checker_policy_version,
+            locked_review_policy_version=task.locked_review_policy_version,
+            locked_revision_policy_version=task.locked_revision_policy_version,
+            locked_payment_policy_version=task.locked_payment_policy_version,
+            supersedes_submission_id=None if latest_submission is None else latest_submission.id,
+            evidence_items=[
+                EvidenceItem(
+                    id=str(uuid4()),
+                    type=evidence.type,
+                    label=evidence.label,
+                    uri=evidence.uri,
+                    hash=evidence.hash,
+                    size_bytes=evidence.size_bytes,
+                    metadata_json=evidence.metadata,
+                )
+                for evidence in payload.evidence_items
+            ],
+        )
+        try:
+            submission = await self._repo.add_submission(submission)
+            event_payload = self._submission_audit_payload(submission)
+            if task.status == TASK_STATUS_IN_PROGRESS:
+                await self._change_task_status(
+                    actor,
+                    task,
+                    TASK_STATUS_SUBMITTED,
+                    reason=None,
+                    event_payload=event_payload,
+                    event_type="submission_created",
+                )
+            else:
+                await self._write_task_audit(
+                    actor,
+                    task,
+                    event_type="submission_created",
+                    from_status=task.status,
+                    to_status=task.status,
+                    reason=None,
+                    event_payload=event_payload,
+                )
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise SubmissionVersionConflict("submission version conflicted; retry") from exc
+
+        persisted = await self._repo.get_submission(submission.id)
+        if persisted is None:
+            raise SubmissionNotFound("submission not found")
+        return SubmissionResponse.model_validate(persisted)
+
+    async def list_task_submissions(
+        self,
+        actor: ActorContext,
+        task_id: str,
+    ) -> list[SubmissionResponse]:
+        """List submission versions for one visible task.
+
+        Args:
+            actor: Verified Flow actor context for the current request.
+            task_id: Task whose submissions should be listed.
+
+        Returns:
+            Submission responses ordered by version.
+        """
+        require_any_role(actor, TASK_VIEW_ROLES)
+        task = await self._get_task(task_id)
+        await self._ensure_task_visible(actor, task)
+        submissions = await self._repo.list_submissions_for_task(task.id)
+        return [SubmissionResponse.model_validate(submission) for submission in submissions]
+
+    async def get_submission(
+        self,
+        actor: ActorContext,
+        submission_id: str,
+    ) -> SubmissionResponse:
+        """Return one visible submission packet.
+
+        Args:
+            actor: Verified Flow actor context for the current request.
+            submission_id: Submission id to load.
+
+        Returns:
+            Submission response.
+        """
+        require_any_role(actor, TASK_VIEW_ROLES)
+        submission = await self._get_submission(submission_id)
+        task = await self._get_task(submission.task_id)
+        await self._ensure_task_visible(actor, task)
+        return SubmissionResponse.model_validate(submission)
+
+    async def lock_submission(
+        self,
+        actor: ActorContext,
+        submission_id: str,
+    ) -> SubmissionResponse:
+        """Lock the latest submission packet before checker execution.
+
+        Args:
+            actor: Verified Flow actor context for the current request.
+            submission_id: Submission id to lock.
+
+        Returns:
+            Locked submission response.
+
+        Raises:
+            PermissionDenied: If the actor cannot lock submissions.
+            TaskTransitionBlocked: If the submission is stale or task state is invalid.
+        """
+        require_any_role(actor, SUBMISSION_LOCK_ROLES)
+        submission = await self._get_submission(submission_id)
+        task = await self._get_task(submission.task_id)
+        if task.status != TASK_STATUS_SUBMITTED:
+            raise TaskTransitionBlocked("task must be submitted before locking submission")
+        latest_submission = await self._repo.get_latest_submission_for_task(task.id)
+        if latest_submission is None or latest_submission.id != submission.id:
+            raise TaskTransitionBlocked("only latest submission version can be locked")
+        if submission.locked_at is not None:
+            return SubmissionResponse.model_validate(submission)
+
+        locked_at = datetime.now(UTC)
+        submission.locked_at = locked_at
+        await self._repo.lock_submission_evidence(submission.id, locked_at)
+        await self._write_task_audit(
+            actor,
+            task,
+            event_type="submission_locked",
+            from_status=task.status,
+            to_status=task.status,
+            reason=None,
+            event_payload=self._submission_audit_payload(submission),
+        )
+        await self._session.commit()
+        persisted = await self._repo.get_submission(submission.id)
+        if persisted is None:
+            raise SubmissionNotFound("submission not found")
+        return SubmissionResponse.model_validate(persisted)
+
     async def list_task_audit_events(
         self,
         actor: ActorContext,
@@ -384,6 +591,23 @@ class TaskService:
         events = await self._repo.list_audit_events("task", task.id)
         return [self._audit_response(event) for event in events]
 
+    async def _get_submission(self, submission_id: str) -> Submission:
+        """Load a submission packet or raise a service error.
+
+        Args:
+            submission_id: Submission id to load.
+
+        Returns:
+            Matching submission model.
+
+        Raises:
+            SubmissionNotFound: If the submission id is unknown.
+        """
+        submission = await self._repo.get_submission(submission_id)
+        if submission is None:
+            raise SubmissionNotFound("submission not found")
+        return submission
+
     async def _get_task(self, task_id: str) -> WorkstreamTask:
         """Load a task or raise a service error.
 
@@ -400,6 +624,67 @@ class TaskService:
         if task is None:
             raise TaskNotFound("task not found")
         return task
+
+    async def _validate_required_submission_fields(
+        self,
+        task: WorkstreamTask,
+        payload: SubmissionCreate,
+    ) -> None:
+        """Validate a submission packet against the locked guide.
+
+        Args:
+            task: Task whose locked guide defines required submission fields.
+            payload: Submission packet supplied by the assigned worker.
+
+        Raises:
+            TaskProjectNotReady: If the locked guide cannot be loaded.
+            TaskValidationError: If required submission fields are missing.
+        """
+        if not task.locked_guide_version:
+            raise TaskProjectNotReady("task has no locked guide version")
+        guide = await self._project_repo.get_guide_by_version(task.project_id, task.locked_guide_version)
+        if guide is None:
+            raise TaskProjectNotReady("locked guide not found")
+        required_fields = set(guide.required_submission_fields or [])
+        required_fields.update({"summary", "worker_attestation"})
+        field_values = {
+            "summary": payload.summary,
+            "output": payload.package_uri or payload.artifact_hash_manifest,
+            "outputs": payload.package_uri or payload.artifact_hash_manifest,
+            "package_uri": payload.package_uri,
+            "package_hash": payload.package_hash,
+            "artifact_hash_manifest": payload.artifact_hash_manifest,
+            "evidence": payload.evidence_items,
+            "evidence_items": payload.evidence_items,
+            "worker_attestation": payload.worker_attestation,
+        }
+        missing = [
+            field
+            for field in sorted(required_fields)
+            if not self._field_has_value(field_values.get(field))
+        ]
+        if missing:
+            raise TaskValidationError(f"submission missing required fields: {', '.join(missing)}")
+
+    @staticmethod
+    def _submission_audit_payload(submission: Submission) -> dict:
+        """Build the task audit payload for a submission event.
+
+        Args:
+            submission: Submission model associated with the audit event.
+
+        Returns:
+            Structured audit payload without raw package or evidence URIs.
+        """
+        return {
+            "submission_id": submission.id,
+            "submission_version": submission.version,
+            "worker_id": submission.worker_id,
+            "package_hash": submission.package_hash,
+            "artifact_hash_manifest": submission.artifact_hash_manifest,
+            "supersedes_submission_id": submission.supersedes_submission_id,
+            "locked_at": submission.locked_at.isoformat() if submission.locked_at else None,
+        }
 
     async def _load_active_policy_context(
         self,

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -24,7 +24,9 @@ from app.main import create_app
 from app.modules.tasks.lifecycle import InvalidTaskTransition, ensure_allowed_transition
 from app.modules.tasks.models import (
     AuditEvent,
+    EvidenceItem,
     ReviewerProfile,
+    Submission,
     TaskAssignment,
     WorkerProfile,
     WorkstreamTask,
@@ -168,6 +170,33 @@ def complete_task_payload() -> dict:
     }
 
 
+def complete_submission_payload(package_hash: str = "sha256:package-v1") -> dict:
+    return {
+        "summary": "Completed the proof evaluation.",
+        "package_uri": "local://submissions/proof-evaluation-v1.tar.zst",
+        "package_hash": package_hash,
+        "artifact_hash_manifest": [
+            {
+                "artifact": "answer.md",
+                "hash": "sha256:answer-v1",
+                "size_bytes": 128,
+                "notes": "main answer",
+            }
+        ],
+        "worker_attestation": "I confirm this submission follows the locked guide.",
+        "evidence_items": [
+            {
+                "type": "log",
+                "label": "checker dry run",
+                "uri": "local://evidence/checker.log",
+                "hash": "sha256:log-v1",
+                "size_bytes": 256,
+                "metadata": {"command": "pytest"},
+            }
+        ],
+    }
+
+
 async def create_active_project(client: AsyncClient) -> dict:
     project_response = await client.post(
         "/api/v1/projects",
@@ -226,6 +255,31 @@ async def create_ready_task(client: AsyncClient, project_id: str) -> dict:
     return release.json()
 
 
+async def create_started_task(
+    client: AsyncClient,
+    project_id: str,
+    monkeypatch: pytest.MonkeyPatch,
+    subject: str = "worker-one",
+) -> dict:
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    ready_task = await create_ready_task(client, project_id)
+    await seed_worker_profile(subject)
+    set_dev_actor(monkeypatch, roles="worker", subject=subject)
+    claim = await client.post(
+        f"/api/v1/tasks/{ready_task['id']}/claim",
+        headers=auth_headers(),
+        json={"reason": "claim"},
+    )
+    assert claim.status_code == 200, claim.text
+    start = await client.post(
+        f"/api/v1/tasks/{ready_task['id']}/start",
+        headers=auth_headers(),
+        json={"reason": "start"},
+    )
+    assert start.status_code == 200, start.text
+    return start.json()
+
+
 async def seed_worker_profile(subject: str, *, skill_tags: list[str] | None = None) -> str:
     worker_actor_id = actor_id(subject)
     async with db_session.get_session_factory()() as session:
@@ -251,6 +305,8 @@ def test_task_models_are_registered_for_alembic_metadata() -> None:
         "reviewer_profiles",
         "workstream_tasks",
         "task_assignments",
+        "submissions",
+        "evidence_items",
         "audit_events",
     }
 
@@ -259,6 +315,8 @@ def test_task_models_are_registered_for_alembic_metadata() -> None:
     assert db_models.ReviewerProfile is ReviewerProfile
     assert db_models.WorkstreamTask is WorkstreamTask
     assert db_models.TaskAssignment is TaskAssignment
+    assert db_models.Submission is Submission
+    assert db_models.EvidenceItem is EvidenceItem
     assert db_models.AuditEvent is AuditEvent
 
 
@@ -273,6 +331,8 @@ async def test_chunk4_migration_creates_expected_tables(task_database_env: str) 
         "reviewer_profiles",
         "workstream_tasks",
         "task_assignments",
+        "submissions",
+        "evidence_items",
         "audit_events",
     }.issubset(table_names)
 
@@ -296,6 +356,8 @@ def test_chunk4_migration_downgrade_removes_task_tables(task_database_env: str) 
         "reviewer_profiles",
         "workstream_tasks",
         "task_assignments",
+        "submissions",
+        "evidence_items",
         "audit_events",
     }.isdisjoint(table_names)
 
@@ -675,6 +737,265 @@ async def test_operator_start_override_requires_reason_and_records_distinct_even
     assert audit.status_code == 200, audit.text
     assert audit.json()[-1]["event_type"] == "task_start_override"
     assert audit.json()[-1]["event_payload"]["operator_override"] is True
+
+
+async def test_assigned_worker_submits_v1_and_task_moves_to_submitted(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    worker_actor_id = actor_id("worker-one")
+
+    response = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+
+    assert response.status_code == 201, response.text
+    submission = response.json()
+    assert submission["task_id"] == started_task["id"]
+    assert submission["worker_id"] == worker_actor_id
+    assert submission["version"] == 1
+    assert submission["status"] == "submitted"
+    assert submission["locked_guide_version"] == "v1"
+    assert submission["locked_checker_policy_version"] == "v1"
+    assert submission["locked_review_policy_version"] == "v1"
+    assert submission["locked_revision_policy_version"] == "v1"
+    assert submission["locked_payment_policy_version"] == "v1"
+    assert submission["artifact_hash_manifest"][0]["artifact"] == "answer.md"
+    assert submission["evidence_items"][0]["metadata"] == {"command": "pytest"}
+
+    task = await task_client.get(f"/api/v1/tasks/{started_task['id']}", headers=auth_headers())
+    assert task.status_code == 200, task.text
+    assert task.json()["status"] == "submitted"
+
+    audit = await task_client.get(
+        f"/api/v1/tasks/{started_task['id']}/audit-events",
+        headers=auth_headers(),
+    )
+    assert audit.status_code == 200, audit.text
+    submission_event = audit.json()[-1]
+    assert submission_event["event_type"] == "submission_created"
+    assert submission_event["from_status"] == "in_progress"
+    assert submission_event["to_status"] == "submitted"
+    assert submission_event["event_payload"]["submission_id"] == submission["id"]
+    assert submission_event["event_payload"]["submission_version"] == 1
+    assert submission_event["event_payload"]["package_hash"] == "sha256:package-v1"
+    assert "package_uri" not in submission_event["event_payload"]
+
+
+async def test_submission_schema_rejects_worker_supplied_locked_context(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    payload = complete_submission_payload()
+    payload.update(
+        {
+            "worker_id": actor_id("worker-one"),
+            "version": 1,
+            "status": "submitted",
+            "locked_guide_version": "malicious",
+            "locked_checker_policy_version": "malicious",
+            "locked_review_policy_version": "malicious",
+            "locked_revision_policy_version": "malicious",
+            "locked_payment_policy_version": "malicious",
+            "locked_at": "2026-06-07T00:00:00Z",
+        }
+    )
+
+    response = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    task = await task_client.get(f"/api/v1/tasks/{started_task['id']}", headers=auth_headers())
+    assert task.status_code == 200, task.text
+    assert task.json()["status"] == "in_progress"
+
+
+async def test_submission_requires_assigned_worker_and_in_progress_task(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    ready_task = await create_ready_task(task_client, project["id"])
+    await seed_worker_profile("worker-two")
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-two")
+
+    ready_response = await task_client.post(
+        f"/api/v1/tasks/{ready_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+
+    assert ready_response.status_code == 409
+
+    started_task = await create_started_task(task_client, project["id"], monkeypatch, "worker-one")
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-two")
+    other_worker_response = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+
+    assert other_worker_response.status_code == 409
+
+
+async def test_submission_validates_locked_guide_required_submission_fields(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    payload = complete_submission_payload()
+    payload["evidence_items"] = []
+
+    response = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    assert "evidence" in response.json()["detail"]
+
+
+async def test_submission_versioning_creates_new_rows_and_preserves_v1(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    v1_payload = complete_submission_payload()
+    v1 = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=v1_payload,
+    )
+    assert v1.status_code == 201, v1.text
+    v2_payload = complete_submission_payload("sha256:package-v2")
+    v2_payload["artifact_hash_manifest"][0]["hash"] = "sha256:answer-v2"
+
+    v2 = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=v2_payload,
+    )
+
+    assert v2.status_code == 201, v2.text
+    first = v1.json()
+    second = v2.json()
+    assert second["version"] == 2
+    assert second["supersedes_submission_id"] == first["id"]
+    assert first["package_hash"] == "sha256:package-v1"
+    assert first["artifact_hash_manifest"][0]["hash"] == "sha256:answer-v1"
+
+    listed = await task_client.get(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+    )
+    assert listed.status_code == 200, listed.text
+    assert [submission["version"] for submission in listed.json()] == [1, 2]
+
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-two")
+    await seed_worker_profile("worker-two")
+    denied = await task_client.get(
+        f"/api/v1/submissions/{second['id']}",
+        headers=auth_headers(),
+    )
+    assert denied.status_code == 404
+
+
+async def test_lock_submission_requires_operator_and_latest_version(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    v1 = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert v1.status_code == 201, v1.text
+    v2 = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload("sha256:package-v2"),
+    )
+    assert v2.status_code == 201, v2.text
+
+    worker_lock = await task_client.post(
+        f"/api/v1/submissions/{v2.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert worker_lock.status_code == 403
+
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    stale_lock = await task_client.post(
+        f"/api/v1/submissions/{v1.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert stale_lock.status_code == 409
+
+    locked = await task_client.post(
+        f"/api/v1/submissions/{v2.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked.status_code == 200, locked.text
+    locked_body = locked.json()
+    assert locked_body["locked_at"] is not None
+    assert locked_body["evidence_items"][0]["locked_at"] == locked_body["locked_at"]
+
+    second_lock = await task_client.post(
+        f"/api/v1/submissions/{v2.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert second_lock.status_code == 200, second_lock.text
+    assert second_lock.json()["locked_at"] == locked_body["locked_at"]
+
+
+async def test_database_enforces_unique_submission_version(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    created = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+
+    async with db_session.get_session_factory()() as session:
+        session.add(
+            Submission(
+                id=str(uuid4()),
+                task_id=body["task_id"],
+                worker_id=body["worker_id"],
+                version=body["version"],
+                status="submitted",
+                summary="duplicate",
+                package_hash="sha256:duplicate",
+                artifact_hash_manifest=body["artifact_hash_manifest"],
+                worker_attestation="duplicate",
+                locked_guide_version=body["locked_guide_version"],
+                locked_checker_policy_version=body["locked_checker_policy_version"],
+                locked_review_policy_version=body["locked_review_policy_version"],
+                locked_revision_policy_version=body["locked_revision_policy_version"],
+                locked_payment_policy_version=body["locked_payment_policy_version"],
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
 
 
 async def test_worker_cannot_create_screen_or_release_tasks(

--- a/docs/spec_chunk_5_submission_packet_foundation.md
+++ b/docs/spec_chunk_5_submission_packet_foundation.md
@@ -1,0 +1,158 @@
+# Chunk 5: Submission Packet Foundation
+
+## Purpose
+
+This chunk adds the backend record for worker submission packets. A worker submits against a task id, Workstream stamps the locked guide and policy context from the task, and every submitted packet version becomes immutable once locked for checker execution.
+
+This completes the Week 1 backend lifecycle through `SUBMITTED`.
+
+## Scope
+
+- submission packet model
+- evidence item model
+- package URI and package hash metadata
+- artifact hash manifest
+- worker attestation
+- submission versioning
+- task transition from `IN_PROGRESS` to `SUBMITTED`
+- submission audit events
+- API paths for creating, reading, listing, and locking submission packets
+
+## Non-Scope
+
+- checker execution
+- checker run records
+- human review decisions
+- revision replay enforcement
+- contribution, payment, or reputation records
+- direct file upload or object storage implementation
+
+Chunk 5 stores package and evidence references. Actual file storage still belongs behind the later object-storage abstraction.
+
+## Data Model
+
+`submissions`
+
+- `id`
+- `task_id`
+- `worker_id`
+- `version`
+- `status`
+- `summary`
+- `package_uri`
+- `package_hash`
+- `artifact_hash_manifest`
+- `worker_attestation`
+- `locked_guide_version`
+- `locked_checker_policy_version`
+- `locked_review_policy_version`
+- `locked_revision_policy_version`
+- `locked_payment_policy_version`
+- `submitted_at`
+- `locked_at`
+- `supersedes_submission_id`
+
+Submissions intentionally reference the task's locked guide and policy version fields. This prevents task-owned locked context from changing silently after a submission has been recorded.
+
+`evidence_items`
+
+- `id`
+- `submission_id`
+- `type`
+- `label`
+- `uri`
+- `hash`
+- `size_bytes`
+- `locked_at`
+- `metadata`
+- `created_at`
+
+## API Contract
+
+POST `/api/v1/tasks/{task_id}/submissions`
+
+Creates a new submission version for the assigned worker.
+
+Request body:
+
+- `summary`
+- `package_uri`
+- `package_hash`
+- `artifact_hash_manifest`
+- `worker_attestation`
+- `evidence_items`
+
+The request body must not accept guide or policy version fields. Those fields come from the task.
+
+GET `/api/v1/tasks/{task_id}/submissions`
+
+Lists submission versions for a task visible to the current actor.
+
+GET `/api/v1/submissions/{submission_id}`
+
+Returns one visible submission packet.
+
+POST `/api/v1/submissions/{submission_id}/lock`
+
+Locks a submission packet before checker execution. Locking makes the packet immutable in place.
+
+## Versioning Rules
+
+- the first packet for a task is version `1`
+- each later packet for that task creates version `2`, `3`, and so on
+- a later packet sets `supersedes_submission_id` to the previous latest submission id
+- `supersedes_submission_id` must point to the previous latest submission for the same task
+- existing submission rows are never edited to replace artifacts
+- artifact changes require a new submission version
+- evidence rows belong to exactly one submission version
+- locked submission packets cannot be mutated in place
+- concurrent version conflicts return a controlled conflict response instead of a server error
+
+## Lifecycle Rules
+
+- a worker can submit only when assigned to the task
+- first submission requires task status `IN_PROGRESS`
+- first submission moves the task to `SUBMITTED`
+- later replacement submissions are allowed while the task is still `SUBMITTED`
+- submission packet content must satisfy the locked guide's `required_submission_fields`
+- every submission creation writes a task audit event
+- the audit event includes submission id, submission version, worker id, package hash, and artifact hash manifest
+- locking a submission writes a task audit event
+- only the latest submission version for a task can be locked
+- Chunk 5 submission status is `submitted`; locking sets `locked_at` and does not change status
+
+## Security And Auth
+
+- Workstream still verifies external Flow auth only
+- no Workstream-owned login or primary auth session is added
+- only the assigned worker can create a submission for the task
+- project managers and admins can read and lock submissions for operational flow
+- workers can read their own task submissions
+- response payloads return server-stamped locked guide and policy versions
+- package and evidence URIs are stored as object references, not signed URLs or credentials
+
+## Evidence Identity
+
+Workstream generates evidence item ids at persistence time. Worker-provided manifest rows may include artifact paths or URIs, but the persisted evidence item id is the stable Workstream evidence id for later checker and review records.
+
+## Audit Scope
+
+Chunk 5 writes task audit events with submission identifiers in `event_payload`. Direct submission audit streams are deferred until a dedicated submission-review surface needs them.
+
+## Conditions Of Satisfaction
+
+- worker submits v1 packet against `task_id`
+- worker does not provide guide or policy versions
+- worker-provided guide or policy version fields are rejected by the API schema
+- Workstream stamps locked guide and policy versions from task context
+- task moves to `SUBMITTED`
+- submitted packet can be locked before checker execution
+- replacing an artifact creates a new submission version instead of mutating v1
+- submission audit events include task, worker, version, package, and artifact context
+- submission and immutability tests pass
+
+## Verifier Agents
+
+- senior engineering
+- QA/test
+- security/auth


### PR DESCRIPTION
## Summary
- add Chunk 5 submission packet specification
- add submission and evidence models, migration, API schemas, routes, repository methods, and service rules
- enforce assigned-worker-only submission, server-stamped locked guide/policy context, versioning, latest-only locking, and task audit events

## Validation
- ruff check app tests
- docstr-coverage --config .docstr.yaml: 100%
- WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream pytest tests/test_tasks.py -q: 27 passed
- WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream pytest -q: 77 passed
- git diff --check
- Markdown link check passed
- stale wording scan only hit AGENTS.md forbidden-term guardrail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workers can create versioned submission packets for tasks, attach evidence items with metadata and artifact hashes, and supersede prior versions.
  * Tasks transition to a submitted state on first submission; admins/project managers can lock submissions before processing.
  * APIs to create, list, fetch, and lock submissions added.

* **Documentation**
  * Added comprehensive spec for the submission packet foundation.

* **Tests**
  * Added end-to-end tests covering submission lifecycle, validation, locking, and version conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->