### PR TITLE
Implement Chunk 7 checker runner registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Workstream is how Flow measures, certifies, and coordinates useful human-agent w
 - If updating the roadmap, update both local XLSX and CSV exports.
 - Do not import XLSX into Google Sheets with "replace spreadsheet"; use a temporary sheet and copy only the roadmap tab.
 - Prefer evidence-backed docs over vague product claims.
+- For workflow states, persisted tokens, API enum values, roles, and lifecycle names, prefer subsystem- or actor-specific names over vague labels. If the naming has product or security impact and the user is unavailable, run the required internal reviewer tracks before locking it.
 - Keep v0.1 focused on project guide -> task -> submission -> checks -> review -> revision -> contribution/payment/reputation records.
 - Review decision stored values are only accept, needs_revision, or reject.
 - Frontend is locked as React + Vite + TypeScript.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Workstream turns that operating knowledge into reusable infrastructure.
 - [Week 1 Backend Plan](docs/roadmap_week1_backend_plan.md)
 - [Week 2 Checker Framework Specification](docs/spec_week2_checker_framework.md)
 - [Chunk 6 Checker Contract And Records](docs/spec_chunk_6_checker_contract_records.md)
+- [Chunk 7 Checker Runner And Registry](docs/spec_chunk_7_checker_runner_registry.md)
 - [Day-by-Day Execution Plan](docs/roadmap_day_by_day_execution_plan.md)
 - [Implementation Backlog](docs/roadmap_implementation_backlog.md)
 - [Product Principles](docs/product_principles.md)

--- a/backend/alembic/versions/0004_submission_packet_foundation.py
+++ b/backend/alembic/versions/0004_submission_packet_foundation.py
@@ -97,6 +97,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_submissions")),
         sa.UniqueConstraint("task_id", "version", name="uq_submissions_task_version"),
+        sa.UniqueConstraint("id", "version", name="uq_submissions_id_version"),
     )
     op.create_index(op.f("ix_submissions_task_id"), "submissions", ["task_id"], unique=False)
     op.create_index(op.f("ix_submissions_worker_id"), "submissions", ["worker_id"], unique=False)

--- a/backend/alembic/versions/0005_checker_runs.py
+++ b/backend/alembic/versions/0005_checker_runs.py
@@ -1,0 +1,190 @@
+"""checker run records
+
+Revision ID: 0005_checker_runs
+Revises: 0004_submission_packets
+Create Date: 2026-06-09
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0005_checker_runs"
+down_revision = "0004_submission_packets"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create durable checker run and result tables."""
+    op.create_table(
+        "checker_runs",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("submission_id", sa.String(length=36), nullable=False),
+        sa.Column("submission_version", sa.Integer(), nullable=False),
+        sa.Column("trigger_source", sa.String(length=50), nullable=False),
+        sa.Column("status", sa.String(length=30), nullable=False),
+        sa.Column("routing_recommendation", sa.String(length=50), nullable=False),
+        sa.Column("outcome_source", sa.String(length=50), nullable=False),
+        sa.Column("triggered_by", sa.String(length=100), nullable=False),
+        sa.Column("triggered_by_subject", sa.String(length=200), nullable=False),
+        sa.Column("triggered_by_issuer", sa.String(length=200), nullable=False),
+        sa.Column("trigger_auth_source", sa.String(length=30), nullable=False),
+        sa.Column("trigger_reason", sa.Text(), nullable=True),
+        sa.Column("audit_event_id", sa.String(length=36), nullable=True),
+        sa.Column("attempt_number", sa.Integer(), nullable=False),
+        sa.Column("supersedes_checker_run_id", sa.String(length=36), nullable=True),
+        sa.Column("is_current_for_submission", sa.Boolean(), nullable=False),
+        sa.Column("locked_guide_version", sa.String(length=50), nullable=False),
+        sa.Column("locked_checker_policy_version", sa.String(length=50), nullable=False),
+        sa.Column("locked_review_policy_version", sa.String(length=50), nullable=False),
+        sa.Column("locked_revision_policy_version", sa.String(length=50), nullable=False),
+        sa.Column("locked_payment_policy_version", sa.String(length=50), nullable=False),
+        sa.Column("package_hash", sa.String(length=128), nullable=False),
+        sa.Column("artifact_hash_manifest", sa.JSON(), nullable=False),
+        sa.Column("artifact_manifest_hash", sa.String(length=128), nullable=False),
+        sa.Column("passed_count", sa.Integer(), nullable=False),
+        sa.Column("warning_count", sa.Integer(), nullable=False),
+        sa.Column("failed_count", sa.Integer(), nullable=False),
+        sa.Column("blocking_count", sa.Integer(), nullable=False),
+        sa.Column("queued_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("failure_code", sa.String(length=100), nullable=True),
+        sa.Column("failure_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["audit_event_id"],
+            ["audit_events.id"],
+            name=op.f("fk_checker_runs_audit_event_id_audit_events"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["submission_id"],
+            ["submissions.id"],
+            name=op.f("fk_checker_runs_submission_id_submissions"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["submission_id", "submission_version"],
+            ["submissions.id", "submissions.version"],
+            name="fk_checker_runs_submission_version",
+        ),
+        sa.ForeignKeyConstraint(
+            ["supersedes_checker_run_id"],
+            ["checker_runs.id"],
+            name=op.f("fk_checker_runs_supersedes_checker_run_id_checker_runs"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id"],
+            ["workstream_tasks.id"],
+            name=op.f("fk_checker_runs_task_id_workstream_tasks"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_guide_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_guide_version"],
+            name="fk_checker_runs_task_locked_guide",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_checker_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_checker_policy_version"],
+            name="fk_checker_runs_task_locked_checker_policy",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_review_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_review_policy_version"],
+            name="fk_checker_runs_task_locked_review_policy",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_revision_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_revision_policy_version"],
+            name="fk_checker_runs_task_locked_revision_policy",
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id", "locked_payment_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_payment_policy_version"],
+            name="fk_checker_runs_task_locked_payment_policy",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_checker_runs")),
+        sa.UniqueConstraint(
+            "submission_id",
+            "attempt_number",
+            name="uq_checker_runs_submission_attempt",
+        ),
+    )
+    op.create_index(op.f("ix_checker_runs_audit_event_id"), "checker_runs", ["audit_event_id"], unique=False)
+    op.create_index(op.f("ix_checker_runs_routing_recommendation"), "checker_runs", ["routing_recommendation"], unique=False)
+    op.create_index(op.f("ix_checker_runs_status"), "checker_runs", ["status"], unique=False)
+    op.create_index(op.f("ix_checker_runs_submission_id"), "checker_runs", ["submission_id"], unique=False)
+    op.create_index(
+        op.f("ix_checker_runs_supersedes_checker_run_id"),
+        "checker_runs",
+        ["supersedes_checker_run_id"],
+        unique=False,
+    )
+    op.create_index(op.f("ix_checker_runs_task_id"), "checker_runs", ["task_id"], unique=False)
+    op.create_index(
+        "uq_checker_runs_current_per_submission",
+        "checker_runs",
+        ["submission_id"],
+        unique=True,
+        postgresql_where=sa.text("is_current_for_submission = true"),
+    )
+
+    op.create_table(
+        "checker_results",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("checker_run_id", sa.String(length=36), nullable=False),
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("submission_id", sa.String(length=36), nullable=False),
+        sa.Column("checker_name", sa.String(length=100), nullable=False),
+        sa.Column("status", sa.String(length=30), nullable=False),
+        sa.Column("severity", sa.String(length=30), nullable=False),
+        sa.Column("blocks_review", sa.Boolean(), nullable=False),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("worker_message", sa.Text(), nullable=True),
+        sa.Column("worker_suggested_fix", sa.Text(), nullable=True),
+        sa.Column("worker_evidence_refs", sa.JSON(), nullable=False),
+        sa.Column("worker_visible", sa.Boolean(), nullable=False),
+        sa.Column("metadata", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["checker_run_id"],
+            ["checker_runs.id"],
+            name=op.f("fk_checker_results_checker_run_id_checker_runs"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["submission_id"],
+            ["submissions.id"],
+            name=op.f("fk_checker_results_submission_id_submissions"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["task_id"],
+            ["workstream_tasks.id"],
+            name=op.f("fk_checker_results_task_id_workstream_tasks"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_checker_results")),
+    )
+    op.create_index(op.f("ix_checker_results_checker_name"), "checker_results", ["checker_name"], unique=False)
+    op.create_index(op.f("ix_checker_results_checker_run_id"), "checker_results", ["checker_run_id"], unique=False)
+    op.create_index(op.f("ix_checker_results_submission_id"), "checker_results", ["submission_id"], unique=False)
+    op.create_index(op.f("ix_checker_results_task_id"), "checker_results", ["task_id"], unique=False)
+    op.create_index(op.f("ix_checker_results_worker_visible"), "checker_results", ["worker_visible"], unique=False)
+
+
+def downgrade() -> None:
+    """Drop durable checker run and result tables."""
+    op.drop_index(op.f("ix_checker_results_worker_visible"), table_name="checker_results")
+    op.drop_index(op.f("ix_checker_results_task_id"), table_name="checker_results")
+    op.drop_index(op.f("ix_checker_results_submission_id"), table_name="checker_results")
+    op.drop_index(op.f("ix_checker_results_checker_run_id"), table_name="checker_results")
+    op.drop_index(op.f("ix_checker_results_checker_name"), table_name="checker_results")
+    op.drop_table("checker_results")
+    op.drop_index("uq_checker_runs_current_per_submission", table_name="checker_runs")
+    op.drop_index(op.f("ix_checker_runs_task_id"), table_name="checker_runs")
+    op.drop_index(op.f("ix_checker_runs_supersedes_checker_run_id"), table_name="checker_runs")
+    op.drop_index(op.f("ix_checker_runs_submission_id"), table_name="checker_runs")
+    op.drop_index(op.f("ix_checker_runs_status"), table_name="checker_runs")
+    op.drop_index(op.f("ix_checker_runs_routing_recommendation"), table_name="checker_runs")
+    op.drop_index(op.f("ix_checker_runs_audit_event_id"), table_name="checker_runs")
+    op.drop_table("checker_runs")

--- a/backend/app/api/router.py
+++ b/backend/app/api/router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter
 from app.api.routes.auth import router as auth_router
 from app.api.routes.demo import router as demo_router
 from app.api.routes.health import router as health_router
+from app.modules.checkers.router import router as checkers_router
 from app.modules.projects.router import router as projects_router
 from app.modules.tasks.router import router as tasks_router
 
@@ -17,3 +18,4 @@ api_router.include_router(auth_router, prefix="/api/v1")
 api_router.include_router(demo_router, prefix="/api/v1")
 api_router.include_router(projects_router, prefix="/api/v1")
 api_router.include_router(tasks_router, prefix="/api/v1")
+api_router.include_router(checkers_router, prefix="/api/v1")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1,5 +1,6 @@
 """Import domain models so Alembic can discover metadata."""
 
+from app.modules.checkers.models import CheckerResult, CheckerRun  # noqa: F401
 from app.modules.projects.models import (  # noqa: F401
     CheckerPolicy,
     PaymentPolicy,

--- a/backend/app/modules/checkers/__init__.py
+++ b/backend/app/modules/checkers/__init__.py
@@ -1,0 +1,2 @@
+"""Checker framework module for Workstream submission validation."""
+

--- a/backend/app/modules/checkers/models.py
+++ b/backend/app/modules/checkers/models.py
@@ -1,0 +1,149 @@
+"""SQLAlchemy models for durable checker runs and checker results."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    ForeignKeyConstraint,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.db.base import Base
+
+
+class CheckerRun(Base):
+    """Durable post-submit checker execution bound to one submission version."""
+
+    __tablename__ = "checker_runs"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["task_id", "locked_guide_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_guide_version"],
+            name="fk_checker_runs_task_locked_guide",
+        ),
+        ForeignKeyConstraint(
+            ["task_id", "locked_checker_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_checker_policy_version"],
+            name="fk_checker_runs_task_locked_checker_policy",
+        ),
+        ForeignKeyConstraint(
+            ["task_id", "locked_review_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_review_policy_version"],
+            name="fk_checker_runs_task_locked_review_policy",
+        ),
+        ForeignKeyConstraint(
+            ["task_id", "locked_revision_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_revision_policy_version"],
+            name="fk_checker_runs_task_locked_revision_policy",
+        ),
+        ForeignKeyConstraint(
+            ["task_id", "locked_payment_policy_version"],
+            ["workstream_tasks.id", "workstream_tasks.locked_payment_policy_version"],
+            name="fk_checker_runs_task_locked_payment_policy",
+        ),
+        ForeignKeyConstraint(
+            ["submission_id", "submission_version"],
+            ["submissions.id", "submissions.version"],
+            name="fk_checker_runs_submission_version",
+        ),
+        UniqueConstraint(
+            "submission_id",
+            "attempt_number",
+            name="uq_checker_runs_submission_attempt",
+        ),
+        Index(
+            "uq_checker_runs_current_per_submission",
+            "submission_id",
+            unique=True,
+            postgresql_where=text("is_current_for_submission = true"),
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    task_id: Mapped[str] = mapped_column(ForeignKey("workstream_tasks.id"), nullable=False, index=True)
+    submission_id: Mapped[str] = mapped_column(ForeignKey("submissions.id"), nullable=False, index=True)
+    submission_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    trigger_source: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, default="queued", index=True)
+    routing_recommendation: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        default="not_evaluated",
+        index=True,
+    )
+    outcome_source: Mapped[str] = mapped_column(String(50), nullable=False, default="none")
+    triggered_by: Mapped[str] = mapped_column(String(100), nullable=False)
+    triggered_by_subject: Mapped[str] = mapped_column(String(200), nullable=False)
+    triggered_by_issuer: Mapped[str] = mapped_column(String(200), nullable=False)
+    trigger_auth_source: Mapped[str] = mapped_column(String(30), nullable=False)
+    trigger_reason: Mapped[str | None] = mapped_column(Text)
+    audit_event_id: Mapped[str | None] = mapped_column(ForeignKey("audit_events.id"), index=True)
+    attempt_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    supersedes_checker_run_id: Mapped[str | None] = mapped_column(
+        ForeignKey("checker_runs.id"),
+        index=True,
+    )
+    is_current_for_submission: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    locked_guide_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_checker_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_review_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_revision_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_payment_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    package_hash: Mapped[str] = mapped_column(String(128), nullable=False)
+    artifact_hash_manifest: Mapped[list[dict]] = mapped_column(JSON, nullable=False, default=list)
+    artifact_manifest_hash: Mapped[str] = mapped_column(String(128), nullable=False)
+    passed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    warning_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    failed_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    blocking_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    queued_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    failure_code: Mapped[str | None] = mapped_column(String(100))
+    failure_message: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    results: Mapped[list[CheckerResult]] = relationship(
+        back_populates="checker_run",
+        cascade="all, delete-orphan",
+    )
+
+
+class CheckerResult(Base):
+    """One immutable checker result produced inside a durable checker run."""
+
+    __tablename__ = "checker_results"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    checker_run_id: Mapped[str] = mapped_column(
+        ForeignKey("checker_runs.id"),
+        nullable=False,
+        index=True,
+    )
+    task_id: Mapped[str] = mapped_column(ForeignKey("workstream_tasks.id"), nullable=False, index=True)
+    submission_id: Mapped[str] = mapped_column(ForeignKey("submissions.id"), nullable=False, index=True)
+    checker_name: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(30), nullable=False)
+    severity: Mapped[str] = mapped_column(String(30), nullable=False)
+    blocks_review: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    worker_message: Mapped[str | None] = mapped_column(Text)
+    worker_suggested_fix: Mapped[str | None] = mapped_column(Text)
+    worker_evidence_refs: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    worker_visible: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, index=True)
+    metadata_json: Mapped[dict] = mapped_column("metadata", JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    checker_run: Mapped[CheckerRun] = relationship(back_populates="results")

--- a/backend/app/modules/checkers/repository.py
+++ b/backend/app/modules/checkers/repository.py
@@ -1,0 +1,90 @@
+"""Database access methods for checker runs and checker results."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.modules.checkers.models import CheckerRun
+
+
+class CheckerRepository:
+    """Wraps SQLAlchemy persistence for checker records."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Create a repository bound to one database session.
+
+        Args:
+            session: Async SQLAlchemy session for the current unit of work.
+        """
+        self._session = session
+
+    async def add_run(self, checker_run: CheckerRun) -> CheckerRun:
+        """Persist a checker run and its result rows.
+
+        Args:
+            checker_run: Checker run model with result rows attached.
+
+        Returns:
+            Persisted checker run with generated database fields refreshed.
+        """
+        self._session.add(checker_run)
+        await self._session.flush()
+        await self._session.refresh(checker_run)
+        return checker_run
+
+    async def get_run(self, checker_run_id: str) -> CheckerRun | None:
+        """Load one checker run with result rows.
+
+        Args:
+            checker_run_id: Checker run id to load.
+
+        Returns:
+            Checker run when found; otherwise ``None``.
+        """
+        result = await self._session.execute(
+            select(CheckerRun)
+            .options(selectinload(CheckerRun.results))
+            .where(CheckerRun.id == checker_run_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_runs_for_submission(self, submission_id: str) -> Sequence[CheckerRun]:
+        """List checker runs for one submission.
+
+        Args:
+            submission_id: Submission id whose checker runs should be listed.
+
+        Returns:
+            Checker runs ordered by attempt number.
+        """
+        result = await self._session.execute(
+            select(CheckerRun)
+            .options(selectinload(CheckerRun.results))
+            .where(CheckerRun.submission_id == submission_id)
+            .order_by(CheckerRun.attempt_number.asc())
+        )
+        return result.scalars().all()
+
+    async def get_current_run_for_submission(self, submission_id: str) -> CheckerRun | None:
+        """Load the current checker run for one submission.
+
+        Args:
+            submission_id: Submission id whose current checker run should be loaded.
+
+        Returns:
+            Current checker run when present; otherwise ``None``.
+        """
+        result = await self._session.execute(
+            select(CheckerRun)
+            .options(selectinload(CheckerRun.results))
+            .where(
+                CheckerRun.submission_id == submission_id,
+                CheckerRun.is_current_for_submission.is_(True),
+            )
+        )
+        return result.scalar_one_or_none()
+

--- a/backend/app/modules/checkers/router.py
+++ b/backend/app/modules/checkers/router.py
@@ -1,0 +1,113 @@
+"""FastAPI routes for checker feedback and durable checker runs."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps.auth import get_current_actor
+from app.core.permissions import PermissionDenied
+from app.db.session import get_db_session
+from app.modules.checkers.schemas import (
+    CheckerRunRequest,
+    CheckerRunResponse,
+    PreSubmitCheckRequest,
+    PreSubmitCheckResponse,
+)
+from app.modules.checkers.service import CheckerService, CheckerServiceError
+from app.schemas.auth import ActorContext
+
+router = APIRouter(tags=["checkers"])
+
+
+def checker_http_error(exc: CheckerServiceError) -> HTTPException:
+    """Convert a checker service error into an HTTP error.
+
+    Args:
+        exc: Checker service exception with an API status code.
+
+    Returns:
+        HTTP exception carrying the service error details.
+    """
+    return HTTPException(status_code=exc.status_code, detail=str(exc))
+
+
+def permission_http_error(exc: PermissionDenied) -> HTTPException:
+    """Convert a permission failure into a 403 HTTP error.
+
+    Args:
+        exc: Permission exception raised by the service layer.
+
+    Returns:
+        HTTP exception with a forbidden status.
+    """
+    return HTTPException(status_code=403, detail=str(exc))
+
+
+@router.post("/tasks/{task_id}/submission-precheck", response_model=PreSubmitCheckResponse)
+async def pre_submit_check(
+    task_id: str,
+    payload: PreSubmitCheckRequest,
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> PreSubmitCheckResponse:
+    """Return non-authoritative static checker feedback for a draft packet."""
+    try:
+        return await CheckerService(session).pre_submit_check(actor, task_id, payload.submission)
+    except PermissionDenied as exc:
+        raise permission_http_error(exc) from exc
+    except CheckerServiceError as exc:
+        raise checker_http_error(exc) from exc
+
+
+@router.post("/submissions/{submission_id}/checker-runs", response_model=CheckerRunResponse)
+async def run_submission_checkers(
+    submission_id: str,
+    payload: CheckerRunRequest,
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> CheckerRunResponse:
+    """Trigger a durable internal checker run for a locked submission."""
+    try:
+        return await CheckerService(session).run_submission_checkers(
+            actor,
+            submission_id,
+            payload.trigger_reason,
+        )
+    except PermissionDenied as exc:
+        raise permission_http_error(exc) from exc
+    except CheckerServiceError as exc:
+        raise checker_http_error(exc) from exc
+
+
+@router.get("/submissions/{submission_id}/checker-runs", response_model=list[CheckerRunResponse])
+async def list_submission_checker_runs(
+    submission_id: str,
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> list[CheckerRunResponse]:
+    """Return checker runs for one visible submission."""
+    try:
+        return await CheckerService(session).list_submission_checker_runs(actor, submission_id)
+    except PermissionDenied as exc:
+        raise permission_http_error(exc) from exc
+    except CheckerServiceError as exc:
+        raise checker_http_error(exc) from exc
+
+
+@router.get("/checker-runs/{checker_run_id}", response_model=CheckerRunResponse)
+async def get_checker_run(
+    checker_run_id: str,
+    actor: Annotated[ActorContext, Depends(get_current_actor)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> CheckerRunResponse:
+    """Return one visible checker run."""
+    try:
+        return await CheckerService(session).get_checker_run(actor, checker_run_id)
+    except PermissionDenied as exc:
+        raise permission_http_error(exc) from exc
+    except CheckerServiceError as exc:
+        raise checker_http_error(exc) from exc
+

--- a/backend/app/modules/checkers/runner.py
+++ b/backend/app/modules/checkers/runner.py
@@ -320,7 +320,7 @@ async def check_policy_context_present(context: CheckerContext) -> CheckerOutcom
         return _fail(
             "check_policy_context_present",
             f"Submission is missing locked policy context: {', '.join(missing)}.",
-            "Ask the operator to re-screen the task before submitting.",
+            "Ask a project manager to re-screen the task before submitting.",
             metadata={"missing_context": missing},
         )
     return _pass("check_policy_context_present", "Submission has locked guide and policy context.")

--- a/backend/app/modules/checkers/runner.py
+++ b/backend/app/modules/checkers/runner.py
@@ -1,0 +1,353 @@
+"""Checker registry, structural checkers, and manifest hashing."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Awaitable
+from typing import Protocol
+
+from app.modules.tasks.models import Submission, WorkstreamTask
+from app.modules.tasks.schemas import SubmissionCreate
+
+CHECKER_STATUS_PASSED = "passed"
+CHECKER_STATUS_WARNING = "warning"
+CHECKER_STATUS_FAILED = "failed"
+
+CHECKER_SEVERITY_INFO = "info"
+CHECKER_SEVERITY_LOW = "low"
+CHECKER_SEVERITY_MEDIUM = "medium"
+CHECKER_SEVERITY_HIGH = "high"
+CHECKER_SEVERITY_CRITICAL = "critical"
+
+BLOCKING_SEVERITIES = {CHECKER_SEVERITY_HIGH, CHECKER_SEVERITY_CRITICAL}
+
+
+class CheckerNameConflict(ValueError):
+    """Raised when duplicate checker names are registered."""
+
+
+class UnknownChecker(ValueError):
+    """Raised when a policy references an unregistered checker."""
+
+
+class ArtifactManifestError(ValueError):
+    """Raised when an artifact manifest cannot be canonicalized."""
+
+
+@dataclass(frozen=True)
+class CheckerOutcome:
+    """In-memory checker result before persistence."""
+
+    checker_name: str
+    status: str
+    severity: str
+    message: str
+    blocks_review: bool = False
+    worker_message: str | None = None
+    worker_suggested_fix: str | None = None
+    worker_evidence_refs: list[str] = field(default_factory=list)
+    worker_visible: bool = True
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class CheckerContext:
+    """Data available to structural checkers."""
+
+    task: WorkstreamTask
+    submission: Submission
+    required_checker_names: frozenset[str]
+    warning_checker_names: frozenset[str]
+    blocking_severities: frozenset[str]
+
+
+class Checker(Protocol):
+    """Protocol implemented by registered checkers."""
+
+    name: str
+
+    async def run(self, context: CheckerContext) -> CheckerOutcome:
+        """Run the checker against a locked submission context."""
+
+
+CheckerHandler = Callable[[CheckerContext], Awaitable[CheckerOutcome]]
+
+
+class FunctionChecker:
+    """Checker adapter around a plain callable."""
+
+    def __init__(self, name: str, handler: "CheckerHandler") -> None:
+        """Create a named checker.
+
+        Args:
+            name: Canonical checker name referenced by checker policies.
+            handler: Function that evaluates a checker context.
+        """
+        self.name = name
+        self._handler = handler
+
+    async def run(self, context: CheckerContext) -> CheckerOutcome:
+        """Run the wrapped checker handler."""
+        return await self._handler(context)
+
+
+class CheckerRegistry:
+    """Registry of canonical checker implementations."""
+
+    def __init__(self) -> None:
+        """Create an empty checker registry."""
+        self._checkers: dict[str, Checker] = {}
+
+    def register(self, checker: Checker) -> None:
+        """Register one checker implementation by canonical name.
+
+        Args:
+            checker: Checker implementation to register.
+
+        Raises:
+            CheckerNameConflict: If another checker already owns the same name.
+        """
+        if checker.name in self._checkers:
+            raise CheckerNameConflict(f"checker already registered: {checker.name}")
+        self._checkers[checker.name] = checker
+
+    def require_registered(self, checker_names: set[str]) -> None:
+        """Validate that all policy checker names have implementations.
+
+        Args:
+            checker_names: Checker names from locked checker policy.
+
+        Raises:
+            UnknownChecker: If any checker name is not registered.
+        """
+        missing = sorted(checker_names.difference(self._checkers))
+        if missing:
+            raise UnknownChecker(f"unregistered checker policy names: {', '.join(missing)}")
+
+    async def run(
+        self,
+        context: CheckerContext,
+        checker_names: list[str],
+    ) -> list[CheckerOutcome]:
+        """Run checkers in policy order.
+
+        Args:
+            context: Locked checker context.
+            checker_names: Canonical checker names to execute.
+
+        Returns:
+            Checker outcomes in the same order as ``checker_names``.
+        """
+        self.require_registered(set(checker_names))
+        return [await self._checkers[name].run(context) for name in checker_names]
+
+    def names(self) -> set[str]:
+        """Return all registered checker names."""
+        return set(self._checkers)
+
+
+def canonical_artifact_manifest_hash(manifest: list[dict]) -> str:
+    """Hash a submission artifact manifest using Workstream canonical JSON.
+
+    Args:
+        manifest: Artifact hash entries persisted on a submission.
+
+    Returns:
+        SHA-256 digest prefixed with ``sha256:``.
+
+    Raises:
+        ArtifactManifestError: If duplicate artifacts or invalid entries are present.
+    """
+    seen_artifacts: set[str] = set()
+    canonical_entries: list[dict] = []
+    for entry in manifest:
+        artifact = str(entry.get("artifact", "")).strip()
+        artifact_hash = str(entry.get("hash", "")).strip()
+        if not artifact or not artifact_hash:
+            raise ArtifactManifestError("artifact manifest entries require artifact and hash")
+        if artifact in seen_artifacts:
+            raise ArtifactManifestError(f"duplicate artifact in manifest: {artifact}")
+        seen_artifacts.add(artifact)
+        canonical_entries.append(
+            {
+                "artifact": artifact,
+                "hash": artifact_hash,
+                "notes": entry.get("notes"),
+                "size_bytes": entry.get("size_bytes"),
+            }
+        )
+    encoded = json.dumps(
+        sorted(canonical_entries, key=lambda item: (item["artifact"], item["hash"])),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+async def pre_submit_static_feedback(
+    task: WorkstreamTask,
+    payload: SubmissionCreate,
+) -> list[CheckerOutcome]:
+    """Run non-authoritative structural checks before a submission is created.
+
+    Args:
+        task: Task receiving the draft packet.
+        payload: Draft submission packet payload.
+
+    Returns:
+        Worker-facing checker feedback items. These are not durable gate records.
+    """
+    outcomes: list[CheckerOutcome] = []
+    manifest = [entry.model_dump() for entry in payload.artifact_hash_manifest]
+    outcomes.append(_packet_shape_outcome(payload.summary, payload.package_hash, manifest))
+    outcomes.append(_artifact_manifest_outcome(manifest))
+    outcomes.append(_evidence_reference_outcome(len(payload.evidence_items), task.required_evidence))
+    return outcomes
+
+
+def _pass(name: str, message: str, *, metadata: dict | None = None) -> CheckerOutcome:
+    """Build a passing checker outcome."""
+    return CheckerOutcome(
+        checker_name=name,
+        status=CHECKER_STATUS_PASSED,
+        severity=CHECKER_SEVERITY_INFO,
+        message=message,
+        worker_message=message,
+        metadata=metadata or {},
+    )
+
+
+def _fail(
+    name: str,
+    message: str,
+    suggested_fix: str,
+    *,
+    metadata: dict | None = None,
+    worker_visible: bool = True,
+) -> CheckerOutcome:
+    """Build a worker-fixable failing checker outcome."""
+    return CheckerOutcome(
+        checker_name=name,
+        status=CHECKER_STATUS_FAILED,
+        severity=CHECKER_SEVERITY_HIGH,
+        message=message,
+        blocks_review=True,
+        worker_message=message if worker_visible else None,
+        worker_suggested_fix=suggested_fix if worker_visible else None,
+        worker_visible=worker_visible,
+        metadata=metadata or {},
+    )
+
+
+def _packet_shape_outcome(summary: str, package_hash: str, manifest: list[dict]) -> CheckerOutcome:
+    """Validate required packet fields shared by pre-submit and durable checks."""
+    missing: list[str] = []
+    if not summary.strip():
+        missing.append("summary")
+    if not package_hash.strip():
+        missing.append("package_hash")
+    if not manifest:
+        missing.append("artifact_hash_manifest")
+    if missing:
+        return _fail(
+            "check_submission_packet",
+            f"Submission packet is missing required fields: {', '.join(missing)}.",
+            "Add the missing packet fields before submitting.",
+            metadata={"missing_fields": missing},
+        )
+    return _pass("check_submission_packet", "Submission packet contains required fields.")
+
+
+def _artifact_manifest_outcome(manifest: list[dict]) -> CheckerOutcome:
+    """Validate manifest canonicalization and expose the derived hash."""
+    try:
+        manifest_hash = canonical_artifact_manifest_hash(manifest)
+    except ArtifactManifestError as exc:
+        return _fail(
+            "check_artifact_manifest_integrity",
+            str(exc),
+            "Use one unique artifact entry per artifact and include its hash.",
+        )
+    return _pass(
+        "check_artifact_manifest_integrity",
+        "Artifact manifest is canonical and hashable.",
+        metadata={"artifact_manifest_hash": manifest_hash},
+    )
+
+
+def _evidence_reference_outcome(
+    evidence_count: int,
+    required_evidence: list[str],
+) -> CheckerOutcome:
+    """Validate that required-evidence tasks include evidence rows."""
+    if required_evidence and evidence_count == 0:
+        return _fail(
+            "check_evidence_references_present",
+            "Submission is missing required evidence references.",
+            "Attach evidence items required by the task before submitting.",
+            metadata={"required_evidence": required_evidence},
+        )
+    return _pass("check_evidence_references_present", "Submission includes evidence references.")
+
+
+async def check_submission_packet(context: CheckerContext) -> CheckerOutcome:
+    """Validate required submission packet fields after the packet is locked."""
+    return _packet_shape_outcome(
+        context.submission.summary,
+        context.submission.package_hash,
+        context.submission.artifact_hash_manifest,
+    )
+
+
+async def check_policy_context_present(context: CheckerContext) -> CheckerOutcome:
+    """Validate that the submission carries all locked guide and policy versions."""
+    missing = [
+        name
+        for name, value in {
+            "locked_guide_version": context.submission.locked_guide_version,
+            "locked_checker_policy_version": context.submission.locked_checker_policy_version,
+            "locked_review_policy_version": context.submission.locked_review_policy_version,
+            "locked_revision_policy_version": context.submission.locked_revision_policy_version,
+            "locked_payment_policy_version": context.submission.locked_payment_policy_version,
+        }.items()
+        if not value
+    ]
+    if missing:
+        return _fail(
+            "check_policy_context_present",
+            f"Submission is missing locked policy context: {', '.join(missing)}.",
+            "Ask the operator to re-screen the task before submitting.",
+            metadata={"missing_context": missing},
+        )
+    return _pass("check_policy_context_present", "Submission has locked guide and policy context.")
+
+
+async def check_artifact_manifest_integrity(context: CheckerContext) -> CheckerOutcome:
+    """Validate artifact manifest uniqueness and canonical hashability."""
+    return _artifact_manifest_outcome(context.submission.artifact_hash_manifest)
+
+
+async def check_evidence_references_present(context: CheckerContext) -> CheckerOutcome:
+    """Validate that evidence references exist when the task requires evidence."""
+    return _evidence_reference_outcome(
+        len(context.submission.evidence_items),
+        context.task.required_evidence,
+    )
+
+
+def default_checker_registry() -> CheckerRegistry:
+    """Create the built-in checker registry for v0.1 structural checks."""
+    registry = CheckerRegistry()
+    registry.register(FunctionChecker("check_submission_packet", check_submission_packet))
+    registry.register(FunctionChecker("check_policy_context_present", check_policy_context_present))
+    registry.register(
+        FunctionChecker("check_artifact_manifest_integrity", check_artifact_manifest_integrity)
+    )
+    registry.register(
+        FunctionChecker("check_evidence_references_present", check_evidence_references_present)
+    )
+    return registry

--- a/backend/app/modules/checkers/schemas.py
+++ b/backend/app/modules/checkers/schemas.py
@@ -18,7 +18,7 @@ CheckerRoutingRecommendation = Literal[
     "not_evaluated",
     "allow_review",
     "needs_revision",
-    "operator_retry",
+    "checker_retry",
 ]
 CheckerOutcomeSource = Literal["none", "auto_checker"]
 

--- a/backend/app/modules/checkers/schemas.py
+++ b/backend/app/modules/checkers/schemas.py
@@ -12,6 +12,8 @@ from app.modules.tasks.schemas import SubmissionCreate
 CheckerStatus = Literal["queued", "running", "completed", "failed"]
 CheckerResultStatus = Literal["passed", "warning", "failed"]
 CheckerSeverity = Literal["info", "low", "medium", "high", "critical"]
+# Checker routing recommendations are not human review decision tokens.
+# Human review decisions remain only: accept, needs_revision, reject.
 CheckerRoutingRecommendation = Literal[
     "not_evaluated",
     "allow_review",

--- a/backend/app/modules/checkers/schemas.py
+++ b/backend/app/modules/checkers/schemas.py
@@ -1,0 +1,137 @@
+"""Pydantic schemas for checker feedback, runs, and results."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.modules.tasks.schemas import SubmissionCreate
+
+CheckerStatus = Literal["queued", "running", "completed", "failed"]
+CheckerResultStatus = Literal["passed", "warning", "failed"]
+CheckerSeverity = Literal["info", "low", "medium", "high", "critical"]
+CheckerRoutingRecommendation = Literal[
+    "not_evaluated",
+    "allow_review",
+    "needs_revision",
+    "operator_retry",
+]
+CheckerOutcomeSource = Literal["none", "auto_checker"]
+
+
+class CheckerRunRequest(BaseModel):
+    """Request schema for manually triggering an internal checker run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trigger_reason: str = Field(min_length=1, max_length=1000)
+
+    @field_validator("trigger_reason")
+    @classmethod
+    def require_non_empty_reason(cls, value: str) -> str:
+        """Require a non-empty audit reason after trimming whitespace."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("trigger_reason must not be blank")
+        return stripped
+
+
+class PreSubmitCheckRequest(BaseModel):
+    """Request schema for non-authoritative pre-submit checker feedback."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    submission: SubmissionCreate
+
+
+class CheckerFeedbackItem(BaseModel):
+    """Worker-facing checker feedback item."""
+
+    checker_name: str
+    status: CheckerResultStatus
+    severity: CheckerSeverity
+    would_block_if_submitted: bool
+    worker_message: str
+    worker_suggested_fix: str | None = None
+    worker_evidence_refs: list[str] = Field(default_factory=list)
+
+
+class PreSubmitCheckResponse(BaseModel):
+    """Response schema for non-authoritative pre-submit feedback."""
+
+    task_id: str
+    authoritative: Literal[False] = False
+    status: Literal["passed", "failed"]
+    eligible_to_submit: bool
+    results: list[CheckerFeedbackItem]
+
+
+class CheckerResultResponse(BaseModel):
+    """Response schema for one persisted checker result."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    checker_run_id: str
+    task_id: str
+    submission_id: str
+    checker_name: str
+    status: CheckerResultStatus
+    severity: CheckerSeverity
+    blocks_review: bool
+    message: str | None = None
+    worker_message: str | None = None
+    worker_suggested_fix: str | None = None
+    worker_evidence_refs: list[str] = Field(default_factory=list)
+    worker_visible: bool
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        validation_alias="metadata_json",
+        serialization_alias="metadata",
+    )
+    created_at: datetime
+
+
+class CheckerRunResponse(BaseModel):
+    """Response schema for one persisted checker run with results."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    task_id: str
+    submission_id: str
+    submission_version: int
+    trigger_source: str
+    status: CheckerStatus
+    routing_recommendation: CheckerRoutingRecommendation
+    outcome_source: CheckerOutcomeSource
+    triggered_by: str | None
+    triggered_by_subject: str | None
+    triggered_by_issuer: str | None
+    trigger_auth_source: str | None
+    trigger_reason: str | None
+    audit_event_id: str | None
+    attempt_number: int
+    supersedes_checker_run_id: str | None
+    is_current_for_submission: bool
+    locked_guide_version: str | None
+    locked_checker_policy_version: str | None
+    locked_review_policy_version: str | None
+    locked_revision_policy_version: str | None
+    locked_payment_policy_version: str | None
+    package_hash: str | None
+    artifact_hash_manifest: list[dict[str, Any]]
+    artifact_manifest_hash: str | None
+    passed_count: int
+    warning_count: int
+    failed_count: int
+    blocking_count: int
+    queued_at: datetime
+    started_at: datetime | None
+    completed_at: datetime | None
+    failure_code: str | None
+    failure_message: str | None
+    created_at: datetime
+    results: list[CheckerResultResponse] = Field(default_factory=list)

--- a/backend/app/modules/checkers/service.py
+++ b/backend/app/modules/checkers/service.py
@@ -1,0 +1,574 @@
+"""Service layer for checker feedback, execution, and visibility."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import require_any_role
+from app.modules.checkers.models import CheckerResult, CheckerRun
+from app.modules.checkers.repository import CheckerRepository
+from app.modules.checkers.runner import (
+    CheckerContext,
+    CheckerOutcome,
+    UnknownChecker,
+    canonical_artifact_manifest_hash,
+    default_checker_registry,
+    pre_submit_static_feedback,
+)
+from app.modules.checkers.schemas import (
+    CheckerFeedbackItem,
+    CheckerResultResponse,
+    CheckerRunResponse,
+    PreSubmitCheckResponse,
+)
+from app.modules.projects.repository import ProjectRepository
+from app.modules.tasks.lifecycle import TASK_STATUS_IN_PROGRESS, TASK_STATUS_SUBMITTED
+from app.modules.tasks.models import AuditEvent, Submission, WorkstreamTask
+from app.modules.tasks.repository import TaskRepository
+from app.modules.tasks.schemas import SubmissionCreate
+from app.schemas.auth import ActorContext
+
+CHECKER_OPERATOR_ROLES = {"admin", "project_manager"}
+CHECKER_READ_ROLES = {"admin", "project_manager", "worker"}
+
+
+class CheckerServiceError(Exception):
+    """Base class for checker service errors."""
+
+    status_code = 400
+
+
+class CheckerRunNotFound(CheckerServiceError):
+    """Raised when a checker run id is unknown or hidden."""
+
+    status_code = 404
+
+
+class CheckerSubmissionNotFound(CheckerServiceError):
+    """Raised when a submission id is unknown or hidden."""
+
+    status_code = 404
+
+
+class CheckerTaskNotFound(CheckerServiceError):
+    """Raised when a task id is unknown or hidden."""
+
+    status_code = 404
+
+
+class CheckerExecutionBlocked(CheckerServiceError):
+    """Raised when a checker run cannot be created for the current state."""
+
+    status_code = 409
+
+
+class CheckerPolicyInvalid(CheckerServiceError):
+    """Raised when locked checker policy names cannot be resolved."""
+
+    status_code = 422
+
+
+class CheckerConflict(CheckerServiceError):
+    """Raised when concurrent checker run attempts conflict."""
+
+    status_code = 409
+
+
+class CheckerService:
+    """Coordinates checker feedback, durable runs, and result redaction."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Create a checker service bound to one database session.
+
+        Args:
+            session: Async SQLAlchemy session for this request.
+        """
+        self._session = session
+        self._task_repo = TaskRepository(session)
+        self._project_repo = ProjectRepository(session)
+        self._checker_repo = CheckerRepository(session)
+        self._registry = default_checker_registry()
+
+    async def pre_submit_check(
+        self,
+        actor: ActorContext,
+        task_id: str,
+        payload: SubmissionCreate,
+    ) -> PreSubmitCheckResponse:
+        """Return non-authoritative static feedback for a draft submission.
+
+        Args:
+            actor: Trusted actor resolved from the Flow token.
+            task_id: Task receiving the draft submission.
+            payload: Draft submission packet payload.
+
+        Returns:
+            Worker-facing pre-submit feedback.
+        """
+        task = await self._get_task_for_actor(actor, task_id)
+        if "worker" in actor.roles and task.status != TASK_STATUS_IN_PROGRESS:
+            raise CheckerExecutionBlocked("task must be in progress for worker pre-submit checks")
+        outcomes = await pre_submit_static_feedback(task, payload)
+        eligible_to_submit = not any(outcome.blocks_review for outcome in outcomes)
+        return PreSubmitCheckResponse(
+            task_id=task.id,
+            status="passed" if eligible_to_submit else "failed",
+            eligible_to_submit=eligible_to_submit,
+            results=[self._feedback_item(outcome) for outcome in outcomes],
+        )
+
+    async def run_submission_checkers(
+        self,
+        actor: ActorContext,
+        submission_id: str,
+        trigger_reason: str,
+    ) -> CheckerRunResponse:
+        """Run registered checkers against one locked submission.
+
+        Args:
+            actor: Trusted operator actor resolved from the Flow token.
+            submission_id: Submission whose latest locked packet should be checked.
+            trigger_reason: Audit reason for the manual v0.1 trigger.
+
+        Returns:
+            Persisted checker run response.
+
+        Raises:
+            PermissionDenied: If the actor cannot trigger internal checks.
+            CheckerExecutionBlocked: If the submission is not locked or not checkable.
+            CheckerPolicyInvalid: If the locked checker policy references unknown names.
+        """
+        require_any_role(actor, CHECKER_OPERATOR_ROLES)
+        submission = await self._get_submission(submission_id)
+        task = await self._get_task_for_actor(actor, submission.task_id)
+        if submission.locked_at is None:
+            raise CheckerExecutionBlocked("submission must be locked before internal checkers run")
+        if task.status != TASK_STATUS_SUBMITTED:
+            raise CheckerExecutionBlocked("task must be submitted before internal checkers run")
+        latest_submission = await self._task_repo.get_latest_submission_for_task(task.id)
+        if latest_submission is None or latest_submission.id != submission.id:
+            raise CheckerExecutionBlocked("only latest submission version can be checked")
+
+        checker_policy = await self._project_repo.get_checker_policy(
+            task.project_id,
+            submission.locked_checker_policy_version,
+        )
+        if checker_policy is None:
+            raise CheckerPolicyInvalid("locked checker policy not found")
+
+        required_names = list(checker_policy.required_checkers or [])
+        warning_names = list(checker_policy.warning_checkers or [])
+        checker_names = list(
+            dict.fromkeys(
+                [
+                    "check_submission_packet",
+                    "check_policy_context_present",
+                    "check_artifact_manifest_integrity",
+                    "check_evidence_references_present",
+                    *required_names,
+                    *warning_names,
+                ]
+            )
+        )
+        try:
+            self._registry.require_registered(set(checker_names))
+        except UnknownChecker as exc:
+            raise CheckerPolicyInvalid(str(exc)) from exc
+        try:
+            artifact_manifest_hash = canonical_artifact_manifest_hash(
+                submission.artifact_hash_manifest,
+            )
+        except ValueError:
+            artifact_manifest_hash = "invalid:artifact_manifest"
+
+        current_run = await self._checker_repo.get_current_run_for_submission(submission.id)
+        if current_run is not None:
+            current_run.is_current_for_submission = False
+        attempt_number = 1 if current_run is None else current_run.attempt_number + 1
+
+        context = CheckerContext(
+            task=task,
+            submission=submission,
+            required_checker_names=frozenset(required_names),
+            warning_checker_names=frozenset(warning_names),
+            blocking_severities=frozenset(checker_policy.blocking_severities or []),
+        )
+        now = datetime.now(UTC)
+        outcomes = self._apply_blocking_policy(
+            await self._registry.run(context, checker_names),
+            context,
+        )
+        audit_event = await self._write_checker_audit(
+            actor,
+            task,
+            submission,
+            attempt_number,
+            trigger_reason,
+        )
+        checker_run = self._build_checker_run(
+            actor=actor,
+            submission=submission,
+            outcomes=outcomes,
+            artifact_manifest_hash=artifact_manifest_hash,
+            attempt_number=attempt_number,
+            supersedes_checker_run_id=None if current_run is None else current_run.id,
+            trigger_reason=trigger_reason,
+            audit_event_id=audit_event.id,
+            now=now,
+        )
+        try:
+            checker_run = await self._checker_repo.add_run(checker_run)
+            await self._session.commit()
+        except IntegrityError as exc:
+            await self._session.rollback()
+            raise CheckerConflict("checker run conflicted with another attempt; retry") from exc
+
+        persisted = await self._checker_repo.get_run(checker_run.id)
+        if persisted is None:
+            raise CheckerRunNotFound("checker run not found")
+        return self._run_response_for_actor(actor, persisted)
+
+    async def list_submission_checker_runs(
+        self,
+        actor: ActorContext,
+        submission_id: str,
+    ) -> list[CheckerRunResponse]:
+        """List visible checker runs for one submission.
+
+        Args:
+            actor: Trusted actor resolved from the Flow token.
+            submission_id: Submission whose checker runs should be listed.
+
+        Returns:
+            Checker run responses visible to the actor.
+        """
+        require_any_role(actor, CHECKER_READ_ROLES)
+        submission = await self._get_submission(submission_id)
+        await self._get_task_for_actor(actor, submission.task_id)
+        runs = await self._checker_repo.list_runs_for_submission(submission.id)
+        return [self._run_response_for_actor(actor, run) for run in runs]
+
+    async def get_checker_run(self, actor: ActorContext, checker_run_id: str) -> CheckerRunResponse:
+        """Return one visible checker run.
+
+        Args:
+            actor: Trusted actor resolved from the Flow token.
+            checker_run_id: Checker run id to return.
+
+        Returns:
+            Checker run response visible to the actor.
+        """
+        require_any_role(actor, CHECKER_READ_ROLES)
+        checker_run = await self._checker_repo.get_run(checker_run_id)
+        if checker_run is None:
+            raise CheckerRunNotFound("checker run not found")
+        await self._get_task_for_actor(actor, checker_run.task_id)
+        return self._run_response_for_actor(actor, checker_run)
+
+    async def _get_submission(self, submission_id: str) -> Submission:
+        """Load a submission or raise a checker-domain not-found error.
+
+        Args:
+            submission_id: Submission id to load.
+
+        Returns:
+            Matching submission model with evidence loaded by the task repository.
+        """
+        submission = await self._task_repo.get_submission(submission_id)
+        if submission is None:
+            raise CheckerSubmissionNotFound("submission not found")
+        return submission
+
+    async def _get_task_for_actor(self, actor: ActorContext, task_id: str) -> WorkstreamTask:
+        """Load a task and enforce checker object-level visibility.
+
+        Args:
+            actor: Trusted actor resolved from the Flow token.
+            task_id: Task id to load.
+
+        Returns:
+            Visible task model.
+        """
+        require_any_role(actor, CHECKER_READ_ROLES)
+        task = await self._task_repo.get_task(task_id)
+        if task is None:
+            raise CheckerTaskNotFound("task not found")
+        if set(actor.roles).intersection(CHECKER_OPERATOR_ROLES):
+            return task
+        if "worker" in actor.roles and task.assigned_to == actor.actor_id:
+            return task
+        raise CheckerTaskNotFound("task not found")
+
+    def _build_checker_run(
+        self,
+        *,
+        actor: ActorContext,
+        submission: Submission,
+        outcomes: list[CheckerOutcome],
+        artifact_manifest_hash: str,
+        attempt_number: int,
+        supersedes_checker_run_id: str | None,
+        trigger_reason: str,
+        audit_event_id: str,
+        now: datetime,
+    ) -> CheckerRun:
+        """Build a persisted checker run model from checker outcomes.
+
+        Args:
+            actor: Trusted actor that triggered the run.
+            submission: Locked submission being checked.
+            outcomes: Policy-adjusted checker outcomes to persist.
+            artifact_manifest_hash: Canonical or invalid marker manifest hash.
+            attempt_number: Monotonic attempt number for the submission.
+            supersedes_checker_run_id: Previous current run id when retrying.
+            trigger_reason: Operator-supplied audit reason.
+            audit_event_id: Audit event id linked to the manual trigger.
+            now: Timestamp for run start and completion.
+
+        Returns:
+            Checker run model with child result models attached.
+        """
+        blocking_count = sum(1 for outcome in outcomes if outcome.blocks_review)
+        failed_count = sum(1 for outcome in outcomes if outcome.status == "failed")
+        warning_count = sum(1 for outcome in outcomes if outcome.status == "warning")
+        passed_count = sum(1 for outcome in outcomes if outcome.status == "passed")
+        checker_run = CheckerRun(
+            id=str(uuid4()),
+            task_id=submission.task_id,
+            submission_id=submission.id,
+            submission_version=submission.version,
+            trigger_source="manual_operator",
+            status="completed",
+            routing_recommendation="needs_revision" if blocking_count else "allow_review",
+            outcome_source="auto_checker" if blocking_count else "none",
+            triggered_by=actor.actor_id,
+            triggered_by_subject=actor.external_subject,
+            triggered_by_issuer=actor.external_issuer,
+            trigger_auth_source=actor.auth_source,
+            trigger_reason=trigger_reason,
+            audit_event_id=audit_event_id,
+            attempt_number=attempt_number,
+            supersedes_checker_run_id=supersedes_checker_run_id,
+            is_current_for_submission=True,
+            locked_guide_version=submission.locked_guide_version,
+            locked_checker_policy_version=submission.locked_checker_policy_version,
+            locked_review_policy_version=submission.locked_review_policy_version,
+            locked_revision_policy_version=submission.locked_revision_policy_version,
+            locked_payment_policy_version=submission.locked_payment_policy_version,
+            package_hash=submission.package_hash,
+            artifact_hash_manifest=submission.artifact_hash_manifest,
+            artifact_manifest_hash=artifact_manifest_hash,
+            passed_count=passed_count,
+            warning_count=warning_count,
+            failed_count=failed_count,
+            blocking_count=blocking_count,
+            started_at=now,
+            completed_at=now,
+        )
+        checker_run.results = [
+            CheckerResult(
+                id=str(uuid4()),
+                checker_run_id=checker_run.id,
+                task_id=submission.task_id,
+                submission_id=submission.id,
+                checker_name=outcome.checker_name,
+                status=outcome.status,
+                severity=outcome.severity,
+                blocks_review=outcome.blocks_review,
+                message=outcome.message,
+                worker_message=outcome.worker_message,
+                worker_suggested_fix=outcome.worker_suggested_fix,
+                worker_evidence_refs=outcome.worker_evidence_refs,
+                worker_visible=outcome.worker_visible,
+                metadata_json=outcome.metadata,
+            )
+            for outcome in outcomes
+        ]
+        return checker_run
+
+    async def _write_checker_audit(
+        self,
+        actor: ActorContext,
+        task: WorkstreamTask,
+        submission: Submission,
+        attempt_number: int,
+        trigger_reason: str,
+    ) -> AuditEvent:
+        """Persist the audit event for a manual checker trigger.
+
+        Args:
+            actor: Trusted operator actor triggering the checker run.
+            task: Task associated with the submission.
+            submission: Submission being checked.
+            attempt_number: Checker attempt number for the submission.
+            trigger_reason: Operator-supplied audit reason.
+
+        Returns:
+            Persisted audit event linked from the checker run.
+        """
+        audit = actor.audit_context()
+        return await self._task_repo.add_audit_event(
+            AuditEvent(
+                id=str(uuid4()),
+                entity_type="submission",
+                entity_id=submission.id,
+                event_type="checker_run_triggered",
+                from_status=task.status,
+                to_status=task.status,
+                actor_id=audit.actor_id,
+                external_subject=audit.external_subject,
+                external_issuer=audit.external_issuer,
+                actor_roles=list(audit.actor_roles),
+                claim_snapshot=audit.claim_snapshot,
+                auth_source=audit.auth_source,
+                is_dev_auth=audit.is_dev_auth,
+                reason=trigger_reason,
+                event_payload={
+                    "task_id": task.id,
+                    "submission_id": submission.id,
+                    "submission_version": submission.version,
+                    "attempt_number": attempt_number,
+                    "locked_guide_version": submission.locked_guide_version,
+                    "locked_checker_policy_version": submission.locked_checker_policy_version,
+                    "locked_review_policy_version": submission.locked_review_policy_version,
+                    "locked_revision_policy_version": submission.locked_revision_policy_version,
+                    "locked_payment_policy_version": submission.locked_payment_policy_version,
+                },
+            )
+        )
+
+    @staticmethod
+    def _apply_blocking_policy(
+        outcomes: list[CheckerOutcome],
+        context: CheckerContext,
+    ) -> list[CheckerOutcome]:
+        """Apply locked checker policy to raw checker outcomes.
+
+        Args:
+            outcomes: Raw checker outcomes from registered checkers.
+            context: Locked checker context with policy checker names and severities.
+
+        Returns:
+            Outcomes with ``blocks_review`` derived from locked policy.
+        """
+        adjusted: list[CheckerOutcome] = []
+        for outcome in outcomes:
+            blocks_review = (
+                outcome.status == "failed"
+                and (
+                    outcome.checker_name in context.required_checker_names
+                    or outcome.severity in context.blocking_severities
+                )
+            )
+            adjusted.append(replace(outcome, blocks_review=blocks_review))
+        return adjusted
+
+    def _run_response_for_actor(
+        self,
+        actor: ActorContext,
+        checker_run: CheckerRun,
+    ) -> CheckerRunResponse:
+        """Build a checker run response with role-sensitive result redaction.
+
+        Args:
+            actor: Trusted actor requesting the run.
+            checker_run: Persisted checker run with result rows loaded.
+
+        Returns:
+            Checker run response visible to that actor.
+        """
+        is_operator = bool(set(actor.roles).intersection(CHECKER_OPERATOR_ROLES))
+        results = []
+        for result in checker_run.results:
+            if not is_operator and not result.worker_visible:
+                continue
+            results.append(
+                CheckerResultResponse(
+                    id=result.id,
+                    checker_run_id=result.checker_run_id,
+                    task_id=result.task_id,
+                    submission_id=result.submission_id,
+                    checker_name=result.checker_name,
+                    status=result.status,
+                    severity=result.severity,
+                    blocks_review=result.blocks_review,
+                    message=result.message if is_operator else None,
+                    worker_message=result.worker_message,
+                    worker_suggested_fix=result.worker_suggested_fix,
+                    worker_evidence_refs=result.worker_evidence_refs,
+                    worker_visible=result.worker_visible,
+                    metadata=result.metadata_json if is_operator else {},
+                    created_at=result.created_at,
+                )
+            )
+        return CheckerRunResponse(
+            id=checker_run.id,
+            task_id=checker_run.task_id,
+            submission_id=checker_run.submission_id,
+            submission_version=checker_run.submission_version,
+            trigger_source=checker_run.trigger_source,
+            status=checker_run.status,
+            routing_recommendation=checker_run.routing_recommendation,
+            outcome_source=checker_run.outcome_source,
+            triggered_by=checker_run.triggered_by if is_operator else None,
+            triggered_by_subject=checker_run.triggered_by_subject if is_operator else None,
+            triggered_by_issuer=checker_run.triggered_by_issuer if is_operator else None,
+            trigger_auth_source=checker_run.trigger_auth_source if is_operator else None,
+            trigger_reason=checker_run.trigger_reason if is_operator else None,
+            audit_event_id=checker_run.audit_event_id if is_operator else None,
+            attempt_number=checker_run.attempt_number,
+            supersedes_checker_run_id=checker_run.supersedes_checker_run_id,
+            is_current_for_submission=checker_run.is_current_for_submission,
+            locked_guide_version=checker_run.locked_guide_version if is_operator else None,
+            locked_checker_policy_version=(
+                checker_run.locked_checker_policy_version if is_operator else None
+            ),
+            locked_review_policy_version=(
+                checker_run.locked_review_policy_version if is_operator else None
+            ),
+            locked_revision_policy_version=(
+                checker_run.locked_revision_policy_version if is_operator else None
+            ),
+            locked_payment_policy_version=(
+                checker_run.locked_payment_policy_version if is_operator else None
+            ),
+            package_hash=checker_run.package_hash if is_operator else None,
+            artifact_hash_manifest=checker_run.artifact_hash_manifest if is_operator else [],
+            artifact_manifest_hash=checker_run.artifact_manifest_hash if is_operator else None,
+            passed_count=checker_run.passed_count,
+            warning_count=checker_run.warning_count,
+            failed_count=checker_run.failed_count,
+            blocking_count=checker_run.blocking_count,
+            queued_at=checker_run.queued_at,
+            started_at=checker_run.started_at,
+            completed_at=checker_run.completed_at,
+            failure_code=checker_run.failure_code if is_operator else None,
+            failure_message=checker_run.failure_message if is_operator else None,
+            created_at=checker_run.created_at,
+            results=results,
+        )
+
+    @staticmethod
+    def _feedback_item(outcome: CheckerOutcome) -> CheckerFeedbackItem:
+        """Convert an internal checker outcome to pre-submit feedback.
+
+        Args:
+            outcome: Checker outcome from a non-authoritative static check.
+
+        Returns:
+            Worker-facing feedback item.
+        """
+        return CheckerFeedbackItem(
+            checker_name=outcome.checker_name,
+            status=outcome.status,
+            severity=outcome.severity,
+            would_block_if_submitted=outcome.blocks_review,
+            worker_message=outcome.worker_message or "Checker feedback is not worker-visible.",
+            worker_suggested_fix=outcome.worker_suggested_fix,
+            worker_evidence_refs=outcome.worker_evidence_refs,
+        )

--- a/backend/app/modules/checkers/service.py
+++ b/backend/app/modules/checkers/service.py
@@ -33,7 +33,7 @@ from app.modules.tasks.repository import TaskRepository
 from app.modules.tasks.schemas import SubmissionCreate
 from app.schemas.auth import ActorContext
 
-CHECKER_OPERATOR_ROLES = {"admin", "project_manager"}
+CHECKER_TRIGGER_ROLES = {"admin", "project_manager"}
 CHECKER_READ_ROLES = {"admin", "project_manager", "worker"}
 
 
@@ -131,7 +131,7 @@ class CheckerService:
         """Run registered checkers against one locked submission.
 
         Args:
-            actor: Trusted operator actor resolved from the Flow token.
+            actor: Trusted admin or project manager actor resolved from the Flow token.
             submission_id: Submission whose latest locked packet should be checked.
             trigger_reason: Audit reason for the manual v0.1 trigger.
 
@@ -143,7 +143,7 @@ class CheckerService:
             CheckerExecutionBlocked: If the submission is not locked or not checkable.
             CheckerPolicyInvalid: If the locked checker policy references unknown names.
         """
-        require_any_role(actor, CHECKER_OPERATOR_ROLES)
+        require_any_role(actor, CHECKER_TRIGGER_ROLES)
         submission = await self._get_submission(submission_id)
         task = await self._get_task_for_actor(actor, submission.task_id)
         if submission.locked_at is None:
@@ -298,7 +298,7 @@ class CheckerService:
         task = await self._task_repo.get_task(task_id)
         if task is None:
             raise CheckerTaskNotFound("task not found")
-        if set(actor.roles).intersection(CHECKER_OPERATOR_ROLES):
+        if set(actor.roles).intersection(CHECKER_TRIGGER_ROLES):
             return task
         if "worker" in actor.roles and task.assigned_to == actor.actor_id:
             return task
@@ -326,7 +326,7 @@ class CheckerService:
             artifact_manifest_hash: Canonical or invalid marker manifest hash.
             attempt_number: Monotonic attempt number for the submission.
             supersedes_checker_run_id: Previous current run id when retrying.
-            trigger_reason: Operator-supplied audit reason.
+            trigger_reason: Audit reason supplied by the trusted trigger actor.
             audit_event_id: Audit event id linked to the manual trigger.
             now: Timestamp for run start and completion.
 
@@ -342,7 +342,7 @@ class CheckerService:
             task_id=submission.task_id,
             submission_id=submission.id,
             submission_version=submission.version,
-            trigger_source="manual_operator",
+            trigger_source="manual_checker_trigger",
             status="completed",
             routing_recommendation="needs_revision" if blocking_count else "allow_review",
             outcome_source="auto_checker" if blocking_count else "none",
@@ -402,11 +402,11 @@ class CheckerService:
         """Persist the audit event for a manual checker trigger.
 
         Args:
-            actor: Trusted operator actor triggering the checker run.
+            actor: Trusted admin or project manager actor triggering the checker run.
             task: Task associated with the submission.
             submission: Submission being checked.
             attempt_number: Checker attempt number for the submission.
-            trigger_reason: Operator-supplied audit reason.
+            trigger_reason: Audit reason supplied by the trusted trigger actor.
 
         Returns:
             Persisted audit event linked from the checker run.
@@ -482,10 +482,10 @@ class CheckerService:
         Returns:
             Checker run response visible to that actor.
         """
-        is_operator = bool(set(actor.roles).intersection(CHECKER_OPERATOR_ROLES))
+        has_checker_admin_access = bool(set(actor.roles).intersection(CHECKER_TRIGGER_ROLES))
         results = []
         for result in checker_run.results:
-            if not is_operator and not result.worker_visible:
+            if not has_checker_admin_access and not result.worker_visible:
                 continue
             results.append(
                 CheckerResultResponse(
@@ -497,12 +497,12 @@ class CheckerService:
                     status=result.status,
                     severity=result.severity,
                     blocks_review=result.blocks_review,
-                    message=result.message if is_operator else None,
+                    message=result.message if has_checker_admin_access else None,
                     worker_message=result.worker_message,
                     worker_suggested_fix=result.worker_suggested_fix,
                     worker_evidence_refs=result.worker_evidence_refs,
                     worker_visible=result.worker_visible,
-                    metadata=result.metadata_json if is_operator else {},
+                    metadata=result.metadata_json if has_checker_admin_access else {},
                     created_at=result.created_at,
                 )
             )
@@ -515,31 +515,43 @@ class CheckerService:
             status=checker_run.status,
             routing_recommendation=checker_run.routing_recommendation,
             outcome_source=checker_run.outcome_source,
-            triggered_by=checker_run.triggered_by if is_operator else None,
-            triggered_by_subject=checker_run.triggered_by_subject if is_operator else None,
-            triggered_by_issuer=checker_run.triggered_by_issuer if is_operator else None,
-            trigger_auth_source=checker_run.trigger_auth_source if is_operator else None,
-            trigger_reason=checker_run.trigger_reason if is_operator else None,
-            audit_event_id=checker_run.audit_event_id if is_operator else None,
+            triggered_by=checker_run.triggered_by if has_checker_admin_access else None,
+            triggered_by_subject=(
+                checker_run.triggered_by_subject if has_checker_admin_access else None
+            ),
+            triggered_by_issuer=(
+                checker_run.triggered_by_issuer if has_checker_admin_access else None
+            ),
+            trigger_auth_source=(
+                checker_run.trigger_auth_source if has_checker_admin_access else None
+            ),
+            trigger_reason=checker_run.trigger_reason if has_checker_admin_access else None,
+            audit_event_id=checker_run.audit_event_id if has_checker_admin_access else None,
             attempt_number=checker_run.attempt_number,
             supersedes_checker_run_id=checker_run.supersedes_checker_run_id,
             is_current_for_submission=checker_run.is_current_for_submission,
-            locked_guide_version=checker_run.locked_guide_version if is_operator else None,
+            locked_guide_version=(
+                checker_run.locked_guide_version if has_checker_admin_access else None
+            ),
             locked_checker_policy_version=(
-                checker_run.locked_checker_policy_version if is_operator else None
+                checker_run.locked_checker_policy_version if has_checker_admin_access else None
             ),
             locked_review_policy_version=(
-                checker_run.locked_review_policy_version if is_operator else None
+                checker_run.locked_review_policy_version if has_checker_admin_access else None
             ),
             locked_revision_policy_version=(
-                checker_run.locked_revision_policy_version if is_operator else None
+                checker_run.locked_revision_policy_version if has_checker_admin_access else None
             ),
             locked_payment_policy_version=(
-                checker_run.locked_payment_policy_version if is_operator else None
+                checker_run.locked_payment_policy_version if has_checker_admin_access else None
             ),
-            package_hash=checker_run.package_hash if is_operator else None,
-            artifact_hash_manifest=checker_run.artifact_hash_manifest if is_operator else [],
-            artifact_manifest_hash=checker_run.artifact_manifest_hash if is_operator else None,
+            package_hash=checker_run.package_hash if has_checker_admin_access else None,
+            artifact_hash_manifest=(
+                checker_run.artifact_hash_manifest if has_checker_admin_access else []
+            ),
+            artifact_manifest_hash=(
+                checker_run.artifact_manifest_hash if has_checker_admin_access else None
+            ),
             passed_count=checker_run.passed_count,
             warning_count=checker_run.warning_count,
             failed_count=checker_run.failed_count,
@@ -547,8 +559,8 @@ class CheckerService:
             queued_at=checker_run.queued_at,
             started_at=checker_run.started_at,
             completed_at=checker_run.completed_at,
-            failure_code=checker_run.failure_code if is_operator else None,
-            failure_message=checker_run.failure_message if is_operator else None,
+            failure_code=checker_run.failure_code if has_checker_admin_access else None,
+            failure_message=checker_run.failure_message if has_checker_admin_access else None,
             created_at=checker_run.created_at,
             results=results,
         )

--- a/backend/app/modules/tasks/models.py
+++ b/backend/app/modules/tasks/models.py
@@ -227,6 +227,7 @@ class Submission(Base):
             name="fk_submissions_task_locked_payment_policy",
         ),
         UniqueConstraint("task_id", "version", name="uq_submissions_task_version"),
+        UniqueConstraint("id", "version", name="uq_submissions_id_version"),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,12 +1,35 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+import fcntl
 import os
+from pathlib import Path
 
 import pytest
 
 from app.core.config import get_settings
 
 DEFAULT_TEST_DATABASE_URL = "postgresql+asyncpg://workstream:workstream@localhost:5433/workstream"
+DDL_LOCK_PATH = Path("/tmp/workstream-postgres-ddl.lock")
+
+
+@contextmanager
+def postgres_ddl_lock() -> Iterator[None]:
+    """Serialize schema-wide Alembic resets across local pytest processes."""
+    DDL_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with DDL_LOCK_PATH.open("w", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+@pytest.fixture
+def migration_lock():
+    """Return the process-wide Postgres DDL lock context manager."""
+    return postgres_ddl_lock
 
 
 @pytest.fixture

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -6,11 +6,12 @@ from alembic import command
 from alembic.config import Config
 
 
-def test_alembic_upgrade_and_downgrade(isolated_database_env: str) -> None:
+def test_alembic_upgrade_and_downgrade(isolated_database_env: str, migration_lock) -> None:
     project_root = Path(__file__).resolve().parents[1]
     config = Config(str(project_root / "alembic.ini"))
     config.set_main_option("script_location", str(project_root / "alembic"))
 
-    command.downgrade(config, "base")
-    command.upgrade(config, "head")
-    command.downgrade(config, "base")
+    with migration_lock():
+        command.downgrade(config, "base")
+        command.upgrade(config, "head")
+        command.downgrade(config, "base")

--- a/backend/tests/test_checkers.py
+++ b/backend/tests/test_checkers.py
@@ -1,0 +1,616 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import inspect, select
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.schema import CreateIndex
+
+from app.core.config import get_settings
+from app.db import models as db_models
+from app.db import session as db_session
+from app.db.base import Base
+from app.main import create_app
+from app.modules.checkers.models import CheckerResult, CheckerRun
+from app.modules.checkers.runner import canonical_artifact_manifest_hash
+from app.modules.tasks.models import AuditEvent, Submission
+from tests.test_tasks import (
+    auth_headers,
+    complete_guide_payload,
+    complete_submission_payload,
+    create_active_project,
+    create_started_task,
+    seed_worker_profile,
+    set_dev_actor,
+)
+
+
+@pytest.fixture
+def checker_database_env(
+    monkeypatch: pytest.MonkeyPatch,
+    postgres_database_url: str,
+    migration_lock,
+) -> Iterator[str]:
+    monkeypatch.setenv("WORKSTREAM_DATABASE_URL", postgres_database_url)
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    get_settings.cache_clear()
+    asyncio.run(db_session.dispose_engine())
+
+    config = alembic_config()
+    with migration_lock():
+        command.downgrade(config, "base")
+        command.upgrade(config, "head")
+        yield postgres_database_url
+        command.downgrade(config, "base")
+    asyncio.run(db_session.dispose_engine())
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def checker_client(checker_database_env: str) -> AsyncIterator[AsyncClient]:
+    app = create_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        yield client
+
+
+def alembic_config() -> Config:
+    project_root = Path(__file__).resolve().parents[1]
+    config = Config(str(project_root / "alembic.ini"))
+    config.set_main_option("script_location", str(project_root / "alembic"))
+    return config
+
+
+def test_checker_models_are_registered_for_alembic_metadata() -> None:
+    expected_tables = {"checker_runs", "checker_results"}
+
+    assert expected_tables.issubset(Base.metadata.tables)
+    assert db_models.CheckerRun is CheckerRun
+    assert db_models.CheckerResult is CheckerResult
+
+
+async def test_checker_migration_creates_expected_tables(checker_database_env: str) -> None:
+    async with db_session.get_engine().connect() as connection:
+        table_names = await connection.run_sync(
+            lambda sync_connection: set(inspect(sync_connection).get_table_names())
+        )
+
+    assert {"checker_runs", "checker_results"}.issubset(table_names)
+
+
+def test_checker_run_current_partial_unique_index_metadata_compiles() -> None:
+    index = next(
+        index
+        for index in CheckerRun.__table__.indexes
+        if index.name == "uq_checker_runs_current_per_submission"
+    )
+
+    postgres_compiled = str(CreateIndex(index).compile(dialect=postgresql.dialect()))
+
+    assert "is_current_for_submission = true" in postgres_compiled
+
+
+def test_artifact_manifest_hash_is_stable_and_rejects_duplicates() -> None:
+    first = [
+        {"artifact": "b.txt", "hash": "sha256:b", "size_bytes": 2, "notes": None},
+        {"hash": "sha256:a", "artifact": "a.txt", "notes": "main", "size_bytes": 1},
+    ]
+    second = [
+        {"size_bytes": 1, "notes": "main", "artifact": "a.txt", "hash": "sha256:a"},
+        {"notes": None, "artifact": "b.txt", "hash": "sha256:b", "size_bytes": 2},
+    ]
+
+    assert canonical_artifact_manifest_hash(first) == canonical_artifact_manifest_hash(second)
+
+    with pytest.raises(ValueError, match="duplicate artifact"):
+        canonical_artifact_manifest_hash(
+            [
+                {"artifact": "a.txt", "hash": "sha256:a"},
+                {"artifact": "a.txt", "hash": "sha256:b"},
+            ]
+        )
+
+
+async def test_pre_submit_check_returns_feedback_without_durable_run(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    payload = complete_submission_payload()
+    payload["artifact_hash_manifest"].append(
+        {
+            "artifact": "answer.md",
+            "hash": "sha256:duplicate",
+            "size_bytes": 129,
+            "notes": "duplicate",
+        }
+    )
+
+    response = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submission-precheck",
+        headers=auth_headers(),
+        json={"submission": payload},
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["authoritative"] is False
+    assert body["status"] == "failed"
+    assert body["eligible_to_submit"] is False
+    assert any(
+        result["checker_name"] == "check_artifact_manifest_integrity"
+        and result["would_block_if_submitted"] is True
+        for result in body["results"]
+    )
+
+    async with db_session.get_session_factory()() as session:
+        rows = (await session.execute(CheckerRun.__table__.select())).all()
+    assert rows == []
+
+
+async def test_locked_submission_checker_run_persists_results_and_allows_review(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked.status_code == 200, locked.text
+
+    run = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "operator dry run"},
+    )
+
+    assert run.status_code == 200, run.text
+    body = run.json()
+    assert body["status"] == "completed"
+    assert body["routing_recommendation"] == "allow_review"
+    assert body["outcome_source"] == "none"
+    assert body["submission_version"] == 1
+    assert body["locked_checker_policy_version"] == "v1"
+    assert body["artifact_manifest_hash"].startswith("sha256:")
+    assert body["audit_event_id"]
+    assert body["passed_count"] >= 4
+    assert body["blocking_count"] == 0
+    assert {
+        "check_submission_packet",
+        "check_policy_context_present",
+        "check_artifact_manifest_integrity",
+        "check_evidence_references_present",
+    }.issubset({result["checker_name"] for result in body["results"]})
+
+    listed = await checker_client.get(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+    )
+    assert listed.status_code == 200, listed.text
+    assert [item["id"] for item in listed.json()] == [body["id"]]
+
+    async with db_session.get_session_factory()() as session:
+        audit = await session.get(AuditEvent, body["audit_event_id"])
+    assert audit is not None
+    assert audit.event_type == "checker_run_triggered"
+    assert audit.entity_id == created.json()["id"]
+    assert audit.reason == "operator dry run"
+    assert audit.event_payload["submission_version"] == 1
+
+
+async def test_checker_run_retry_supersedes_previous_current_run(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked.status_code == 200, locked.text
+    first = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "first run"},
+    )
+    assert first.status_code == 200, first.text
+
+    second = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "retry run"},
+    )
+
+    assert second.status_code == 200, second.text
+    assert second.json()["attempt_number"] == 2
+    assert second.json()["supersedes_checker_run_id"] == first.json()["id"]
+    listed = await checker_client.get(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+    )
+    assert listed.status_code == 200, listed.text
+    assert [item["attempt_number"] for item in listed.json()] == [1, 2]
+    assert listed.json()[0]["is_current_for_submission"] is False
+    assert listed.json()[1]["is_current_for_submission"] is True
+
+
+async def test_checker_run_with_duplicate_artifact_persists_needs_revision_result(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    payload = complete_submission_payload()
+    payload["artifact_hash_manifest"].append(
+        {
+            "artifact": "answer.md",
+            "hash": "sha256:duplicate",
+            "size_bytes": 129,
+            "notes": "duplicate",
+        }
+    )
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=payload,
+    )
+    assert created.status_code == 201, created.text
+
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked.status_code == 200, locked.text
+
+    run = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "operator dry run"},
+    )
+
+    assert run.status_code == 200, run.text
+    body = run.json()
+    assert body["routing_recommendation"] == "needs_revision"
+    assert body["outcome_source"] == "auto_checker"
+    assert body["artifact_manifest_hash"] == "invalid:artifact_manifest"
+    duplicate_result = next(
+        result
+        for result in body["results"]
+        if result["checker_name"] == "check_artifact_manifest_integrity"
+    )
+    assert duplicate_result["status"] == "failed"
+    assert duplicate_result["blocks_review"] is True
+    assert "duplicate artifact" in duplicate_result["worker_message"]
+
+
+async def test_worker_can_read_only_worker_visible_checker_result_fields(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked.status_code == 200, locked.text
+    run = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "operator dry run"},
+    )
+    assert run.status_code == 200, run.text
+
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-one")
+    read = await checker_client.get(
+        f"/api/v1/checker-runs/{run.json()['id']}",
+        headers=auth_headers(),
+    )
+
+    assert read.status_code == 200, read.text
+    body = read.json()
+    assert body["failure_message"] is None
+    assert body["triggered_by"] is None
+    assert body["triggered_by_subject"] is None
+    assert body["triggered_by_issuer"] is None
+    assert body["trigger_auth_source"] is None
+    assert body["trigger_reason"] is None
+    assert body["audit_event_id"] is None
+    assert body["locked_guide_version"] is None
+    assert body["locked_checker_policy_version"] is None
+    assert body["locked_review_policy_version"] is None
+    assert body["locked_revision_policy_version"] is None
+    assert body["locked_payment_policy_version"] is None
+    assert body["package_hash"] is None
+    assert body["artifact_hash_manifest"] == []
+    assert body["artifact_manifest_hash"] is None
+    assert body["results"]
+    assert all(result["message"] is None for result in body["results"])
+    assert all(result["metadata"] == {} for result in body["results"])
+    assert all(result["worker_visible"] is True for result in body["results"])
+
+
+async def test_worker_cannot_see_hidden_checker_results(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked.status_code == 200, locked.text
+    run = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "operator dry run"},
+    )
+    assert run.status_code == 200, run.text
+
+    async with db_session.get_session_factory()() as session:
+        session.add(
+            CheckerResult(
+                id="hidden-result",
+                checker_run_id=run.json()["id"],
+                task_id=started_task["id"],
+                submission_id=created.json()["id"],
+                checker_name="internal_hidden_checker",
+                status="failed",
+                severity="high",
+                blocks_review=True,
+                message="internal stack and private path",
+                worker_message=None,
+                worker_suggested_fix=None,
+                worker_evidence_refs=[],
+                worker_visible=False,
+                metadata_json={"private_path": "local://private/hidden"},
+            )
+        )
+        await session.commit()
+
+    operator_read = await checker_client.get(
+        f"/api/v1/checker-runs/{run.json()['id']}",
+        headers=auth_headers(),
+    )
+    assert operator_read.status_code == 200, operator_read.text
+    assert "internal_hidden_checker" in {
+        result["checker_name"] for result in operator_read.json()["results"]
+    }
+
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-one")
+    worker_read = await checker_client.get(
+        f"/api/v1/checker-runs/{run.json()['id']}",
+        headers=auth_headers(),
+    )
+    assert worker_read.status_code == 200, worker_read.text
+    worker_names = {result["checker_name"] for result in worker_read.json()["results"]}
+    assert "internal_hidden_checker" not in worker_names
+
+
+async def test_checker_endpoints_reject_unassigned_worker_and_fake_result_payloads(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    payload = complete_submission_payload()
+    payload["status"] = "completed"
+    payload["routing_recommendation"] = "allow_review"
+    payload["results"] = [{"checker_name": "fake", "status": "passed"}]
+
+    fake_precheck = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submission-precheck",
+        headers=auth_headers(),
+        json={"submission": payload},
+    )
+    assert fake_precheck.status_code == 422
+
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked.status_code == 200, locked.text
+    fake_run = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={
+            "trigger_reason": "operator dry run",
+            "status": "completed",
+            "routing_recommendation": "allow_review",
+            "results": [{"checker_name": "fake", "status": "passed"}],
+        },
+    )
+    assert fake_run.status_code == 422
+    blank_reason = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "   "},
+    )
+    assert blank_reason.status_code == 422
+
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-one")
+    worker_run = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "worker tries to trigger"},
+    )
+    assert worker_run.status_code == 403
+
+    await seed_worker_profile("worker-two")
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-two")
+    denied = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submission-precheck",
+        headers=auth_headers(),
+        json={"submission": complete_submission_payload()},
+    )
+    assert denied.status_code == 404
+
+    set_dev_actor(monkeypatch, roles="auditor", subject="auditor-subject")
+    no_role_existing = await checker_client.get(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+    )
+    no_role_missing = await checker_client.get(
+        "/api/v1/submissions/00000000-0000-0000-0000-000000000000/checker-runs",
+        headers=auth_headers(),
+    )
+    assert no_role_existing.status_code == 403
+    assert no_role_missing.status_code == 403
+
+    async with db_session.get_session_factory()() as session:
+        rows = (await session.execute(select(CheckerRun))).scalars().all()
+    assert rows == []
+
+
+async def test_stale_locked_submission_cannot_receive_checker_run(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    first = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert first.status_code == 201, first.text
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked_first = await checker_client.post(
+        f"/api/v1/submissions/{first.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked_first.status_code == 200, locked_first.text
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-one")
+    second_payload = complete_submission_payload("sha256:package-v2")
+    second_payload["artifact_hash_manifest"][0]["hash"] = "sha256:answer-v2"
+    second = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=second_payload,
+    )
+    assert second.status_code == 201, second.text
+
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    stale_run = await checker_client.post(
+        f"/api/v1/submissions/{first.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "stale run"},
+    )
+
+    assert stale_run.status_code == 409
+    assert "latest submission" in stale_run.json()["detail"]
+
+    async with db_session.get_session_factory()() as session:
+        submissions = (
+            await session.execute(
+                select(Submission).where(Submission.id == first.json()["id"])
+            )
+        ).scalars().all()
+    assert submissions[0].version == 1
+
+
+async def test_unknown_policy_checker_blocks_durable_run_without_fake_results(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_response = await checker_client.post(
+        "/api/v1/projects",
+        headers=auth_headers(),
+        json={
+            "name": "Unknown Checker Project",
+            "slug": "unknown-checker-project",
+            "base_amount": "25.00",
+            "currency": "USD",
+        },
+    )
+    assert project_response.status_code == 201, project_response.text
+    project = project_response.json()
+    guide_payload = complete_guide_payload()
+    guide_payload["checker_policy"]["required_checkers"] = ["check_missing_registered_checker"]
+    guide_response = await checker_client.post(
+        f"/api/v1/projects/{project['id']}/guides",
+        headers=auth_headers(),
+        json=guide_payload,
+    )
+    assert guide_response.status_code == 201, guide_response.text
+    activation_response = await checker_client.post(
+        f"/api/v1/projects/{project['id']}/guides/{guide_response.json()['id']}/activate",
+        headers=auth_headers(),
+    )
+    assert activation_response.status_code == 200, activation_response.text
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+    assert locked.status_code == 200, locked.text
+
+    run = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+        json={"trigger_reason": "operator dry run"},
+    )
+
+    assert run.status_code == 422
+    assert "unregistered checker policy names" in run.json()["detail"]
+
+    async with db_session.get_session_factory()() as session:
+        rows = (await session.execute(CheckerRun.__table__.select())).all()
+    assert rows == []

--- a/backend/tests/test_checkers.py
+++ b/backend/tests/test_checkers.py
@@ -8,6 +8,7 @@ import pytest
 from alembic import command
 from alembic.config import Config
 from httpx import ASGITransport, AsyncClient
+from pydantic import TypeAdapter, ValidationError
 from sqlalchemy import inspect, select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.schema import CreateIndex
@@ -19,6 +20,7 @@ from app.db.base import Base
 from app.main import create_app
 from app.modules.checkers.models import CheckerResult, CheckerRun
 from app.modules.checkers.runner import canonical_artifact_manifest_hash
+from app.modules.checkers.schemas import CheckerRoutingRecommendation
 from app.modules.tasks.models import AuditEvent, Submission
 from tests.test_tasks import (
     auth_headers,
@@ -75,6 +77,14 @@ def test_checker_models_are_registered_for_alembic_metadata() -> None:
     assert expected_tables.issubset(Base.metadata.tables)
     assert db_models.CheckerRun is CheckerRun
     assert db_models.CheckerResult is CheckerResult
+
+
+def test_checker_routing_recommendation_schema_uses_checker_retry_token() -> None:
+    adapter = TypeAdapter(CheckerRoutingRecommendation)
+
+    assert adapter.validate_python("checker_retry") == "checker_retry"
+    with pytest.raises(ValidationError):
+        adapter.validate_python("operator" + "_retry")
 
 
 async def test_checker_migration_creates_expected_tables(checker_database_env: str) -> None:
@@ -180,12 +190,13 @@ async def test_locked_submission_checker_run_persists_results_and_allows_review(
     run = await checker_client.post(
         f"/api/v1/submissions/{created.json()['id']}/checker-runs",
         headers=auth_headers(),
-        json={"trigger_reason": "operator dry run"},
+        json={"trigger_reason": "manual checker dry run"},
     )
 
     assert run.status_code == 200, run.text
     body = run.json()
     assert body["status"] == "completed"
+    assert body["trigger_source"] == "manual_checker_trigger"
     assert body["routing_recommendation"] == "allow_review"
     assert body["outcome_source"] == "none"
     assert body["submission_version"] == 1
@@ -213,7 +224,7 @@ async def test_locked_submission_checker_run_persists_results_and_allows_review(
     assert audit is not None
     assert audit.event_type == "checker_run_triggered"
     assert audit.entity_id == created.json()["id"]
-    assert audit.reason == "operator dry run"
+    assert audit.reason == "manual checker dry run"
     assert audit.event_payload["submission_version"] == 1
 
 
@@ -293,7 +304,7 @@ async def test_checker_run_with_duplicate_artifact_persists_needs_revision_resul
     run = await checker_client.post(
         f"/api/v1/submissions/{created.json()['id']}/checker-runs",
         headers=auth_headers(),
-        json={"trigger_reason": "operator dry run"},
+        json={"trigger_reason": "manual checker dry run"},
     )
 
     assert run.status_code == 200, run.text
@@ -332,7 +343,7 @@ async def test_worker_can_read_only_worker_visible_checker_result_fields(
     run = await checker_client.post(
         f"/api/v1/submissions/{created.json()['id']}/checker-runs",
         headers=auth_headers(),
-        json={"trigger_reason": "operator dry run"},
+        json={"trigger_reason": "manual checker dry run"},
     )
     assert run.status_code == 200, run.text
 
@@ -386,7 +397,7 @@ async def test_worker_cannot_see_hidden_checker_results(
     run = await checker_client.post(
         f"/api/v1/submissions/{created.json()['id']}/checker-runs",
         headers=auth_headers(),
-        json={"trigger_reason": "operator dry run"},
+        json={"trigger_reason": "manual checker dry run"},
     )
     assert run.status_code == 200, run.text
 
@@ -411,13 +422,13 @@ async def test_worker_cannot_see_hidden_checker_results(
         )
         await session.commit()
 
-    operator_read = await checker_client.get(
+    manager_read = await checker_client.get(
         f"/api/v1/checker-runs/{run.json()['id']}",
         headers=auth_headers(),
     )
-    assert operator_read.status_code == 200, operator_read.text
+    assert manager_read.status_code == 200, manager_read.text
     assert "internal_hidden_checker" in {
-        result["checker_name"] for result in operator_read.json()["results"]
+        result["checker_name"] for result in manager_read.json()["results"]
     }
 
     set_dev_actor(monkeypatch, roles="worker", subject="worker-one")
@@ -464,7 +475,7 @@ async def test_checker_endpoints_reject_unassigned_worker_and_fake_result_payloa
         f"/api/v1/submissions/{created.json()['id']}/checker-runs",
         headers=auth_headers(),
         json={
-            "trigger_reason": "operator dry run",
+            "trigger_reason": "manual checker dry run",
             "status": "completed",
             "routing_recommendation": "allow_review",
             "results": [{"checker_name": "fake", "status": "passed"}],
@@ -605,7 +616,7 @@ async def test_unknown_policy_checker_blocks_durable_run_without_fake_results(
     run = await checker_client.post(
         f"/api/v1/submissions/{created.json()['id']}/checker-runs",
         headers=auth_headers(),
-        json={"trigger_reason": "operator dry run"},
+        json={"trigger_reason": "manual checker dry run"},
     )
 
     assert run.status_code == 422

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -29,6 +29,7 @@ from app.modules.projects.repository import ProjectRepository, ProjectRepository
 def project_database_env(
     monkeypatch: pytest.MonkeyPatch,
     postgres_database_url: str,
+    migration_lock,
 ) -> Iterator[str]:
     monkeypatch.setenv("WORKSTREAM_DATABASE_URL", postgres_database_url)
     monkeypatch.setenv("WORKSTREAM_AUTH_PROVIDER", "dev")
@@ -43,12 +44,11 @@ def project_database_env(
     project_root = Path(__file__).resolve().parents[1]
     config = Config(str(project_root / "alembic.ini"))
     config.set_main_option("script_location", str(project_root / "alembic"))
-    command.downgrade(config, "base")
-    command.upgrade(config, "head")
-
-    yield postgres_database_url
-
-    command.downgrade(config, "base")
+    with migration_lock():
+        command.downgrade(config, "base")
+        command.upgrade(config, "head")
+        yield postgres_database_url
+        command.downgrade(config, "base")
     asyncio.run(db_session.dispose_engine())
     get_settings.cache_clear()
 

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -38,6 +38,7 @@ from app.modules.tasks.repository import TaskRepository
 def task_database_env(
     monkeypatch: pytest.MonkeyPatch,
     postgres_database_url: str,
+    migration_lock,
 ) -> Iterator[str]:
     monkeypatch.setenv("WORKSTREAM_DATABASE_URL", postgres_database_url)
     set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
@@ -45,12 +46,11 @@ def task_database_env(
     asyncio.run(db_session.dispose_engine())
 
     config = alembic_config()
-    command.downgrade(config, "base")
-    command.upgrade(config, "head")
-
-    yield postgres_database_url
-
-    command.downgrade(config, "base")
+    with migration_lock():
+        command.downgrade(config, "base")
+        command.upgrade(config, "head")
+        yield postgres_database_url
+        command.downgrade(config, "base")
     asyncio.run(db_session.dispose_engine())
     get_settings.cache_clear()
 

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -214,7 +214,7 @@ Draft packet
 -> calculate blocking status
 -> if no blocking failures remain: issue ReadinessCertificate and move to REVIEW_PENDING
 -> if worker-fixable blocking failures exist: route to user-facing needs_revision with outcome_source = auto_checker
--> if checker infrastructure fails: keep in operator retry handling
+-> if checker infrastructure fails: keep in checker retry handling
 ```
 
 The checker run must bind to one immutable submission version. If the worker uploads a replacement file, the platform creates a new submission version and reruns checks.
@@ -311,7 +311,7 @@ Each blind spot becomes a guide update, checker update, reviewer policy update, 
 The first checker runner can be simple:
 
 - async-first execution
-- request-bound manual operator trigger for the first structural checks
+- request-bound authorized manual checker trigger for the first structural checks
 - markdown/json output
 - attached logs
 

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -311,10 +311,12 @@ Each blind spot becomes a guide update, checker update, reviewer policy update, 
 The first checker runner can be simple:
 
 - async-first execution
-- local background worker process or FastAPI background task for simple local v0.1 jobs
+- request-bound manual operator trigger for the first structural checks
 - markdown/json output
 - attached logs
 
-The request path does not block on long-running checker execution. A checker run is created as `running`, then completed by background execution.
+The checker interface is async-first from the start so storage reads, external checks, and later agent evaluation do not require a contract rewrite.
+
+Chunk 7 may complete the first structural checker run inside the request path because those checks are local and fast. Longer-running checker execution should create a run as `running` and complete it through FastAPI background tasks, Celery, or an equivalent worker boundary.
 
 Use Celery or an equivalent durable queue when checker execution needs retries, scheduled jobs, progress reporting, worker isolation, or distributed execution.

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -429,7 +429,7 @@ Routing recommendation:
 - not_evaluated
 - allow_review
 - needs_revision
-- operator_retry
+- checker_retry
 
 `routing_recommendation` is a checker-side workflow hint, not a human review decision. `allow_review` means the automated checker found no blocking issue and the submission may proceed to human review. It must not be stored or reported as `accept`.
 

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -424,6 +424,15 @@ Status:
 
 Run pass/warn/fail summary is derived from checker result counts, not stored as run status.
 
+Routing recommendation:
+
+- not_evaluated
+- allow_review
+- needs_revision
+- operator_retry
+
+`routing_recommendation` is a checker-side workflow hint, not a human review decision. `allow_review` means the automated checker found no blocking issue and the submission may proceed to human review. It must not be stored or reported as `accept`.
+
 ## CheckerResult
 
 Fields:

--- a/docs/decision_0009_review_decisions_are_canonical.md
+++ b/docs/decision_0009_review_decisions_are_canonical.md
@@ -26,14 +26,14 @@ Display labels may render these as "Accept", "Needs revision", and "Reject", but
 
 Disputes, second review, suspected fraud, payment holds, or admin overrides may create separate workflow records and audit events, but they do not replace the reviewer decision contract.
 
-Checker routing recommendations use a separate contract. A checker can recommend that a submission is ready for review, needs worker revision, or needs operator retry handling. A checker cannot accept or reject work.
+Checker routing recommendations use a separate contract. A checker can recommend that a submission is ready for review, needs worker revision, or needs checker retry handling. A checker cannot accept or reject work.
 
 Canonical checker routing recommendation values are:
 
 - not_evaluated
 - allow_review
 - needs_revision
-- operator_retry
+- checker_retry
 
 `allow_review` must not be stored as `accept`. It only means the automated checker found no blocking issue and the packet may proceed to human review. Only a human review decision can store `accept`.
 

--- a/docs/decision_0009_review_decisions_are_canonical.md
+++ b/docs/decision_0009_review_decisions_are_canonical.md
@@ -10,6 +10,8 @@ Workstream review results drive task state, revision loops, contribution records
 
 If projects invent their own review outcome labels, downstream lifecycle rules become ambiguous.
 
+Automated checker results also influence workflow routing before human review. That routing is not the same thing as a human review decision.
+
 ## Decision
 
 The only canonical stored review decision values are:
@@ -24,6 +26,22 @@ Display labels may render these as "Accept", "Needs revision", and "Reject", but
 
 Disputes, second review, suspected fraud, payment holds, or admin overrides may create separate workflow records and audit events, but they do not replace the reviewer decision contract.
 
+Checker routing recommendations use a separate contract. A checker can recommend that a submission is ready for review, needs worker revision, or needs operator retry handling. A checker cannot accept or reject work.
+
+Canonical checker routing recommendation values are:
+
+- not_evaluated
+- allow_review
+- needs_revision
+- operator_retry
+
+`allow_review` must not be stored as `accept`. It only means the automated checker found no blocking issue and the packet may proceed to human review. Only a human review decision can store `accept`.
+
+`needs_revision` can appear in both contracts, but the source must be explicit:
+
+- checker-caused revision: `outcome_source = auto_checker`, `review_decision_id = null`
+- human reviewer revision: `outcome_source = human_review`, `review_decision_id = <review decision id>`
+
 ## Consequences
 
 Positive:
@@ -32,7 +50,9 @@ Positive:
 - review analytics can compare decisions across projects
 - revision policy has one clear entry point
 - payment and reputation logic can depend on a stable decision set
+- automated checker routing cannot accidentally masquerade as human acceptance or rejection
 
 Tradeoff:
 
 - special handling must be modeled as workflow, audit, dispute, or override records instead of extra review decisions
+- code and docs must name checker routing fields clearly so reviewers do not confuse them with review decision fields

--- a/docs/operations_project_operating_manual.md
+++ b/docs/operations_project_operating_manual.md
@@ -156,7 +156,7 @@ Each lesson must have an action owner and one target:
 - reviewer policy update
 - revision policy update
 - payment policy update
-- operator training note
+- project manager training note
 
 ## Weekly Project Review
 
@@ -179,4 +179,4 @@ Output:
 - guide amendments
 - revision policy amendments
 - payment policy amendments
-- operator training notes
+- project manager training notes

--- a/docs/operations_project_operating_manual.md
+++ b/docs/operations_project_operating_manual.md
@@ -49,7 +49,7 @@ A task cannot move to `READY` until the task contract is complete, the guide ver
 
 ### Submission Quality Gate
 
-A submission cannot move to human review until required checkers run against the exact submission version and artifact hashes. High-severity failures return to the worker when submission-caused; platform infrastructure failures remain in checker/admin handling with audit records.
+A submission cannot move to human review until required checkers run against the exact submission version and artifact hashes. High-severity failures return to the worker when submission-caused; platform infrastructure failures remain in checker retry handling or audited admin/project manager intervention.
 
 External origin qualification and webhook drop notifications are future adapter concerns, not v0.1 gates.
 

--- a/docs/operations_queue_policy.md
+++ b/docs/operations_queue_policy.md
@@ -103,7 +103,7 @@ Owner:
 
 Policy:
 
-- checker failure because of platform/tooling stays in checker/admin handling and does not move to human review
+- checker failure because of platform/tooling stays in checker retry handling or audited admin/project manager intervention and does not move to human review
 - retry and admin actions are recorded in audit history
 
 ### Pre Review Gate

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -1,6 +1,6 @@
 # Workstream Roadmap Status
 
-Current phase: Week 1 backend foundation complete; preparing checker framework.
+Current phase: Week 2 checker framework implementation.
 
 ## Completed
 
@@ -38,6 +38,7 @@ Current phase: Week 1 backend foundation complete; preparing checker framework.
 - Week 1 backend dry run through `Project -> Guide -> Task -> Screening -> Ready -> Claim -> Start -> Submit -> Lock submission`.
 - Week 2 checker framework scope specification.
 - Chunk 6 checker contract and records specification.
+- Chunk 7 checker runner, registry, structural checkers, durable checker records, and API tests.
 
 ## Review Tracks Closed
 
@@ -54,7 +55,7 @@ Current phase: Week 1 backend foundation complete; preparing checker framework.
 - Create the first 5 pilot task records.
 - Confirm who owns product, engineering, review, operations, and payment reconciliation during the first build cycle.
 - Confirm the first v0.1 project guide uses the locked guide fields, task contract fields, evidence IDs, and contribution record flow.
-- Build checker run records and `check_submission_packet` in Week 2.
+- Build evidence and policy checkers in Week 2.
 - Keep Week 2 backend/checker-framework only: expose checker results through APIs and dry-run/demo output, not product frontend pages.
 
 ## Week 1 Dry Run

--- a/docs/spec_chunk_6_checker_contract_records.md
+++ b/docs/spec_chunk_6_checker_contract_records.md
@@ -114,6 +114,12 @@ This chunk does not run the full checker framework yet. It defines the durable p
 - `needs_revision`
 - `operator_retry`
 
+`routing_recommendation` is not a human review decision field. It is a checker-side routing recommendation used before human review.
+
+`allow_review` means the checker run found no blocking issue and the submission may proceed to human review. It must not be stored as `accept`, because no human reviewer has accepted the work yet.
+
+`needs_revision` from a checker run must carry `outcome_source = auto_checker` and no review decision id. `needs_revision` from a human reviewer must carry `outcome_source = human_review` and a review decision id.
+
 `checker_runs.outcome_source`
 
 - `none`

--- a/docs/spec_chunk_6_checker_contract_records.md
+++ b/docs/spec_chunk_6_checker_contract_records.md
@@ -97,7 +97,7 @@ This chunk does not run the full checker framework yet. It defines the durable p
 `checker_runs.trigger_source`
 
 - `submission_locked`
-- `manual_operator`
+- `manual_checker_trigger`
 - `retry`
 
 `checker_runs.status`
@@ -112,7 +112,7 @@ This chunk does not run the full checker framework yet. It defines the durable p
 - `not_evaluated`
 - `allow_review`
 - `needs_revision`
-- `operator_retry`
+- `checker_retry`
 
 `routing_recommendation` is not a human review decision field. It is a checker-side routing recommendation used before human review.
 
@@ -272,7 +272,7 @@ Project managers and admins can see operational metadata.
 
 ## Manual And Retry Audit Rules
 
-`manual_operator` and `retry` trigger sources require:
+`manual_checker_trigger` and `retry` trigger sources require:
 
 - `triggered_by`
 - Flow auth subject
@@ -281,7 +281,7 @@ Project managers and admins can see operational metadata.
 - reason
 - `audit_event_id`
 
-System-triggered runs use a Workstream service principal. Manual runs must be attributable to an authorized admin/operator and must not overwrite prior checker results.
+System-triggered runs use a Workstream service principal. Manual runs must be attributable to an authorized admin or project manager and must not overwrite prior checker results.
 
 ## Immutability Rules
 

--- a/docs/spec_chunk_7_checker_runner_registry.md
+++ b/docs/spec_chunk_7_checker_runner_registry.md
@@ -52,7 +52,7 @@ Pre-submit feedback:
 POST /api/v1/tasks/{task_id}/submission-precheck
 ```
 
-This endpoint accepts a draft `SubmissionCreate` payload wrapped in a pre-submit request body. It returns immediate feedback for the UI/operator flow.
+This endpoint accepts a draft `SubmissionCreate` payload wrapped in a pre-submit request body. It returns immediate feedback for the UI submission flow.
 
 Pre-submit feedback is not authoritative review-gate proof and does not create durable `checker_runs`. The response uses `eligible_to_submit` and `would_block_if_submitted` language so the UI does not confuse draft feedback with post-submit review gating.
 
@@ -62,7 +62,7 @@ Durable post-submit checker run:
 POST /api/v1/submissions/{submission_id}/checker-runs
 ```
 
-This endpoint triggers the v0.1 manual operator path for internal checker execution. It accepts only a trigger reason. It does not accept checker status, severity, routing, result, metadata, or pass/fail fields from the caller.
+This endpoint triggers the v0.1 authorized manual checker path for internal checker execution. It accepts only a trigger reason. It does not accept checker status, severity, routing, result, metadata, or pass/fail fields from the caller.
 
 Checker read APIs:
 
@@ -104,7 +104,7 @@ The checker interface is async-first. Chunk 7 can complete the first structural 
 
 It creates one current checker run per submission. A later manual run supersedes the previous current run for that submission and increments `attempt_number`.
 
-Manual operator triggers create an append-only audit event and link it from `checker_runs.audit_event_id`.
+Authorized manual checker triggers create an append-only audit event and link it from `checker_runs.audit_event_id`.
 
 For a clean submission, the run records:
 
@@ -161,7 +161,7 @@ Worker responses must not expose:
 - duplicate artifact manifests persist worker-visible checker failures
 - unknown policy checker names block execution before fake results are written
 - assigned worker reads are sanitized
-- operator/manual checker triggers are linked to audit events
+- authorized manual checker triggers are linked to audit events
 - non-latest submissions cannot receive new checker runs
 - unassigned workers cannot read or precheck another worker's task
 - caller-supplied fake checker result payloads are rejected by schemas

--- a/docs/spec_chunk_7_checker_runner_registry.md
+++ b/docs/spec_chunk_7_checker_runner_registry.md
@@ -1,0 +1,174 @@
+# Chunk 7: Checker Runner And Registry
+
+## Purpose
+
+Chunk 7 turns the checker contract into a working backend slice.
+
+Workstream now has a checker module that can:
+
+- return non-authoritative pre-submit feedback before a packet is finalized
+- run registered structural checkers against a real locked submission
+- persist durable `checker_runs` and `checker_results`
+- validate checker policy names against the registry
+- expose checker runs/results through authenticated backend APIs
+- keep worker-visible checker output separate from internal metadata
+
+This is still not the automatic pre-review gate. Chunk 9 owns automatic transition into `REVIEW_PENDING` or checker-caused `needs_revision`.
+
+## Scope
+
+- `checker_runs` and `checker_results` migration
+- SQLAlchemy checker models
+- checker schemas
+- checker repository
+- checker service
+- checker API router
+- checker registry
+- pre-submit static feedback path
+- first structural checkers:
+  - `check_submission_packet`
+  - `check_policy_context_present`
+  - `check_artifact_manifest_integrity`
+  - `check_evidence_references_present`
+- canonical artifact manifest hash helper
+- real Postgres-backed API and migration tests
+
+## Non-Scope
+
+- automatic checker trigger after submission locking
+- moving tasks into `REVIEW_PENDING`
+- creating human review decision records
+- creating contribution, payment, or reputation records
+- product frontend pages
+- reviewer object-level checker visibility before review assignment exists
+- external checker adapters
+- Celery or distributed worker execution
+
+## API Contract
+
+Pre-submit feedback:
+
+```text
+POST /api/v1/tasks/{task_id}/submission-precheck
+```
+
+This endpoint accepts a draft `SubmissionCreate` payload wrapped in a pre-submit request body. It returns immediate feedback for the UI/operator flow.
+
+Pre-submit feedback is not authoritative review-gate proof and does not create durable `checker_runs`. The response uses `eligible_to_submit` and `would_block_if_submitted` language so the UI does not confuse draft feedback with post-submit review gating.
+
+Durable post-submit checker run:
+
+```text
+POST /api/v1/submissions/{submission_id}/checker-runs
+```
+
+This endpoint triggers the v0.1 manual operator path for internal checker execution. It accepts only a trigger reason. It does not accept checker status, severity, routing, result, metadata, or pass/fail fields from the caller.
+
+Checker read APIs:
+
+```text
+GET /api/v1/submissions/{submission_id}/checker-runs
+GET /api/v1/checker-runs/{checker_run_id}
+```
+
+Project managers and admins can see internal result messages and metadata. Assigned workers can only see worker-visible result rows and sanitized worker-facing fields.
+
+Reviewer checker visibility is deferred until reviewer assignment/routing exists. Reviewers should eventually see checker proof for packets assigned to them, but Chunk 7 does not grant broad reviewer read access without an object-level review assignment.
+
+## Registry Contract
+
+Checker policy names must match registered checker names.
+
+If a locked checker policy references an unknown checker, Workstream rejects durable checker execution with a validation error and does not write fake checker results.
+
+The initial registered checker names are:
+
+- `check_submission_packet`
+- `check_policy_context_present`
+- `check_artifact_manifest_integrity`
+- `check_evidence_references_present`
+
+## Runner Behavior
+
+The runner loads:
+
+- task
+- latest locked submission by id
+- locked checker policy
+- locked guide and policy versions already stamped on the submission
+- package hash
+- artifact hash manifest
+- actor audit context from the verified Flow token
+
+The checker interface is async-first. Chunk 7 can complete the first structural checker run inside the request path because the built-in checks are local and fast. Background execution, retries, and distributed worker isolation stay deferred until the pre-review gate and later runner hardening.
+
+It creates one current checker run per submission. A later manual run supersedes the previous current run for that submission and increments `attempt_number`.
+
+Manual operator triggers create an append-only audit event and link it from `checker_runs.audit_event_id`.
+
+For a clean submission, the run records:
+
+- `status = completed`
+- `routing_recommendation = allow_review`
+- `outcome_source = none`
+
+For worker-fixable blocking structural failures, the run records:
+
+- `status = completed`
+- `routing_recommendation = needs_revision`
+- `outcome_source = auto_checker`
+
+Chunk 7 records the recommendation only. Chunk 9 applies the lifecycle transition.
+
+## Artifact Manifest Hash
+
+The artifact manifest hash uses SHA-256 over canonical UTF-8 JSON:
+
+- preserve `artifact`, `hash`, `size_bytes`, and `notes`
+- sort entries by `artifact` and `hash`
+- sort keys inside JSON objects
+- use compact JSON separators
+- reject duplicate artifact names
+
+Malformed artifact manifests become persisted checker failures in durable post-submit runs.
+
+## Security Boundary
+
+Workstream still verifies external Flow authentication tokens. Chunk 7 does not add Workstream-owned login, signup, passwords, auth sessions, or API keys.
+
+Only Workstream-owned checker code writes durable checker results. API callers can trigger an allowed run path, but they cannot supply result payloads.
+
+Worker responses must not expose:
+
+- raw checker metadata
+- internal messages
+- stack traces
+- private object paths
+- hidden-test details
+- reviewer simulation prompts
+- secrets or security heuristics
+
+## Conditions Of Satisfaction
+
+- Alembic upgrade/downgrade creates and removes checker tables
+- checker ORM models are registered in Alembic metadata
+- partial unique index allows one current run per submission
+- pre-submit check returns feedback without durable checker rows
+- durable checker run works through real authenticated API calls
+- `check_submission_packet` runs against real submission data
+- duplicate artifact manifests persist worker-visible checker failures
+- unknown policy checker names block execution before fake results are written
+- assigned worker reads are sanitized
+- operator/manual checker triggers are linked to audit events
+- non-latest submissions cannot receive new checker runs
+- unassigned workers cannot read or precheck another worker's task
+- caller-supplied fake checker result payloads are rejected by schemas
+- tests use real Postgres-backed API flows, not monkeypatch-only unit tests
+
+## Verification
+
+Run from `backend/` against local Postgres:
+
+```bash
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py -q
+```

--- a/docs/spec_chunk_7_checker_runner_registry.md
+++ b/docs/spec_chunk_7_checker_runner_registry.md
@@ -112,6 +112,8 @@ For a clean submission, the run records:
 - `routing_recommendation = allow_review`
 - `outcome_source = none`
 
+`routing_recommendation` is a checker routing field, not a human review decision. It must not be normalized to `accept`, because a checker can only recommend that the packet is ready for human review. Human review decisions remain only `accept`, `needs_revision`, and `reject`.
+
 For worker-fixable blocking structural failures, the run records:
 
 - `status = completed`

--- a/docs/spec_week2_checker_framework.md
+++ b/docs/spec_week2_checker_framework.md
@@ -105,7 +105,7 @@ Checkers decide:
 - passing required checks can allow `REVIEW_PENDING`
 - warning checks can still allow `REVIEW_PENDING` with visible context
 - worker-fixable blocking failures route to `needs_revision`
-- platform/infrastructure failures stay in checker/admin retry handling
+- platform/infrastructure failures stay in checker retry handling or audited admin intervention
 
 Checker routing recommendations are not human review decisions. `allow_review` means "ready for human review", not `accept`. A checker must never write `accept` or `reject`.
 
@@ -117,7 +117,7 @@ Human review decisions remain only:
 
 Stored human review decision tokens are `accept`, `needs_revision`, and `reject`. User-facing task outcomes are displayed as Accepted, Rejected, and Needs revision. Internal lifecycle constants may use uppercase enum names, but persisted workflow values and API payloads should use canonical lowercase tokens.
 
-Checker routing recommendation tokens are separate: `not_evaluated`, `allow_review`, `needs_revision`, and `operator_retry`.
+Checker routing recommendation tokens are separate: `not_evaluated`, `allow_review`, `needs_revision`, and `checker_retry`.
 
 ## Week 2 Visibility Boundary
 
@@ -143,7 +143,7 @@ Conditions of satisfaction:
 - checker results are immutable after persistence
 - status and severity values are canonical
 - pre-submit feedback has a response contract but is not authoritative review-gate proof
-- post-submit checker runs can record `allow_review`, `needs_revision`, or `operator_retry` as routing recommendations
+- post-submit checker runs can record `allow_review`, `needs_revision`, or `checker_retry` as routing recommendations
 - `allow_review` is not stored as `accept`; it only means the submission can proceed to human review
 - checker-caused `needs_revision` stores `outcome_source = auto_checker`
 - checker output can be read through backend APIs

--- a/docs/spec_week2_checker_framework.md
+++ b/docs/spec_week2_checker_framework.md
@@ -107,6 +107,8 @@ Checkers decide:
 - worker-fixable blocking failures route to `needs_revision`
 - platform/infrastructure failures stay in checker/admin retry handling
 
+Checker routing recommendations are not human review decisions. `allow_review` means "ready for human review", not `accept`. A checker must never write `accept` or `reject`.
+
 Human review decisions remain only:
 
 - `accept`
@@ -114,6 +116,8 @@ Human review decisions remain only:
 - `reject`
 
 Stored human review decision tokens are `accept`, `needs_revision`, and `reject`. User-facing task outcomes are displayed as Accepted, Rejected, and Needs revision. Internal lifecycle constants may use uppercase enum names, but persisted workflow values and API payloads should use canonical lowercase tokens.
+
+Checker routing recommendation tokens are separate: `not_evaluated`, `allow_review`, `needs_revision`, and `operator_retry`.
 
 ## Week 2 Visibility Boundary
 
@@ -140,6 +144,7 @@ Conditions of satisfaction:
 - status and severity values are canonical
 - pre-submit feedback has a response contract but is not authoritative review-gate proof
 - post-submit checker runs can record `allow_review`, `needs_revision`, or `operator_retry` as routing recommendations
+- `allow_review` is not stored as `accept`; it only means the submission can proceed to human review
 - checker-caused `needs_revision` stores `outcome_source = auto_checker`
 - checker output can be read through backend APIs
 

--- a/docs/spec_week2_checker_framework.md
+++ b/docs/spec_week2_checker_framework.md
@@ -147,6 +147,8 @@ Conditions of satisfaction:
 
 Creates the checker interface, registry, pre-submit static checker path, runner service, and first structural checkers.
 
+Detailed spec: [Chunk 7 Checker Runner And Registry](spec_chunk_7_checker_runner_registry.md).
+
 Conditions of satisfaction:
 
 - registered checker names cannot drift from policy names


### PR DESCRIPTION
## Summary
- adds checker run/result migration, ORM models, repository, schemas, router, and service
- adds async-first checker registry and first structural checkers
- adds pre-submit feedback and durable operator-triggered checker runs with audit linkage
- enforces latest locked submission, policy-name registration, worker redaction, and fake payload rejection
- adds Chunk 7 spec/docs and DDL test lock for shared Postgres test stability

## Verification
- cd backend && .venv/bin/python -m pytest tests/test_checkers.py -q
- cd backend && .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py::test_chunk4_migration_downgrade_removes_task_tables -q
- cd backend && .venv/bin/python -m pytest -q
- cd backend && .venv/bin/python -m ruff check app tests
- cd backend && .venv/bin/docstr-coverage app --config .docstr.yaml
- Markdown relative links OK
- stale wording scan OK except AGENTS.md guardrail

## Internal Review Gate
- senior engineering: PASS
- QA/test: PASS
- security/auth: PASS
- product/ops: PASS

All sub-agent sessions were closed after re-review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a checker framework: pre-submit static feedback, durable checker runs, APIs to trigger/list/get runs with role-aware visibility, artifact-manifest canonical hashing, duplicate-artifact detection, and retry/current-run semantics.

* **Bug Fixes / Data**
  * Enforced submission (id, version) uniqueness to prevent duplicate-version records.

* **Documentation**
  * New and updated specs, architecture guidance, roadmap and README planning entry for the checker runner/registry.

* **Tests**
  * End-to-end integration tests for checker behavior, auth, persistence, manifest hashing; test migrations serialized for local runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->