### PR TITLE
Align Week 2 checker scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Workstream turns that operating knowledge into reusable infrastructure.
 - [30-Day Master Plan](docs/roadmap_30_day_master_plan.md)
 - [Roadmap Status](docs/roadmap_status.md)
 - [Week 1 Backend Plan](docs/roadmap_week1_backend_plan.md)
+- [Week 2 Checker Framework Specification](docs/spec_week2_checker_framework.md)
 - [Day-by-Day Execution Plan](docs/roadmap_day_by_day_execution_plan.md)
 - [Implementation Backlog](docs/roadmap_implementation_backlog.md)
 - [Product Principles](docs/product_principles.md)

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -210,10 +210,12 @@ Submission received
 -> store CheckerResult records
 -> calculate blocking status
 -> issue ReadinessCertificate when no blocking failures remain
--> move to REVIEW_PENDING or NEEDS_REVISION
+-> move to REVIEW_PENDING or remain checker-blocked from human review
 ```
 
 The checker run must bind to one immutable submission version. If the worker uploads a replacement file, the platform creates a new submission version and reruns checks.
+
+Checker failures are not review decisions. They do not accept, reject, or request revision. They block review entry until the worker submits a replacement packet, an allowed policy override is recorded, or a later review/revision workflow handles the issue.
 
 If a checker crashes or cannot run because of platform infrastructure, the checker run remains failed as an infrastructure failure and the task does not move to human review. The retry or admin action is recorded in audit history.
 

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -142,6 +142,8 @@ This thin slice is the first proof that Workstream can measure and certify usefu
 
 Objective: prevent broken submissions from reaching human review.
 
+Week 2 is backend/checker-framework work. Checker results must be available through backend APIs, dry-run scripts, and demo/debug output. Product frontend pages, reviewer queue UI, and review decision screens stay in Week 3 or later.
+
 Deliverables:
 
 - checker runner
@@ -151,6 +153,7 @@ Deliverables:
 - blocking versus warning checks
 - evidence log per checker run
 - review gate enforcement
+- API-readable checker output for the exact submission version and artifact hash manifest
 
 Required first checkers:
 
@@ -169,6 +172,7 @@ Day 6:
 - define checker interface
 - define checker result record
 - build checker runner
+- expose checker run and result reads through backend contracts
 
 Day 7:
 
@@ -178,7 +182,7 @@ Day 7:
 Day 8:
 
 - implement evidence and rubric/acceptance checks
-- block REVIEW_PENDING when high-severity checks fail
+- block `REVIEW_PENDING` when high-severity checks fail
 
 Day 9:
 
@@ -194,8 +198,8 @@ Week 2 acceptance bar:
 
 - every submitted task runs checks
 - checker output is stored permanently
-- high-severity failures block human review
-- a reviewer can see the exact checker results before reviewing
+- high-severity failures block human review without creating a review decision
+- backend contracts expose the exact checker results before Week 3 reviewer UI work begins
 
 ## Week 3: Review And Revision Engine
 

--- a/docs/roadmap_day_by_day_execution_plan.md
+++ b/docs/roadmap_day_by_day_execution_plan.md
@@ -130,6 +130,14 @@ Exit criteria:
 
 ## Week 2: Checker System
 
+Week 2 is backend-first checker infrastructure. Checker output is exposed through APIs, dry-run scripts, and demo/debug output. It does not build the product frontend, reviewer queue UI, review decision form, contribution records, payment records, or reputation updates.
+
+The core invariant is:
+
+`Submission -> Lock -> CheckerRun -> CheckerResults -> Gate -> REVIEW_PENDING or checker-blocked`
+
+The checker framework does not accept, reject, or request revision. It decides whether the latest locked submission can move toward human review.
+
 ### Day 6: Checker Interface
 
 Deliver:
@@ -144,7 +152,8 @@ Exit criteria:
 
 - run a checker against a submission
 - store pass/warn/fail results
-- display results on task page
+- expose checker run and result data through backend API responses and dry-run/demo output
+- no product frontend task page is added in Week 2
 
 ### Day 7: Core Structural Checkers
 
@@ -160,6 +169,7 @@ Exit criteria:
 
 - broken submissions fail before review
 - high severity failures block `REVIEW_PENDING`
+- checker runs bind to the exact submission id, submission version, package hash, and artifact hash manifest
 
 ### Day 8: Evidence And Acceptance Checkers
 
@@ -175,8 +185,8 @@ Deliver:
 
 Exit criteria:
 
-- task cannot be review-ready with no evidence
-- task cannot be review-ready when checker artifact hashes do not match submission hashes
+- task cannot become review-pending with no evidence
+- task cannot become review-pending when checker artifact hashes do not match submission hashes
 - task cannot be accepted later without payment policy
 
 ### Day 9: Project Checker Policy
@@ -192,6 +202,7 @@ Exit criteria:
 
 - two projects can require different checkers
 - override creates audit record
+- project-required checker policy is read from the locked task context, not from mutable worker input
 
 ### Day 10: Checker Trial
 
@@ -206,6 +217,7 @@ Exit criteria:
 
 - at least one intentionally broken submission is blocked
 - at least one clean submission reaches `REVIEW_PENDING`
+- trial output documents which checker results would be visible to Week 3 reviewers through backend APIs
 
 ## Week 3: Review And Revision
 

--- a/docs/roadmap_implementation_backlog.md
+++ b/docs/roadmap_implementation_backlog.md
@@ -76,9 +76,10 @@
 - checker result storage
 - blocking status calculation
 - project-specific required checkers
-- reviewer-visible checker results
+- API-readable checker results for the future reviewer surface
 - worker-visible failure summary
 - bind checker run to exact submission version and artifact hash manifest
+- bind checker run to package hash and locked task guide/policy context
 - implement `check_evidence_integrity`
 - implement `check_confidentiality_attestation`
 - implement `check_low_quality_generated_artifacts`

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -36,6 +36,7 @@ Current phase: Week 1 backend foundation complete; preparing checker framework.
 - Chunk 4 task queue, worker/reviewer profiles, assignment, claim, start, and task audit events.
 - Chunk 5 submission packet foundation with evidence items, versioning, server-stamped locked context, and submission locking.
 - Week 1 backend dry run through `Project -> Guide -> Task -> Screening -> Ready -> Claim -> Start -> Submit -> Lock submission`.
+- Week 2 checker framework scope specification.
 
 ## Review Tracks Closed
 
@@ -52,8 +53,9 @@ Current phase: Week 1 backend foundation complete; preparing checker framework.
 - Create the first 5 pilot task records.
 - Confirm who owns product, engineering, review, operations, and payment reconciliation during the first build cycle.
 - Confirm the first v0.1 project guide uses the locked guide fields, task contract fields, evidence IDs, and contribution record flow.
-- Lock the checker framework implementation spec and conditions of satisfaction.
+- Lock Chunk 6 checker contract and records specification with conditions of satisfaction.
 - Build checker run records and `check_submission_packet` in Week 2.
+- Keep Week 2 backend/checker-framework only: expose checker results through APIs and dry-run/demo output, not product frontend pages.
 
 ## Week 1 Dry Run
 

--- a/docs/spec_week2_checker_framework.md
+++ b/docs/spec_week2_checker_framework.md
@@ -1,0 +1,145 @@
+# Week 2 Checker Framework Specification
+
+## Purpose
+
+Week 2 adds the automated checker boundary between locked submissions and human review.
+
+The checker framework protects reviewer time by proving that the latest locked submission is structurally valid, evidence-backed, policy-complete, and tied to the exact artifact hashes that were checked.
+
+## Scope
+
+- `CheckerRun` records
+- `CheckerResult` records
+- checker status and severity model
+- checker registry and runner service
+- project-required checker policy enforcement
+- blocking versus warning calculation
+- backend API access to checker runs and results
+- dry-run/demo output for checker visibility
+- pre-review gate enforcement for `REVIEW_PENDING`
+
+## Non-Scope
+
+- product frontend implementation
+- reviewer queue UI
+- review decision form
+- accept, needs_revision, or reject decisions
+- revision replay enforcement
+- contribution records
+- payment records
+- reputation updates
+- external source adapters
+- blockchain, x402, escrow, or settlement rails
+
+## Core Invariant
+
+```text
+Submission -> Lock -> CheckerRun -> CheckerResults -> Gate -> REVIEW_PENDING or checker-blocked
+```
+
+A task cannot reach `REVIEW_PENDING` unless the latest locked submission has a completed checker run for the exact submission version and artifact context.
+
+The checker binding includes:
+
+- `task_id`
+- `submission_id`
+- `submission_version`
+- `package_hash`
+- `artifact_hash_manifest`
+- locked project guide version
+- locked checker policy version
+- locked review policy version
+- locked revision policy version
+- locked payment policy version
+
+## Checker Decision Boundary
+
+Checkers do not accept, reject, or request revision.
+
+Checkers only decide whether a submission is allowed to enter human review:
+
+- passing required checks can allow `REVIEW_PENDING`
+- warning checks remain visible but do not block by default
+- blocking failures prevent `REVIEW_PENDING`
+
+Human review decisions remain only:
+
+- `accept`
+- `needs_revision`
+- `reject`
+
+## Week 2 Visibility Boundary
+
+Checker results are exposed through backend contracts and operational output:
+
+- checker run API responses
+- checker result API responses
+- task/submission API expansion where needed
+- dry-run scripts
+- Week 1 API demo/debug output when useful
+
+Week 2 does not build the product frontend page for checker results. The planned React + Vite operations dashboard consumes these backend contracts later.
+
+## Chunk Breakdown
+
+### Chunk 6: Checker Contract And Records
+
+Creates the durable checker run/result model, API schemas, service boundaries, and migration.
+
+Conditions of satisfaction:
+
+- checker runs are tied to one submission version
+- checker results are immutable after persistence
+- status and severity values are canonical
+- checker output can be read through backend APIs
+
+### Chunk 7: Checker Runner And Registry
+
+Creates the checker interface, registry, runner service, and first structural checkers.
+
+Conditions of satisfaction:
+
+- registered checker names cannot drift from policy names
+- `check_submission_packet` runs against real submission data
+- failed structural checks produce stored checker results
+- broken submissions are blocked before human review
+
+### Chunk 8: Evidence And Policy Checkers
+
+Adds evidence, integrity, acceptance criteria, policy context, forbidden file, confidentiality, and generated-artifact checks.
+
+Conditions of satisfaction:
+
+- missing evidence blocks `REVIEW_PENDING`
+- artifact hash mismatch blocks `REVIEW_PENDING`
+- missing locked policy context blocks `REVIEW_PENDING`
+- worker-visible messages do not leak sensitive internals
+
+### Chunk 9: Pre-Review Gate
+
+Calculates whether a checked submission can move to `REVIEW_PENDING`.
+
+Conditions of satisfaction:
+
+- the gate uses the latest locked submission only
+- required checker list comes from locked project checker policy
+- blocking severities come from locked project checker policy
+- override requires actor, reason, and audit event
+
+### Chunk 10: Checker Trial
+
+Runs real sample submissions through the checker framework.
+
+Conditions of satisfaction:
+
+- at least one clean submission reaches `REVIEW_PENDING`
+- at least one intentionally broken submission is blocked
+- checker failures are documented in a failure catalog
+- false-positive and missing-checker notes are recorded
+
+## Verifier Agents
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops


### PR DESCRIPTION
## Summary
- add a Week 2 checker framework scope/spec document
- clarify Week 2 is backend/checker-framework only, not product frontend or review UI work
- replace task-page/reviewer-visible wording with API/dry-run visibility wording
- clarify checker failures are gates, not accept/needs_revision/reject review decisions

## Verification
- stale wording scan only hits the intentional banned-word guardrail in AGENTS.md
- Markdown links OK
- no local XLSX export present
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Week 2 Checker Framework Specification document
  * Updated architecture and roadmap documentation with clarified checker control-flow and scope boundaries for automated submission validation
  * Refined execution plans and backlog tracking with explicit checker binding and API exposure requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->