### PR TITLE
Lock Chunk 6 checker contract spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@ Workstream is how Flow measures, certifies, and coordinates useful human-agent w
 - Postgres is the record database.
 - Local filesystem storage is acceptable only behind an object-storage abstraction compatible with R2/S3-style storage.
 - Do not expand into blockchain settlement, marketplace, external source adapters, automated routing, or agent workspace until the internal loop is proven.
+- Every implementation or specification chunk must receive internal sub-agent review before external PR review is treated as sufficient.
+- Required internal reviewer tracks are senior engineering, QA/test, security/auth, and product/ops unless the chunk is explicitly unrelated to that track.
+- Do not report a chunk complete while reviewer agents are still running. Wait for them, address valid findings, and close any open sub-agent sessions.
+- CodeRabbit, CI, and GitHub review are external checks. They supplement internal reviewer agents; they do not replace them.
 
 ## Done Criteria
 
@@ -40,3 +44,5 @@ Before reporting completion:
 - verify the local XLSX has one sheet only when local sheet exports are present
 - verify the current Workstream definition appears in README and local sheet exports when local sheet exports are present
 - update related docs/templates and local sheet exports together when the roadmap changes
+- run required internal sub-agent reviewers for the chunk and resolve or explicitly document every valid finding
+- confirm no sub-agent sessions remain open

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Workstream turns that operating knowledge into reusable infrastructure.
 - [Roadmap Status](docs/roadmap_status.md)
 - [Week 1 Backend Plan](docs/roadmap_week1_backend_plan.md)
 - [Week 2 Checker Framework Specification](docs/spec_week2_checker_framework.md)
+- [Chunk 6 Checker Contract And Records](docs/spec_chunk_6_checker_contract_records.md)
 - [Day-by-Day Execution Plan](docs/roadmap_day_by_day_execution_plan.md)
 - [Implementation Backlog](docs/roadmap_implementation_backlog.md)
 - [Product Principles](docs/product_principles.md)

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -203,19 +203,22 @@ Examples:
 ## Checker Run Flow
 
 ```text
-Submission received
+Draft packet
+-> run pre-submit static checks
+-> submit packet
+-> lock submission
 -> create CheckerRun
 -> load project CheckerPolicy
 -> run required checkers
 -> store CheckerResult records
 -> calculate blocking status
 -> issue ReadinessCertificate when no blocking failures remain
--> move to REVIEW_PENDING or remain checker-blocked from human review
+-> move to REVIEW_PENDING or NEEDS_REVISION
 ```
 
 The checker run must bind to one immutable submission version. If the worker uploads a replacement file, the platform creates a new submission version and reruns checks.
 
-Checker failures are not review decisions. They do not accept, reject, or request revision. They block review entry until the worker submits a replacement packet, an allowed policy override is recorded, or a later review/revision workflow handles the issue.
+Checker failures are not human review decisions. They do not accept or reject work. Worker-fixable blocking failures can route the task to user-facing `NEEDS_REVISION`, with `outcome_source = auto_checker` and no review decision id. Human review can also produce `needs_revision` later, but that records `outcome_source = human_review` and a review decision id.
 
 If a checker crashes or cannot run because of platform infrastructure, the checker run remains failed as an infrastructure failure and the task does not move to human review. The retry or admin action is recorded in audit history.
 

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -212,8 +212,9 @@ Draft packet
 -> run required checkers
 -> store CheckerResult records
 -> calculate blocking status
--> issue ReadinessCertificate when no blocking failures remain
--> move to REVIEW_PENDING or NEEDS_REVISION
+-> if no blocking failures remain: issue ReadinessCertificate and move to REVIEW_PENDING
+-> if worker-fixable blocking failures exist: route to user-facing needs_revision with outcome_source = auto_checker
+-> if checker infrastructure fails: keep in operator retry handling
 ```
 
 The checker run must bind to one immutable submission version. If the worker uploads a replacement file, the platform creates a new submission version and reruns checks.

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -392,23 +392,37 @@ Types:
 Fields:
 
 - `id`
+- `task_id`
 - `submission_id`
+- `submission_version`
 - `status`
+- `routing_recommendation`
+- `outcome_source`
+- `trigger_source`
+- `attempt_number`
+- `supersedes_checker_run_id`
+- `is_current_for_submission`
 - `started_at`
-- `finished_at`
+- `completed_at`
 - `runner_version`
 - `locked_guide_version`
 - `locked_checker_policy_version`
-- `submission_version`
+- `locked_review_policy_version`
+- `locked_revision_policy_version`
+- `locked_payment_policy_version`
+- `package_hash`
 - `artifact_hash_manifest`
+- `artifact_manifest_hash`
 - `summary`
 
 Status:
 
+- queued
 - running
-- passed
-- warning
+- completed
 - failed
+
+Run pass/warn/fail summary is derived from checker result counts, not stored as run status.
 
 ## CheckerResult
 
@@ -421,7 +435,12 @@ Fields:
 - `severity`
 - `message`
 - `suggested_fix`
+- `worker_message`
+- `worker_suggested_fix`
 - `evidence_refs`
+- `worker_evidence_refs`
+- `worker_visible`
+- `metadata`
 - `created_at`
 
 Status:

--- a/docs/architecture_lifecycle_state_machine.md
+++ b/docs/architecture_lifecycle_state_machine.md
@@ -129,12 +129,19 @@ Required before entering:
 
 ### NEEDS_REVISION
 
-The human reviewer found fixable issues.
+The worker-facing state for fixable issues.
+
+This state can be entered from:
+
+- `AUTO_CHECKING`, when automated checker results contain worker-fixable blocking failures.
+- `PRE_REVIEW_GATE`, when pre-review policy finds worker-fixable blocking failures.
+- `REVIEW_PENDING`, when a human reviewer records a `needs_revision` decision.
 
 Required before entering:
 
-- at least one review finding
-- required fix for each high/medium finding
+- from `AUTO_CHECKING`: checker run id, blocking checker results, worker-visible messages, and suggested fixes
+- from `PRE_REVIEW_GATE`: gate run id, worker-visible findings, and suggested fixes
+- from `REVIEW_PENDING`: review decision id and at least one structured review finding
 
 ### ACCEPTED
 

--- a/docs/operations_queue_policy.md
+++ b/docs/operations_queue_policy.md
@@ -137,7 +137,7 @@ Policy:
 
 ### Needs Revision
 
-Reviewer found fixable issues.
+Worker-facing lane for fixable issues from automated checks, pre-review gates, or human review.
 
 Owner:
 
@@ -209,7 +209,7 @@ Every operating day starts with:
 | `IN_PROGRESS -> SUBMITTED` | submission packet, evidence ids, artifact hash manifest, worker attestation |
 | `SUBMITTED -> AUTO_CHECKING` | immutable submission version, checker policy version derived from the locked task context |
 | `AUTO_CHECKING -> REVIEW_PENDING` | checker run for exact submission version, readiness certificate, no blocking failures |
-| `AUTO_CHECKING -> NEEDS_REVISION` | checker failures with severity, message, suggested fix |
+| `AUTO_CHECKING -> NEEDS_REVISION` | checker run id, outcome source `auto_checker`, worker-visible checker failures with severity, message, suggested fix |
 | `REVIEW_PENDING -> NEEDS_REVISION` | review decision, at least one structured finding, revision policy still permits revision |
 | `REVIEW_PENDING -> ACCEPTED` | accepted review, acceptance evidence refs, contribution record, payment record |
 | `NEEDS_REVISION -> IN_PROGRESS` | prior findings visible to worker, revision deadline active |

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -146,6 +146,8 @@ Week 2 is backend/checker-framework work. Checker results must be available thro
 
 Deliverables:
 
+- pre-submit static checker path
+- post-submit internal auto-check path
 - checker runner
 - checker result schema
 - project checker policy
@@ -198,7 +200,7 @@ Week 2 acceptance bar:
 
 - every submitted task runs checks
 - checker output is stored permanently
-- high-severity failures block human review without creating a review decision
+- high-severity failures block human review and can route to user-facing `NEEDS_REVISION` without creating a human review decision
 - backend contracts expose the exact checker results before Week 3 reviewer UI work begins
 
 ## Week 3: Review And Revision Engine

--- a/docs/roadmap_day_by_day_execution_plan.md
+++ b/docs/roadmap_day_by_day_execution_plan.md
@@ -134,9 +134,9 @@ Week 2 is backend-first checker infrastructure. Checker output is exposed throug
 
 The core invariant is:
 
-`Submission -> Lock -> CheckerRun -> CheckerResults -> Gate -> REVIEW_PENDING or checker-blocked`
+`Draft packet -> Pre-submit checks -> Submit -> Lock -> Internal CheckerRun -> CheckerResults -> REVIEW_PENDING or NEEDS_REVISION`
 
-The checker framework does not accept, reject, or request revision. It decides whether the latest locked submission can move toward human review.
+The checker framework does not accept or reject work. It may route worker-fixable checker failures to user-facing `NEEDS_REVISION`, but that does not create a human review decision. Internally the source is recorded as `auto_checker`.
 
 ### Day 6: Checker Interface
 
@@ -154,6 +154,7 @@ Exit criteria:
 - store pass/warn/fail results
 - expose checker run and result data through backend API responses and dry-run/demo output
 - no product frontend task page is added in Week 2
+- checker records can distinguish pre-submit feedback from post-submit internal auto checks
 
 ### Day 7: Core Structural Checkers
 
@@ -170,6 +171,7 @@ Exit criteria:
 - broken submissions fail before review
 - high severity failures block `REVIEW_PENDING`
 - checker runs bind to the exact submission id, submission version, package hash, and artifact hash manifest
+- worker-fixable checker failures route to user-facing `NEEDS_REVISION`
 
 ### Day 8: Evidence And Acceptance Checkers
 

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -37,6 +37,7 @@ Current phase: Week 1 backend foundation complete; preparing checker framework.
 - Chunk 5 submission packet foundation with evidence items, versioning, server-stamped locked context, and submission locking.
 - Week 1 backend dry run through `Project -> Guide -> Task -> Screening -> Ready -> Claim -> Start -> Submit -> Lock submission`.
 - Week 2 checker framework scope specification.
+- Chunk 6 checker contract and records specification.
 
 ## Review Tracks Closed
 
@@ -53,7 +54,6 @@ Current phase: Week 1 backend foundation complete; preparing checker framework.
 - Create the first 5 pilot task records.
 - Confirm who owns product, engineering, review, operations, and payment reconciliation during the first build cycle.
 - Confirm the first v0.1 project guide uses the locked guide fields, task contract fields, evidence IDs, and contribution record flow.
-- Lock Chunk 6 checker contract and records specification with conditions of satisfaction.
 - Build checker run records and `check_submission_packet` in Week 2.
 - Keep Week 2 backend/checker-framework only: expose checker results through APIs and dry-run/demo output, not product frontend pages.
 

--- a/docs/spec_chunk_6_checker_contract_records.md
+++ b/docs/spec_chunk_6_checker_contract_records.md
@@ -1,0 +1,222 @@
+# Chunk 6: Checker Contract And Records
+
+## Purpose
+
+Chunk 6 creates the durable checker run and checker result contract for Week 2.
+
+This chunk does not run the full checker framework yet. It defines the records, schemas, service boundaries, and read APIs that later chunks use for pre-submit static checks, post-submit internal auto checks, and review gating.
+
+## Scope
+
+- checker run model
+- checker result model
+- checker run status values
+- checker result status and severity values
+- run type and trigger source fields
+- gate outcome fields
+- source tracking for checker-caused `needs_revision`
+- backend read APIs for checker runs and results
+- internal service method for creating checker runs/results
+- migration and ORM metadata
+- tests for persistence, visibility, and immutability expectations
+
+## Non-Scope
+
+- real checker registry
+- real checker execution
+- automatic background trigger after submission locking
+- task lifecycle movement to `AUTO_CHECKING`, `REVIEW_PENDING`, or `NEEDS_REVISION`
+- product frontend
+- reviewer queue UI
+- human review decisions
+- revision replay enforcement
+- contribution, payment, or reputation records
+
+## Required Model
+
+`checker_runs`
+
+- `id`
+- `task_id`
+- `submission_id`
+- `submission_version`
+- `run_type`
+- `trigger_source`
+- `status`
+- `gate_outcome`
+- `outcome_source`
+- `triggered_by`
+- `locked_guide_version`
+- `locked_checker_policy_version`
+- `locked_review_policy_version`
+- `locked_revision_policy_version`
+- `locked_payment_policy_version`
+- `package_hash`
+- `artifact_hash_manifest`
+- `artifact_manifest_hash`
+- `blocking_failure_count`
+- `warning_count`
+- `started_at`
+- `completed_at`
+- `failure_message`
+- `created_at`
+- `updated_at`
+
+`checker_results`
+
+- `id`
+- `checker_run_id`
+- `checker_id`
+- `checker_name`
+- `checker_version`
+- `phase`
+- `status`
+- `severity`
+- `blocks_review`
+- `message`
+- `suggested_fix`
+- `evidence_refs`
+- `metadata`
+- `worker_visible`
+- `created_at`
+
+## Canonical Values
+
+`checker_runs.run_type`
+
+- `pre_submit`
+- `post_submit`
+
+`checker_runs.trigger_source`
+
+- `api_preflight`
+- `submission_locked`
+- `manual_operator`
+- `retry`
+
+`checker_runs.status`
+
+- `queued`
+- `running`
+- `completed`
+- `failed`
+
+`checker_runs.gate_outcome`
+
+- `not_evaluated`
+- `allow_review`
+- `needs_revision`
+- `operator_retry`
+
+`checker_runs.outcome_source`
+
+- `none`
+- `auto_checker`
+
+`checker_results.status`
+
+- `pass`
+- `warn`
+- `fail`
+
+`checker_results.severity`
+
+- `low`
+- `medium`
+- `high`
+
+## Record Binding
+
+Post-submit checker runs must bind to one locked submission version.
+
+The run snapshots:
+
+- `task_id`
+- `submission_id`
+- `submission_version`
+- `package_hash`
+- `artifact_hash_manifest`
+- deterministic `artifact_manifest_hash`
+- locked project guide version
+- locked checker policy version
+- locked review policy version
+- locked revision policy version
+- locked payment policy version
+
+The client does not provide locked guide or policy versions for checker runs. Workstream copies them from the persisted submission.
+
+## User-Facing Revision Rule
+
+User-facing outcomes remain simple:
+
+- `accepted`
+- `rejected`
+- `needs_revision`
+
+Checker-caused revision uses the same user-facing `needs_revision` state, but records the source internally:
+
+- `gate_outcome = needs_revision`
+- `outcome_source = auto_checker`
+- `review_decision_id = null` when that field exists in later review work
+
+Human reviewer revision remains separate later:
+
+- `outcome = needs_revision`
+- `outcome_source = human_review`
+- `review_decision_id` present
+
+Chunk 6 stores the checker-side source fields but does not implement human review decisions.
+
+## API Contract
+
+Read APIs:
+
+- GET `/api/v1/submissions/{submission_id}/checker-runs`
+- GET `/api/v1/checker-runs/{checker_run_id}`
+
+The API must not allow clients to create arbitrary successful checker results.
+
+Write behavior is internal service/repository only in Chunk 6. Chunk 7 and Chunk 9 can expose controlled trigger paths.
+
+## Visibility Rules
+
+Workers can read checker runs/results for their assigned task submissions.
+
+Project managers and admins can read checker runs/results for project operations.
+
+Worker-visible responses must include:
+
+- checker name
+- status
+- severity
+- message
+- suggested fix when safe
+- evidence references when safe
+
+Worker-visible responses must not expose internal metadata when `worker_visible` is false.
+
+Project managers and admins can see operational metadata.
+
+## Conditions Of Satisfaction
+
+- migration creates checker run and checker result tables
+- ORM models match migration metadata
+- checker runs reference existing task and submission records
+- post-submit checker run creation snapshots locked submission context server-side
+- artifact manifest hash is deterministic for equivalent manifests
+- checker results are tied to one checker run
+- canonical status/severity values are enforced by schemas/service constants
+- read APIs return checker run and checker result records
+- workers cannot read unrelated checker runs
+- workers do not receive non-worker-visible metadata
+- project managers and admins can read operational checker output
+- clients cannot submit fake passed checker results through public APIs
+- tests cover persistence, visibility, and locked-context snapshotting
+- docstring coverage remains above threshold
+
+## Verifier Agents
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops

--- a/docs/spec_chunk_6_checker_contract_records.md
+++ b/docs/spec_chunk_6_checker_contract_records.md
@@ -4,7 +4,7 @@
 
 Chunk 6 creates the durable checker run and checker result contract for Week 2.
 
-This chunk does not run the full checker framework yet. It defines the records, schemas, service boundaries, and read APIs that later chunks use for pre-submit static checks, post-submit internal auto checks, and review gating.
+This chunk does not run the full checker framework yet. It defines the durable post-submit checker records, the pre-submit feedback response contract, schemas, service boundaries, and read APIs that later chunks use for static checks, internal auto checks, and review gating.
 
 ## Scope
 
@@ -12,9 +12,10 @@ This chunk does not run the full checker framework yet. It defines the records, 
 - checker result model
 - checker run status values
 - checker result status and severity values
-- run type and trigger source fields
-- gate outcome fields
+- trigger source fields
+- routing recommendation fields
 - source tracking for checker-caused `needs_revision`
+- pre-submit feedback response contract
 - backend read APIs for checker runs and results
 - internal service method for creating checker runs/results
 - migration and ORM metadata
@@ -26,6 +27,7 @@ This chunk does not run the full checker framework yet. It defines the records, 
 - real checker execution
 - automatic background trigger after submission locking
 - task lifecycle movement to `AUTO_CHECKING`, `REVIEW_PENDING`, or `NEEDS_REVISION`
+- readiness certificate creation; deferred to Chunk 9 when the pre-review gate is implemented
 - product frontend
 - reviewer queue UI
 - human review decisions
@@ -40,12 +42,19 @@ This chunk does not run the full checker framework yet. It defines the records, 
 - `task_id`
 - `submission_id`
 - `submission_version`
-- `run_type`
 - `trigger_source`
 - `status`
-- `gate_outcome`
+- `routing_recommendation`
 - `outcome_source`
 - `triggered_by`
+- `triggered_by_subject`
+- `triggered_by_issuer`
+- `trigger_auth_source`
+- `trigger_reason`
+- `audit_event_id`
+- `attempt_number`
+- `supersedes_checker_run_id`
+- `is_current_for_submission`
 - `locked_guide_version`
 - `locked_checker_policy_version`
 - `locked_review_policy_version`
@@ -75,21 +84,18 @@ This chunk does not run the full checker framework yet. It defines the records, 
 - `blocks_review`
 - `message`
 - `suggested_fix`
+- `worker_message`
+- `worker_suggested_fix`
 - `evidence_refs`
+- `worker_evidence_refs`
 - `metadata`
 - `worker_visible`
 - `created_at`
 
 ## Canonical Values
 
-`checker_runs.run_type`
-
-- `pre_submit`
-- `post_submit`
-
 `checker_runs.trigger_source`
 
-- `api_preflight`
 - `submission_locked`
 - `manual_operator`
 - `retry`
@@ -101,7 +107,7 @@ This chunk does not run the full checker framework yet. It defines the records, 
 - `completed`
 - `failed`
 
-`checker_runs.gate_outcome`
+`checker_runs.routing_recommendation`
 
 - `not_evaluated`
 - `allow_review`
@@ -127,7 +133,7 @@ This chunk does not run the full checker framework yet. It defines the records, 
 
 ## Record Binding
 
-Post-submit checker runs must bind to one locked submission version.
+Durable `checker_runs` are authoritative post-submit records only. They must bind to one locked submission version.
 
 The run snapshots:
 
@@ -143,7 +149,56 @@ The run snapshots:
 - locked revision policy version
 - locked payment policy version
 
-The client does not provide locked guide or policy versions for checker runs. Workstream copies them from the persisted submission.
+Post-submit checker runs must be created only from a loaded, locked submission. The service must copy `task_id`, `submission_version`, `package_hash`, `artifact_hash_manifest`, `artifact_manifest_hash`, and locked policy versions from that submission. The client does not provide locked guide or policy versions for checker runs.
+
+The migration must add enough constraints or service-level tests to prove a checker run cannot bind `submission_id` to a different task, submission version, or package hash. Prefer a composite foreign key or unique binding where practical; otherwise add explicit service validation and integration tests that fail on mismatched context.
+
+Only the current completed post-submit checker run can be used by Chunk 9's pre-review gate. Chunk 6 stores the provenance needed for that later gate:
+
+- `attempt_number`
+- `supersedes_checker_run_id`
+- `is_current_for_submission`
+- `completed_at`
+- `artifact_manifest_hash`
+- `package_hash`
+
+## Artifact Manifest Hash
+
+`artifact_manifest_hash` is SHA-256 over canonical UTF-8 JSON.
+
+Normalization rules:
+
+- validate every entry against `ArtifactHashEntry`
+- sort entries by `artifact`, then `hash`
+- reject duplicate `artifact` values
+- serialize with sorted object keys and compact separators
+- preserve all persisted fields that affect artifact identity: `artifact`, `hash`, `size_bytes`, and `notes`
+- equivalent manifests with different JSON key order or entry order must produce the same hash
+- any changed artifact hash, size, path, or notes must produce a different hash
+
+## Pre-Submit Feedback Contract
+
+Pre-submit static checks run before a submission is finalized. They return immediate API feedback without creating an authoritative post-submit checker run.
+
+Response fields:
+
+- `run_type = pre_submit`
+- `task_id`
+- `actor_id`
+- `request_hash`
+- `eligible_to_submit`
+- `artifact_manifest_hash`
+- `blocking_failure_count`
+- `warning_count`
+- `results`
+- `submission_created = false`
+- `durable_checker_run_id = null`
+- `created_at`
+- `expires_at`
+
+Pre-submit feedback may bind to `task_id`, draft packet fields, package hash, and artifact manifest shape. It does not require a locked `submission_id`, locked submission version, or locked policy context.
+
+Pre-submit results are not authoritative for `REVIEW_PENDING` and cannot create `NEEDS_REVISION`. Only post-submit runs against locked submissions can produce routing recommendations for `REVIEW_PENDING` or user-facing `needs_revision`.
 
 ## User-Facing Revision Rule
 
@@ -155,7 +210,7 @@ User-facing outcomes remain simple:
 
 Checker-caused revision uses the same user-facing `needs_revision` state, but records the source internally:
 
-- `gate_outcome = needs_revision`
+- `routing_recommendation = needs_revision`
 - `outcome_source = auto_checker`
 - `review_decision_id = null` when that field exists in later review work
 
@@ -174,44 +229,86 @@ Read APIs:
 - GET `/api/v1/submissions/{submission_id}/checker-runs`
 - GET `/api/v1/checker-runs/{checker_run_id}`
 
-The API must not allow clients to create arbitrary successful checker results.
+Checker read and trigger APIs use the existing external Flow authentication boundary. Workstream verifies Flow-issued tokens, resolves actor context, and applies object-level authorization. Chunk 6 must not introduce Workstream-owned login, password, session, or API key auth.
 
-Write behavior is internal service/repository only in Chunk 6. Chunk 7 and Chunk 9 can expose controlled trigger paths.
+Public APIs must not create, update, or delete durable checker results.
+
+Durable `CheckerRun` and `CheckerResult` records are written only by Workstream-owned checker services using server-derived checker output. External Flow actors may request allowed pre-submit checks or authorized retry triggers in later chunks, but they must never provide result status, severity, `blocks_review`, metadata, routing recommendation, locked policy context, or pass/fail payloads.
+
+Any future trigger endpoint creates only a run request. The checker service computes and persists all results.
+
+Write behavior is internal service/repository only in Chunk 6. Chunk 7 and Chunk 9 can expose controlled trigger paths that still do not accept caller-supplied result payloads.
 
 ## Visibility Rules
 
-Workers can read checker runs/results for their assigned task submissions.
+Read authorization must be object-scoped, not role-only.
 
-Project managers and admins can read checker runs/results for project operations.
+- workers can read worker-visible checker output only for submissions on tasks assigned to them
+- project managers can read operational checker output only for projects they manage
+- admins can read operational checker output globally
+- reviewers can read checker output only after the submission is assigned to them for review in later review work
+- auditors can read according to the audit/read-only policy, but cannot see worker-hidden sensitive metadata unless explicitly allowed by audit policy
 
-Worker-visible responses must include:
+Worker responses include only result rows where `worker_visible = true`. For hidden operational results, worker responses may expose aggregate counts but must not expose checker id, metadata, internal rule ids, logs, stack traces, or unsafe evidence refs.
+
+Worker-visible responses are built from sanitized worker-facing fields, not raw checker metadata. They may include:
 
 - checker name
 - status
 - severity
-- message
-- suggested fix when safe
-- evidence references when safe
+- `worker_message`
+- `worker_suggested_fix`
+- safe `worker_evidence_refs`
 
-Worker-visible responses must not expose internal metadata when `worker_visible` is false.
+Raw `metadata`, internal rule IDs, stack traces, hidden-test details, reviewer-simulation prompts, private storage paths, secrets, and security heuristics are never returned to workers.
 
 Project managers and admins can see operational metadata.
+
+## Manual And Retry Audit Rules
+
+`manual_operator` and `retry` trigger sources require:
+
+- `triggered_by`
+- Flow auth subject
+- Flow auth issuer
+- auth source
+- reason
+- `audit_event_id`
+
+System-triggered runs use a Workstream service principal. Manual runs must be attributable to an authorized admin/operator and must not overwrite prior checker results.
+
+## Immutability Rules
+
+Checker results are append-only after persistence. No public API can update or delete checker results.
+
+Internal services may only create new runs/results or transition a run status through allowed states. Checker runs may update only lifecycle fields before terminal status: `status`, counts, `started_at`, `completed_at`, and `failure_message`. After `completed` or `failed`, run records are immutable except for explicit audited retry records in later chunks. Corrections require a new checker run linked to the prior run.
 
 ## Conditions Of Satisfaction
 
 - migration creates checker run and checker result tables
 - ORM models match migration metadata
 - checker runs reference existing task and submission records
+- migration upgrade/downgrade passes against Postgres
 - post-submit checker run creation snapshots locked submission context server-side
-- artifact manifest hash is deterministic for equivalent manifests
+- creating run for an unlocked submission fails
+- creating run with mismatched task/submission context fails
+- later task policy changes do not mutate historical checker run context
+- artifact manifest hash follows the canonical SHA-256 JSON algorithm
+- equivalent manifests with different entry or key order hash identically
+- duplicate artifact names are rejected
+- pre-submit invalid packet returns structured feedback without creating a submission
+- pre-submit result cannot be reused as post-submit gate proof
 - checker results are tied to one checker run
 - canonical status/severity values are enforced by schemas/service constants
 - read APIs return checker run and checker result records
 - workers cannot read unrelated checker runs
-- workers do not receive non-worker-visible metadata
+- workers do not receive hidden result rows, raw metadata, internal rule ids, logs, stack traces, unsafe evidence refs, secrets, or security heuristics
 - project managers and admins can read operational checker output
-- clients cannot submit fake passed checker results through public APIs
+- clients cannot create, update, delete, or spoof checker results through public APIs
 - tests cover persistence, visibility, and locked-context snapshotting
+- API integration tests use real Postgres-backed data and authenticated Flow actor headers
+- tests do not rely only on monkeypatch/unit-only paths for checker run creation, visibility, or binding
+- no public update/delete endpoints exist for checker results
 - docstring coverage remains above threshold
 
 ## Verifier Agents

--- a/docs/spec_week2_checker_framework.md
+++ b/docs/spec_week2_checker_framework.md
@@ -26,7 +26,7 @@ The checker framework protects reviewer time by proving that the latest locked s
 - product frontend implementation
 - reviewer queue UI
 - review decision form
-- accept, needs_revision, or reject decisions
+- human review decision records/forms for `accept`, `needs_revision`, or `reject`
 - revision replay enforcement
 - contribution records
 - payment records
@@ -83,6 +83,8 @@ Users see the same simple outcome language everywhere:
 
 Automated checker failures may route a submitted packet to `needs_revision` when the failure is worker-fixable. This is user-facing revision, not a human review decision.
 
+Week 2 may set a checker-caused task/submission outcome of `needs_revision`, but it does not create a human review decision record.
+
 Internally Workstream records the source:
 
 - `outcome = needs_revision`
@@ -111,6 +113,8 @@ Human review decisions remain only:
 - `needs_revision`
 - `reject`
 
+Stored human review decision tokens are `accept`, `needs_revision`, and `reject`. User-facing task outcomes are displayed as Accepted, Rejected, and Needs revision. Internal lifecycle constants may use uppercase enum names, but persisted workflow values and API payloads should use canonical lowercase tokens.
+
 ## Week 2 Visibility Boundary
 
 Checker results are exposed through backend contracts and operational output:
@@ -134,8 +138,8 @@ Conditions of satisfaction:
 - checker runs are tied to one submission version
 - checker results are immutable after persistence
 - status and severity values are canonical
-- run type supports `pre_submit` and `post_submit`
-- gate outcome can record `allow_review`, `needs_revision`, or `operator_retry`
+- pre-submit feedback has a response contract but is not authoritative review-gate proof
+- post-submit checker runs can record `allow_review`, `needs_revision`, or `operator_retry` as routing recommendations
 - checker-caused `needs_revision` stores `outcome_source = auto_checker`
 - checker output can be read through backend APIs
 

--- a/docs/spec_week2_checker_framework.md
+++ b/docs/spec_week2_checker_framework.md
@@ -11,9 +11,12 @@ The checker framework protects reviewer time by proving that the latest locked s
 - `CheckerRun` records
 - `CheckerResult` records
 - checker status and severity model
+- pre-submit static checker path
+- post-submit internal auto-check path
 - checker registry and runner service
 - project-required checker policy enforcement
 - blocking versus warning calculation
+- user-facing `needs_revision` routing from checker failures
 - backend API access to checker runs and results
 - dry-run/demo output for checker visibility
 - pre-review gate enforcement for `REVIEW_PENDING`
@@ -34,7 +37,7 @@ The checker framework protects reviewer time by proving that the latest locked s
 ## Core Invariant
 
 ```text
-Submission -> Lock -> CheckerRun -> CheckerResults -> Gate -> REVIEW_PENDING or checker-blocked
+Draft packet -> Pre-submit checks -> Submit -> Lock -> Internal CheckerRun -> CheckerResults -> REVIEW_PENDING or NEEDS_REVISION
 ```
 
 A task cannot reach `REVIEW_PENDING` unless the latest locked submission has a completed checker run for the exact submission version and artifact context.
@@ -52,15 +55,55 @@ The checker binding includes:
 - locked revision policy version
 - locked payment policy version
 
-## Checker Decision Boundary
+## Two-Stage Checker Model
 
-Checkers do not accept, reject, or request revision.
+Workstream has two checker moments.
 
-Checkers only decide whether a submission is allowed to enter human review:
+Pre-submit static checks run before the packet is finalized. They give immediate feedback on packet shape and obvious policy issues:
+
+- required field presence
+- package hash presence
+- artifact hash manifest shape
+- evidence references
+- worker attestation
+- storage reference safety
+- task assignment and state compatibility
+
+Pre-submit failures do not create review decisions and do not need to create durable post-submit checker runs.
+
+Post-submit internal checks run after a submission is created and locked. These checks are the source of truth for review gating. They run from Workstream-owned services, use locked task guide and policy context, and persist durable checker runs/results.
+
+## User-Facing Outcome Boundary
+
+Users see the same simple outcome language everywhere:
+
+- `accepted`
+- `rejected`
+- `needs_revision`
+
+Automated checker failures may route a submitted packet to `needs_revision` when the failure is worker-fixable. This is user-facing revision, not a human review decision.
+
+Internally Workstream records the source:
+
+- `outcome = needs_revision`
+- `outcome_source = auto_checker`
+- `checker_run_id = <run id>`
+- `review_decision_id = null`
+
+Human reviewer revision remains:
+
+- `outcome = needs_revision`
+- `outcome_source = human_review`
+- `review_decision_id = <review decision id>`
+
+Checkers can route to `needs_revision`, but they must not create fake human review decisions.
+
+Checkers decide:
 
 - passing required checks can allow `REVIEW_PENDING`
-- warning checks remain visible but do not block by default
-- blocking failures prevent `REVIEW_PENDING`
+- warning checks can still allow `REVIEW_PENDING` with visible context
+- worker-fixable blocking failures route to `needs_revision`
+- platform/infrastructure failures stay in checker/admin retry handling
 
 Human review decisions remain only:
 
@@ -84,22 +127,26 @@ Week 2 does not build the product frontend page for checker results. The planned
 
 ### Chunk 6: Checker Contract And Records
 
-Creates the durable checker run/result model, API schemas, service boundaries, and migration.
+Creates the durable checker run/result model, pre-submit response contract, API schemas, service boundaries, and migration.
 
 Conditions of satisfaction:
 
 - checker runs are tied to one submission version
 - checker results are immutable after persistence
 - status and severity values are canonical
+- run type supports `pre_submit` and `post_submit`
+- gate outcome can record `allow_review`, `needs_revision`, or `operator_retry`
+- checker-caused `needs_revision` stores `outcome_source = auto_checker`
 - checker output can be read through backend APIs
 
 ### Chunk 7: Checker Runner And Registry
 
-Creates the checker interface, registry, runner service, and first structural checkers.
+Creates the checker interface, registry, pre-submit static checker path, runner service, and first structural checkers.
 
 Conditions of satisfaction:
 
 - registered checker names cannot drift from policy names
+- pre-submit checks return immediate feedback before final submission
 - `check_submission_packet` runs against real submission data
 - failed structural checks produce stored checker results
 - broken submissions are blocked before human review
@@ -117,13 +164,14 @@ Conditions of satisfaction:
 
 ### Chunk 9: Pre-Review Gate
 
-Calculates whether a checked submission can move to `REVIEW_PENDING`.
+Automatically triggers internal post-submit checks after submission locking and calculates whether a checked submission moves to `REVIEW_PENDING` or user-facing `NEEDS_REVISION`.
 
 Conditions of satisfaction:
 
 - the gate uses the latest locked submission only
 - required checker list comes from locked project checker policy
 - blocking severities come from locked project checker policy
+- checker-caused revision does not create a human review decision
 - override requires actor, reason, and audit event
 
 ### Chunk 10: Checker Trial


### PR DESCRIPTION
## Summary
- lock the two-stage Week 2 checker model: pre-submit static checks plus post-submit internal auto checks
- clarify checker failures route to user-facing needs_revision without creating human review decisions
- add Chunk 6 checker contract and records spec with models, canonical values, APIs, visibility rules, and CoS
- remove checker-blocked wording in favor of internal source tracking and user-facing needs_revision

## Verification
- stale wording scan only hits the intentional banned-word guardrail in AGENTS.md
- Markdown links OK
- no local XLSX export present
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the Chunk 6 checker contract & records specification and marked it complete.
  * Expanded the checker framework into a clarified two-stage flow (pre-submit static feedback vs post-submit durable runs/results).
  * Defined durable checker run/result semantics, visibility rules, and user-facing routing (auto-checker vs human review).
  * Updated lifecycle/state transitions, operations queue, roadmap, and reviewer/agent guidance to reflect the new flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->