### PR TITLE
Lock revision context rebase contract

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -32,10 +32,14 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
+
+      - name: Internal review evidence gate
+        run: python3 scripts/check_internal_review_evidence.py
 
       - name: Install backend
         working-directory: backend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ Workstream is how Flow measures, certifies, and coordinates useful human-agent w
 - Required internal reviewer tracks are senior engineering, QA/test, security/auth, and product/ops unless the chunk is explicitly unrelated to that track.
 - Do not report a chunk complete while reviewer agents are still running. Wait for them, address valid findings, and close any open sub-agent sessions.
 - CodeRabbit, CI, and GitHub review are external checks. They supplement internal reviewer agents; they do not replace them.
+- Do not open, push, or ask for review on a PR until required internal reviewer tracks have run for the chunk, all valid findings are addressed or documented, and no sub-agent sessions remain open.
 
 ## Done Criteria
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Workstream turns that operating knowledge into reusable infrastructure.
 - [ADR 0007: Execution Is Async-First](docs/decision_0007_async_first_execution.md)
 - [ADR 0008: Files Use An Object-Storage Abstraction](docs/decision_0008_object_storage_abstraction.md)
 - [ADR 0009: Review Decisions Are Canonical](docs/decision_0009_review_decisions_are_canonical.md)
+- [ADR 0010: Revision Context Rebase Is Controlled By Policy](docs/decision_0010_revision_context_rebase.md)
 
 ## Local Backend Database
 
@@ -192,11 +193,13 @@ Workstream is built as durable operational infrastructure:
 - status is a ledger, not a loose label
 - reviews cite evidence and required changes
 - revisions replay prior findings one by one
+- revision context is prepared before resubmission when guide or policy versions changed
 - payments are recorded separately from task acceptance
 - every checker result is stored and auditable
 - lessons learned become guide updates or new checkers
 - submitted artifacts are immutable and hash-bound to checker runs
 - accepted work cites evidence before payment exposure is created
 - guide and policy versions are locked per task so rules do not drift silently
+- out-of-band guidance is not enforceable until it becomes a guide, policy, template, or checker contract update
 - accepted work creates an evidence-backed contribution record before payment or reputation updates
 - quality gates remain separate: project activation, task screening, and submission quality

--- a/README.md
+++ b/README.md
@@ -189,17 +189,31 @@ The system is successful only if it prevents weak work from reaching review, pre
 
 Workstream is built as durable operational infrastructure:
 
+Governance:
+
 - project rules live in guides and policies, not chat memory
-- status is a ledger, not a loose label
-- reviews cite evidence and required changes
-- revisions replay prior findings one by one
-- revision context is prepared before resubmission when guide or policy versions changed
-- payments are recorded separately from task acceptance
-- every checker result is stored and auditable
-- lessons learned become guide updates or new checkers
-- submitted artifacts are immutable and hash-bound to checker runs
-- accepted work cites evidence before payment exposure is created
 - guide and policy versions are locked per task so rules do not drift silently
 - out-of-band guidance is not enforceable until it becomes a guide, policy, template, or checker contract update
+
+Lifecycle and revision:
+
+- status is a ledger, not a loose label
+- revisions replay prior findings one by one
+- revision context is prepared before resubmission when guide or policy versions change
+
+Artifacts, evidence, and auditing:
+
+- reviews cite evidence and required changes
+- submitted artifacts are immutable and hash-bound to checker runs
+- every checker result is stored and auditable
+
+Acceptance and payment:
+
+- accepted work cites evidence before payment exposure is created
 - accepted work creates an evidence-backed contribution record before payment or reputation updates
+- payments are recorded separately from task acceptance
+
+Checkers, lessons, and gates:
+
+- lessons learned become guide updates or new checkers
 - quality gates remain separate: project activation, task screening, and submission quality

--- a/backend/app/modules/checkers/runner.py
+++ b/backend/app/modules/checkers/runner.py
@@ -24,7 +24,7 @@ CHECKER_SEVERITY_HIGH = "high"
 CHECKER_SEVERITY_CRITICAL = "critical"
 
 BLOCKING_SEVERITIES = {CHECKER_SEVERITY_HIGH, CHECKER_SEVERITY_CRITICAL}
-ROUTING_PROJECT_SETUP_REQUIRED = "project_setup_required"
+ROUTING_TASK_SETUP_BLOCKED = "task_setup_blocked"
 
 HASH_TOKEN_PATTERN = re.compile(r"^sha256:\S+$")
 GENERIC_ATTESTATIONS = {"ok", "done", "yes", "i agree", "confirmed"}
@@ -551,7 +551,7 @@ async def check_policy_context_present(context: CheckerContext) -> CheckerOutcom
             "A project manager must re-screen the task before review can continue.",
             metadata={"missing_context": missing},
             worker_visible=False,
-            routing_recommendation=ROUTING_PROJECT_SETUP_REQUIRED,
+            routing_recommendation=ROUTING_TASK_SETUP_BLOCKED,
         )
     return _pass("check_policy_context_present", "Submission has locked guide and policy context.")
 
@@ -586,7 +586,7 @@ async def check_acceptance_criteria_present(context: CheckerContext) -> CheckerO
             "Task is not review-ready because acceptance criteria are missing.",
             "A project manager must add reviewable acceptance criteria before review can continue.",
             worker_visible=False,
-            routing_recommendation=ROUTING_PROJECT_SETUP_REQUIRED,
+            routing_recommendation=ROUTING_TASK_SETUP_BLOCKED,
         )
     return _pass(
         "check_acceptance_criteria_present",

--- a/backend/app/modules/checkers/schemas.py
+++ b/backend/app/modules/checkers/schemas.py
@@ -19,7 +19,7 @@ CheckerRoutingRecommendation = Literal[
     "allow_review",
     "needs_revision",
     "checker_retry",
-    "project_setup_required",
+    "task_setup_blocked",
 ]
 CheckerOutcomeSource = Literal["none", "auto_checker"]
 

--- a/backend/app/modules/checkers/service.py
+++ b/backend/app/modules/checkers/service.py
@@ -15,7 +15,7 @@ from app.modules.checkers.repository import CheckerRepository
 from app.modules.checkers.runner import (
     CheckerContext,
     CheckerOutcome,
-    ROUTING_PROJECT_SETUP_REQUIRED,
+    ROUTING_TASK_SETUP_BLOCKED,
     UnknownChecker,
     canonical_artifact_manifest_hash,
     default_checker_registry,
@@ -41,7 +41,7 @@ ROUTING_NEEDS_REVISION = "needs_revision"
 ROUTING_CHECKER_RETRY = "checker_retry"
 INTERNAL_ROUTING_RECOMMENDATIONS = {
     ROUTING_CHECKER_RETRY,
-    ROUTING_PROJECT_SETUP_REQUIRED,
+    ROUTING_TASK_SETUP_BLOCKED,
 }
 DEFAULT_DURABLE_CHECKERS = [
     "check_submission_packet",
@@ -364,7 +364,7 @@ class CheckerService:
             outcome_source=(
                 "auto_checker"
                 if routing_recommendation
-                in {ROUTING_NEEDS_REVISION, ROUTING_PROJECT_SETUP_REQUIRED}
+                in {ROUTING_NEEDS_REVISION, ROUTING_TASK_SETUP_BLOCKED}
                 else "none"
             ),
             triggered_by=actor.actor_id,
@@ -476,10 +476,10 @@ class CheckerService:
         if any(outcome.routing_recommendation == ROUTING_CHECKER_RETRY for outcome in outcomes):
             return ROUTING_CHECKER_RETRY
         if any(
-            outcome.routing_recommendation == ROUTING_PROJECT_SETUP_REQUIRED
+            outcome.routing_recommendation == ROUTING_TASK_SETUP_BLOCKED
             for outcome in outcomes
         ):
-            return ROUTING_PROJECT_SETUP_REQUIRED
+            return ROUTING_TASK_SETUP_BLOCKED
         if any(outcome.blocks_review for outcome in outcomes):
             return ROUTING_NEEDS_REVISION
         return ROUTING_ALLOW_REVIEW

--- a/backend/tests/test_checkers.py
+++ b/backend/tests/test_checkers.py
@@ -83,7 +83,7 @@ def test_checker_routing_recommendation_schema_uses_canonical_routing_tokens() -
     adapter = TypeAdapter(CheckerRoutingRecommendation)
 
     assert adapter.validate_python("checker_retry") == "checker_retry"
-    assert adapter.validate_python("project_setup_required") == "project_setup_required"
+    assert adapter.validate_python("task_setup_blocked") == "task_setup_blocked"
     with pytest.raises(ValidationError):
         adapter.validate_python("operator" + "_retry")
 
@@ -621,7 +621,7 @@ async def test_chunk8_low_quality_generated_artifacts_warns_without_blocking(
     assert low_quality["blocks_review"] is False
 
 
-async def test_chunk8_project_setup_required_takes_priority_over_worker_revision(
+async def test_chunk8_task_setup_blocked_takes_priority_over_worker_revision(
     checker_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -629,8 +629,8 @@ async def test_chunk8_project_setup_required_takes_priority_over_worker_revision
         "/api/v1/projects",
         headers=auth_headers(),
         json={
-            "name": "Project Setup Checker Project",
-            "slug": "project-setup-checker-project",
+            "name": "Task Setup Checker Project",
+            "slug": "task-setup-checker-project",
             "base_amount": "25.00",
             "currency": "USD",
         },
@@ -684,12 +684,12 @@ async def test_chunk8_project_setup_required_takes_priority_over_worker_revision
     run = await checker_client.post(
         f"/api/v1/submissions/{created.json()['id']}/checker-runs",
         headers=auth_headers(),
-        json={"trigger_reason": "project setup route validation"},
+        json={"trigger_reason": "task setup blocked route validation"},
     )
 
     assert run.status_code == 200, run.text
     body = run.json()
-    assert body["routing_recommendation"] == "project_setup_required"
+    assert body["routing_recommendation"] == "task_setup_blocked"
     assert body["outcome_source"] == "auto_checker"
     setup_result = next(
         result
@@ -715,7 +715,7 @@ async def test_chunk8_project_setup_required_takes_priority_over_worker_revision
     assert worker_body["failed_count"] == 0
     assert worker_body["blocking_count"] == 0
     assert worker_body["results"] == []
-    assert "project_setup_required" not in worker_read.text
+    assert "task_setup_blocked" not in worker_read.text
     assert "acceptance_criteria" not in worker_read.text
 
 

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -216,6 +216,7 @@ Draft packet
 -> calculate blocking status
 -> if no blocking failures remain: issue ReadinessCertificate and move to REVIEW_PENDING
 -> if worker-fixable blocking failures exist: route to user-facing needs_revision with outcome_source = auto_checker
+-> if locked task setup is incomplete or unsafe: route to internal task_setup_blocked
 -> if checker infrastructure fails: keep in checker retry handling
 ```
 
@@ -224,6 +225,8 @@ The checker run must bind to one immutable submission version. If the worker upl
 Checker failures are not human review decisions. They do not accept or reject work. Worker-fixable blocking failures can route the task to user-facing `NEEDS_REVISION`, with `outcome_source = auto_checker` and no review decision id. Human review can also produce `needs_revision` later, but that records `outcome_source = human_review` and a review decision id.
 
 If a checker crashes or cannot run because of platform infrastructure, the checker run remains failed as an infrastructure failure and the task does not move to human review. The retry or admin action is recorded in audit history.
+
+If a checker finds missing locked guide or policy context, missing acceptance criteria, or another task setup defect that is not worker-fixable, the run uses `task_setup_blocked`. That route is internal to project managers and must not be shown to workers as a revision request.
 
 ## Readiness Certificate
 

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -29,6 +29,7 @@ Task
     Review
       ReviewFinding
     RevisionReplay
+    RevisionContextPreparation
   ContributionRecord
   PaymentRecord
   ReputationEvent
@@ -201,8 +202,12 @@ Fields:
 - `revision_deadline_hours`
 - `auto_reject_after_limit`
 - `allowed_resubmission_states`
+- `context_rebase_rule`
+- `context_rebase_triggers`
 - `reviewer_reassignment_rule`
 - `created_at`
+
+`context_rebase_rule` defines whether a revision attempt keeps prior context, rebases to current active context, or blocks for project-manager repair when guide or policy context changed. `context_rebase_triggers` names the guide or policy changes that require preparation before the worker resumes.
 
 ## PaymentPolicy
 
@@ -430,9 +435,11 @@ Routing recommendation:
 - allow_review
 - needs_revision
 - checker_retry
-- project_setup_required
+- task_setup_blocked
 
 `routing_recommendation` is a checker-side workflow hint, not a human review decision. `allow_review` means the automated checker found no blocking issue and the submission may proceed to human review. It must not be stored or reported as `accept`.
+
+`task_setup_blocked` means the task's locked contract or policy context is incomplete, stale, or unsafe to review. It is an internal project-manager route, not a worker-facing revision outcome.
 
 ## CheckerResult
 
@@ -588,6 +595,38 @@ Reviewer closure status:
 - partially_closed
 - still_open
 - obsolete
+
+## RevisionContextPreparation
+
+Fields:
+
+- `id`
+- `task_id`
+- `prior_submission_id`
+- `prior_submission_version`
+- `next_submission_version`
+- `prior_locked_guide_version`
+- `next_locked_guide_version`
+- `prior_locked_checker_policy_version`
+- `next_locked_checker_policy_version`
+- `prior_locked_review_policy_version`
+- `next_locked_review_policy_version`
+- `prior_locked_revision_policy_version`
+- `next_locked_revision_policy_version`
+- `prior_locked_payment_policy_version`
+- `next_locked_payment_policy_version`
+- `context_rebased`
+- `rebase_reason`
+- `change_summary`
+- `prepared_by`
+- `audit_event_id`
+- `created_at`
+
+Purpose:
+
+This record is created before a worker resumes a task in `NEEDS_REVISION` when guide or policy context must be checked for the next attempt. It does not mutate the prior submission. It records whether the next attempt keeps the prior context or rebases to the current active guide and policy context under revision policy.
+
+The worker and reviewer packets must show the old version, new version, rebase reason, and change summary when `context_rebased = true`.
 
 ## ContributionRecord
 
@@ -748,6 +787,7 @@ Audit events are append-only.
 - a review cannot accept a submission if the checker run belongs to a different submission version
 - every status transition creates an audit event
 - every needs-revision decision has at least one review finding
+- every revision context rebase creates an audit event and preserves prior submission context
 - every accept decision cites evidence
 - repeated review/checker failures become ProjectLesson records
 - submission artifacts are immutable after `locked_at`

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -626,7 +626,7 @@ Purpose:
 
 This record is created before a worker resumes a task in `NEEDS_REVISION` when guide or policy context must be checked for the next attempt. It does not mutate the prior submission. It records whether the next attempt keeps the prior context or rebases to the current active guide and policy context under revision policy.
 
-The worker and reviewer packets must show the old version, new version, rebase reason, and change summary when `context_rebased = true`.
+The worker and reviewer packets must show the prior version, next version, rebase reason, and change summary when `context_rebased = true`.
 
 ## ContributionRecord
 

--- a/docs/architecture_lifecycle_state_machine.md
+++ b/docs/architecture_lifecycle_state_machine.md
@@ -143,6 +143,10 @@ Required before entering:
 - from `PRE_REVIEW_GATE`: gate run id, worker-visible findings, and suggested fixes
 - from `REVIEW_PENDING`: review decision id and at least one structured review finding
 
+Before the worker resumes, Workstream prepares the next revision context. That preparation checks whether the active project guide or policy context changed since the prior submission was locked. Revision policy decides whether the next attempt keeps the prior context, rebases to the current active context, or is blocked for project-manager repair.
+
+A revision context rebase never mutates the prior submitted attempt. It only stamps the next submission attempt. The worker and reviewer must see the old version, the new version, and the guide or policy change summary.
+
 ### ACCEPTED
 
 The submission is accepted.
@@ -227,6 +231,8 @@ submission v2 -> accepted
 ```
 
 Each resubmission must link to the prior submission it supersedes.
+
+Each submitted version keeps its own locked guide and policy context. If a later revision is rebased to a newer active guide, that rebase is recorded as next-attempt preparation and does not rewrite earlier submission records.
 
 ## Revision Replay
 

--- a/docs/architecture_lifecycle_state_machine.md
+++ b/docs/architecture_lifecycle_state_machine.md
@@ -145,7 +145,7 @@ Required before entering:
 
 Before the worker resumes, Workstream prepares the next revision context. That preparation checks whether the active project guide or policy context changed since the prior submission was locked. Revision policy decides whether the next attempt keeps the prior context, rebases to the current active context, or is blocked for project-manager repair.
 
-A revision context rebase never mutates the prior submitted attempt. It only stamps the next submission attempt. The worker and reviewer must see the old version, the new version, and the guide or policy change summary.
+A revision context rebase never mutates the prior submitted attempt. It only stamps the next submission attempt. The worker and reviewer must see the prior version, the next version, and the guide or policy change summary.
 
 ### ACCEPTED
 

--- a/docs/decision_0003_project_guides_are_first_class.md
+++ b/docs/decision_0003_project_guides_are_first_class.md
@@ -34,6 +34,10 @@ Project guide activation requires the guide plus its required policy context bef
 
 Revision policy is not optional. It defines the revision loop contract, including revision limits, revision deadlines, allowed resubmission states, and automatic rejection behavior after the limit.
 
+Guide and policy changes do not silently mutate submitted attempts. A submitted attempt stays tied to the guide and policy versions stamped on that submission. When a task enters `NEEDS_REVISION`, revision policy controls whether the next attempt keeps the prior context or rebases to the latest active guide and policy context.
+
+Rules that affect acceptance must be encoded in the project guide, checker policy, review policy, revision policy, payment policy, task template, or checker implementation. Chat messages and informal notices are not enforceable rules until they are moved into those contracts.
+
 ## Consequences
 
 Positive:

--- a/docs/decision_0009_review_decisions_are_canonical.md
+++ b/docs/decision_0009_review_decisions_are_canonical.md
@@ -26,7 +26,7 @@ Display labels may render these as "Accept", "Needs revision", and "Reject", but
 
 Disputes, second review, suspected fraud, payment holds, or admin overrides may create separate workflow records and audit events, but they do not replace the reviewer decision contract.
 
-Checker routing recommendations use a separate contract. A checker can recommend that a submission is ready for review, needs worker revision, needs checker retry handling, or needs project setup correction. A checker cannot accept or reject work.
+Checker routing recommendations use a separate contract. A checker can recommend that a submission is ready for review, needs worker revision, needs checker retry handling, or cannot proceed because the task's locked setup is incomplete. A checker cannot accept or reject work.
 
 Canonical checker routing recommendation values are:
 
@@ -34,11 +34,11 @@ Canonical checker routing recommendation values are:
 - allow_review
 - needs_revision
 - checker_retry
-- project_setup_required
+- task_setup_blocked
 
 `allow_review` must not be stored as `accept`. It only means the automated checker found no blocking issue and the packet may proceed to human review. Only a human review decision can store `accept`.
 
-`project_setup_required` must not be stored as `needs_revision`. It means the task/project contract is incomplete and a project manager must fix setup before worker-facing revision or human review can continue.
+`task_setup_blocked` must not be stored as `needs_revision`. It means the task's locked contract or policy context is incomplete, stale, or unsafe to review. A project manager must repair or re-screen the task before worker-facing revision or human review can continue.
 
 `needs_revision` can appear in both contracts, but the source must be explicit:
 

--- a/docs/decision_0010_revision_context_rebase.md
+++ b/docs/decision_0010_revision_context_rebase.md
@@ -1,0 +1,69 @@
+# ADR 0010: Revision Context Rebase Is Controlled By Policy
+
+## Status
+
+Accepted
+
+## Context
+
+Project guidance can change while a task is already in progress or under review.
+
+If rule changes live only in Slack, chat, or memory, workers can be punished for missing an out-of-band update and reviewers can apply inconsistent standards. If guide changes silently mutate prior submissions, Workstream loses auditability.
+
+Workstream needs both fairness and correctness:
+
+- a submitted attempt must remain tied to the exact guide and policy versions it used
+- a revised attempt may need the latest active guide and policy context before the worker resumes
+- the worker and reviewer must be able to see what changed
+
+## Decision
+
+Submitted attempts are immutable. Each submission remains evaluated against the locked project guide, checker policy, review policy, revision policy, and payment policy versions stamped on that submission.
+
+When a task enters `NEEDS_REVISION`, Workstream runs a revision context preparation step before the worker resumes. That step compares the submission's locked guide and policy context with the current active project guide and policy context.
+
+Revision policy controls whether the next attempt:
+
+- keeps the prior locked context
+- rebases to the current active guide and policy context
+- is blocked for project-manager repair when the task setup is incomplete or unsafe
+
+Every revision context preparation must record its outcome. When the next attempt keeps the prior context, Workstream records that no rebase occurred and why. When the next attempt is rebased, Workstream records:
+
+- task id
+- prior submission id and version
+- prior locked guide and policy versions
+- next locked guide and policy versions
+- rebase reason
+- guide or policy change summary shown to the worker
+- actor or system process that prepared the revision context
+- audit event id
+
+The worker must see the old context, the new context, and the change summary before submitting the revised attempt when a rebase occurs. The reviewer packet must also show that the revised attempt used a different guide or policy context.
+
+Out-of-band guidance has no acceptance force until it is encoded in one of:
+
+- project guide
+- checker policy
+- review policy
+- revision policy
+- payment policy
+- task template
+- checker implementation governed by the checker policy
+
+Acceptance-affecting checker implementation changes must be tied to visible guide, policy, or checker-policy context. When those changes affect a rebased revision attempt, the worker-visible change summary must describe the new requirement without exposing private detection details.
+
+## Consequences
+
+Positive:
+
+- workers are not expected to monitor chat to discover rule changes
+- reviewers can see which standards governed each attempt
+- guide and policy updates can improve future revisions without mutating prior submissions
+- repeated lessons become durable guide, checker, review, revision, payment, or template changes
+
+Tradeoff:
+
+- revision preparation needs an explicit audit record
+- revision replay must show context changes, not only finding closure
+- services must keep submitted-attempt immutability separate from next-attempt preparation

--- a/docs/internal_reviews/2026-06-11_revision_context_rebase.md
+++ b/docs/internal_reviews/2026-06-11_revision_context_rebase.md
@@ -1,0 +1,56 @@
+# Internal Review Evidence: Revision Context Rebase
+
+## Scope
+
+- ADR 0010 revision context rebase
+- `task_setup_blocked` checker routing rename
+- worker/reviewer visibility for revision context
+- internal review evidence gate
+
+## Required Tracks
+
+### Senior Engineering
+
+Status: passed after fixes.
+
+Findings addressed:
+
+- task-state wording changed from `needs_revision` to `NEEDS_REVISION`
+- ADR 0010 now records every revision context preparation outcome, not only rebases
+- stale project-setup wording changed to locked task setup wording
+
+### QA/Test
+
+Status: passed after fixes.
+
+Findings addressed:
+
+- `task_setup_blocked` is covered in schema, runner, service routing, and checker tests
+- stale test wording changed to task setup blocked route
+- PR evidence gate added through `scripts/check_internal_review_evidence.py` and backend CI
+
+### Security/Auth
+
+Status: passed after fixes.
+
+Findings addressed:
+
+- revision replay template now separates worker-visible fields from reviewer/admin fields
+- acceptance-affecting checker implementation changes must be tied to visible guide, policy, or checker-policy context
+- worker redaction keeps internal routing and setup details hidden
+
+### Product/Ops
+
+Status: passed after fixes.
+
+Findings addressed:
+
+- revision policy now has `context_rebase_rule` and `context_rebase_triggers`
+- `task_setup_blocked` is documented as an internal checker routing recommendation, not a lifecycle state
+- out-of-band guidance is not enforceable until it becomes guide, policy, template, or checker contract
+
+## Final Gate
+
+Valid findings addressed: yes.
+
+Open sub-agent sessions: none.

--- a/docs/operations_project_operating_manual.md
+++ b/docs/operations_project_operating_manual.md
@@ -150,7 +150,7 @@ Do not let repeated mistakes remain tribal knowledge.
 
 If a lesson changes acceptance, review, revision, payment, evidence, or checker expectations, it must become a guide, policy, template, or checker update before it is enforced. Chat and Slack messages can announce the change, but they are not the source of truth.
 
-When a task already in `NEEDS_REVISION` is affected by a new guide or policy version, revision policy decides whether the next attempt is rebased. The worker must see the old version, new version, and change summary before resubmitting.
+When a task already in `NEEDS_REVISION` is affected by a new guide or policy version, revision policy decides whether the next attempt is rebased. The worker must see the prior version, next version, and change summary before resubmitting.
 
 Each lesson must have an action owner and one target:
 

--- a/docs/operations_project_operating_manual.md
+++ b/docs/operations_project_operating_manual.md
@@ -148,6 +148,10 @@ Every repeated failure becomes one of:
 
 Do not let repeated mistakes remain tribal knowledge.
 
+If a lesson changes acceptance, review, revision, payment, evidence, or checker expectations, it must become a guide, policy, template, or checker update before it is enforced. Chat and Slack messages can announce the change, but they are not the source of truth.
+
+When a task already in `NEEDS_REVISION` is affected by a new guide or policy version, revision policy decides whether the next attempt is rebased. The worker must see the old version, new version, and change summary before resubmitting.
+
 Each lesson must have an action owner and one target:
 
 - guide update

--- a/docs/operations_queue_policy.md
+++ b/docs/operations_queue_policy.md
@@ -143,7 +143,7 @@ Policy:
 
 - before the worker resumes, Workstream prepares revision context against the active guide and policy records
 - revision policy decides whether the next attempt keeps the prior locked context or rebases to the current active context
-- a rebase must show the worker the old version, new version, and change summary
+- a rebase must show the worker the prior version, next version, and change summary
 - out-of-band guidance is not enforceable until it is encoded into guide, policy, task template, or checker contracts
 
 Owner:

--- a/docs/operations_queue_policy.md
+++ b/docs/operations_queue_policy.md
@@ -139,6 +139,13 @@ Policy:
 
 Worker-facing lane for fixable issues from automated checks, pre-review gates, or human review.
 
+Policy:
+
+- before the worker resumes, Workstream prepares revision context against the active guide and policy records
+- revision policy decides whether the next attempt keeps the prior locked context or rebases to the current active context
+- a rebase must show the worker the old version, new version, and change summary
+- out-of-band guidance is not enforceable until it is encoded into guide, policy, task template, or checker contracts
+
 Owner:
 
 - worker

--- a/docs/operations_revision_replay.md
+++ b/docs/operations_revision_replay.md
@@ -55,6 +55,23 @@ A resubmission cannot move to `REVIEW_PENDING` when:
 
 Low findings can be left unresolved if the reviewer marks them as informational.
 
+## Revision Context Preparation
+
+Before the worker resumes a task in `NEEDS_REVISION`, Workstream prepares the next revision context.
+
+That preparation compares the prior submission's locked project guide and policy versions with the current active guide and policy versions. Revision policy decides whether the next attempt keeps the prior context, rebases to the latest active context, or is blocked for project-manager repair.
+
+A rebase does not change the prior submission. It only defines the guide and policy context for the next submission attempt.
+
+When a rebase happens, the worker must see:
+
+- prior guide and policy versions
+- next guide and policy versions
+- guide or policy change summary
+- reason the next attempt was rebased
+
+The reviewer must see the same context change in the review packet. A reviewer cannot apply out-of-band guidance unless it was encoded into the guide, policy, task template, or checker contract that governed the attempt.
+
 ## Replay Table
 
 | Prior Finding ID | Required Fix | Worker Fix Summary | Evidence | Worker Status | Reviewer Closure |

--- a/docs/operations_subagent_review_protocol.md
+++ b/docs/operations_subagent_review_protocol.md
@@ -2,38 +2,46 @@
 
 Workstream planning and major system changes receive multiple review perspectives before being treated as ready.
 
-This repository may not have actual autonomous subagents wired in yet, but the review roles are simulated consistently until tooling exists.
+Implementation and specification chunks must run internal reviewer agents before PR review. The PR must include a changed `docs/internal_reviews/*.md` evidence file, and CI runs `scripts/check_internal_review_evidence.py` to block missing or incomplete evidence.
 
 ## Review Roles
 
-### Product Strategy Reviewer
+### Senior Engineering Reviewer
 
 Focus:
 
-- product clarity
-- 30-day scope
-- MVP risk
-- first-user flow
-- operator value
-- whether the plan is too broad
+- architecture consistency
+- code boundaries
+- naming clarity
+- lifecycle and data-model invariants
+- implementation risk
 
-### Architecture Reviewer
-
-Focus:
-
-- system boundaries
-- state model
-- data model
-- extensibility
-- failure modes
-- whether future adapters can be added without rewriting the core
-
-### Operations Reviewer
+### QA/Test Reviewer
 
 Focus:
 
-- daily operator workflow
-- reviewer workflow
+- test coverage
+- real API and persistence behavior
+- stale wording scans
+- regression risk
+- CI coverage
+
+### Security/Auth Reviewer
+
+Focus:
+
+- auth boundary
+- redaction and visibility
+- sensitive metadata exposure
+- audit integrity
+- permission risks
+
+### Product/Ops Reviewer
+
+Focus:
+
+- daily project manager workflow
+- worker and reviewer workflow
 - checker policy
 - revision replay
 - payment/reputation consistency
@@ -71,7 +79,7 @@ Severity:
 
 ## Rule
 
-No major plan is marked ready without at least product, architecture, and operations review passes.
+No implementation or specification chunk is marked ready, pushed for PR review, or reported complete until required reviewer tracks have run, valid findings are fixed or documented, and every reviewer-agent session is closed.
 
 ## Task Readiness Gate
 

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -33,6 +33,8 @@ Each project has a guide that defines the rules for that project. A guide specif
 
 If a rule matters, it belongs in the guide, checker policy, review policy, revision policy, payment policy, or task template.
 
+Out-of-band guidance is not enforceable until it is moved into those contracts or into a checker that is governed by those contracts.
+
 ## 3. Automated Checks Protect Human Time
 
 Human reviewers do not spend time discovering basic package failures. Workstream checkers catch structural issues before review:
@@ -68,6 +70,8 @@ NEEDS_REVISION -> IN_PROGRESS -> SUBMITTED -> AUTO_CHECKING -> REVIEW_PENDING
 ```
 
 The system must preserve original feedback, fix notes, evidence, and closure.
+
+The system must also preserve guide and policy context. Prior submissions keep their locked context; revision policy decides whether the next attempt rebases to the latest active context before the worker resumes.
 
 ## 6. Payment Follows Acceptance
 

--- a/docs/product_first_user_flows.md
+++ b/docs/product_first_user_flows.md
@@ -80,7 +80,7 @@ Acceptance:
 
 1. Worker opens needs-revision task.
 2. Workstream prepares revision context from the revision policy.
-3. Worker sees old guide/policy version, current guide/policy version, and any change summary when the task was rebased.
+3. Worker sees prior guide/policy version, next guide/policy version, and any change summary when the task was rebased.
 4. Worker sees each finding as a checklist item.
 5. Worker adds fix note and evidence per finding.
 6. Worker resubmits.

--- a/docs/product_first_user_flows.md
+++ b/docs/product_first_user_flows.md
@@ -79,15 +79,18 @@ Acceptance:
 ## Flow 6: Revision Replay
 
 1. Worker opens needs-revision task.
-2. Worker sees each finding as a checklist item.
-3. Worker adds fix note and evidence per finding.
-4. Worker resubmits.
-5. Checkers rerun.
-6. Reviewer closes or reopens each finding.
+2. Workstream prepares revision context from the revision policy.
+3. Worker sees old guide/policy version, current guide/policy version, and any change summary when the task was rebased.
+4. Worker sees each finding as a checklist item.
+5. Worker adds fix note and evidence per finding.
+6. Worker resubmits.
+7. Checkers rerun.
+8. Reviewer closes or reopens each finding.
 
 Acceptance:
 
 - Prior review remains visible.
+- Context changes are visible before the worker revises.
 - Each required finding has a closure state.
 - Revision count is tracked against the locked revision policy.
 - Resubmission is blocked or rejected when the revision policy limit or deadline says so.

--- a/docs/product_principles.md
+++ b/docs/product_principles.md
@@ -23,6 +23,8 @@ Every project has its own guide, quality bar, checker policy, review policy, rev
 
 The platform does not rely on memory or chat messages to enforce rules. If a rule matters, it belongs in the project guide, checker policy, review policy, revision policy, payment policy, or task template.
 
+When a guide or policy changes while work is already in progress, prior submitted attempts remain tied to their locked context. If the task returns for revision, revision policy decides whether the next attempt rebases to the latest active context, and the worker must see what changed.
+
 ## 3. Same Lifecycle, Different Domain Language
 
 Projects may differ by domain, language, task format, or review style. The lifecycle remains stable:
@@ -52,6 +54,8 @@ The first version enforces accountability through assignment ownership, worker a
 ## 6. Revision Is A State, Not A Failure
 
 Needs revision is a normal lifecycle state. The system must preserve feedback, require closure, and make resubmission easy to audit.
+
+Revision must also preserve context. Workers and reviewers need to know which guide and policy versions governed the prior attempt and which versions govern the next attempt.
 
 ## 7. Evidence Beats Claims
 

--- a/docs/proposal_workstream_arch_today_source.md
+++ b/docs/proposal_workstream_arch_today_source.md
@@ -617,7 +617,7 @@ const LockdownSection = () => (
         action:"Agree the field list in this document. Team reviews, challenges, and confirms. Must be frozen before any schema is written." },
       { n:"02",title:"Guide versioning policy",color:c.red,tag:"HIGHEST PRIORITY",
         why:"Must be in from day one. Retrofitting versioning after tasks are in flight creates disputes that are impossible to resolve fairly.",
-        action:"Confirm: version field is required, tasks lock at assignment, version increments on material guide changes, old versions are never deleted." },
+        action:"Confirm: version field is required, tasks lock at assignment, version increments on material guide changes, prior versions are never deleted." },
       { n:"03",title:"Origin qualification criteria",color:c.accent,tag:"HIGH",
         why:"Defines what Workstream accepts at the source level. Determines who can become an origin and on what terms.",
         action:"Confirm the three checks. Set the platform floor value — recommended starting point is $5 USD equivalent, configurable per currency." },

--- a/docs/risk_register.md
+++ b/docs/risk_register.md
@@ -33,7 +33,7 @@ Mitigation:
 
 - prior submissions remain tied to their locked guide and policy versions
 - revision policy controls whether the next attempt rebases to current active guide and policy context
-- worker and reviewer packets show old version, new version, rebase reason, and change summary
+- worker and reviewer packets show prior version, next version, rebase reason, and change summary
 - every rebase records an audit event
 
 ### R2: Weak Submissions Reach Review

--- a/docs/risk_register.md
+++ b/docs/risk_register.md
@@ -18,6 +18,23 @@ Mitigation:
 
 - every rule belongs in project guide, checker policy, review policy, revision policy, or payment policy
 - daily lessons learned become document updates
+- out-of-band guidance has no acceptance force until it becomes a guide, policy, template, or checker contract update
+- revision context preparation shows workers any guide or policy changes before resubmission
+
+### R1A: Revision Uses Stale Or Hidden Rules
+
+Severity: high
+
+Problem:
+
+A task can be sent back for revision after the project guide or policies changed. If the worker is not shown the new context, the revision loop becomes unfair and reviewers may apply standards that were not visible when the worker resumed.
+
+Mitigation:
+
+- prior submissions remain tied to their locked guide and policy versions
+- revision policy controls whether the next attempt rebases to current active guide and policy context
+- worker and reviewer packets show old version, new version, rebase reason, and change summary
+- every rebase records an audit event
 
 ### R2: Weak Submissions Reach Review
 

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -140,7 +140,7 @@ This thin slice is the first proof that Workstream can measure and certify usefu
 
 ## Week 2: Checker Framework
 
-Objective: prevent worker-fixable submission failures and project setup defects from reaching human review.
+Objective: prevent worker-fixable submission failures and locked task setup defects from reaching human review.
 
 Week 2 is backend/checker-framework work. Checker results must be available through backend APIs, dry-run scripts, and demo/debug output. Product frontend pages, reviewer queue UI, and review decision screens stay in Week 3 or later.
 
@@ -215,6 +215,7 @@ Deliverables:
 - severity model
 - accept / needs_revision / reject decisions
 - revision replay
+- revision context preparation and guide/policy rebase audit
 - reviewer metrics
 - second-review flag
 

--- a/docs/spec_chunk_6_checker_contract_records.md
+++ b/docs/spec_chunk_6_checker_contract_records.md
@@ -113,13 +113,13 @@ This chunk does not run the full checker framework yet. It defines the durable p
 - `allow_review`
 - `needs_revision`
 - `checker_retry`
-- `project_setup_required`
+- `task_setup_blocked`
 
 `routing_recommendation` is not a human review decision field. It is a checker-side routing recommendation used before human review.
 
 `allow_review` means the checker run found no blocking issue and the submission may proceed to human review. It must not be stored as `accept`, because no human reviewer has accepted the work yet.
 
-`project_setup_required` means the task/project contract is incomplete and the fix belongs to a project manager, not the worker.
+`task_setup_blocked` means the task's locked contract or policy context is incomplete, stale, or unsafe to review. The fix belongs to a project manager, not the worker.
 
 `needs_revision` from a checker run must carry `outcome_source = auto_checker` and no review decision id. `needs_revision` from a human reviewer must carry `outcome_source = human_review` and a review decision id.
 

--- a/docs/spec_chunk_8_evidence_policy_checkers.md
+++ b/docs/spec_chunk_8_evidence_policy_checkers.md
@@ -109,7 +109,7 @@ Project-manager operational message:
 
 - tell the project manager to add reviewable acceptance criteria before review can continue
 
-This is a project setup failure, not worker-fixable submission work. Worker-facing checker responses must not expose the internal `project_setup_required` route or the missing setup field names.
+This is a locked task setup failure, not worker-fixable submission work. Worker-facing checker responses must not expose the internal `task_setup_blocked` route or the missing setup field names.
 
 ### `check_required_files`
 
@@ -218,7 +218,7 @@ Durable post-submit checker runs run the canonical default submission-quality ch
 - additional locked `required_checkers`
 - additional locked `warning_checkers`
 
-`check_acceptance_criteria_present` is registered in Chunk 8, but it is a project/task setup checker. It is not part of the default durable submission-quality list. If a locked checker policy requires it and it fails, the run must use project setup routing, not worker revision routing.
+`check_acceptance_criteria_present` is registered in Chunk 8, but it is a locked task setup checker. It is not part of the default durable submission-quality list. If a locked checker policy requires it and it fails, the run must use task setup routing, not worker revision routing.
 
 ## Routing Boundary
 
@@ -232,10 +232,10 @@ If worker-fixable submission checks fail, the durable checker run records:
 
 Worker-fixable submission checks include missing evidence, missing required files, malformed artifact/evidence hash references, forbidden file patterns, and missing/invalid confidentiality attestation.
 
-If project setup checks fail, the durable checker run records:
+If task setup checks fail, the durable checker run records:
 
 - `status = completed`
-- `routing_recommendation = project_setup_required`
+- `routing_recommendation = task_setup_blocked`
 - `outcome_source = auto_checker`
 
 Project setup checks include missing acceptance criteria or missing locked project/policy context. These are not worker revision outcomes.
@@ -243,13 +243,13 @@ Project setup checks include missing acceptance criteria or missing locked proje
 Routing priority is deterministic:
 
 1. `checker_retry` for checker/platform execution failures
-2. `project_setup_required` for project/task setup defects
+2. `task_setup_blocked` for locked task setup defects
 3. `needs_revision` for worker-fixable submission failures
 4. `allow_review` when there are no blocking failures
 
-When one checker run contains both project setup failures and worker-fixable submission failures, `project_setup_required` wins because the project manager must fix the task contract before the worker can receive a meaningful revision request.
+When one checker run contains both task setup failures and worker-fixable submission failures, `task_setup_blocked` wins because the project manager must fix the task contract before the worker can receive a meaningful revision request.
 
-Chunk 8 schema-documents `project_setup_required` and implements the routing contract, but normal API flows are expected to prevent project setup defects before submission. For example, current task screening requires acceptance criteria before a task can be released. Chunk 8 tests must verify the enum/source-of-truth contract and may verify project setup routing through controlled service/repository setup if no normal FastAPI path can produce a locked submission with that defect. A later admin repair workflow can add a real API path for this route.
+Chunk 8 schema-documents `task_setup_blocked` and implements the routing contract, but normal API flows are expected to prevent task setup defects before submission. For example, current task screening requires acceptance criteria before a task can be released. Chunk 8 tests must verify the enum/source-of-truth contract and may verify task setup routing through controlled service/repository setup if no normal FastAPI path can produce a locked submission with that defect. A later admin repair workflow can add a real API path for this route.
 
 Chunk 9 owns applying the lifecycle transition.
 
@@ -298,7 +298,7 @@ Safe evidence references mean opaque Workstream evidence ids, sanitized labels, 
 - low-quality generated artifact patterns persist warning results by default
 - clean submissions keep `routing_recommendation = allow_review`
 - worker-fixable submission failures keep `routing_recommendation = needs_revision` and `outcome_source = auto_checker`
-- project setup failures keep `routing_recommendation = project_setup_required` and do not create worker revision outcomes
+- task setup failures keep `routing_recommendation = task_setup_blocked` and do not create worker revision outcomes
 - tests use real FastAPI calls and Postgres-backed persistence, not monkeypatch-only unit tests
 - senior engineering, QA/test, security/auth, and product/ops reviewer tracks pass before PR completion
 

--- a/docs/spec_chunk_8_evidence_policy_checkers.md
+++ b/docs/spec_chunk_8_evidence_policy_checkers.md
@@ -249,7 +249,7 @@ Routing priority is deterministic:
 
 When one checker run contains both task setup failures and worker-fixable submission failures, `task_setup_blocked` wins because the project manager must fix the task contract before the worker can receive a meaningful revision request.
 
-Chunk 8 schema-documents `task_setup_blocked` and implements the routing contract, but normal API flows are expected to prevent task setup defects before submission. For example, current task screening requires acceptance criteria before a task can be released. Chunk 8 tests must verify the enum/source-of-truth contract and may verify task setup routing through controlled service/repository setup if no normal FastAPI path can produce a locked submission with that defect. A later admin repair workflow can add a real API path for this route.
+Chunk 8 documents `task_setup_blocked` in its schema and implements the routing contract, but normal API flows are expected to prevent task setup defects before submission. For example, current task screening requires acceptance criteria before a task can be released. Chunk 8 tests must verify the enum/source-of-truth contract and may verify task setup routing through controlled service/repository setup if no normal FastAPI path can produce a locked submission with that defect. A later admin repair workflow can add a real API path for this route.
 
 Chunk 9 owns applying the lifecycle transition.
 

--- a/docs/spec_week2_checker_framework.md
+++ b/docs/spec_week2_checker_framework.md
@@ -37,12 +37,12 @@ The checker framework protects reviewer time by proving that the latest locked s
 ## Core Invariant
 
 ```text
-Draft packet -> Pre-submit checks -> Submit -> Lock -> Internal CheckerRun -> CheckerResults -> REVIEW_PENDING or NEEDS_REVISION or PROJECT_SETUP_REQUIRED
+Draft packet -> Pre-submit checks -> Submit -> Lock -> Internal CheckerRun -> CheckerResults -> routing recommendation
 ```
 
 A task cannot reach `REVIEW_PENDING` unless the latest locked submission has a completed checker run for the exact submission version and artifact context.
 
-`NEEDS_REVISION` is the worker-facing route for worker-fixable submission failures. `PROJECT_SETUP_REQUIRED` is the internal route for project/task setup defects owned by a project manager.
+`allow_review` can move the task toward `REVIEW_PENDING`. `needs_revision` is the worker-facing route for worker-fixable submission failures. `task_setup_blocked` is an internal checker routing recommendation for locked task setup defects owned by a project manager; it is not a task lifecycle state.
 
 The checker binding includes:
 
@@ -119,7 +119,7 @@ Human review decisions remain only:
 
 Stored human review decision tokens are `accept`, `needs_revision`, and `reject`. User-facing task outcomes are displayed as Accepted, Rejected, and Needs revision. Internal lifecycle constants may use uppercase enum names, but persisted workflow values and API payloads should use canonical lowercase tokens.
 
-Checker routing recommendation tokens are separate: `not_evaluated`, `allow_review`, `needs_revision`, `checker_retry`, and `project_setup_required`.
+Checker routing recommendation tokens are separate: `not_evaluated`, `allow_review`, `needs_revision`, `checker_retry`, and `task_setup_blocked`.
 
 ## Week 2 Visibility Boundary
 
@@ -145,7 +145,7 @@ Conditions of satisfaction:
 - checker results are immutable after persistence
 - status and severity values are canonical
 - pre-submit feedback has a response contract but is not authoritative review-gate proof
-- post-submit checker runs can record `allow_review`, `needs_revision`, `checker_retry`, or `project_setup_required` as routing recommendations
+- post-submit checker runs can record `allow_review`, `needs_revision`, `checker_retry`, or `task_setup_blocked` as routing recommendations
 - `allow_review` is not stored as `accept`; it only means the submission can proceed to human review
 - checker-caused `needs_revision` stores `outcome_source = auto_checker`
 - checker output can be read through backend APIs
@@ -162,7 +162,7 @@ Conditions of satisfaction:
 - pre-submit checks return immediate feedback before final submission
 - `check_submission_packet` runs against real submission data
 - failed structural checks produce stored checker results
-- worker-fixable submission failures and project setup failures are blocked before human review with distinct routing recommendations
+- worker-fixable submission failures and locked task setup failures are blocked before human review with distinct routing recommendations
 
 ### Chunk 8: Evidence And Policy Checkers
 
@@ -179,7 +179,7 @@ Conditions of satisfaction:
 
 ### Chunk 9: Pre-Review Gate
 
-Automatically triggers internal post-submit checks after submission locking and calculates whether a checked submission moves to `REVIEW_PENDING`, user-facing `NEEDS_REVISION`, or internal `PROJECT_SETUP_REQUIRED`.
+Automatically triggers internal post-submit checks after submission locking and calculates whether a checked submission moves to `REVIEW_PENDING`, user-facing `NEEDS_REVISION`, or an internal `task_setup_blocked` repair route.
 
 Conditions of satisfaction:
 
@@ -197,7 +197,7 @@ Conditions of satisfaction:
 
 - at least one clean submission reaches `REVIEW_PENDING`
 - at least one worker-fixable submission failure is blocked
-- project setup failures and worker-fixable submission failures use distinct routing recommendations
+- locked task setup failures and worker-fixable submission failures use distinct routing recommendations
 - checker failures are documented in a failure catalog
 - false-positive and missing-checker notes are recorded
 

--- a/docs/template_review_packet.md
+++ b/docs/template_review_packet.md
@@ -56,11 +56,11 @@ Required when reviewing a resubmission.
 
 | Field | Value |
 | --- | --- |
-| context rebased | `yes | no` |
+| context rebased | yes or no |
 | prior guide version | `<guide version>` |
-| current submission guide version | `<guide version>` |
+| next guide version | `<guide version>` |
 | prior policy versions | `<checker/review/revision/payment policy versions>` |
-| current policy versions | `<checker/review/revision/payment policy versions>` |
+| next policy versions | `<checker/review/revision/payment policy versions>` |
 | change summary shown to worker | `<summary>` |
 | revision context audit event | `<audit event id>` |
 

--- a/docs/template_review_packet.md
+++ b/docs/template_review_packet.md
@@ -50,6 +50,20 @@ State whether checker output supports the decision.
 
 For resubmissions, list whether prior findings are closed.
 
+## Revision Context
+
+Required when reviewing a resubmission.
+
+| Field | Value |
+| --- | --- |
+| context rebased | `yes | no` |
+| prior guide version | `<guide version>` |
+| current submission guide version | `<guide version>` |
+| prior policy versions | `<checker/review/revision/payment policy versions>` |
+| current policy versions | `<checker/review/revision/payment policy versions>` |
+| change summary shown to worker | `<summary>` |
+| revision context audit event | `<audit event id>` |
+
 ## Payment Eligibility
 
 State whether this decision creates a pending payment.

--- a/docs/template_revision_replay.md
+++ b/docs/template_revision_replay.md
@@ -8,6 +8,34 @@
 
 ## Revision Summary
 
+## Revision Context
+
+Worker-visible fields:
+
+| Field | Value |
+| --- | --- |
+| prior submission id | `<submission id>` |
+| prior submission version | `<version>` |
+| context rebased | `yes | no` |
+| prior guide version | `<guide version>` |
+| next guide version | `<guide version>` |
+| prior checker policy version | `<checker policy version>` |
+| next checker policy version | `<checker policy version>` |
+| prior review policy version | `<review policy version>` |
+| next review policy version | `<review policy version>` |
+| prior revision policy version | `<revision policy version>` |
+| next revision policy version | `<revision policy version>` |
+| prior payment policy version | `<payment policy version>` |
+| next payment policy version | `<payment policy version>` |
+| rebase reason | `<reason>` |
+| change summary shown to worker | `<summary>` |
+
+Reviewer/admin fields:
+
+| Field | Value |
+| --- | --- |
+| audit event id | `<audit event id>` |
+
 ## Finding Closure
 
 Every high and medium prior finding must have one row. A resubmission cannot move to review if any required finding is unmapped.

--- a/docs/template_revision_replay.md
+++ b/docs/template_revision_replay.md
@@ -16,7 +16,7 @@ Worker-visible fields:
 | --- | --- |
 | prior submission id | `<submission id>` |
 | prior submission version | `<version>` |
-| context rebased | `yes | no` |
+| context rebased | yes or no |
 | prior guide version | `<guide version>` |
 | next guide version | `<guide version>` |
 | prior checker policy version | `<checker policy version>` |
@@ -42,7 +42,7 @@ Every high and medium prior finding must have one row. A resubmission cannot mov
 
 | Prior Finding ID | Prior Severity | Area | Required Fix | Worker Fix Summary | Evidence Ref | Worker Claim Status | Reviewer Closure Status |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `<finding id>` | `high | medium | low` | `<area>` | `<required fix>` | `<what changed>` | `<evidence id>` | `fixed | disputed | not_applicable` | `closed_fixed | closed_rebutted | partially_closed | still_open | obsolete` |
+| `<finding id>` | high / medium / low | `<area>` | `<required fix>` | `<what changed>` | `<evidence id>` | fixed / disputed / not_applicable | closed_fixed / closed_rebutted / partially_closed / still_open / obsolete |
 
 ## Checker Results After Revision
 

--- a/docs/template_submission_packet.md
+++ b/docs/template_submission_packet.md
@@ -50,6 +50,8 @@ Any known checker considerations.
 
 Only required for resubmissions.
 
+Workstream provides prior and next guide/policy context for the revision. The worker responds to the findings and changed requirements, but does not provide guide or policy versions manually.
+
 | Prior Finding | Fix Summary | Evidence | Status |
 | --- | --- | --- | --- |
 | `<finding>` | `<fix>` | `<evidence>` | `closed` |

--- a/scripts/check_internal_review_evidence.py
+++ b/scripts/check_internal_review_evidence.py
@@ -1,0 +1,131 @@
+"""Require internal reviewer evidence when PRs change Workstream contracts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+RELEVANT_PREFIXES = (
+    ".github/workflows/",
+    "AGENTS.md",
+    "README.md",
+    "backend/app/",
+    "backend/tests/",
+    "docs/",
+)
+IGNORED_PREFIXES = (
+    "docs/internal_reviews/",
+    "docs/diagrams/rendered/",
+)
+EVIDENCE_PREFIX = "docs/internal_reviews/"
+REQUIRED_TRACKS = (
+    "senior engineering",
+    "qa/test",
+    "security/auth",
+    "product/ops",
+)
+REQUIRED_PHRASES = (
+    "open sub-agent sessions: none",
+    "valid findings addressed",
+)
+
+
+def git(*args: str) -> str:
+    """Run git and return stdout."""
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def changed_files() -> list[str]:
+    """Return files changed by this PR or local branch."""
+    paths: list[str] = []
+
+    def add(output: str) -> None:
+        for line in output.splitlines():
+            if line and line not in paths:
+                paths.append(line)
+
+    base_ref = os.environ.get("INTERNAL_REVIEW_BASE_REF") or os.environ.get("GITHUB_BASE_REF")
+    if base_ref:
+        candidates = [f"origin/{base_ref}", base_ref]
+        for candidate in candidates:
+            try:
+                add(git("diff", "--name-only", f"{candidate}...HEAD"))
+                break
+            except subprocess.CalledProcessError:
+                continue
+    else:
+        try:
+            add(git("diff", "--name-only", "HEAD~1...HEAD"))
+        except subprocess.CalledProcessError:
+            pass
+
+    add(git("diff", "--name-only", "--cached"))
+    add(git("diff", "--name-only"))
+    add(git("ls-files", "--others", "--exclude-standard"))
+    return paths
+
+
+def is_relevant(path: str) -> bool:
+    """Return whether a changed path requires internal review evidence."""
+    if path.startswith(IGNORED_PREFIXES):
+        return False
+    return path.startswith(RELEVANT_PREFIXES)
+
+
+def validate_evidence(path: Path) -> list[str]:
+    """Validate one internal review evidence file."""
+    text = path.read_text(encoding="utf-8").lower()
+    missing = [track for track in REQUIRED_TRACKS if track not in text]
+    missing.extend(phrase for phrase in REQUIRED_PHRASES if phrase not in text)
+    return missing
+
+
+def main() -> int:
+    """Check that changed contract files include complete review evidence."""
+    changed = changed_files()
+    relevant = [path for path in changed if is_relevant(path)]
+    if not relevant:
+        print("No internal review evidence required for this change.")
+        return 0
+
+    evidence_paths = [
+        Path(path)
+        for path in changed
+        if path.startswith(EVIDENCE_PREFIX) and path.endswith(".md")
+    ]
+    if not evidence_paths:
+        print(
+            "Internal review evidence is required for Workstream contract changes.\n"
+            "Add a changed docs/internal_reviews/*.md file with senior engineering, "
+            "QA/test, security/auth, and product/ops results before opening the PR.",
+            file=sys.stderr,
+        )
+        return 1
+
+    failures: list[str] = []
+    for path in evidence_paths:
+        missing = validate_evidence(path)
+        if missing:
+            failures.append(f"{path}: missing {', '.join(missing)}")
+
+    if failures:
+        print("Internal review evidence is incomplete:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print("Internal review evidence gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add ADR 0010 for policy-controlled revision context preparation and guide/policy rebasing
- rename internal checker route from project_setup_required to task_setup_blocked across backend contracts, tests, and docs
- add internal review evidence gate plus reviewer evidence for this change

## Validation
- INTERNAL_REVIEW_BASE_REF=main python3 scripts/check_internal_review_evidence.py
- python3 -m py_compile scripts/check_internal_review_evidence.py
- backend: .venv/bin/python -m ruff check app tests scripts
- backend: .venv/bin/docstr-coverage --config .docstr.yaml
- backend: WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q (111 passed)
- backend: WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py -q (22 passed)
- Markdown local link check: 79 files ok
- stale routing wording scan: clean

## Internal reviewer tracks
- senior engineering: passed after fixes
- QA/test: passed after fixes
- security/auth: passed after fixes
- product/ops: passed after fixes

All sub-agent sessions were closed before opening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Revision workflow now shows prior and current guide/policy versions, plus a change summary, before workers resume.
  * PRs touching contract/docs now require internal review evidence for relevant changes (CI will block if missing).

* **Improvements**
  * System prepares revision context automatically and decides keep/rebase/block behavior before resumption.
  * Tasks with incomplete/stale locked setup are blocked from worker-facing revision and routed for project-manager repair.

* **Documentation**
  * Comprehensive updates clarifying revision context, routing, and audit requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->