### PR TITLE
Mark Week 2 closed with real API drill

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -14,19 +14,19 @@ jobs:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
         env:
-          POSTGRES_DB: workstream
+          POSTGRES_DB: workstream_test
           POSTGRES_USER: workstream
           POSTGRES_PASSWORD: workstream
         ports:
           - 5433:5432
         options: >-
-          --health-cmd "pg_isready -U workstream -d workstream"
+          --health-cmd "pg_isready -U workstream -d workstream_test"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
 
     env:
-      WORKSTREAM_TEST_DATABASE_URL: postgresql+asyncpg://workstream:workstream@localhost:5433/workstream
+      WORKSTREAM_TEST_DATABASE_URL: postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -62,5 +62,5 @@ jobs:
       - name: Week 1 real API e2e
         working-directory: backend
         env:
-          WORKSTREAM_DATABASE_URL: postgresql+asyncpg://workstream:workstream@localhost:5433/workstream
+          WORKSTREAM_DATABASE_URL: postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test
         run: python scripts/week1_api_e2e.py

--- a/README.md
+++ b/README.md
@@ -119,10 +119,16 @@ Workstream uses Postgres locally and in CI. Start the local database with:
 docker compose up -d postgres
 ```
 
-The default local test URL is:
+The default local development URL is:
 
 ```text
 postgresql+asyncpg://workstream:workstream@localhost:5433/workstream
+```
+
+Destructive real API drills use the separate local test database:
+
+```text
+postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test
 ```
 
 ## Week 1 API Demo UI

--- a/backend/app/modules/projects/service.py
+++ b/backend/app/modules/projects/service.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.permissions import require_any_role
+from app.modules.checkers.runner import UnknownChecker, default_checker_registry
 from app.modules.projects.models import (
     CheckerPolicy,
     PaymentPolicy,
@@ -39,6 +40,7 @@ from app.schemas.auth import ActorContext
 
 PROJECT_SETUP_ROLES = {"admin", "project_manager"}
 ALLOWED_REVIEW_DECISIONS = {"accept", "needs_revision", "reject"}
+ALLOWED_REVISION_RESUBMISSION_STATES = {"needs_revision"}
 
 
 class ProjectServiceError(Exception):
@@ -419,6 +421,13 @@ class ProjectService:
             raise GuideActivationBlocked("guide evidence policy is required before activation")
         if checker_policy is None or not checker_policy.required_checkers:
             raise GuideActivationBlocked("checker policy with required checkers is required")
+        checker_names = set(checker_policy.required_checkers or []).union(
+            checker_policy.warning_checkers or []
+        )
+        try:
+            default_checker_registry().require_registered(checker_names)
+        except UnknownChecker as exc:
+            raise GuideActivationBlocked(str(exc)) from exc
         if review_policy is None or not review_policy.allowed_decisions:
             raise GuideActivationBlocked("review policy with allowed decisions is required")
         if not set(review_policy.allowed_decisions).issubset(ALLOWED_REVIEW_DECISIONS):
@@ -431,6 +440,10 @@ class ProjectService:
             or not revision_policy.allowed_resubmission_states
         ):
             raise GuideActivationBlocked("revision policy is incomplete")
+        if not set(revision_policy.allowed_resubmission_states).issubset(
+            ALLOWED_REVISION_RESUBMISSION_STATES
+        ):
+            raise GuideActivationBlocked("revision policy contains invalid resubmission states")
         if payment_policy is None:
             raise GuideActivationBlocked("payment policy is required")
         if (

--- a/backend/scripts/week1_api_e2e.py
+++ b/backend/scripts/week1_api_e2e.py
@@ -14,14 +14,53 @@ import sys
 import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from urllib.parse import urlparse
 from uuid import uuid4
 
 import httpx
 from alembic import command
 from alembic.config import Config
+from sqlalchemy import select
 
+from app.db import session as db_session
+from app.modules.checkers.models import CheckerResult, CheckerRun
+from app.modules.projects.models import (
+    CheckerPolicy,
+    PaymentPolicy,
+    Project,
+    ProjectGuide,
+    RevisionPolicy,
+    ReviewPolicy,
+)
+from app.modules.tasks.models import (
+    AuditEvent,
+    EvidenceItem,
+    Submission,
+    TaskAssignment,
+    WorkstreamTask,
+)
+
+EXPECTED_DURABLE_CHECKERS = {
+    "check_submission_packet",
+    "check_policy_context_present",
+    "check_evidence_present",
+    "check_evidence_integrity",
+    "check_required_files",
+    "check_forbidden_files",
+    "check_confidentiality_attestation",
+    "check_low_quality_generated_artifacts",
+}
 DEFAULT_FLOW_ISSUER = "https://auth.flow.local/e2e"
 DEFAULT_FLOW_AUDIENCE = "workstream-api"
+LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
+LOCAL_DATABASE_NAMES = {"workstream_test", "test_workstream"}
+ASYNC_POSTGRES_SCHEMES = {"postgresql+asyncpg"}
+NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
+STRONG_ATTESTATION = (
+    "I attest this submission contains no confidential client data, credentials, "
+    "secrets, tokens, passwords, API keys, private source material, source code, "
+    "copied platform artifacts, or copied platform content."
+)
 
 
 def base64url_json(payload: dict) -> str:
@@ -72,6 +111,9 @@ def issue_flow_token(
     issuer: str,
     audience: str,
     secret: str,
+    issued_at: datetime | None = None,
+    expires_at: datetime | None = None,
+    not_before: datetime | None = None,
 ) -> str:
     """Issue a local Flow-compatible signed token for one QA actor.
 
@@ -81,11 +123,14 @@ def issue_flow_token(
         issuer: Flow issuer claim.
         audience: Flow audience claim.
         secret: HMAC secret shared with the local Flow verifier.
+        issued_at: Optional issued-at timestamp override.
+        expires_at: Optional expiration timestamp override.
+        not_before: Optional not-before timestamp override.
 
     Returns:
         HMAC-signed bearer token consumed by ``FlowAuthVerifier``.
     """
-    now = datetime.now(UTC)
+    now = issued_at or datetime.now(UTC)
     header = base64url_json({"alg": "HS256", "typ": "JWT"})
     payload = base64url_json(
         {
@@ -96,8 +141,8 @@ def issue_flow_token(
             "name": subject.replace("-", " ").title(),
             "roles": roles,
             "iat": int(now.timestamp()),
-            "nbf": int((now - timedelta(seconds=5)).timestamp()),
-            "exp": int((now + timedelta(minutes=30)).timestamp()),
+            "nbf": int((not_before or (now - timedelta(seconds=5))).timestamp()),
+            "exp": int((expires_at or (now + timedelta(minutes=30))).timestamp()),
         }
     )
     signed_content = f"{header}.{payload}".encode()
@@ -158,7 +203,7 @@ def api_environment() -> dict[str, str]:
     env = os.environ.copy()
     env.setdefault(
         "WORKSTREAM_DATABASE_URL",
-        "postgresql+asyncpg://workstream:workstream@localhost:5433/workstream",
+        "postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test",
     )
     flow_issuer, flow_audience, flow_secret = flow_settings(env)
     env["WORKSTREAM_E2E_FLOW_SECRET"] = flow_secret
@@ -284,6 +329,108 @@ async def request_json(
     return body
 
 
+async def wait_for_submission_checker_run(
+    client: httpx.AsyncClient,
+    manager_token: str,
+    submission_id: str,
+) -> dict:
+    """Wait for exactly one automatic checker run after submission lock.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        submission_id: Locked submission id.
+
+    Returns:
+        Completed checker run response.
+    """
+    last_count = 0
+    for _ in range(50):
+        runs = await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{submission_id}/checker-runs",
+            manager_token,
+        )
+        ensure(isinstance(runs, list), "checker run list did not return a list")
+        last_count = len(runs)
+        if len(runs) == 1 and runs[0]["trigger_source"] == "submission_locked":
+            run = await request_json(
+                client,
+                "GET",
+                f"/api/v1/checker-runs/{runs[0]['id']}",
+                manager_token,
+            )
+            if run["status"] == "completed":
+                return run
+        await asyncio.sleep(0.2)
+    raise AssertionError(f"expected one automatic checker run, got {last_count}")
+
+
+async def wait_for_task_status(
+    client: httpx.AsyncClient,
+    manager_token: str,
+    task_id: str,
+    expected_status: str,
+) -> dict:
+    """Wait for a task to reach an expected status through the API.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        task_id: Task id to poll.
+        expected_status: Expected status token.
+
+    Returns:
+        Task response at the expected status.
+    """
+    task: dict | None = None
+    for _ in range(50):
+        task = await request_json(client, "GET", f"/api/v1/tasks/{task_id}", manager_token)
+        if task["status"] == expected_status:
+            return task
+        await asyncio.sleep(0.2)
+    raise AssertionError(
+        f"expected task status {expected_status}, got {task['status'] if task else None}"
+    )
+
+
+def ensure(condition: bool, message: str) -> None:
+    """Raise a normal assertion error when a system invariant is false.
+
+    Args:
+        condition: Invariant result.
+        message: Failure message.
+    """
+    if not condition:
+        raise AssertionError(message)
+
+
+def assert_local_database_url(database_url: str) -> None:
+    """Fail closed unless the E2E database URL is explicitly local.
+
+    Args:
+        database_url: SQLAlchemy async database URL resolved for the drill.
+    """
+    parsed = urlparse(database_url)
+    database_name = parsed.path.lstrip("/")
+    is_local_async_postgres = (
+        parsed.scheme in ASYNC_POSTGRES_SCHEMES
+        and parsed.hostname in LOCAL_DATABASE_HOSTS
+        and database_name in LOCAL_DATABASE_NAMES
+    )
+    override = os.environ.get("WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE")
+    if is_local_async_postgres or override == NONLOCAL_DATABASE_OVERRIDE_VALUE:
+        return
+    raise RuntimeError(
+        "Refusing to run Week 1 API E2E against a non-local database. "
+        "Use an async Postgres URL such as postgresql+asyncpg:// on "
+        "localhost/127.0.0.1 with a local test database named "
+        "workstream_test or test_workstream, or set "
+        f"WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE={NONLOCAL_DATABASE_OVERRIDE_VALUE}."
+    )
+
+
 def guide_payload(run_id: str) -> dict:
     """Build a complete project guide payload.
 
@@ -369,6 +516,13 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
         audience=flow_audience,
         secret=flow_secret,
     )
+    unassigned_worker_token = issue_flow_token(
+        f"real-api-unassigned-worker-{run_id}",
+        ["worker"],
+        issuer=flow_issuer,
+        audience=flow_audience,
+        secret=flow_secret,
+    )
     reviewer_token = issue_flow_token(
         f"real-api-reviewer-{run_id}",
         ["reviewer"],
@@ -386,11 +540,47 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
         )[:-8]
         + "tampered"
     )
+    wrong_issuer_token = issue_flow_token(
+        f"real-api-wrong-issuer-{run_id}",
+        ["worker"],
+        issuer="https://auth.flow.local/wrong",
+        audience=flow_audience,
+        secret=flow_secret,
+    )
+    wrong_audience_token = issue_flow_token(
+        f"real-api-wrong-audience-{run_id}",
+        ["worker"],
+        issuer=flow_issuer,
+        audience="wrong-audience",
+        secret=flow_secret,
+    )
+    expired_token = issue_flow_token(
+        f"real-api-expired-{run_id}",
+        ["worker"],
+        issuer=flow_issuer,
+        audience=flow_audience,
+        secret=flow_secret,
+        issued_at=datetime.now(UTC) - timedelta(hours=1),
+        expires_at=datetime.now(UTC) - timedelta(minutes=30),
+    )
+    future_nbf_token = issue_flow_token(
+        f"real-api-future-nbf-{run_id}",
+        ["worker"],
+        issuer=flow_issuer,
+        audience=flow_audience,
+        secret=flow_secret,
+        not_before=datetime.now(UTC) + timedelta(minutes=30),
+    )
 
     async with httpx.AsyncClient(base_url=base_url, timeout=10) as client:
         await request_json(client, "GET", "/health")
         await request_json(client, "GET", "/api/v1/health")
+        await request_json(client, "GET", "/api/v1/auth/me", expected_status=401)
         await request_json(client, "GET", "/api/v1/auth/me", invalid_token, expected_status=401)
+        await request_json(client, "GET", "/api/v1/auth/me", wrong_issuer_token, expected_status=401)
+        await request_json(client, "GET", "/api/v1/auth/me", wrong_audience_token, expected_status=401)
+        await request_json(client, "GET", "/api/v1/auth/me", expired_token, expected_status=401)
+        await request_json(client, "GET", "/api/v1/auth/me", future_nbf_token, expected_status=401)
         manager = await request_json(client, "GET", "/api/v1/auth/me", manager_token)
         assert manager["auth_source"] == "flow"
         assert manager["is_dev_auth"] is False
@@ -435,7 +625,29 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
             manager_token,
         )
         assert active["guide"]["version"] == "v1"
+        await request_json(
+            client,
+            "PATCH",
+            f"/api/v1/projects/{project['id']}/guides/{guide['id']}",
+            manager_token,
+            {"change_summary": "Illegal active guide edit"},
+            409,
+        )
         await request_json(client, "GET", f"/api/v1/projects/{project['id']}/active-guide", manager_token)
+        await request_json(
+            client,
+            "POST",
+            f"/api/v1/projects/{project['id']}/tasks",
+            worker_token,
+            {
+                "title": "Worker must not create task",
+                "description": "Unauthorized task create probe.",
+                "source_type": "manual",
+                "acceptance_criteria": "Must fail.",
+                "required_evidence": ["log"],
+            },
+            403,
+        )
 
         task = await request_json(
             client,
@@ -460,13 +672,23 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
             201,
         )
         await request_json(client, "GET", f"/api/v1/tasks/{task['id']}", manager_token)
-        await request_json(
+        screened = await request_json(
             client,
             "POST",
             f"/api/v1/tasks/{task['id']}/screen",
             manager_token,
             {"reason": "real API screening passed"},
         )
+        assert {
+            screened["locked_guide_version"],
+            screened["locked_checker_policy_version"],
+            screened["locked_review_policy_version"],
+            screened["locked_revision_policy_version"],
+            screened["locked_payment_policy_version"],
+        } == {"v1"}
+        assert screened["base_amount"] == "25.00"
+        assert screened["currency"] == "USD"
+        assert screened["payout_type"] == "fixed"
         await request_json(
             client,
             "POST",
@@ -490,12 +712,26 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
         assert worker_profile["status"] == "active"
         assert set(worker_profile["skill_tags"]) == {"stem", "proofs"}
         await request_json(client, "GET", f"/api/v1/tasks/{task['id']}", worker_token)
+        await request_json(
+            client,
+            "GET",
+            f"/api/v1/tasks/{task['id']}",
+            unassigned_worker_token,
+            expected_status=200,
+        )
         claim = await request_json(
             client,
             "POST",
             f"/api/v1/tasks/{task['id']}/claim",
             worker_token,
             {"reason": "real worker claim"},
+        )
+        await request_json(
+            client,
+            "GET",
+            f"/api/v1/tasks/{task['id']}",
+            unassigned_worker_token,
+            expected_status=404,
         )
         await request_json(
             client,
@@ -521,7 +757,7 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
                         "notes": "real API artifact",
                     }
                 ],
-                "worker_attestation": "I confirm this packet follows the locked guide.",
+                "worker_attestation": STRONG_ATTESTATION,
                 "evidence_items": [
                     {
                         "type": "log",
@@ -535,9 +771,38 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
             },
             201,
         )
-        assert submission["locked_guide_version"] == "v1"
+        assert {
+            submission["locked_guide_version"],
+            submission["locked_checker_policy_version"],
+            submission["locked_review_policy_version"],
+            submission["locked_revision_policy_version"],
+            submission["locked_payment_policy_version"],
+        } == {"v1"}
+        await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{task['id']}/submissions",
+            manager_token,
+            {
+                "summary": "Manager cannot submit for worker.",
+                "package_hash": f"sha256:manager-package-{run_id}",
+                "artifact_hash_manifest": [
+                    {"artifact": "answer.md", "hash": f"sha256:manager-answer-{run_id}"}
+                ],
+                "worker_attestation": STRONG_ATTESTATION,
+                "evidence_items": [],
+            },
+            403,
+        )
         await request_json(client, "GET", f"/api/v1/tasks/{task['id']}/submissions", worker_token)
         await request_json(client, "GET", f"/api/v1/submissions/{submission['id']}", worker_token)
+        await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{submission['id']}",
+            unassigned_worker_token,
+            expected_status=404,
+        )
         await request_json(
             client,
             "POST",
@@ -552,13 +817,44 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
             manager_token,
         )
         assert locked["locked_at"] is not None
+        assert all(item["locked_at"] == locked["locked_at"] for item in locked["evidence_items"])
+        checker_run = await wait_for_submission_checker_run(client, manager_token, submission["id"])
+        assert checker_run["routing_recommendation"] == "allow_review"
+        assert {result["checker_name"] for result in checker_run["results"]} == EXPECTED_DURABLE_CHECKERS
+        await wait_for_task_status(client, manager_token, task["id"], "review_pending")
         audit_events = await request_json(
             client,
             "GET",
             f"/api/v1/tasks/{task['id']}/audit-events",
             manager_token,
         )
-        assert len(audit_events) >= 6
+        audit_transitions = {
+            (event["event_type"], event["from_status"], event["to_status"])
+            for event in audit_events
+        }
+        for expected_transition in {
+            ("task_created", None, "draft"),
+            ("task_status_changed", "draft", "screening"),
+            ("task_status_changed", "screening", "ready"),
+            ("task_status_changed", "ready", "claimed"),
+            ("task_status_changed", "claimed", "in_progress"),
+            ("submission_created", "in_progress", "submitted"),
+            ("submission_locked", "submitted", "submitted"),
+            ("pre_review_gate_started", "submitted", "auto_checking"),
+            ("pre_review_gate_passed", "auto_checking", "review_pending"),
+        }:
+            assert expected_transition in audit_transitions
+        worker_audit_events = await request_json(
+            client,
+            "GET",
+            f"/api/v1/tasks/{task['id']}/audit-events",
+            worker_token,
+        )
+        assert all(event["claim_snapshot"] == {} for event in worker_audit_events)
+        assert all(
+            "artifact_hash_manifest" not in event["event_payload"]
+            for event in worker_audit_events
+        )
         await request_json(
             client,
             "GET",
@@ -566,6 +862,16 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
             reviewer_token,
             expected_status=403,
         )
+
+    await assert_week1_database_invariants(
+        project_id=project["id"],
+        guide_id=guide["id"],
+        task_id=task["id"],
+        assignment_id=claim["assignment"]["id"],
+        submission_id=submission["id"],
+        worker_subject=worker_subject,
+        flow_issuer=flow_issuer,
+    )
 
     print("Week 1 real API e2e passed")
     print(f"project_id={project['id']}")
@@ -576,14 +882,159 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
     print(f"submission_locked_at={locked['locked_at']}")
 
 
+async def assert_week1_database_invariants(
+    *,
+    project_id: str,
+    guide_id: str,
+    task_id: str,
+    assignment_id: str,
+    submission_id: str,
+    worker_subject: str,
+    flow_issuer: str,
+) -> None:
+    """Verify Week 1 API calls produced the expected durable database state.
+
+    Args:
+        project_id: Created project id.
+        guide_id: Activated guide id.
+        task_id: Created task id.
+        assignment_id: Active assignment id.
+        submission_id: Locked submission id.
+        worker_subject: External Flow subject for the worker.
+        flow_issuer: External Flow issuer for the local token.
+    """
+    async with db_session.get_session_factory()() as session:
+        project = await session.get(Project, project_id)
+        guide = await session.get(ProjectGuide, guide_id)
+        task = await session.get(WorkstreamTask, task_id)
+        assignment = await session.get(TaskAssignment, assignment_id)
+        submission = await session.get(Submission, submission_id)
+
+        ensure(project is not None, "project was not persisted")
+        ensure(guide is not None, "guide was not persisted")
+        ensure(task is not None, "task was not persisted")
+        ensure(assignment is not None, "assignment was not persisted")
+        ensure(submission is not None, "submission was not persisted")
+
+        ensure(project.status == "active", f"project status drifted: {project.status}")
+        ensure(guide.status == "active", f"guide status drifted: {guide.status}")
+        ensure(guide.version == "v1", f"guide version drifted: {guide.version}")
+        ensure(guide.approved_by is not None, "active guide missing approver")
+        ensure(guide.effective_at is not None, "active guide missing effective_at")
+
+        for model, label in [
+            (CheckerPolicy, "checker policy"),
+            (ReviewPolicy, "review policy"),
+            (RevisionPolicy, "revision policy"),
+            (PaymentPolicy, "payment policy"),
+        ]:
+            policy = await session.scalar(
+                select(model).where(model.project_id == project_id, model.guide_version == "v1")
+            )
+            ensure(policy is not None, f"{label} missing for active guide")
+
+        locked_versions = {
+            task.locked_guide_version,
+            task.locked_checker_policy_version,
+            task.locked_review_policy_version,
+            task.locked_revision_policy_version,
+            task.locked_payment_policy_version,
+        }
+        ensure(locked_versions == {"v1"}, f"task locked versions drifted: {locked_versions}")
+        ensure(task.status == "review_pending", f"task status drifted: {task.status}")
+        ensure(task.assigned_to == assignment.worker_id, "task assignment pointer drifted")
+        ensure(assignment.status == "active", f"assignment status drifted: {assignment.status}")
+        ensure(assignment.accepted_at is not None, "assignment missing accepted_at")
+
+        ensure(submission.version == 1, f"submission version drifted: {submission.version}")
+        ensure(submission.status == "submitted", f"submission status drifted: {submission.status}")
+        ensure(submission.locked_at is not None, "submission was not locked")
+        ensure(submission.worker_id == assignment.worker_id, "submission worker drifted")
+        ensure(submission.supersedes_submission_id is None, "first submission supersedes another")
+        submission_versions = {
+            submission.locked_guide_version,
+            submission.locked_checker_policy_version,
+            submission.locked_review_policy_version,
+            submission.locked_revision_policy_version,
+            submission.locked_payment_policy_version,
+        }
+        ensure(submission_versions == {"v1"}, f"submission locked versions drifted: {submission_versions}")
+
+        evidence_items = (
+            await session.scalars(
+                select(EvidenceItem).where(EvidenceItem.submission_id == submission_id)
+            )
+        ).all()
+        ensure(len(evidence_items) == 1, f"expected 1 evidence item, got {len(evidence_items)}")
+        ensure(evidence_items[0].locked_at is not None, "evidence item was not locked")
+
+        checker_runs = (
+            await session.scalars(
+                select(CheckerRun).where(CheckerRun.submission_id == submission_id)
+            )
+        ).all()
+        ensure(len(checker_runs) == 1, f"expected 1 checker run, got {len(checker_runs)}")
+        checker_run = checker_runs[0]
+        ensure(checker_run.trigger_source == "submission_locked", "checker trigger source drifted")
+        ensure(checker_run.status == "completed", f"checker status drifted: {checker_run.status}")
+        ensure(checker_run.routing_recommendation == "allow_review", "checker route drifted")
+        ensure(checker_run.is_current_for_submission is True, "checker run is not current")
+        ensure(checker_run.attempt_number == 1, "first checker attempt number drifted")
+        ensure(checker_run.locked_guide_version == submission.locked_guide_version, "checker guide lock drifted")
+        ensure(checker_run.package_hash == submission.package_hash, "checker package hash drifted")
+
+        results = (
+            await session.scalars(
+                select(CheckerResult).where(CheckerResult.checker_run_id == checker_run.id)
+            )
+        ).all()
+        result_names = [result.checker_name for result in results]
+        duplicate_names = {
+            checker_name for checker_name in result_names if result_names.count(checker_name) > 1
+        }
+        ensure(not duplicate_names, f"duplicate checker results persisted: {duplicate_names}")
+        ensure(
+            set(result_names) == EXPECTED_DURABLE_CHECKERS,
+            f"checker result set drifted: {result_names}",
+        )
+        ensure(checker_run.passed_count == len(results), "checker passed count drifted")
+        ensure(checker_run.warning_count == 0, "unexpected checker warnings")
+        ensure(checker_run.failed_count == 0, "unexpected checker failures")
+        ensure(checker_run.blocking_count == 0, "unexpected checker blockers")
+
+        audit_events = (
+            await session.scalars(
+                select(AuditEvent).where(AuditEvent.entity_type == "task", AuditEvent.entity_id == task_id)
+            )
+        ).all()
+        event_types = [event.event_type for event in audit_events]
+        for required_event in [
+            "task_created",
+            "task_status_changed",
+            "submission_created",
+            "submission_locked",
+            "pre_review_gate_started",
+            "pre_review_gate_passed",
+        ]:
+            ensure(required_event in event_types, f"audit event missing: {required_event}")
+        ensure(
+            any(event.external_subject == worker_subject for event in audit_events),
+            "worker subject missing from task audit trail",
+        )
+        ensure(
+            all(event.external_issuer == flow_issuer for event in audit_events),
+            "audit issuer drifted",
+        )
+
+    print("PASS Week 1 database invariants")
+
+
 async def main(env: dict[str, str]) -> None:
     """Start the API server and exercise every Week 1 API.
 
     Args:
         env: Environment variables for the API server.
     """
-    from app.db import session as db_session
-
     await db_session.dispose_engine()
 
     port = find_free_port()
@@ -603,6 +1054,7 @@ async def main(env: dict[str, str]) -> None:
 
 if __name__ == "__main__":
     api_env = api_environment()
+    assert_local_database_url(api_env["WORKSTREAM_DATABASE_URL"])
     os.environ.update(api_env)
     command.upgrade(alembic_config(), "head")
     asyncio.run(main(api_env))

--- a/backend/scripts/week2_api_e2e.py
+++ b/backend/scripts/week2_api_e2e.py
@@ -1,0 +1,1025 @@
+"""Run real HTTP Week 2 checker flows against Postgres and local Flow tokens."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urlparse
+from uuid import uuid4
+
+import httpx
+from alembic import command
+
+from app.db import session as db_session
+from app.modules.tasks.models import WorkstreamTask
+from week1_api_e2e import (
+    alembic_config,
+    api_environment,
+    find_free_port,
+    flow_settings,
+    guide_payload,
+    issue_flow_token,
+    project_root,
+    request_json,
+    wait_for_health,
+)
+
+EXPECTED_DURABLE_CHECKERS = {
+    "check_submission_packet",
+    "check_policy_context_present",
+    "check_evidence_present",
+    "check_evidence_integrity",
+    "check_required_files",
+    "check_forbidden_files",
+    "check_confidentiality_attestation",
+    "check_low_quality_generated_artifacts",
+}
+EXPECTED_PRE_SUBMIT_CHECKERS = {
+    "check_submission_packet",
+    "check_evidence_present",
+    "check_evidence_integrity",
+    "check_required_files",
+    "check_forbidden_files",
+    "check_confidentiality_attestation",
+}
+LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
+LOCAL_DATABASE_NAMES = {"workstream", "workstream_test", "test_workstream"}
+NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
+STRONG_ATTESTATION = (
+    "I attest this submission contains no confidential client data, credentials, "
+    "secrets, tokens, passwords, API keys, private source material, source code, "
+    "copied platform artifacts, or copied platform content."
+)
+
+
+def ensure(condition: bool, message: str) -> None:
+    """Raise a normal assertion error when a drill invariant is false.
+
+    Args:
+        condition: Invariant result.
+        message: Failure message.
+    """
+    if not condition:
+        raise AssertionError(message)
+
+
+def assert_local_database_url(database_url: str) -> None:
+    """Fail closed unless the E2E database URL is explicitly local.
+
+    Args:
+        database_url: SQLAlchemy async database URL resolved for the drill.
+    """
+    parsed = urlparse(database_url)
+    database_name = parsed.path.lstrip("/")
+    is_local = (
+        parsed.scheme.startswith("postgresql")
+        and parsed.hostname in LOCAL_DATABASE_HOSTS
+        and database_name in LOCAL_DATABASE_NAMES
+    )
+    override = os.environ.get("WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE")
+    if is_local or override == NONLOCAL_DATABASE_OVERRIDE_VALUE:
+        return
+    raise RuntimeError(
+        "Refusing to run Week 2 API E2E against a non-local database. "
+        "Use localhost/127.0.0.1 with a local Workstream database, or set "
+        f"WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE={NONLOCAL_DATABASE_OVERRIDE_VALUE}."
+    )
+
+
+def start_week2_api_server(port: int, env: dict[str, str]) -> tuple[subprocess.Popen, Path]:
+    """Start a real uvicorn server process for the Week 2 drill.
+
+    Args:
+        port: Localhost port for the server.
+        env: Environment variables for the server process.
+
+    Returns:
+        Server process and Week 2-specific log path.
+    """
+    log_path = project_root() / ".week2_api_e2e_server.log"
+    log_file = log_path.open("w", encoding="utf-8")
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "app.main:create_app",
+            "--factory",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--log-level",
+            "warning",
+        ],
+        cwd=project_root(),
+        env=env,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    log_file.close()
+    return process, log_path
+
+
+def checker_result(run: dict, checker_name: str) -> dict:
+    """Return one checker result from a checker run response.
+
+    Args:
+        run: Checker run response payload.
+        checker_name: Checker name to find.
+
+    Returns:
+        Matching checker result payload.
+    """
+    for result in run["results"]:
+        if result["checker_name"] == checker_name:
+            return result
+    raise AssertionError(f"checker result missing: {checker_name}")
+
+
+def assert_default_checker_set(run: dict) -> None:
+    """Assert the Week 2 durable checker set ran.
+
+    Args:
+        run: Checker run response payload.
+    """
+    names = {result["checker_name"] for result in run["results"]}
+    missing = EXPECTED_DURABLE_CHECKERS.difference(names)
+    ensure(not missing, f"missing Week 2 durable checkers: {sorted(missing)}")
+
+
+def task_payload(run_id: str, suffix: str) -> dict:
+    """Build a complete task payload for a Week 2 API scenario.
+
+    Args:
+        run_id: Unique test run id.
+        suffix: Scenario suffix for source references.
+
+    Returns:
+        Task creation payload.
+    """
+    return {
+        "title": f"Week 2 checker task {suffix}",
+        "description": "Exercise Week 2 checker routing over real HTTP.",
+        "task_type": "evaluation",
+        "difficulty": "medium",
+        "skill_tags": ["stem", "proofs"],
+        "estimated_time_minutes": 45,
+        "source_type": "manual",
+        "source_ref": f"week2-{suffix}-{run_id}",
+        "source_payload_hash": f"sha256:source-{suffix}-{run_id}",
+        "acceptance_criteria": "Submission packet is complete and reviewable.",
+        "rejection_criteria": "Evidence or required output is missing.",
+        "required_files": ["answer.md"],
+        "required_evidence": ["checker log"],
+    }
+
+
+def submission_payload(run_id: str, suffix: str) -> dict:
+    """Build a complete submission packet payload.
+
+    Args:
+        run_id: Unique test run id.
+        suffix: Scenario suffix for deterministic hashes.
+
+    Returns:
+        Submission creation payload.
+    """
+    return {
+        "summary": f"Week 2 {suffix} packet completed.",
+        "package_uri": f"local://week2/{run_id}/{suffix}/package.tar.zst",
+        "package_hash": f"sha256:package-{suffix}-{run_id}",
+        "artifact_hash_manifest": [
+            {
+                "artifact": "answer.md",
+                "hash": f"sha256:answer-{suffix}-{run_id}",
+                "size_bytes": 128,
+                "notes": "main answer",
+            }
+        ],
+        "worker_attestation": STRONG_ATTESTATION,
+        "evidence_items": [
+            {
+                "type": "log",
+                "label": f"checker evidence {suffix}",
+                "uri": f"local://week2/{run_id}/{suffix}/checker.log",
+                "hash": f"sha256:evidence-{suffix}-{run_id}",
+                "size_bytes": 256,
+                "metadata": {"command": "week2_api_e2e"},
+            }
+        ],
+    }
+
+
+def token_for(
+    subject: str,
+    roles: list[str],
+    *,
+    issuer: str,
+    audience: str,
+    secret: str,
+) -> str:
+    """Issue one local Flow token for the Week 2 API drill.
+
+    Args:
+        subject: External Flow subject.
+        roles: Flow roles to include in the signed token.
+        issuer: Expected Flow issuer.
+        audience: Expected Flow audience.
+        secret: Local HMAC secret.
+
+    Returns:
+        Signed local Flow bearer token.
+    """
+    return issue_flow_token(
+        subject,
+        roles,
+        issuer=issuer,
+        audience=audience,
+        secret=secret,
+    )
+
+
+async def create_project_with_guide(
+    client: httpx.AsyncClient,
+    manager_token: str,
+    run_id: str,
+    suffix: str,
+    required_checkers: list[str] | None = None,
+) -> dict:
+    """Create a project and activate a complete guide over HTTP.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        run_id: Unique test run id.
+        suffix: Scenario suffix used in the project slug.
+        required_checkers: Optional checker policy override.
+
+    Returns:
+        Created project payload.
+    """
+    project = await request_json(
+        client,
+        "POST",
+        "/api/v1/projects",
+        manager_token,
+        {
+            "name": f"Week 2 API {suffix} {run_id}",
+            "slug": f"week2-api-{suffix}-{run_id}",
+            "description": "Real Week 2 checker API lifecycle QA",
+            "base_amount": "25.00",
+            "currency": "USD",
+        },
+        201,
+    )
+    payload = guide_payload(run_id)
+    if required_checkers is not None:
+        payload["checker_policy"]["required_checkers"] = required_checkers
+    guide = await request_json(
+        client,
+        "POST",
+        f"/api/v1/projects/{project['id']}/guides",
+        manager_token,
+        payload,
+        201,
+    )
+    await request_json(
+        client,
+        "POST",
+        f"/api/v1/projects/{project['id']}/guides/{guide['id']}/activate",
+        manager_token,
+    )
+    return project
+
+
+async def create_started_task(
+    client: httpx.AsyncClient,
+    *,
+    manager_token: str,
+    worker_token: str,
+    project_id: str,
+    run_id: str,
+    suffix: str,
+    worker_subject: str,
+    flow_issuer: str,
+) -> dict:
+    """Create, release, claim, and start one task over HTTP.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        worker_token: Worker Flow token.
+        project_id: Project id that owns the task.
+        run_id: Unique test run id.
+        suffix: Scenario suffix.
+        worker_subject: External Flow worker subject.
+        flow_issuer: Expected Flow issuer for the worker profile.
+
+    Returns:
+        Started task payload.
+    """
+    task = await request_json(
+        client,
+        "POST",
+        f"/api/v1/projects/{project_id}/tasks",
+        manager_token,
+        task_payload(run_id, suffix),
+        201,
+    )
+    await request_json(
+        client,
+        "POST",
+        f"/api/v1/tasks/{task['id']}/screen",
+        manager_token,
+        {"reason": f"{suffix} screening passed"},
+    )
+    await request_json(
+        client,
+        "POST",
+        f"/api/v1/tasks/{task['id']}/release",
+        manager_token,
+        {"reason": f"{suffix} release"},
+    )
+    worker_profile = await request_json(
+        client,
+        "POST",
+        "/api/v1/demo/worker-profile",
+        worker_token,
+        {"skill_tags": ["stem", "proofs"]},
+        201,
+    )
+    ensure(worker_profile["external_subject"] == worker_subject, "worker subject mismatch")
+    ensure(worker_profile["external_issuer"] == flow_issuer, "worker issuer mismatch")
+    await request_json(
+        client,
+        "POST",
+        f"/api/v1/tasks/{task['id']}/claim",
+        worker_token,
+        {"reason": f"{suffix} claim"},
+    )
+    started = await request_json(
+        client,
+        "POST",
+        f"/api/v1/tasks/{task['id']}/start",
+        worker_token,
+        {"reason": f"{suffix} start"},
+    )
+    ensure(started["status"] == "in_progress", "task did not start")
+    return started
+
+
+async def submit_lock_and_get_run(
+    client: httpx.AsyncClient,
+    *,
+    manager_token: str,
+    worker_token: str,
+    task_id: str,
+    payload: dict,
+) -> tuple[dict, dict]:
+    """Submit a packet, lock it, and return the automatic checker run.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        worker_token: Worker Flow token.
+        task_id: Task receiving the submission.
+        payload: Submission packet payload.
+
+    Returns:
+        Created submission and automatic checker run payload.
+    """
+    submission = await request_json(
+        client,
+        "POST",
+        f"/api/v1/tasks/{task_id}/submissions",
+        worker_token,
+        payload,
+        201,
+    )
+    await request_json(
+        client,
+        "POST",
+        f"/api/v1/submissions/{submission['id']}/lock",
+        manager_token,
+    )
+    runs = await request_json(
+        client,
+        "GET",
+        f"/api/v1/submissions/{submission['id']}/checker-runs",
+        manager_token,
+    )
+    ensure(isinstance(runs, list), "checker run list did not return a list")
+    ensure(len(runs) == 1, "automatic checker run was not created exactly once")
+    ensure(runs[0]["trigger_source"] == "submission_locked", "unexpected trigger source")
+    return submission, runs[0]
+
+
+async def assert_task_status(
+    client: httpx.AsyncClient,
+    manager_token: str,
+    task_id: str,
+    expected_status: str,
+) -> None:
+    """Assert the current task status through the API.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        task_id: Task id to read.
+        expected_status: Expected task status token.
+    """
+    task = await request_json(client, "GET", f"/api/v1/tasks/{task_id}", manager_token)
+    ensure(task["status"] == expected_status, f"expected {expected_status}, got {task['status']}")
+
+
+async def break_acceptance_criteria(task_id: str) -> None:
+    """Create a controlled locked task setup defect that normal APIs prevent.
+
+    Args:
+        task_id: Task id whose acceptance criteria should be removed.
+    """
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, task_id)
+        if task is None:
+            raise AssertionError(f"task not found: {task_id}")
+        task.acceptance_criteria = None
+        await session.commit()
+
+
+async def repair_acceptance_criteria(task_id: str) -> None:
+    """Repair the controlled task setup defect before trusted checker retry.
+
+    Args:
+        task_id: Task id whose acceptance criteria should be restored.
+    """
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, task_id)
+        if task is None:
+            raise AssertionError(f"task not found: {task_id}")
+        task.acceptance_criteria = "Submission packet is complete and reviewable."
+        await session.commit()
+
+
+async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
+    """Run real Week 2 checker flows over HTTP.
+
+    Args:
+        base_url: Real API server base URL.
+        env: Runtime environment shared by the API server and token issuer.
+    """
+    flow_issuer, flow_audience, flow_secret = flow_settings(env)
+    run_id = uuid4().hex[:8]
+    manager_token = token_for(
+        f"week2-manager-{run_id}",
+        ["project_manager"],
+        issuer=flow_issuer,
+        audience=flow_audience,
+        secret=flow_secret,
+    )
+    reviewer_token = token_for(
+        f"week2-reviewer-{run_id}",
+        ["reviewer"],
+        issuer=flow_issuer,
+        audience=flow_audience,
+        secret=flow_secret,
+    )
+
+    async with httpx.AsyncClient(base_url=base_url, timeout=10) as client:
+        await request_json(client, "GET", "/api/v1/health")
+
+        clean_worker_subject = f"week2-worker-clean-{run_id}"
+        clean_worker_token = token_for(
+            clean_worker_subject,
+            ["worker"],
+            issuer=flow_issuer,
+            audience=flow_audience,
+            secret=flow_secret,
+        )
+        clean_project = await create_project_with_guide(
+            client,
+            manager_token,
+            run_id,
+            "clean",
+        )
+        clean_task = await create_started_task(
+            client,
+            manager_token=manager_token,
+            worker_token=clean_worker_token,
+            project_id=clean_project["id"],
+            run_id=run_id,
+            suffix="clean",
+            worker_subject=clean_worker_subject,
+            flow_issuer=flow_issuer,
+        )
+        clean_precheck = await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{clean_task['id']}/submission-precheck",
+            clean_worker_token,
+            {"submission": submission_payload(run_id, "clean")},
+        )
+        ensure(clean_precheck["authoritative"] is False, "precheck must be non-authoritative")
+        ensure(clean_precheck["eligible_to_submit"] is True, "clean precheck should pass")
+        clean_precheck_names = {result["checker_name"] for result in clean_precheck["results"]}
+        ensure(
+            EXPECTED_PRE_SUBMIT_CHECKERS.issubset(clean_precheck_names),
+            "pre-submit checker set drifted",
+        )
+        clean_submission, clean_run = await submit_lock_and_get_run(
+            client,
+            manager_token=manager_token,
+            worker_token=clean_worker_token,
+            task_id=clean_task["id"],
+            payload=submission_payload(run_id, "clean"),
+        )
+        assert_default_checker_set(clean_run)
+        ensure(clean_run["routing_recommendation"] == "allow_review", "clean run was blocked")
+        ensure(clean_run["blocking_count"] == 0, "clean run had blocking checker results")
+        await assert_task_status(client, manager_token, clean_task["id"], "review_pending")
+        worker_clean_run = await request_json(
+            client,
+            "GET",
+            f"/api/v1/checker-runs/{clean_run['id']}",
+            clean_worker_token,
+        )
+        ensure(
+            worker_clean_run["routing_recommendation"] == "allow_review",
+            "worker clean route mismatch",
+        )
+        ensure(worker_clean_run["artifact_hash_manifest"] == [], "worker saw artifact manifest")
+        await request_json(
+            client,
+            "GET",
+            f"/api/v1/checker-runs/{clean_run['id']}",
+            reviewer_token,
+            expected_status=403,
+        )
+
+        revision_worker_subject = f"week2-worker-revision-{run_id}"
+        revision_worker_token = token_for(
+            revision_worker_subject,
+            ["worker"],
+            issuer=flow_issuer,
+            audience=flow_audience,
+            secret=flow_secret,
+        )
+        revision_project = await create_project_with_guide(
+            client,
+            manager_token,
+            run_id,
+            "revision",
+        )
+        revision_task = await create_started_task(
+            client,
+            manager_token=manager_token,
+            worker_token=revision_worker_token,
+            project_id=revision_project["id"],
+            run_id=run_id,
+            suffix="revision",
+            worker_subject=revision_worker_subject,
+            flow_issuer=flow_issuer,
+        )
+        missing_file_payload = submission_payload(run_id, "revision-v1")
+        missing_file_payload["artifact_hash_manifest"] = [
+            {
+                "artifact": "other.md",
+                "hash": f"sha256:other-{run_id}",
+                "size_bytes": 128,
+                "notes": "wrong artifact",
+            }
+        ]
+        failed_precheck = await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{revision_task['id']}/submission-precheck",
+            revision_worker_token,
+            {"submission": missing_file_payload},
+        )
+        ensure(failed_precheck["eligible_to_submit"] is False, "missing file precheck passed")
+        first_submission, first_run = await submit_lock_and_get_run(
+            client,
+            manager_token=manager_token,
+            worker_token=revision_worker_token,
+            task_id=revision_task["id"],
+            payload=missing_file_payload,
+        )
+        assert_default_checker_set(first_run)
+        ensure(first_run["routing_recommendation"] == "needs_revision", "missing file route drifted")
+        ensure(first_run["outcome_source"] == "auto_checker", "missing file source drifted")
+        await assert_task_status(client, manager_token, revision_task["id"], "needs_revision")
+        worker_revision_run = await request_json(
+            client,
+            "GET",
+            f"/api/v1/checker-runs/{first_run['id']}",
+            revision_worker_token,
+        )
+        required_file_result = checker_result(worker_revision_run, "check_required_files")
+        ensure(bool(required_file_result["worker_message"]), "required-file worker message missing")
+        ensure(required_file_result["metadata"] == {}, "worker saw required-file metadata")
+        second_submission, second_run = await submit_lock_and_get_run(
+            client,
+            manager_token=manager_token,
+            worker_token=revision_worker_token,
+            task_id=revision_task["id"],
+            payload=submission_payload(run_id, "revision-v2"),
+        )
+        assert_default_checker_set(second_run)
+        ensure(first_submission["version"] == 1, "first submission version drifted")
+        ensure(second_submission["version"] == 2, "second submission version drifted")
+        ensure(second_run["routing_recommendation"] == "allow_review", "fixed v2 did not pass")
+        await assert_task_status(client, manager_token, revision_task["id"], "review_pending")
+
+        missing_evidence_worker_subject = f"week2-worker-no-evidence-{run_id}"
+        missing_evidence_worker_token = token_for(
+            missing_evidence_worker_subject,
+            ["worker"],
+            issuer=flow_issuer,
+            audience=flow_audience,
+            secret=flow_secret,
+        )
+        missing_evidence_project = await create_project_with_guide(
+            client,
+            manager_token,
+            run_id,
+            "no-evidence",
+        )
+        missing_evidence_task = await create_started_task(
+            client,
+            manager_token=manager_token,
+            worker_token=missing_evidence_worker_token,
+            project_id=missing_evidence_project["id"],
+            run_id=run_id,
+            suffix="no-evidence",
+            worker_subject=missing_evidence_worker_subject,
+            flow_issuer=flow_issuer,
+        )
+        missing_evidence_payload = submission_payload(run_id, "no-evidence")
+        missing_evidence_payload["evidence_items"] = []
+        missing_evidence_precheck = await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{missing_evidence_task['id']}/submission-precheck",
+            missing_evidence_worker_token,
+            {"submission": missing_evidence_payload},
+        )
+        ensure(
+            missing_evidence_precheck["eligible_to_submit"] is False,
+            "missing evidence precheck should block submission",
+        )
+        missing_evidence_precheck_result = next(
+            result
+            for result in missing_evidence_precheck["results"]
+            if result["checker_name"] == "check_evidence_present"
+        )
+        ensure(
+            missing_evidence_precheck_result["status"] == "failed",
+            "missing evidence precheck did not fail",
+        )
+        await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{missing_evidence_task['id']}/submissions",
+            missing_evidence_worker_token,
+            missing_evidence_payload,
+            422,
+        )
+
+        integrity_worker_subject = f"week2-worker-integrity-{run_id}"
+        integrity_worker_token = token_for(
+            integrity_worker_subject,
+            ["worker"],
+            issuer=flow_issuer,
+            audience=flow_audience,
+            secret=flow_secret,
+        )
+        integrity_project = await create_project_with_guide(
+            client,
+            manager_token,
+            run_id,
+            "integrity",
+        )
+        integrity_task = await create_started_task(
+            client,
+            manager_token=manager_token,
+            worker_token=integrity_worker_token,
+            project_id=integrity_project["id"],
+            run_id=run_id,
+            suffix="integrity",
+            worker_subject=integrity_worker_subject,
+            flow_issuer=flow_issuer,
+        )
+        duplicate_artifact_payload = submission_payload(run_id, "integrity")
+        duplicate_artifact_payload["artifact_hash_manifest"].append(
+            {
+                "artifact": "answer.md",
+                "hash": f"sha256:duplicate-{run_id}",
+                "size_bytes": 128,
+                "notes": "duplicate artifact",
+            }
+        )
+        _, integrity_run = await submit_lock_and_get_run(
+            client,
+            manager_token=manager_token,
+            worker_token=integrity_worker_token,
+            task_id=integrity_task["id"],
+            payload=duplicate_artifact_payload,
+        )
+        assert_default_checker_set(integrity_run)
+        ensure(
+            integrity_run["routing_recommendation"] == "needs_revision",
+            "integrity failure did not route to needs_revision",
+        )
+        ensure(
+            checker_result(integrity_run, "check_evidence_integrity")["status"] == "failed",
+            "evidence integrity checker did not fail",
+        )
+
+        attestation_worker_subject = f"week2-worker-attestation-{run_id}"
+        attestation_worker_token = token_for(
+            attestation_worker_subject,
+            ["worker"],
+            issuer=flow_issuer,
+            audience=flow_audience,
+            secret=flow_secret,
+        )
+        attestation_project = await create_project_with_guide(
+            client,
+            manager_token,
+            run_id,
+            "attestation",
+        )
+        attestation_task = await create_started_task(
+            client,
+            manager_token=manager_token,
+            worker_token=attestation_worker_token,
+            project_id=attestation_project["id"],
+            run_id=run_id,
+            suffix="attestation",
+            worker_subject=attestation_worker_subject,
+            flow_issuer=flow_issuer,
+        )
+        weak_attestation_payload = submission_payload(run_id, "attestation")
+        weak_attestation_payload["worker_attestation"] = "ok"
+        _, attestation_run = await submit_lock_and_get_run(
+            client,
+            manager_token=manager_token,
+            worker_token=attestation_worker_token,
+            task_id=attestation_task["id"],
+            payload=weak_attestation_payload,
+        )
+        assert_default_checker_set(attestation_run)
+        ensure(
+            attestation_run["routing_recommendation"] == "needs_revision",
+            "weak attestation did not route to needs_revision",
+        )
+        ensure(
+            checker_result(attestation_run, "check_confidentiality_attestation")["status"]
+            == "failed",
+            "confidentiality attestation checker did not fail",
+        )
+
+        warning_worker_subject = f"week2-worker-warning-{run_id}"
+        warning_worker_token = token_for(
+            warning_worker_subject,
+            ["worker"],
+            issuer=flow_issuer,
+            audience=flow_audience,
+            secret=flow_secret,
+        )
+        warning_project = await create_project_with_guide(
+            client,
+            manager_token,
+            run_id,
+            "warning",
+        )
+        warning_task = await create_started_task(
+            client,
+            manager_token=manager_token,
+            worker_token=warning_worker_token,
+            project_id=warning_project["id"],
+            run_id=run_id,
+            suffix="warning",
+            worker_subject=warning_worker_subject,
+            flow_issuer=flow_issuer,
+        )
+        warning_payload = submission_payload(run_id, "warning")
+        warning_payload["summary"] = "Completed with a placeholder note that must be reviewed."
+        _, warning_run = await submit_lock_and_get_run(
+            client,
+            manager_token=manager_token,
+            worker_token=warning_worker_token,
+            task_id=warning_task["id"],
+            payload=warning_payload,
+        )
+        assert_default_checker_set(warning_run)
+        ensure(warning_run["routing_recommendation"] == "allow_review", "warning blocked review")
+        ensure(warning_run["warning_count"] >= 1, "warning checker count missing")
+        ensure(
+            checker_result(warning_run, "check_low_quality_generated_artifacts")["status"]
+            == "warning",
+            "low-quality generated artifact checker did not warn",
+        )
+
+        forbidden_worker_subject = f"week2-worker-forbidden-{run_id}"
+        forbidden_worker_token = token_for(
+            forbidden_worker_subject,
+            ["worker"],
+            issuer=flow_issuer,
+            audience=flow_audience,
+            secret=flow_secret,
+        )
+        forbidden_project = await create_project_with_guide(
+            client,
+            manager_token,
+            run_id,
+            "forbidden",
+        )
+        forbidden_task = await create_started_task(
+            client,
+            manager_token=manager_token,
+            worker_token=forbidden_worker_token,
+            project_id=forbidden_project["id"],
+            run_id=run_id,
+            suffix="forbidden",
+            worker_subject=forbidden_worker_subject,
+            flow_issuer=flow_issuer,
+        )
+        forbidden_payload = submission_payload(run_id, "forbidden")
+        forbidden_payload["artifact_hash_manifest"].append(
+            {
+                "artifact": "secrets/.env",
+                "hash": f"sha256:forbidden-{run_id}",
+                "size_bytes": 64,
+                "notes": "must be blocked",
+            }
+        )
+        _, forbidden_run = await submit_lock_and_get_run(
+            client,
+            manager_token=manager_token,
+            worker_token=forbidden_worker_token,
+            task_id=forbidden_task["id"],
+            payload=forbidden_payload,
+        )
+        assert_default_checker_set(forbidden_run)
+        ensure(
+            forbidden_run["routing_recommendation"] == "needs_revision",
+            "forbidden path did not route to needs_revision",
+        )
+        ensure(
+            checker_result(forbidden_run, "check_forbidden_files")["status"] == "failed",
+            "forbidden-file checker did not fail",
+        )
+        worker_forbidden_run = await request_json(
+            client,
+            "GET",
+            f"/api/v1/checker-runs/{forbidden_run['id']}",
+            forbidden_worker_token,
+        )
+        serialized_forbidden = str(worker_forbidden_run)
+        ensure(".env" not in serialized_forbidden, "worker saw forbidden .env path")
+        ensure("secrets/" not in serialized_forbidden, "worker saw forbidden directory path")
+        ensure("local://" not in serialized_forbidden, "worker saw internal storage URI")
+
+        setup_worker_subject = f"week2-worker-setup-{run_id}"
+        setup_worker_token = token_for(
+            setup_worker_subject,
+            ["worker"],
+            issuer=flow_issuer,
+            audience=flow_audience,
+            secret=flow_secret,
+        )
+        setup_project = await create_project_with_guide(
+            client,
+            manager_token,
+            run_id,
+            "setup",
+            required_checkers=["check_acceptance_criteria_present"],
+        )
+        setup_task = await create_started_task(
+            client,
+            manager_token=manager_token,
+            worker_token=setup_worker_token,
+            project_id=setup_project["id"],
+            run_id=run_id,
+            suffix="setup",
+            worker_subject=setup_worker_subject,
+            flow_issuer=flow_issuer,
+        )
+        setup_submission = await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{setup_task['id']}/submissions",
+            setup_worker_token,
+            submission_payload(run_id, "setup"),
+            201,
+        )
+        await break_acceptance_criteria(setup_task["id"])
+        await request_json(
+            client,
+            "POST",
+            f"/api/v1/submissions/{setup_submission['id']}/lock",
+            manager_token,
+        )
+        setup_runs = await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{setup_submission['id']}/checker-runs",
+            manager_token,
+        )
+        setup_run = setup_runs[0]
+        ensure(
+            setup_run["routing_recommendation"] == "task_setup_blocked",
+            "task setup defect did not use internal route",
+        )
+        ensure(
+            checker_result(setup_run, "check_acceptance_criteria_present")["status"] == "failed",
+            "acceptance criteria checker did not fail",
+        )
+        await assert_task_status(client, manager_token, setup_task["id"], "auto_checking")
+        worker_setup_run = await request_json(
+            client,
+            "GET",
+            f"/api/v1/checker-runs/{setup_run['id']}",
+            setup_worker_token,
+        )
+        ensure(
+            worker_setup_run["routing_recommendation"] == "not_evaluated",
+            "worker saw internal setup route",
+        )
+        ensure(worker_setup_run["results"] == [], "worker saw internal setup results")
+        await repair_acceptance_criteria(setup_task["id"])
+        retry = await request_json(
+            client,
+            "POST",
+            f"/api/v1/submissions/{setup_submission['id']}/checker-runs",
+            manager_token,
+            {"trigger_reason": "Week 2 API setup repair"},
+        )
+        ensure(retry["attempt_number"] == 2, "trusted checker retry did not create attempt 2")
+        ensure(
+            retry["routing_recommendation"] == "allow_review",
+            "trusted checker retry did not pass",
+        )
+        ensure(
+            retry["supersedes_checker_run_id"] == setup_run["id"],
+            "trusted checker retry did not supersede blocked run",
+        )
+        await assert_task_status(client, manager_token, setup_task["id"], "review_pending")
+
+    print("Week 2 real API e2e passed")
+    print("scenario_summary:")
+    print("clean=review_pending")
+    print("missing_file=needs_revision")
+    print("missing_evidence=pre_submit_blocked")
+    print("duplicate_artifact_integrity=needs_revision")
+    print("weak_attestation=needs_revision")
+    print("generated_output_warning=review_pending")
+    print("forbidden_path=needs_revision")
+    print("task_setup_blocked=auto_checking->review_pending")
+    print(f"clean_task_id={clean_task['id']}")
+    print(f"clean_submission_id={clean_submission['id']}")
+    print(f"revision_task_id={revision_task['id']}")
+    print(f"revision_v1_submission_id={first_submission['id']}")
+    print(f"revision_v2_submission_id={second_submission['id']}")
+    print(f"missing_evidence_task_id={missing_evidence_task['id']}")
+    print(f"integrity_task_id={integrity_task['id']}")
+    print(f"attestation_task_id={attestation_task['id']}")
+    print(f"warning_task_id={warning_task['id']}")
+    print(f"forbidden_task_id={forbidden_task['id']}")
+    print(f"setup_task_id={setup_task['id']}")
+
+
+async def main(env: dict[str, str]) -> None:
+    """Start the API server and exercise Week 2 checker APIs.
+
+    Args:
+        env: Environment variables for the API server.
+    """
+    await db_session.dispose_engine()
+
+    port = find_free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    process, log_path = start_week2_api_server(port, env)
+    try:
+        await wait_for_health(base_url, process, log_path)
+        await exercise_week2_api(base_url, env)
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+
+if __name__ == "__main__":
+    api_env = api_environment()
+    assert_local_database_url(api_env["WORKSTREAM_DATABASE_URL"])
+    os.environ.update(api_env)
+    command.upgrade(alembic_config(), "head")
+    asyncio.run(main(api_env))

--- a/backend/scripts/week2_api_e2e.py
+++ b/backend/scripts/week2_api_e2e.py
@@ -47,6 +47,7 @@ EXPECTED_PRE_SUBMIT_CHECKERS = {
 }
 LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
 LOCAL_DATABASE_NAMES = {"workstream", "workstream_test", "test_workstream"}
+ASYNC_POSTGRES_SCHEMES = {"postgresql+asyncpg"}
 NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
 STRONG_ATTESTATION = (
     "I attest this submission contains no confidential client data, credentials, "
@@ -74,17 +75,18 @@ def assert_local_database_url(database_url: str) -> None:
     """
     parsed = urlparse(database_url)
     database_name = parsed.path.lstrip("/")
-    is_local = (
-        parsed.scheme.startswith("postgresql")
+    is_local_async_postgres = (
+        parsed.scheme in ASYNC_POSTGRES_SCHEMES
         and parsed.hostname in LOCAL_DATABASE_HOSTS
         and database_name in LOCAL_DATABASE_NAMES
     )
     override = os.environ.get("WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE")
-    if is_local or override == NONLOCAL_DATABASE_OVERRIDE_VALUE:
+    if is_local_async_postgres or override == NONLOCAL_DATABASE_OVERRIDE_VALUE:
         return
     raise RuntimeError(
         "Refusing to run Week 2 API E2E against a non-local database. "
-        "Use localhost/127.0.0.1 with a local Workstream database, or set "
+        "Use an async Postgres URL such as postgresql+asyncpg:// on "
+        "localhost/127.0.0.1 with a local Workstream database, or set "
         f"WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE={NONLOCAL_DATABASE_OVERRIDE_VALUE}."
     )
 
@@ -147,9 +149,49 @@ def assert_default_checker_set(run: dict) -> None:
     Args:
         run: Checker run response payload.
     """
-    names = {result["checker_name"] for result in run["results"]}
-    missing = EXPECTED_DURABLE_CHECKERS.difference(names)
-    ensure(not missing, f"missing Week 2 durable checkers: {sorted(missing)}")
+    assert_checker_set(run["results"], EXPECTED_DURABLE_CHECKERS, "default durable")
+
+
+def assert_setup_checker_set(run: dict) -> None:
+    """Assert the setup-defect checker set ran exactly.
+
+    Args:
+        run: Checker run response payload.
+    """
+    assert_checker_set(
+        run["results"],
+        EXPECTED_DURABLE_CHECKERS | {"check_acceptance_criteria_present"},
+        "setup durable",
+    )
+
+
+def assert_checker_set(results: list[dict], expected: set[str], label: str) -> None:
+    """Assert a checker result list matches the expected checker contract.
+
+    Args:
+        results: Checker result payloads.
+        expected: Expected checker names.
+        label: Human-readable checker set label.
+    """
+    names = {result["checker_name"] for result in results}
+    missing = expected.difference(names)
+    unexpected = names.difference(expected)
+    ensure(
+        not missing and not unexpected,
+        (
+            f"{label} checker set drifted: "
+            f"missing={sorted(missing)} unexpected={sorted(unexpected)}"
+        ),
+    )
+
+
+def assert_pre_submit_checker_set(response: dict) -> None:
+    """Assert the Week 2 pre-submit checker set ran exactly.
+
+    Args:
+        response: Pre-submit checker response payload.
+    """
+    assert_checker_set(response["results"], EXPECTED_PRE_SUBMIT_CHECKERS, "pre-submit")
 
 
 def task_payload(run_id: str, suffix: str) -> dict:
@@ -407,16 +449,83 @@ async def submit_lock_and_get_run(
         f"/api/v1/submissions/{submission['id']}/lock",
         manager_token,
     )
-    runs = await request_json(
+    checker_run = await wait_for_submission_checker_run(
         client,
-        "GET",
-        f"/api/v1/submissions/{submission['id']}/checker-runs",
         manager_token,
+        submission["id"],
     )
-    ensure(isinstance(runs, list), "checker run list did not return a list")
-    ensure(len(runs) == 1, "automatic checker run was not created exactly once")
-    ensure(runs[0]["trigger_source"] == "submission_locked", "unexpected trigger source")
-    return submission, runs[0]
+    return submission, checker_run
+
+
+async def wait_for_submission_checker_run(
+    client: httpx.AsyncClient,
+    manager_token: str,
+    submission_id: str,
+) -> dict:
+    """Wait for the automatic submission-locked checker run.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        submission_id: Submission id whose checker run should exist.
+
+    Returns:
+        Completed checker run payload.
+    """
+    last_count = 0
+    for _ in range(50):
+        runs = await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{submission_id}/checker-runs",
+            manager_token,
+        )
+        ensure(isinstance(runs, list), "checker run list did not return a list")
+        last_count = len(runs)
+        if len(runs) == 1 and runs[0]["trigger_source"] == "submission_locked":
+            return await wait_for_checker_run_terminal(
+                client,
+                manager_token,
+                runs[0]["id"],
+            )
+        await asyncio.sleep(0.2)
+    raise AssertionError(
+        "automatic checker run was not created exactly once: "
+        f"submission_id={submission_id} count={last_count}"
+    )
+
+
+async def wait_for_checker_run_terminal(
+    client: httpx.AsyncClient,
+    manager_token: str,
+    checker_run_id: str,
+) -> dict:
+    """Wait for a checker run to reach a terminal status.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        checker_run_id: Checker run id to poll.
+
+    Returns:
+        Terminal checker run payload.
+    """
+    terminal_statuses = {"completed", "failed"}
+    checker_run: dict | None = None
+    for _ in range(50):
+        checker_run = await request_json(
+            client,
+            "GET",
+            f"/api/v1/checker-runs/{checker_run_id}",
+            manager_token,
+        )
+        if checker_run["status"] in terminal_statuses:
+            return checker_run
+        await asyncio.sleep(0.2)
+    raise AssertionError(
+        "checker run did not reach terminal status: "
+        f"checker_run_id={checker_run_id} status={checker_run['status'] if checker_run else None}"
+    )
 
 
 async def assert_task_status(
@@ -433,8 +542,15 @@ async def assert_task_status(
         task_id: Task id to read.
         expected_status: Expected task status token.
     """
-    task = await request_json(client, "GET", f"/api/v1/tasks/{task_id}", manager_token)
-    ensure(task["status"] == expected_status, f"expected {expected_status}, got {task['status']}")
+    task: dict | None = None
+    for _ in range(50):
+        task = await request_json(client, "GET", f"/api/v1/tasks/{task_id}", manager_token)
+        if task["status"] == expected_status:
+            return
+        await asyncio.sleep(0.2)
+    raise AssertionError(
+        f"expected {expected_status}, got {task['status'] if task else None}"
+    )
 
 
 async def break_acceptance_criteria(task_id: str) -> None:
@@ -525,11 +641,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         )
         ensure(clean_precheck["authoritative"] is False, "precheck must be non-authoritative")
         ensure(clean_precheck["eligible_to_submit"] is True, "clean precheck should pass")
-        clean_precheck_names = {result["checker_name"] for result in clean_precheck["results"]}
-        ensure(
-            EXPECTED_PRE_SUBMIT_CHECKERS.issubset(clean_precheck_names),
-            "pre-submit checker set drifted",
-        )
+        assert_pre_submit_checker_set(clean_precheck)
         clean_submission, clean_run = await submit_lock_and_get_run(
             client,
             manager_token=manager_token,
@@ -600,6 +712,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             revision_worker_token,
             {"submission": missing_file_payload},
         )
+        assert_pre_submit_checker_set(failed_precheck)
         ensure(failed_precheck["eligible_to_submit"] is False, "missing file precheck passed")
         first_submission, first_run = await submit_lock_and_get_run(
             client,
@@ -667,6 +780,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             missing_evidence_worker_token,
             {"submission": missing_evidence_payload},
         )
+        assert_pre_submit_checker_set(missing_evidence_precheck)
         ensure(
             missing_evidence_precheck["eligible_to_submit"] is False,
             "missing evidence precheck should block submission",
@@ -925,13 +1039,12 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             f"/api/v1/submissions/{setup_submission['id']}/lock",
             manager_token,
         )
-        setup_runs = await request_json(
+        setup_run = await wait_for_submission_checker_run(
             client,
-            "GET",
-            f"/api/v1/submissions/{setup_submission['id']}/checker-runs",
             manager_token,
+            setup_submission["id"],
         )
-        setup_run = setup_runs[0]
+        assert_setup_checker_set(setup_run)
         ensure(
             setup_run["routing_recommendation"] == "task_setup_blocked",
             "task setup defect did not use internal route",
@@ -960,6 +1073,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             manager_token,
             {"trigger_reason": "Week 2 API setup repair"},
         )
+        assert_setup_checker_set(retry)
         ensure(retry["attempt_number"] == 2, "trusted checker retry did not create attempt 2")
         ensure(
             retry["routing_recommendation"] == "allow_review",

--- a/backend/scripts/week2_api_e2e.py
+++ b/backend/scripts/week2_api_e2e.py
@@ -12,9 +12,11 @@ from uuid import uuid4
 
 import httpx
 from alembic import command
+from sqlalchemy import select
 
 from app.db import session as db_session
-from app.modules.tasks.models import WorkstreamTask
+from app.modules.checkers.models import CheckerResult, CheckerRun
+from app.modules.tasks.models import AuditEvent, EvidenceItem, Submission, WorkstreamTask
 from week1_api_e2e import (
     alembic_config,
     api_environment,
@@ -46,7 +48,7 @@ EXPECTED_PRE_SUBMIT_CHECKERS = {
     "check_confidentiality_attestation",
 }
 LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
-LOCAL_DATABASE_NAMES = {"workstream", "workstream_test", "test_workstream"}
+LOCAL_DATABASE_NAMES = {"workstream_test", "test_workstream"}
 ASYNC_POSTGRES_SCHEMES = {"postgresql+asyncpg"}
 NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
 STRONG_ATTESTATION = (
@@ -86,7 +88,8 @@ def assert_local_database_url(database_url: str) -> None:
     raise RuntimeError(
         "Refusing to run Week 2 API E2E against a non-local database. "
         "Use an async Postgres URL such as postgresql+asyncpg:// on "
-        "localhost/127.0.0.1 with a local Workstream database, or set "
+        "localhost/127.0.0.1 with a local test database named "
+        "workstream_test or test_workstream, or set "
         f"WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE={NONLOCAL_DATABASE_OVERRIDE_VALUE}."
     )
 
@@ -173,9 +176,12 @@ def assert_checker_set(results: list[dict], expected: set[str], label: str) -> N
         expected: Expected checker names.
         label: Human-readable checker set label.
     """
-    names = {result["checker_name"] for result in results}
-    missing = expected.difference(names)
-    unexpected = names.difference(expected)
+    names = [result["checker_name"] for result in results]
+    duplicate_names = {checker_name for checker_name in names if names.count(checker_name) > 1}
+    ensure(not duplicate_names, f"{label} checker set has duplicate results: {duplicate_names}")
+    name_set = set(names)
+    missing = expected.difference(name_set)
+    unexpected = name_set.difference(expected)
     ensure(
         not missing and not unexpected,
         (
@@ -422,7 +428,7 @@ async def submit_lock_and_get_run(
     worker_token: str,
     task_id: str,
     payload: dict,
-) -> tuple[dict, dict]:
+) -> tuple[dict, dict, dict]:
     """Submit a packet, lock it, and return the automatic checker run.
 
     Args:
@@ -433,7 +439,7 @@ async def submit_lock_and_get_run(
         payload: Submission packet payload.
 
     Returns:
-        Created submission and automatic checker run payload.
+        Created submission, locked submission, and automatic checker run payload.
     """
     submission = await request_json(
         client,
@@ -443,18 +449,75 @@ async def submit_lock_and_get_run(
         payload,
         201,
     )
-    await request_json(
+    locked = await request_json(
         client,
         "POST",
         f"/api/v1/submissions/{submission['id']}/lock",
         manager_token,
     )
+    assert_locked_submission_response(locked)
     checker_run = await wait_for_submission_checker_run(
         client,
         manager_token,
         submission["id"],
     )
-    return submission, checker_run
+    return submission, locked, checker_run
+
+
+def assert_locked_submission_response(submission: dict) -> None:
+    """Assert a locked submission response has complete locked context.
+
+    Args:
+        submission: Locked submission response payload.
+    """
+    ensure(submission["locked_at"] is not None, "locked submission missing locked_at")
+    locked_versions = {
+        submission["locked_guide_version"],
+        submission["locked_checker_policy_version"],
+        submission["locked_review_policy_version"],
+        submission["locked_revision_policy_version"],
+        submission["locked_payment_policy_version"],
+    }
+    ensure(locked_versions == {"v1"}, f"locked context drifted: {locked_versions}")
+    ensure(
+        all(item["locked_at"] == submission["locked_at"] for item in submission["evidence_items"]),
+        "evidence item locked_at does not match submission locked_at",
+    )
+
+
+async def assert_lock_idempotency(
+    client: httpx.AsyncClient,
+    *,
+    manager_token: str,
+    submission_id: str,
+    expected_locked_at: str,
+    expected_checker_run_id: str,
+) -> None:
+    """Assert locking an already locked submission does not create another run.
+
+    Args:
+        client: Real HTTP client.
+        manager_token: Project manager Flow token.
+        submission_id: Submission id to relock.
+        expected_locked_at: Original lock timestamp.
+        expected_checker_run_id: Original automatic checker run id.
+    """
+    relocked = await request_json(
+        client,
+        "POST",
+        f"/api/v1/submissions/{submission_id}/lock",
+        manager_token,
+    )
+    ensure(relocked["locked_at"] == expected_locked_at, "idempotent lock changed locked_at")
+    runs = await request_json(
+        client,
+        "GET",
+        f"/api/v1/submissions/{submission_id}/checker-runs",
+        manager_token,
+    )
+    ensure(len(runs) == 1, f"idempotent lock created extra checker runs: {len(runs)}")
+    ensure(runs[0]["id"] == expected_checker_run_id, "idempotent lock changed checker run")
+    ensure(runs[0]["attempt_number"] == 1, "idempotent lock changed attempt number")
 
 
 async def wait_for_submission_checker_run(
@@ -581,6 +644,176 @@ async def repair_acceptance_criteria(task_id: str) -> None:
         await session.commit()
 
 
+async def assert_week2_database_invariants(scenarios: list[dict]) -> None:
+    """Verify Week 2 API scenarios produced exact durable database state.
+
+    Args:
+        scenarios: Scenario expectations captured from real API responses.
+    """
+    async with db_session.get_session_factory()() as session:
+        for scenario in scenarios:
+            task = await session.get(WorkstreamTask, scenario["task_id"])
+            submission = await session.get(Submission, scenario["submission_id"])
+            checker_run = await session.get(CheckerRun, scenario["checker_run_id"])
+            ensure(task is not None, f"{scenario['name']} task missing")
+            ensure(submission is not None, f"{scenario['name']} submission missing")
+            ensure(checker_run is not None, f"{scenario['name']} checker run missing")
+
+            ensure(
+                task.status == scenario["expected_task_status"],
+                f"{scenario['name']} task status drifted: {task.status}",
+            )
+            task_versions = {
+                task.locked_guide_version,
+                task.locked_checker_policy_version,
+                task.locked_review_policy_version,
+                task.locked_revision_policy_version,
+                task.locked_payment_policy_version,
+            }
+            ensure(task_versions == {"v1"}, f"{scenario['name']} task context drifted")
+            submission_versions = {
+                submission.locked_guide_version,
+                submission.locked_checker_policy_version,
+                submission.locked_review_policy_version,
+                submission.locked_revision_policy_version,
+                submission.locked_payment_policy_version,
+            }
+            ensure(
+                submission_versions == task_versions,
+                f"{scenario['name']} submission context drifted",
+            )
+            ensure(submission.locked_at is not None, f"{scenario['name']} submission not locked")
+            ensure(
+                submission.locked_at.isoformat().replace("+00:00", "Z")
+                == scenario["locked_at"],
+                f"{scenario['name']} locked_at response/database drifted",
+            )
+            evidence_items = (
+                await session.scalars(
+                    select(EvidenceItem).where(EvidenceItem.submission_id == submission.id)
+                )
+            ).all()
+            ensure(evidence_items, f"{scenario['name']} evidence items missing")
+            ensure(
+                all(item.locked_at == submission.locked_at for item in evidence_items),
+                f"{scenario['name']} evidence lock drifted",
+            )
+
+            ensure(
+                checker_run.routing_recommendation == scenario["expected_route"],
+                f"{scenario['name']} checker route drifted",
+            )
+            ensure(checker_run.status == "completed", f"{scenario['name']} checker incomplete")
+            ensure(
+                checker_run.trigger_source == scenario["expected_trigger_source"],
+                f"{scenario['name']} checker trigger drifted",
+            )
+            ensure(
+                checker_run.attempt_number == scenario["expected_attempt"],
+                f"{scenario['name']} checker attempt drifted",
+            )
+            ensure(
+                checker_run.is_current_for_submission is scenario["expected_current"],
+                f"{scenario['name']} current-run flag drifted",
+            )
+            ensure(
+                checker_run.submission_version == submission.version,
+                f"{scenario['name']} submission version drifted on checker run",
+            )
+            ensure(
+                checker_run.package_hash == submission.package_hash,
+                f"{scenario['name']} package hash drifted on checker run",
+            )
+            run_versions = {
+                checker_run.locked_guide_version,
+                checker_run.locked_checker_policy_version,
+                checker_run.locked_review_policy_version,
+                checker_run.locked_revision_policy_version,
+                checker_run.locked_payment_policy_version,
+            }
+            ensure(run_versions == submission_versions, f"{scenario['name']} checker context drifted")
+
+            results = (
+                await session.scalars(
+                    select(CheckerResult).where(CheckerResult.checker_run_id == checker_run.id)
+                )
+            ).all()
+            result_names = [result.checker_name for result in results]
+            duplicate_names = {
+                checker_name for checker_name in result_names if result_names.count(checker_name) > 1
+            }
+            ensure(
+                not duplicate_names,
+                f"{scenario['name']} duplicate checker results persisted: {duplicate_names}",
+            )
+            ensure(
+                set(result_names) == scenario["expected_checkers"],
+                f"{scenario['name']} checker set drifted: {result_names}",
+            )
+            ensure(
+                checker_run.passed_count
+                == sum(1 for result in results if result.status == "passed"),
+                f"{scenario['name']} passed count drifted",
+            )
+            ensure(
+                checker_run.warning_count
+                == sum(1 for result in results if result.status == "warning"),
+                f"{scenario['name']} warning count drifted",
+            )
+            ensure(
+                checker_run.failed_count
+                == sum(1 for result in results if result.status == "failed"),
+                f"{scenario['name']} failed count drifted",
+            )
+            ensure(
+                checker_run.blocking_count
+                == sum(1 for result in results if result.blocks_review),
+                f"{scenario['name']} blocking count drifted",
+            )
+
+            runs = (
+                await session.scalars(
+                    select(CheckerRun)
+                    .where(CheckerRun.submission_id == submission.id)
+                    .order_by(CheckerRun.attempt_number.asc())
+                )
+            ).all()
+            ensure(
+                [run.attempt_number for run in runs] == scenario["expected_attempts"],
+                f"{scenario['name']} checker attempts drifted",
+            )
+            ensure(
+                sum(1 for run in runs if run.is_current_for_submission) == 1,
+                f"{scenario['name']} current-run uniqueness drifted",
+            )
+            ensure(
+                [run.id for run in runs if run.is_current_for_submission][0]
+                == scenario["expected_current_run_id"],
+                f"{scenario['name']} current run id drifted",
+            )
+
+            task_events = (
+                await session.scalars(
+                    select(AuditEvent).where(
+                        AuditEvent.entity_type == "task",
+                        AuditEvent.entity_id == task.id,
+                    )
+                )
+            ).all()
+            ensure(
+                any(
+                    event.event_type == scenario["expected_gate_event"]
+                    and event.event_payload.get("checker_run_id") == checker_run.id
+                    and event.event_payload.get("trigger_source")
+                    == scenario["expected_trigger_source"]
+                    for event in task_events
+                ),
+                f"{scenario['name']} gate audit event missing matching trigger/run payload",
+            )
+
+    print("PASS Week 2 database invariants")
+
+
 async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
     """Run real Week 2 checker flows over HTTP.
 
@@ -600,6 +833,13 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
     reviewer_token = token_for(
         f"week2-reviewer-{run_id}",
         ["reviewer"],
+        issuer=flow_issuer,
+        audience=flow_audience,
+        secret=flow_secret,
+    )
+    unassigned_worker_token = token_for(
+        f"week2-worker-unassigned-{run_id}",
+        ["worker"],
         issuer=flow_issuer,
         audience=flow_audience,
         secret=flow_secret,
@@ -642,7 +882,15 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         ensure(clean_precheck["authoritative"] is False, "precheck must be non-authoritative")
         ensure(clean_precheck["eligible_to_submit"] is True, "clean precheck should pass")
         assert_pre_submit_checker_set(clean_precheck)
-        clean_submission, clean_run = await submit_lock_and_get_run(
+        await assert_task_status(client, manager_token, clean_task["id"], "in_progress")
+        clean_precheck_submissions = await request_json(
+            client,
+            "GET",
+            f"/api/v1/tasks/{clean_task['id']}/submissions",
+            clean_worker_token,
+        )
+        ensure(clean_precheck_submissions == [], "clean precheck created a submission")
+        clean_submission, clean_locked, clean_run = await submit_lock_and_get_run(
             client,
             manager_token=manager_token,
             worker_token=clean_worker_token,
@@ -652,6 +900,13 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         assert_default_checker_set(clean_run)
         ensure(clean_run["routing_recommendation"] == "allow_review", "clean run was blocked")
         ensure(clean_run["blocking_count"] == 0, "clean run had blocking checker results")
+        await assert_lock_idempotency(
+            client,
+            manager_token=manager_token,
+            submission_id=clean_submission["id"],
+            expected_locked_at=clean_locked["locked_at"],
+            expected_checker_run_id=clean_run["id"],
+        )
         await assert_task_status(client, manager_token, clean_task["id"], "review_pending")
         worker_clean_run = await request_json(
             client,
@@ -664,12 +919,44 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             "worker clean route mismatch",
         )
         ensure(worker_clean_run["artifact_hash_manifest"] == [], "worker saw artifact manifest")
+        manager_clean_runs = await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{clean_submission['id']}/checker-runs",
+            manager_token,
+        )
+        ensure(len(manager_clean_runs) == 1, "manager checker-run list count drifted")
+        worker_clean_runs = await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{clean_submission['id']}/checker-runs",
+            clean_worker_token,
+        )
+        ensure(len(worker_clean_runs) == 1, "worker checker-run list count drifted")
+        ensure(
+            worker_clean_runs[0]["artifact_hash_manifest"] == [],
+            "worker checker-run list exposed artifact manifest",
+        )
         await request_json(
             client,
             "GET",
             f"/api/v1/checker-runs/{clean_run['id']}",
             reviewer_token,
             expected_status=403,
+        )
+        await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{clean_submission['id']}/checker-runs",
+            reviewer_token,
+            expected_status=403,
+        )
+        await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{clean_submission['id']}/checker-runs",
+            unassigned_worker_token,
+            expected_status=404,
         )
 
         revision_worker_subject = f"week2-worker-revision-{run_id}"
@@ -714,7 +1001,15 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         )
         assert_pre_submit_checker_set(failed_precheck)
         ensure(failed_precheck["eligible_to_submit"] is False, "missing file precheck passed")
-        first_submission, first_run = await submit_lock_and_get_run(
+        await assert_task_status(client, manager_token, revision_task["id"], "in_progress")
+        revision_precheck_submissions = await request_json(
+            client,
+            "GET",
+            f"/api/v1/tasks/{revision_task['id']}/submissions",
+            revision_worker_token,
+        )
+        ensure(revision_precheck_submissions == [], "failed precheck created a submission")
+        first_submission, first_locked, first_run = await submit_lock_and_get_run(
             client,
             manager_token=manager_token,
             worker_token=revision_worker_token,
@@ -734,7 +1029,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         required_file_result = checker_result(worker_revision_run, "check_required_files")
         ensure(bool(required_file_result["worker_message"]), "required-file worker message missing")
         ensure(required_file_result["metadata"] == {}, "worker saw required-file metadata")
-        second_submission, second_run = await submit_lock_and_get_run(
+        second_submission, second_locked, second_run = await submit_lock_and_get_run(
             client,
             manager_token=manager_token,
             worker_token=revision_worker_token,
@@ -785,6 +1080,14 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             missing_evidence_precheck["eligible_to_submit"] is False,
             "missing evidence precheck should block submission",
         )
+        await assert_task_status(client, manager_token, missing_evidence_task["id"], "in_progress")
+        missing_evidence_submissions = await request_json(
+            client,
+            "GET",
+            f"/api/v1/tasks/{missing_evidence_task['id']}/submissions",
+            missing_evidence_worker_token,
+        )
+        ensure(missing_evidence_submissions == [], "missing evidence precheck created a submission")
         missing_evidence_precheck_result = next(
             result
             for result in missing_evidence_precheck["results"]
@@ -836,7 +1139,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
                 "notes": "duplicate artifact",
             }
         )
-        _, integrity_run = await submit_lock_and_get_run(
+        integrity_submission, integrity_locked, integrity_run = await submit_lock_and_get_run(
             client,
             manager_token=manager_token,
             worker_token=integrity_worker_token,
@@ -879,7 +1182,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         )
         weak_attestation_payload = submission_payload(run_id, "attestation")
         weak_attestation_payload["worker_attestation"] = "ok"
-        _, attestation_run = await submit_lock_and_get_run(
+        attestation_submission, attestation_locked, attestation_run = await submit_lock_and_get_run(
             client,
             manager_token=manager_token,
             worker_token=attestation_worker_token,
@@ -923,7 +1226,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         )
         warning_payload = submission_payload(run_id, "warning")
         warning_payload["summary"] = "Completed with a placeholder note that must be reviewed."
-        _, warning_run = await submit_lock_and_get_run(
+        warning_submission, warning_locked, warning_run = await submit_lock_and_get_run(
             client,
             manager_token=manager_token,
             worker_token=warning_worker_token,
@@ -972,7 +1275,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
                 "notes": "must be blocked",
             }
         )
-        _, forbidden_run = await submit_lock_and_get_run(
+        forbidden_submission, forbidden_locked, forbidden_run = await submit_lock_and_get_run(
             client,
             manager_token=manager_token,
             worker_token=forbidden_worker_token,
@@ -1033,12 +1336,13 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             201,
         )
         await break_acceptance_criteria(setup_task["id"])
-        await request_json(
+        setup_locked = await request_json(
             client,
             "POST",
             f"/api/v1/submissions/{setup_submission['id']}/lock",
             manager_token,
         )
+        assert_locked_submission_response(setup_locked)
         setup_run = await wait_for_submission_checker_run(
             client,
             manager_token,
@@ -1083,7 +1387,187 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             retry["supersedes_checker_run_id"] == setup_run["id"],
             "trusted checker retry did not supersede blocked run",
         )
+        setup_runs_after_retry = await request_json(
+            client,
+            "GET",
+            f"/api/v1/submissions/{setup_submission['id']}/checker-runs",
+            manager_token,
+        )
+        ensure(len(setup_runs_after_retry) == 2, "trusted checker retry run count drifted")
+        setup_runs_by_attempt = {
+            run["attempt_number"]: run for run in setup_runs_after_retry
+        }
+        ensure(
+            sorted(setup_runs_by_attempt) == [1, 2],
+            f"trusted checker retry attempts drifted: {sorted(setup_runs_by_attempt)}",
+        )
+        ensure(
+            setup_runs_by_attempt[1]["is_current_for_submission"] is False,
+            "superseded checker run still current",
+        )
+        ensure(
+            setup_runs_by_attempt[2]["is_current_for_submission"] is True,
+            "retry checker run is not current",
+        )
+        ensure(
+            setup_runs_by_attempt[1]["trigger_source"] == "submission_locked",
+            "first setup checker trigger source drifted",
+        )
+        ensure(
+            setup_runs_by_attempt[2]["trigger_source"] == "manual_checker_trigger",
+            "retry checker trigger source drifted",
+        )
         await assert_task_status(client, manager_token, setup_task["id"], "review_pending")
+
+    setup_checker_set = EXPECTED_DURABLE_CHECKERS | {"check_acceptance_criteria_present"}
+    await assert_week2_database_invariants(
+        [
+            {
+                "name": "clean",
+                "task_id": clean_task["id"],
+                "submission_id": clean_submission["id"],
+                "checker_run_id": clean_run["id"],
+                "locked_at": clean_locked["locked_at"],
+                "expected_route": "allow_review",
+                "expected_task_status": "review_pending",
+                "expected_trigger_source": "submission_locked",
+                "expected_attempt": 1,
+                "expected_attempts": [1],
+                "expected_current": True,
+                "expected_current_run_id": clean_run["id"],
+                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
+                "expected_gate_event": "pre_review_gate_passed",
+            },
+            {
+                "name": "missing_file_v1",
+                "task_id": revision_task["id"],
+                "submission_id": first_submission["id"],
+                "checker_run_id": first_run["id"],
+                "locked_at": first_locked["locked_at"],
+                "expected_route": "needs_revision",
+                "expected_task_status": "review_pending",
+                "expected_trigger_source": "submission_locked",
+                "expected_attempt": 1,
+                "expected_attempts": [1],
+                "expected_current": True,
+                "expected_current_run_id": first_run["id"],
+                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
+                "expected_gate_event": "pre_review_gate_needs_revision",
+            },
+            {
+                "name": "revision_v2",
+                "task_id": revision_task["id"],
+                "submission_id": second_submission["id"],
+                "checker_run_id": second_run["id"],
+                "locked_at": second_locked["locked_at"],
+                "expected_route": "allow_review",
+                "expected_task_status": "review_pending",
+                "expected_trigger_source": "submission_locked",
+                "expected_attempt": 1,
+                "expected_attempts": [1],
+                "expected_current": True,
+                "expected_current_run_id": second_run["id"],
+                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
+                "expected_gate_event": "pre_review_gate_passed",
+            },
+            {
+                "name": "integrity",
+                "task_id": integrity_task["id"],
+                "submission_id": integrity_submission["id"],
+                "checker_run_id": integrity_run["id"],
+                "locked_at": integrity_locked["locked_at"],
+                "expected_route": "needs_revision",
+                "expected_task_status": "needs_revision",
+                "expected_trigger_source": "submission_locked",
+                "expected_attempt": 1,
+                "expected_attempts": [1],
+                "expected_current": True,
+                "expected_current_run_id": integrity_run["id"],
+                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
+                "expected_gate_event": "pre_review_gate_needs_revision",
+            },
+            {
+                "name": "attestation",
+                "task_id": attestation_task["id"],
+                "submission_id": attestation_submission["id"],
+                "checker_run_id": attestation_run["id"],
+                "locked_at": attestation_locked["locked_at"],
+                "expected_route": "needs_revision",
+                "expected_task_status": "needs_revision",
+                "expected_trigger_source": "submission_locked",
+                "expected_attempt": 1,
+                "expected_attempts": [1],
+                "expected_current": True,
+                "expected_current_run_id": attestation_run["id"],
+                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
+                "expected_gate_event": "pre_review_gate_needs_revision",
+            },
+            {
+                "name": "warning",
+                "task_id": warning_task["id"],
+                "submission_id": warning_submission["id"],
+                "checker_run_id": warning_run["id"],
+                "locked_at": warning_locked["locked_at"],
+                "expected_route": "allow_review",
+                "expected_task_status": "review_pending",
+                "expected_trigger_source": "submission_locked",
+                "expected_attempt": 1,
+                "expected_attempts": [1],
+                "expected_current": True,
+                "expected_current_run_id": warning_run["id"],
+                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
+                "expected_gate_event": "pre_review_gate_passed",
+            },
+            {
+                "name": "forbidden",
+                "task_id": forbidden_task["id"],
+                "submission_id": forbidden_submission["id"],
+                "checker_run_id": forbidden_run["id"],
+                "locked_at": forbidden_locked["locked_at"],
+                "expected_route": "needs_revision",
+                "expected_task_status": "needs_revision",
+                "expected_trigger_source": "submission_locked",
+                "expected_attempt": 1,
+                "expected_attempts": [1],
+                "expected_current": True,
+                "expected_current_run_id": forbidden_run["id"],
+                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
+                "expected_gate_event": "pre_review_gate_needs_revision",
+            },
+            {
+                "name": "setup_blocked",
+                "task_id": setup_task["id"],
+                "submission_id": setup_submission["id"],
+                "checker_run_id": setup_run["id"],
+                "locked_at": setup_locked["locked_at"],
+                "expected_route": "task_setup_blocked",
+                "expected_task_status": "review_pending",
+                "expected_trigger_source": "submission_locked",
+                "expected_attempt": 1,
+                "expected_attempts": [1, 2],
+                "expected_current": False,
+                "expected_current_run_id": retry["id"],
+                "expected_checkers": setup_checker_set,
+                "expected_gate_event": "pre_review_gate_blocked",
+            },
+            {
+                "name": "setup_retry",
+                "task_id": setup_task["id"],
+                "submission_id": setup_submission["id"],
+                "checker_run_id": retry["id"],
+                "locked_at": setup_locked["locked_at"],
+                "expected_route": "allow_review",
+                "expected_task_status": "review_pending",
+                "expected_trigger_source": "manual_checker_trigger",
+                "expected_attempt": 2,
+                "expected_attempts": [1, 2],
+                "expected_current": True,
+                "expected_current_run_id": retry["id"],
+                "expected_checkers": setup_checker_set,
+                "expected_gate_event": "pre_review_gate_passed",
+            },
+        ]
+    )
 
     print("Week 2 real API e2e passed")
     print("scenario_summary:")

--- a/backend/tests/test_checkers.py
+++ b/backend/tests/test_checkers.py
@@ -1219,9 +1219,8 @@ async def test_stale_locked_submission_cannot_receive_checker_run(
     "old_checker_name",
     ["check_evidence_references_present", "check_artifact_manifest_integrity"],
 )
-async def test_old_checker_name_blocks_durable_run_without_alias(
+async def test_old_checker_name_blocks_guide_activation_without_alias(
     checker_client: AsyncClient,
-    monkeypatch: pytest.MonkeyPatch,
     old_checker_name: str,
 ) -> None:
     project_response = await checker_client.post(
@@ -1248,21 +1247,8 @@ async def test_old_checker_name_blocks_durable_run_without_alias(
         f"/api/v1/projects/{project['id']}/guides/{guide_response.json()['id']}/activate",
         headers=auth_headers(),
     )
-    assert activation_response.status_code == 200, activation_response.text
-    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
-    created = await checker_client.post(
-        f"/api/v1/tasks/{started_task['id']}/submissions",
-        headers=auth_headers(),
-        json=complete_submission_payload(),
-    )
-    assert created.status_code == 201, created.text
-    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
-    locked = await checker_client.post(
-        f"/api/v1/submissions/{created.json()['id']}/lock",
-        headers=auth_headers(),
-    )
-    assert locked.status_code == 422, locked.text
-    assert "unregistered checker policy names" in locked.json()["detail"]
+    assert activation_response.status_code == 422, activation_response.text
+    assert "unregistered checker policy names" in activation_response.json()["detail"]
 
     async with db_session.get_session_factory()() as session:
         rows = (await session.execute(CheckerRun.__table__.select())).all()

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -122,7 +122,7 @@ def complete_guide_payload(version: str = "v1") -> dict:
         "unacceptable_work_policy": "Copied or unverifiable work.",
         "change_summary": f"Initial {version}",
         "checker_policy": {
-            "required_checkers": ["check_task_schema"],
+            "required_checkers": ["check_policy_context_present"],
             "warning_checkers": [],
             "blocking_severities": ["high"],
         },
@@ -331,6 +331,40 @@ async def test_revision_policy_requires_deadline(project_client: AsyncClient) ->
     assert "revision_deadline_hours" in detail["loc"]
 
 
+async def test_activation_rejects_unregistered_checker_names(
+    project_client: AsyncClient,
+) -> None:
+    project = await create_project(project_client)
+    payload = complete_guide_payload()
+    payload["checker_policy"]["required_checkers"] = ["missing_checker"]
+    guide = await create_guide(project_client, project["id"], payload)
+
+    response = await project_client.post(
+        f"/api/v1/projects/{project['id']}/guides/{guide['id']}/activate",
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 422
+    assert "unregistered checker policy names" in response.json()["detail"]
+
+
+async def test_activation_rejects_unsupported_revision_resubmission_states(
+    project_client: AsyncClient,
+) -> None:
+    project = await create_project(project_client)
+    payload = complete_guide_payload()
+    payload["revision_policy"]["allowed_resubmission_states"] = ["random_state"]
+    guide = await create_guide(project_client, project["id"], payload)
+
+    response = await project_client.post(
+        f"/api/v1/projects/{project['id']}/guides/{guide['id']}/activate",
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 422
+    assert "invalid resubmission states" in response.json()["detail"]
+
+
 async def test_guide_activation_and_active_guide_retrieval(project_client: AsyncClient) -> None:
     project = await create_project(project_client)
     guide = await create_guide(project_client, project["id"], complete_guide_payload())
@@ -348,7 +382,9 @@ async def test_guide_activation_and_active_guide_retrieval(project_client: Async
     assert active.status_code == 200, active.text
     assert active.json()["guide"]["status"] == "active"
     assert active.json()["guide"]["version"] == "v1"
-    assert active.json()["checker_policy"]["required_checkers"] == ["check_task_schema"]
+    assert active.json()["checker_policy"]["required_checkers"] == [
+        "check_policy_context_present"
+    ]
     assert active.json()["revision_policy"]["max_revision_rounds"] == 7
     assert active.json()["revision_policy"]["auto_reject_after_limit"] is True
     assert active.json()["payment_policy"]["base_amount"] == "25.00"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       retries: 10
     volumes:
       - workstream_postgres_data:/var/lib/postgresql/data
+      - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
 
 volumes:
   workstream_postgres_data:

--- a/docker/postgres/init/001-create-test-db.sql
+++ b/docker/postgres/init/001-create-test-db.sql
@@ -1,0 +1,4 @@
+SELECT 'CREATE DATABASE workstream_test'
+WHERE NOT EXISTS (
+    SELECT FROM pg_database WHERE datname = 'workstream_test'
+)\gexec

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -76,17 +76,9 @@ The checker framework is conservative. It blocks objective structural failures a
 
 ## Required Core Checkers
 
-### check_task_schema
-
-Validates task record fields required by the project guide.
-
-### check_project_guide_attached
-
-Ensures the task has a guide version attached.
-
 ### check_policy_context_present
 
-Ensures the task has locked checker, review, revision, and payment policy context, including base amount and currency where required.
+Ensures the task has locked guide, checker, review, revision, and payment policy context, including base amount and currency where required.
 
 ### check_submission_packet
 
@@ -129,42 +121,22 @@ Ensures the worker explicitly attests that the submission does not contain prohi
 
 Flags repeated low-quality generated patterns banned by the project guide, such as generic helper files, hidden-test leakage patterns, fabricated model files, placeholder evidence, or boilerplate reports that do not prove task-specific work.
 
-### check_prior_revision_closed
+Revision closure, task lifecycle movement, task readiness, and pre-review routing are enforced as lifecycle guards in v0.1. They must not be configured as checker policy names until a registered checker exists for that contract.
 
-For resubmissions, ensures prior review findings are addressed in a revision replay.
-
-### check_status_transition
-
-Validates that requested lifecycle movement is legal.
-
-### check_ready_gate
-
-Ensures the task has passed the project-specific release checklist before entering `READY`.
-
-### check_preflight_evidence
-
-Ensures the submission has a stored preflight evidence record with checker results, package references, artifact hashes, and review-readiness confirmation.
-
-### check_pre_review_gate
-
-Runs project-configured reviewer simulation, adversarial pass, or readiness guard before moving a submission to human review.
-
-`pre_review_gate` is a checker phase. The persisted task status during this phase is `auto_checking`.
+The pre-review gate is a checker execution phase. The persisted task status during this phase is `auto_checking`.
 
 ## Gate Mapping
 
 Project activation gate:
 
-- `check_project_guide_attached`
 - `check_policy_context_present`
 - project-specific guide completeness checks
 
 Task screening gate:
 
-- `check_task_schema`
+- `check_policy_context_present`
 - `check_acceptance_criteria_present`
-- `check_ready_gate`
-- `check_status_transition`
+- task lifecycle transition guards
 
 Submission quality gate:
 
@@ -175,12 +147,10 @@ Submission quality gate:
 - `check_forbidden_files`
 - `check_confidentiality_attestation`
 - `check_low_quality_generated_artifacts`
-- `check_prior_revision_closed`
-- `check_preflight_evidence`
 
 Pre-review gate phase:
 
-- `check_pre_review_gate`
+- project-configured registered checkers run against the locked submission and policy context
 
 The first two gates replace external origin qualification and task ingestion for v0.1. Origin qualification and webhook drop notifications are future adapter concerns.
 
@@ -222,7 +192,7 @@ Draft packet
 
 The checker run must bind to one immutable submission version. If the worker uploads a replacement file, the platform creates a new submission version and reruns checks.
 
-Checker failures are not human review decisions. They do not accept or reject work. Worker-fixable blocking failures can route the task to user-facing `NEEDS_REVISION`, with `outcome_source = auto_checker` and no review decision id. Human review can also produce `needs_revision` later, but that records `outcome_source = human_review` and a review decision id.
+Checker failures are not human review decisions. They do not `accept` or `reject` work. Worker-fixable blocking failures can route the task to user-facing `needs_revision`, with `outcome_source = auto_checker` and no review decision id. Human review can also produce `needs_revision` later, but that records `outcome_source = human_review` and a review decision id.
 
 If a checker crashes or cannot run because of platform infrastructure, the checker run remains failed as an infrastructure failure and the task does not move to human review. The retry or admin action is recorded in audit history.
 

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -170,7 +170,7 @@ Example:
 ```json
 {
   "required_checkers": [
-    "check_task_schema",
+    "check_policy_context_present",
     "check_submission_packet",
     "check_evidence_present"
   ],

--- a/docs/architecture_lifecycle_state_machine.md
+++ b/docs/architecture_lifecycle_state_machine.md
@@ -117,7 +117,7 @@ Required before entering:
 
 - checker run exists for the exact submission version
 - checker run references the same artifact hashes as the submission packet
-- no high-severity checker failure is open
+- no unresolved blocking checker failure is open under the locked checker policy
 
 ### NEEDS_REVISION
 
@@ -144,7 +144,7 @@ The submission is accepted.
 Required before entering:
 
 - accepted review decision
-- no unresolved high-severity checker failure
+- no unresolved blocking checker failure under the locked checker policy
 - evidence present
 - reviewer cited evidence supporting acceptance
 - no unresolved high or medium prior revision finding

--- a/docs/internal_reviews/2026-06-11_chunk9_pre_review_gate.md
+++ b/docs/internal_reviews/2026-06-11_chunk9_pre_review_gate.md
@@ -58,8 +58,8 @@ Findings addressed:
 ## Verification
 
 - `cd backend && .venv/bin/python -m ruff check app tests scripts`
-- `cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q`
-- `cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q`
+- `cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q`
+- `cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest -q`
 
 ## Final Gate
 

--- a/docs/internal_reviews/2026-06-12_chunk10_checker_trial.md
+++ b/docs/internal_reviews/2026-06-12_chunk10_checker_trial.md
@@ -73,7 +73,7 @@ cd backend && .venv/bin/python -m ruff check app tests scripts
 Passed:
 
 ```bash
-cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py::test_chunk10_checker_trial_runs_sample_submissions_through_real_api -q
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py::test_chunk10_checker_trial_runs_sample_submissions_through_real_api -q
 ```
 
 Result: `1 passed in 23.20s`.
@@ -81,7 +81,7 @@ Result: `1 passed in 23.20s`.
 Passed:
 
 ```bash
-cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py -q
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py -q
 ```
 
 Result: `23 passed in 150.27s`.
@@ -89,7 +89,7 @@ Result: `23 passed in 150.27s`.
 Passed:
 
 ```bash
-cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_tasks.py tests/test_checkers.py -q
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py tests/test_checkers.py -q
 ```
 
 Result: `62 passed in 406.92s`.
@@ -97,7 +97,7 @@ Result: `62 passed in 406.92s`.
 Passed:
 
 ```bash
-cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest -q
 ```
 
 Result: `112 passed in 695.21s`.

--- a/docs/internal_reviews/2026-06-12_week2_closeout_real_api_drill.md
+++ b/docs/internal_reviews/2026-06-12_week2_closeout_real_api_drill.md
@@ -42,7 +42,7 @@ Targeted QA re-review confirmed the blockers are resolved. The remaining operati
 
 Finding: the first drill could inherit any `WORKSTREAM_DATABASE_URL` and run migrations/write drill data against it.
 
-Resolution: added `assert_local_database_url()` before environment update, migrations, API startup, or writes. The drill now allows only local `postgresql+asyncpg://` URLs for `workstream`, `workstream_test`, or `test_workstream`, unless an explicit non-local override is set.
+Resolution: added `assert_local_database_url()` before environment update, migrations, API startup, or writes. The drill now allows only local `postgresql+asyncpg://` URLs for `workstream_test` or `test_workstream`, unless an explicit write-risk override is set.
 
 Security re-review confirmed:
 
@@ -105,13 +105,13 @@ cd backend && .venv/bin/python -m ruff check app tests scripts
 Passed:
 
 ```bash
-cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week1_api_e2e.py
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week1_api_e2e.py
 ```
 
 Passed:
 
 ```bash
-cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week2_api_e2e.py
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week2_api_e2e.py
 ```
 
 Scenario summary:
@@ -130,7 +130,7 @@ task_setup_blocked=auto_checking->review_pending
 Passed:
 
 ```bash
-cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q
 ```
 
 Result: `62 passed in 415.29s`.
@@ -138,7 +138,7 @@ Result: `62 passed in 415.29s`.
 Passed:
 
 ```bash
-cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest -q
 ```
 
 Result: `112 passed in 565.34s`.

--- a/docs/internal_reviews/2026-06-12_week2_closeout_real_api_drill.md
+++ b/docs/internal_reviews/2026-06-12_week2_closeout_real_api_drill.md
@@ -1,0 +1,135 @@
+# Internal Review: Week 2 Closeout Real API Drill
+
+## Scope
+
+This review covers the roadmap status update and the real HTTP Week 2 API drill.
+
+Changed contract surfaces:
+
+- `backend/scripts/week2_api_e2e.py`
+- `docs/roadmap_status.md`
+- `docs/roadmap_day_by_day_execution_plan.md`
+
+## Verifier Results
+
+### Senior engineering
+
+Finding: the first version of the Week 2 drill proved lifecycle routing but not every Week 2 checker family over HTTP.
+
+Resolution: expanded the drill to cover clean pass, missing required file, missing evidence pre-submit block, evidence integrity failure, weak confidentiality attestation, generated-output warning, forbidden path redaction, internal `task_setup_blocked`, and trusted checker retry.
+
+Verdict after fix: the branch stays within scope, adds no product behavior, and introduces no lifecycle state or review decision.
+
+### QA/test
+
+Findings:
+
+- the first drill did not assert that the full Week 2 durable checker set ran
+- the roadmap documented only the E2E script instead of the full Week 2 validation gate
+- the first script output lacked a compact scenario summary
+
+Resolution:
+
+- added `EXPECTED_DURABLE_CHECKERS` and clean-path checker-set assertions
+- added `EXPECTED_PRE_SUBMIT_CHECKERS` for pre-submit feedback
+- added negative and warning scenarios for evidence, integrity, confidentiality, generated-output warning, forbidden path, and task setup routes
+- documented the full Week 2 validation gate in roadmap status
+- added scenario summary output
+
+Targeted QA re-review confirmed the blockers are resolved. The remaining operational note was to ensure `backend/scripts/week2_api_e2e.py` is committed with the PR.
+
+### Security/auth
+
+Finding: the first drill could inherit any `WORKSTREAM_DATABASE_URL` and run migrations/write drill data against it.
+
+Resolution: added `assert_local_database_url()` before environment update, migrations, API startup, or writes. The drill now allows only local Postgres URLs for `workstream`, `workstream_test`, or `test_workstream`, unless an explicit non-local override is set.
+
+Security re-review confirmed:
+
+- non-local host is blocked
+- local host with non-local database name is blocked
+- non-Postgres URL is blocked
+- local Postgres `workstream` and `workstream_test` are allowed
+- Flow-token auth remains in use
+- demo worker-profile route remains local/test gated
+- worker redaction and reviewer denial are asserted
+- no production route or checker-read permission is widened
+
+### Product/ops
+
+Findings:
+
+- no blocking findings
+- the demo worker-profile helper is acceptable for v0.1 drills but should not be described as production worker onboarding
+- uppercase lifecycle labels must not drift into persisted token contracts
+
+Resolution: roadmap wording keeps Week 3 readiness explicit and does not overclaim reviewer checker visibility.
+
+## Validation
+
+Passed:
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+```
+
+Passed:
+
+```bash
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week1_api_e2e.py
+```
+
+Passed:
+
+```bash
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week2_api_e2e.py
+```
+
+Scenario summary:
+
+```text
+clean=review_pending
+missing_file=needs_revision
+missing_evidence=pre_submit_blocked
+duplicate_artifact_integrity=needs_revision
+weak_attestation=needs_revision
+generated_output_warning=review_pending
+forbidden_path=needs_revision
+task_setup_blocked=auto_checking->review_pending
+```
+
+Passed:
+
+```bash
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q
+```
+
+Result: `62 passed in 293.20s`.
+
+Passed:
+
+```bash
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q
+```
+
+Result: `112 passed in 426.89s`.
+
+Passed:
+
+```bash
+cd backend && .venv/bin/docstr-coverage --config .docstr.yaml
+```
+
+Result: `100.0%`.
+
+Passed:
+
+- stale wording scan
+- Markdown relative link check
+- XLSX/sheets check: no local sheet exports present
+
+## Closure
+
+Valid findings addressed.
+
+Open sub-agent sessions: none.

--- a/docs/internal_reviews/2026-06-12_week2_closeout_real_api_drill.md
+++ b/docs/internal_reviews/2026-06-12_week2_closeout_real_api_drill.md
@@ -42,14 +42,14 @@ Targeted QA re-review confirmed the blockers are resolved. The remaining operati
 
 Finding: the first drill could inherit any `WORKSTREAM_DATABASE_URL` and run migrations/write drill data against it.
 
-Resolution: added `assert_local_database_url()` before environment update, migrations, API startup, or writes. The drill now allows only local Postgres URLs for `workstream`, `workstream_test`, or `test_workstream`, unless an explicit non-local override is set.
+Resolution: added `assert_local_database_url()` before environment update, migrations, API startup, or writes. The drill now allows only local `postgresql+asyncpg://` URLs for `workstream`, `workstream_test`, or `test_workstream`, unless an explicit non-local override is set.
 
 Security re-review confirmed:
 
 - non-local host is blocked
 - local host with non-local database name is blocked
 - non-Postgres URL is blocked
-- local Postgres `workstream` and `workstream_test` are allowed
+- local async Postgres URLs for `workstream` and `workstream_test` are allowed
 - Flow-token auth remains in use
 - demo worker-profile route remains local/test gated
 - worker redaction and reviewer denial are asserted
@@ -65,7 +65,36 @@ Findings:
 
 Resolution: roadmap wording keeps Week 3 readiness explicit and does not overclaim reviewer checker visibility.
 
+### CodeRabbit follow-up
+
+Findings:
+
+- the local database safety gate allowed plain `postgresql://` URLs even though the backend uses SQLAlchemy async engines
+- checker-set assertions only proved expected checkers were present, not that the contract had no unexpected extras
+- the drill read checker runs and task status immediately after submission lock, which made async background execution timing-sensitive
+
+Resolution:
+
+- tightened the database guard to local `postgresql+asyncpg://`
+- made durable, setup-defect, and pre-submit checker-set assertions exact
+- added polling for automatic checker-run creation, checker-run terminal status, and task status transitions
+
+Internal follow-up findings:
+
+- QA found that setup-defect checker runs and trusted checker retry responses also needed exact checker-set assertions
+- QA found that failed pre-submit responses needed the same exact pre-submit checker-set assertion as the clean pre-submit response
+- docs/product-ops found that the evidence still used broad local Postgres wording after the guard was narrowed to async Postgres
+
+Internal follow-up resolution:
+
+- added exact setup-defect checker-set assertions for the blocked run and trusted checker retry
+- added exact pre-submit checker-set assertions for failed missing-file and missing-evidence prechecks
+- narrowed the accepted local database scheme to the installed `postgresql+asyncpg` driver
+- tightened this evidence file to say local async Postgres instead of generic local Postgres
+
 ## Validation
+
+The following checks were rerun after the CodeRabbit follow-up edits and internal re-review fixes.
 
 Passed:
 

--- a/docs/internal_reviews/2026-06-12_week2_closeout_real_api_drill.md
+++ b/docs/internal_reviews/2026-06-12_week2_closeout_real_api_drill.md
@@ -133,7 +133,7 @@ Passed:
 cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q
 ```
 
-Result: `62 passed in 293.20s`.
+Result: `62 passed in 415.29s`.
 
 Passed:
 
@@ -141,7 +141,7 @@ Passed:
 cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q
 ```
 
-Result: `112 passed in 426.89s`.
+Result: `112 passed in 565.34s`.
 
 Passed:
 

--- a/docs/internal_reviews/2026-06-13_week1_week2_deterministic_hardening.md
+++ b/docs/internal_reviews/2026-06-13_week1_week2_deterministic_hardening.md
@@ -1,0 +1,153 @@
+# Internal Review Evidence: Week 1 And Week 2 Deterministic Hardening
+
+Date: 2026-06-13
+
+## Scope
+
+This review covers the deterministic Week 1 and Week 2 hardening pass:
+
+- Week 1 real API drill
+- Week 2 real API drill
+- guide activation checker-name validation
+- revision policy state validation
+- checker result and audit invariant checks
+- local Postgres test database guard
+- checker-policy documentation cleanup
+
+## Reviewer Tracks
+
+### Senior Engineering
+
+Result: valid findings addressed. Final bounded re-review reported no blocking findings.
+
+Findings:
+
+- current docs still advertised unregistered checker names as policy checkers
+- checker policy docs contained duplicate/conflicting checker entries
+- the roadmap listed `check_policy_context_present` twice in the first checker set
+
+Resolution:
+
+- removed unregistered checker names from current policy-facing docs/templates
+- documented readiness, lifecycle movement, revision closure, and pre-review routing as lifecycle guards unless a checker is registered
+- removed duplicate checker template rows and duplicate roadmap checker entries
+- added guide activation validation that rejects unregistered required or warning checker names
+
+### QA/Test
+
+Result: valid findings addressed. Final bounded re-review reported no blocking findings.
+
+Findings:
+
+- checker result assertions used sets and could miss duplicate persisted checker results
+- Week 2 audit invariant could match event type and trigger source on different audit rows
+
+Resolution:
+
+- Week 1 and Week 2 drills now fail on duplicate checker result names
+- Week 2 DB invariants now bind expected audit event type, `checker_run_id`, and `trigger_source` on the same audit event row
+- real API drills were rerun against local `workstream_test` Postgres
+
+### Security/Auth
+
+Result: valid findings addressed. Final bounded re-review reported no blocking findings.
+
+Findings:
+
+- the E2E database guard allowed plain local `workstream`, which could be a tunnel/proxy to a shared database
+
+Resolution:
+
+- destructive real API drills now allow only local async Postgres databases named `workstream_test` or `test_workstream` by default
+- plain `workstream` requires the explicit `WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE=I_UNDERSTAND_THIS_WRITES_DATA` override for E2E drills
+- Docker Compose now creates `workstream_test` on fresh local Postgres volumes
+- Flow token negative probes, role visibility, worker redaction, and checker policy activation hardening remain covered by real API drills and tests
+
+### Product/Ops
+
+Result: valid findings addressed. Final bounded re-review reported no blocking findings.
+
+Findings:
+
+- checker template duplicated `check_forbidden_files`, `check_confidentiality_attestation`, and `check_low_quality_generated_artifacts`
+- checker framework duplicated `check_submission_packet`
+- proposal source still referenced a stale guide-attached checker
+- roadmap status undercounted the expanded Chunk 10 trial matrix
+- template checker policy and project guide checker lists diverged
+- Day 10 docs still referenced five sample submissions
+- public lifecycle wording used uppercase outcome-state names where canonical public decision language was required
+
+Resolution:
+
+- checker templates now show only the registered v0.1 checker names
+- status now describes the expanded real API sample matrix
+- retired checker names were removed from current policy-facing docs
+- DB URL wording now separates normal local development from destructive real API drills
+- project guide and checker policy templates now share the same registered checker set
+- Day 10 docs now use expanded sample matrix wording
+- public lifecycle prose now uses `accept`, `needs_revision`, `reject`, or accepted/rejected work wording as appropriate
+- proposal source checker list now matches the locked nine-checker set and no longer carries checker version suffixes
+
+## Sub-Agent Sessions
+
+The first reviewer pass completed for all required tracks and produced the findings above.
+
+Later broad follow-up reviewer sessions became stale after repeated waits. Root-cause checks showed the sub-agent service and repo access were healthy; the broad diff-review prompts were too large. The final required reviewer tracks were rerun one at a time with bounded file scopes on `gpt-5.5` high reasoning. QA/test, security/auth, product/ops, and senior engineering completed and reported no blocking findings after fixes. Product/ops was rerun again after the proposal checker-list cleanup and reported no blocking findings.
+
+Open sub-agent sessions: none.
+
+## Validation
+
+Passed:
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+```
+
+Result: `All checks passed!`
+
+Passed:
+
+```bash
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week1_api_e2e.py
+```
+
+Result: `Week 1 real API e2e passed` and `PASS Week 1 database invariants`.
+
+Passed:
+
+```bash
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week2_api_e2e.py
+```
+
+Result: `Week 2 real API e2e passed` and `PASS Week 2 database invariants`.
+
+Passed:
+
+```bash
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest -q
+```
+
+Result: `114 passed in 1128.04s`.
+
+Passed:
+
+```bash
+cd backend && .venv/bin/docstr-coverage --config .docstr.yaml
+```
+
+Result: `100.0%`.
+
+Passed:
+
+- stale wording scan
+- retired checker-name scan for current policy-facing docs
+- Markdown relative link check
+- `git diff --check`
+- XLSX/sheets check: no local sheet exports present
+
+## Closure
+
+Valid findings addressed.
+
+Open sub-agent sessions: none.

--- a/docs/internal_reviews/2026-06-13_week1_week2_deterministic_hardening.md
+++ b/docs/internal_reviews/2026-06-13_week1_week2_deterministic_hardening.md
@@ -12,6 +12,7 @@ This review covers the deterministic Week 1 and Week 2 hardening pass:
 - revision policy state validation
 - checker result and audit invariant checks
 - local Postgres test database guard
+- backend CI database alignment with the E2E guard
 - checker-policy documentation cleanup
 
 ## Reviewer Tracks
@@ -63,6 +64,13 @@ Resolution:
 - Docker Compose now creates `workstream_test` on fresh local Postgres volumes
 - Flow token negative probes, role visibility, worker redaction, and checker policy activation hardening remain covered by real API drills and tests
 
+CI follow-up:
+
+- backend CI initially still pointed the Week 1 real API drill at `/workstream`
+- the hardened E2E guard correctly refused that non-test database name
+- backend CI now creates, health-checks, and uses `/workstream_test`
+- QA/test and security/auth CI-fix reviewer passes reported no blocking findings
+
 ### Product/Ops
 
 Result: valid findings addressed. Final bounded re-review reported no blocking findings.
@@ -92,7 +100,7 @@ Resolution:
 
 The first reviewer pass completed for all required tracks and produced the findings above.
 
-Later broad follow-up reviewer sessions became stale after repeated waits. Root-cause checks showed the sub-agent service and repo access were healthy; the broad diff-review prompts were too large. The final required reviewer tracks were rerun one at a time with bounded file scopes on `gpt-5.5` high reasoning. QA/test, security/auth, product/ops, and senior engineering completed and reported no blocking findings after fixes. Product/ops was rerun again after the proposal checker-list cleanup and reported no blocking findings.
+Later broad follow-up reviewer sessions became stale after repeated waits. Root-cause checks showed the sub-agent service and repo access were healthy; the broad diff-review prompts were too large. The final required reviewer tracks were rerun one at a time with bounded file scopes on `gpt-5.5` high reasoning. QA/test, security/auth, product/ops, and senior engineering completed and reported no blocking findings after fixes. Product/ops was rerun again after the proposal checker-list cleanup and reported no blocking findings. QA/test and security/auth were also rerun on the backend CI database fix and reported no blocking findings.
 
 Open sub-agent sessions: none.
 

--- a/docs/proposal_workstream_arch_today_source.md
+++ b/docs/proposal_workstream_arch_today_source.md
@@ -160,15 +160,17 @@ const Gates = () => {
       note:"Configuration enforces guide attachment at project creation — you physically cannot publish a project without a guide. The ingestion gate validates the task contract, not guide existence."
     },
     { id:"g3",num:"03",title:"Submission Quality",sub:"Runtime — after a worker submits",color:c.amber,tag:"SUBMISSION GATE",
-      desc:"Checkers run against the specific project guide governing that task — not generic rules. The guide is the rule set. High-severity failures return the packet to the worker before it ever reaches a reviewer.",
+      desc:"Checkers run against the specific project guide governing that task — not generic rules. The guide is the rule set. Blocking checker policy failures return the packet to the worker before it ever reaches a reviewer.",
       checks:[
-        "check_task_schema — submission packet matches required structure",
-        "check_submission_packet — all required fields present and non-empty",
-        "check_required_files — all files listed in guide requirements are attached",
+        "check_acceptance_criteria_present — task includes reviewable acceptance criteria",
+        "check_policy_context_present — locked guide and policy context is present",
+        "check_submission_packet — submission packet matches required structure",
+        "check_evidence_present — evidence references are present",
         "check_evidence_integrity — EvidenceManifest present, artifact hashes validate",
+        "check_required_files — all files listed in guide requirements are attached",
         "check_forbidden_files — no disqualified file types or content",
-        "check_low_quality_generated_artifacts v1 — basic quality signal on submitted output",
-        "check_project_guide_attached — submission is consistent with the governing guide version",
+        "check_confidentiality_attestation — worker attestation covers confidential data and credentials",
+        "check_low_quality_generated_artifacts — basic quality signal on submitted output",
       ],
       dropLabel:"Checker failure response to worker",
       dropFields:[
@@ -422,8 +424,8 @@ const LifecycleSection = () => {
     { id:"OWNER_REVIEW", color:c.accent, layer:"Control",      desc:"HUMAN GATE. Owner reviews agent output. Can approve, send back to IN_PROGRESS for retry, or reject. Nothing reaches verification without owner sign-off.", highlight:true },
     { id:"SUBMITTED",    color:c.accent, layer:"Control",      desc:"Owner approves and signs submission. EvidenceManifest attached. Packet sent to verification." },
     { id:"UNDER_REVIEW", color:c.green,  layer:"Verification", desc:"Verification engine or external evaluator reviews against the project guide rubric." },
-    { id:"COMPLETED",    color:c.green,  layer:"Terminal",     desc:"Accepted. Settlement triggered. Reputation updated positively for owner and agent." },
-    { id:"REJECTED",     color:c.red,    layer:"Terminal",     desc:"Rejected. Reputation hit on both owner and agent. Partial or no payment per policy." },
+    { id:"COMPLETED",    color:c.green,  layer:"Terminal",     desc:"Accepted work. Settlement triggered. Reputation updated positively for owner and agent." },
+    { id:"rejected_work",color:c.red,    layer:"Terminal",     desc:"Rejected work. Reputation hit on both owner and agent. Partial or no payment per policy." },
     { id:"EXPIRED",      color:c.muted,  layer:"Terminal",     desc:"Deadline passed. Funds returned to client. Reputation impact based on stage reached." },
   ];
   const layerColors = { Source:c.blue,Normalization:c.teal,Execution:c.purple,Control:c.accent,Verification:c.green,Terminal:c.muted };
@@ -460,12 +462,12 @@ const LifecycleSection = () => {
               <p style={{ margin:0,fontFamily:"monospace",fontSize:12,color:c.muted,lineHeight:1.7 }}>{s.desc}</p>
               {s.id==="OWNER_REVIEW" && (
                 <p style={{ margin:"8px 0 0",fontFamily:"monospace",fontSize:11,color:c.accent }}>
-                  Sending back to IN_PROGRESS has no external consequence. Once submitted and rejected — both owner and agent take the reputation hit. The human gate is the point of no return.
+                  Sending back to IN_PROGRESS has no external consequence. Once submitted and rejected by policy, both owner and agent take the reputation hit. The human gate is the point of no return.
                 </p>
               )}
             </div>
           )}
-          {i<states.length-1 && !["COMPLETED","REJECTED"].includes(s.id) && (
+          {i<states.length-1 && !["COMPLETED","rejected_work"].includes(s.id) && (
             <div style={{ display:"flex",justifyContent:"center",height:12,alignItems:"center",opacity:.3 }}>
               <div style={{ width:1,height:"100%",background:c.borderLight }} />
             </div>

--- a/docs/review_process_baseline_operations_review.md
+++ b/docs/review_process_baseline_operations_review.md
@@ -42,7 +42,7 @@ Existing projects repeatedly preserve preflight/checker evidence. Workstream had
 
 Suggested change:
 
-Add preflight evidence template and checker support for `check_preflight_evidence`.
+Add a preflight evidence template and later checker support after the readiness/pre-review record shape is locked.
 
 Status: fixed in `docs/template_preflight_evidence.md` and `docs/architecture_checker_framework.md`.
 
@@ -81,4 +81,3 @@ Suggested change:
 Require each lesson to have an owner and target action.
 
 Status: fixed in `docs/operations_project_operating_manual.md`.
-

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -39,7 +39,7 @@ Future settlement rails such as ERC-8004, ERC-8183, x402, and OmniClaw remain ar
 Every feature must support the core lifecycle:
 
 ```text
-DRAFT -> SCREENING -> READY -> CLAIMED -> IN_PROGRESS -> SUBMITTED -> AUTO_CHECKING -> REVIEW_PENDING -> NEEDS_REVISION | ACCEPTED | REJECTED
+DRAFT -> SCREENING -> READY -> CLAIMED -> IN_PROGRESS -> SUBMITTED -> AUTO_CHECKING -> REVIEW_PENDING -> needs_revision | accepted work | rejected work
 ```
 
 `pre_review_gate` is the checker/audit phase that runs while the persisted task status is `AUTO_CHECKING`.
@@ -161,15 +161,17 @@ Deliverables:
 
 Required first checkers:
 
-- `check_task_schema`
-- `check_required_files`
+- `check_acceptance_criteria_present`
+- `check_policy_context_present`
 - `check_submission_packet`
 - `check_evidence_present`
-- `check_acceptance_criteria_present`
-- `check_status_transition`
-- `check_prior_revision_closed`
-- `check_policy_context_present`
+- `check_evidence_integrity`
+- `check_required_files`
 - `check_forbidden_files`
+- `check_confidentiality_attestation`
+- `check_low_quality_generated_artifacts`
+
+Task lifecycle transitions and revision closure are enforced as lifecycle guards until they have registered checker contracts.
 
 Day 6:
 
@@ -195,14 +197,14 @@ Day 9:
 
 Day 10:
 
-- run five internal sample submissions through the checker framework
+- run the expanded internal sample matrix through the checker framework
 - document false positives and missing checks
 
 Week 2 acceptance bar:
 
 - every submitted task runs checks
 - checker output is stored permanently
-- high-severity failures block human review and can route to user-facing `NEEDS_REVISION` without creating a human review decision
+- blocking checker policy failures block human review and can route to user-facing `needs_revision` without creating a human review decision
 - backend contracts expose the exact checker results before Week 3 reviewer UI work begins
 
 ## Week 3: Review And Revision Engine
@@ -238,7 +240,7 @@ Day 12:
 
 Day 13:
 
-- implement NEEDS_REVISION flow
+- implement `needs_revision` flow
 - store feedback history
 - force resubmission to reference prior feedback
 
@@ -258,7 +260,7 @@ Day 15:
 Week 3 acceptance bar:
 
 - reviewers cannot issue vague decisions without findings
-- every NEEDS_REVISION has concrete fix requirements
+- every `needs_revision` has concrete fix requirements
 - every resubmission must close prior feedback
 - accept, needs_revision, and reject decisions are auditable
 

--- a/docs/roadmap_day_by_day_execution_plan.md
+++ b/docs/roadmap_day_by_day_execution_plan.md
@@ -134,7 +134,7 @@ Week 2 is backend-first checker infrastructure. Checker output is exposed throug
 
 The core invariant is:
 
-`Draft packet -> Pre-submit checks -> Submit -> Lock -> Internal CheckerRun -> CheckerResults -> review_pending or needs_revision`
+`Draft packet -> Pre-submit checks -> Submit -> Lock -> Internal CheckerRun -> CheckerResults -> review_pending | needs_revision | internal task_setup_blocked -> trusted checker retry when repaired`
 
 The checker framework does not accept or reject work. It may route worker-fixable checker failures to user-facing `needs_revision`, but that does not create a human review decision. Internally the source is recorded as `auto_checker`.
 
@@ -160,16 +160,15 @@ Exit criteria:
 
 Deliver:
 
-- `check_project_guide_attached`
-- `check_task_schema`
+- `check_policy_context_present`
 - `check_submission_packet`
 - `check_required_files`
-- `check_status_transition`
+- `check_forbidden_files`
 
 Exit criteria:
 
 - worker-fixable submission failures fail before review
-- high severity failures block `review_pending`
+- locked checker policy blocking failures block `review_pending`
 - checker runs bind to the exact submission id, submission version, package hash, and artifact hash manifest
 - worker-fixable checker failures route to user-facing `needs_revision`
 
@@ -198,19 +197,19 @@ Deliver:
 - `CheckerPolicy`
 - project-required checker list
 - blocking severity settings
-- admin override with reason
+- trusted checker retry with reason after internal setup repair
 
 Exit criteria:
 
 - two projects can require different checkers
-- override creates audit record
+- trusted checker retry creates audit record
 - project-required checker policy is read from the locked task context, not from mutable worker input
 
 ### Day 10: Checker Trial
 
 Deliver:
 
-- 5 sample submissions
+- expanded sample matrix
 - [checker failure catalog](checker_trial_failure_catalog.md)
 - false-positive notes
 - missing-checker list
@@ -315,8 +314,8 @@ Deliver:
 
 Exit criteria:
 
-- `ACCEPTED` creates a contribution record
-- `ACCEPTED` creates pending payment record
+- accepted work creates a contribution record
+- accepted work creates pending payment record
 - paid payment status requires payment reference
 
 ### Day 17: Reputation Ledger

--- a/docs/roadmap_day_by_day_execution_plan.md
+++ b/docs/roadmap_day_by_day_execution_plan.md
@@ -219,7 +219,7 @@ Exit criteria:
 
 - at least one worker-fixable submission failure is blocked
 - at least one clean submission reaches `REVIEW_PENDING`
-- trial output documents which checker results would be visible to Week 3 reviewers through backend APIs
+- trial output documents project-manager/admin checker API visibility and worker redaction
 
 ## Week 3: Review And Revision
 

--- a/docs/roadmap_implementation_backlog.md
+++ b/docs/roadmap_implementation_backlog.md
@@ -83,8 +83,8 @@
 - implement `check_evidence_integrity`
 - implement `check_confidentiality_attestation`
 - implement `check_low_quality_generated_artifacts`
-- implement `check_ready_gate`
-- implement `check_preflight_evidence`
+- implement registered readiness checkers only after their contracts are locked
+- implement preflight evidence guards after the readiness/pre-review record shape is locked
 
 ### Review
 

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -41,7 +41,7 @@ Current phase: Week 3 review and revision preparation.
 - Chunk 7 checker runner, registry, structural checkers, durable checker records, and API tests.
 - Chunk 8 evidence, policy, forbidden-file, confidentiality, and generated-artifact checkers.
 - Chunk 9 automatic pre-review gate with checker-caused `needs_revision`, internal `task_setup_blocked`, trusted checker retry, and worker redaction.
-- Chunk 10 checker trial with five real API sample submissions, failure catalog, false-positive notes, missing-checker notes, and internal verifier evidence.
+- Chunk 10 checker trial with the expanded real API sample matrix, failure catalog, false-positive notes, missing-checker notes, and internal verifier evidence.
 - Week 2 real HTTP API drill through Flow-token auth, project/guide/task/submission lifecycle, pre-submit checks, automatic checker runs, checker-caused `needs_revision`, worker redaction, internal `task_setup_blocked`, and trusted checker retry.
 
 ## Review Tracks Closed
@@ -75,7 +75,7 @@ Current phase: Week 3 review and revision preparation.
 Run from the backend directory against local Postgres:
 
 ```bash
-WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week1_dry_run.py
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week1_dry_run.py
 ```
 
 The script runs migrations forward and exercises:
@@ -87,21 +87,37 @@ The script runs migrations forward and exercises:
 Run from the backend directory against local Postgres:
 
 ```bash
-WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week2_api_e2e.py
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week2_api_e2e.py
 ```
 
 The script starts a real local API server, issues local Flow-compatible tokens, runs migrations forward, and exercises:
 
 `Project -> Guide -> Task -> Screening -> Ready -> Claim -> Start -> Pre-submit checks -> Submit -> Lock submission -> Automatic checker run -> review_pending | needs_revision | internal task_setup_blocked -> trusted checker retry`
 
+## Deterministic Week 2 Closeout Gate
+
+The Week 2 closeout gate is deterministic and must fail on contract drift.
+
+Required invariants:
+
+- Week 1 and Week 2 real API drills run only against local `postgresql+asyncpg://` test databases named `workstream_test` or `test_workstream` unless an explicit write-risk override is supplied.
+- Pre-submit checker responses are non-authoritative and must not create submissions, checker runs, or lifecycle transitions.
+- Missing or unexpected pre-submit checker names fail the drill.
+- Missing or unexpected durable checker names fail the drill.
+- Submission locking returns `locked_at`, locks evidence rows, and is idempotent.
+- Automatic checker-run creation, checker terminal status, and task-status transitions are polled because execution is async-first.
+- Checker-run list visibility is checked for project manager, assigned worker, unassigned worker, and reviewer roles.
+- Trusted checker retry proves attempt ordering, supersession, and current-run flags.
+- Postgres invariants are checked after the real API flows for locked guide/policy context, evidence locks, checker results, checker counters, current-run uniqueness, and gate audit events.
+
 Week 2 closeout validation is not only this script. The full gate is:
 
 ```bash
 .venv/bin/python -m ruff check app tests scripts
-WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week1_api_e2e.py
-WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week2_api_e2e.py
-WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q
-WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week1_api_e2e.py
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week2_api_e2e.py
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest -q
 .venv/bin/docstr-coverage --config .docstr.yaml
 ```
 

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -1,6 +1,6 @@
 # Workstream Roadmap Status
 
-Current phase: Week 2 checker framework implementation.
+Current phase: Week 3 review and revision preparation.
 
 ## Completed
 
@@ -39,6 +39,10 @@ Current phase: Week 2 checker framework implementation.
 - Week 2 checker framework scope specification.
 - Chunk 6 checker contract and records specification.
 - Chunk 7 checker runner, registry, structural checkers, durable checker records, and API tests.
+- Chunk 8 evidence, policy, forbidden-file, confidentiality, and generated-artifact checkers.
+- Chunk 9 automatic pre-review gate with checker-caused `needs_revision`, internal `task_setup_blocked`, trusted checker retry, and worker redaction.
+- Chunk 10 checker trial with five real API sample submissions, failure catalog, false-positive notes, missing-checker notes, and internal verifier evidence.
+- Week 2 real HTTP API drill through Flow-token auth, project/guide/task/submission lifecycle, pre-submit checks, automatic checker runs, checker-caused `needs_revision`, worker redaction, internal `task_setup_blocked`, and trusted checker retry.
 
 ## Review Tracks Closed
 
@@ -48,15 +52,23 @@ Current phase: Week 2 checker framework implementation.
 - Operations and review workflow.
 - Process-pattern baseline.
 - Adversarial quality.
+- Chunk 9 pre-review gate internal verifier pass.
+- Chunk 10 checker trial internal verifier pass.
 
-## Pending Before Week 2
+## Ready For Week 3
+
+- Review queue scope can start from `review_pending` tasks that already passed internal checkers.
+- Reviewer access must be object-level and tied to assigned review work; broad reviewer checker-run access is still intentionally deferred.
+- Week 3 must keep review decisions canonical: `accept`, `needs_revision`, and `reject`.
+- `needs_revision` from human review must carry `outcome_source = human_review` and a review decision id; checker-caused `needs_revision` keeps `outcome_source = auto_checker`.
+- Review findings, revision replay, and reviewer-quality metrics are the next backend contracts to lock.
+
+## Pending Before Pilot
 
 - Create the first pilot project guide from the template.
 - Create the first 5 pilot task records.
 - Confirm who owns product, engineering, review, operations, and payment reconciliation during the first build cycle.
 - Confirm the first v0.1 project guide uses the locked guide fields, task contract fields, evidence IDs, and contribution record flow.
-- Build evidence and policy checkers in Week 2.
-- Keep Week 2 backend/checker-framework only: expose checker results through APIs and dry-run/demo output, not product frontend pages.
 
 ## Week 1 Dry Run
 
@@ -69,6 +81,31 @@ WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:543
 The script runs migrations forward and exercises:
 
 `Project -> Guide -> Task -> Screening -> Ready -> Claim -> Start -> Submit -> Lock submission`
+
+## Week 2 Real API Drill
+
+Run from the backend directory against local Postgres:
+
+```bash
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week2_api_e2e.py
+```
+
+The script starts a real local API server, issues local Flow-compatible tokens, runs migrations forward, and exercises:
+
+`Project -> Guide -> Task -> Screening -> Ready -> Claim -> Start -> Pre-submit checks -> Submit -> Lock submission -> Automatic checker run -> review_pending | needs_revision | internal task_setup_blocked -> trusted checker retry`
+
+Week 2 closeout validation is not only this script. The full gate is:
+
+```bash
+.venv/bin/python -m ruff check app tests scripts
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week1_api_e2e.py
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week2_api_e2e.py
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q
+.venv/bin/docstr-coverage --config .docstr.yaml
+```
+
+The closeout also requires stale wording scan, Markdown link check, and internal verifier evidence before PR.
 
 ## Operating Rule
 

--- a/docs/roadmap_week1_backend_plan.md
+++ b/docs/roadmap_week1_backend_plan.md
@@ -99,7 +99,7 @@ Conditions of satisfaction:
 - roadmap says Workstream verifies Flow auth tokens instead of managing auth directly
 - roadmap defines the review protocol for each implementation chunk
 - roadmap defines the required test gates for backend implementation chunks
-- stale wording and markdown link checks pass
+- stale wording and Markdown link checks pass
 
 Verifier agents:
 

--- a/docs/spec_chunk_10_checker_trial.md
+++ b/docs/spec_chunk_10_checker_trial.md
@@ -28,14 +28,17 @@ This chunk does not add a new lifecycle state or review decision. It exercises t
 
 ## Trial Matrix
 
-The trial must include at least five sample submissions:
+The trial must include the closeout sample submissions below:
 
 | Scenario | Expected Routing | Expected Task Status | Worker Visible |
 | --- | --- | --- | --- |
 | Clean packet | `allow_review` | `review_pending` | Passing checker context |
 | Missing required file | `needs_revision` | `needs_revision` | Required-file fix message |
+| Missing evidence pre-submit | pre-submit blocked | `in_progress` | Non-authoritative evidence feedback |
+| Duplicate artifact manifest | `needs_revision` | `needs_revision` | Evidence-integrity fix message |
 | Forbidden file path | `needs_revision` | `needs_revision` | Safe forbidden-file fix message |
 | Weak confidentiality attestation | `needs_revision` | `needs_revision` | Attestation fix message |
+| Low-quality generated artifact warning | `allow_review` | `review_pending` | Warning result without blocking review |
 | Locked task setup defect | `task_setup_blocked` | `auto_checking` | Internal route hidden |
 
 The worker-facing output must keep the same public language as the rest of Workstream. Worker-fixable checker failures are `needs_revision`. Internal setup defects stay hidden from workers and are repaired by a project manager before a trusted checker retry.
@@ -54,9 +57,15 @@ task_setup_blocked
 
 - at least one clean submission reaches `review_pending`
 - at least one worker-fixable submission failure reaches `needs_revision`
+- missing or unexpected pre-submit checker names fail the closeout drill
+- missing or unexpected durable checker names fail the closeout drill
+- the setup-defect checker set includes `check_acceptance_criteria_present` exactly when the locked checker policy requires it
 - locked task setup failures and worker-fixable failures use distinct routing recommendations
 - worker-visible responses do not expose internal `task_setup_blocked` routing
 - trusted checker retry from an internal blocked gate is covered
+- trusted checker retry proves attempt/current-run semantics after repair
+- submission locking is idempotent and does not create duplicate automatic checker runs
+- submission, evidence, checker run, and audit rows are verified against Postgres after the real API drill
 - false-positive notes are written down
 - missing-checker notes are written down
 - failure catalog links every trial scenario to the checker that produced the route
@@ -69,6 +78,16 @@ Trial evidence is stored in:
 - backend API integration tests for the sample matrix
 
 The trial test must use real backend API calls for project creation, guide activation, task screening/release, worker claim/start, submission creation, submission locking, checker run reads, and trusted checker retry. Direct database setup is allowed only to create the controlled locked task setup defect that normal lifecycle guards are designed to prevent.
+
+The deterministic closeout drill must then query Postgres directly and verify:
+
+- task, submission, and checker run locked guide/policy context match
+- evidence rows are locked with the submission
+- checker result names exactly match the expected checker set
+- checker run counters match persisted checker results
+- only one checker run is current per submission
+- trusted checker retry supersedes the blocked run
+- gate audit events exist for the expected route
 
 ## Verifier Agents
 

--- a/docs/spec_chunk_1_backend_scaffold.md
+++ b/docs/spec_chunk_1_backend_scaffold.md
@@ -96,7 +96,7 @@ Auth interfaces/adapters can be added in Chunk 2.
 - Alembic has an initial migration path
 - tests pass locally
 - stale wording scan passes
-- markdown link check passes
+- Markdown link check passes
 - senior engineering verifier passes
 - QA/test verifier passes
 - security/auth verifier passes

--- a/docs/spec_chunk_2_auth_actor_boundary.md
+++ b/docs/spec_chunk_2_auth_actor_boundary.md
@@ -104,7 +104,7 @@ The actor context created here becomes the input later services use for audit at
 - permission checks live outside routers
 - backend tests pass
 - stale wording scan passes
-- markdown link check passes
+- Markdown link check passes
 - senior engineering verifier passes
 - QA/test verifier passes
 - security/auth verifier passes

--- a/docs/spec_chunk_7_checker_runner_registry.md
+++ b/docs/spec_chunk_7_checker_runner_registry.md
@@ -17,7 +17,7 @@ This is still not the automatic pre-review gate. Chunk 9 owns automatic transiti
 
 ## Scope
 
-Note: Chunk 8 supersedes the temporary public checker names `check_artifact_manifest_integrity` and `check_evidence_references_present` with `check_evidence_integrity` and `check_evidence_present`. This Chunk 7 spec preserves the historical implementation point; current checker policies should use the Chunk 8 names.
+Note: Chunk 8 supersedes the temporary Chunk 7 artifact-manifest and evidence-reference checker names with `check_evidence_integrity` and `check_evidence_present`. This Chunk 7 spec preserves the historical implementation point; current checker policies must use the Chunk 8 names.
 
 - `checker_runs` and `checker_results` migration
 - SQLAlchemy checker models
@@ -30,8 +30,8 @@ Note: Chunk 8 supersedes the temporary public checker names `check_artifact_mani
 - first structural checkers:
   - `check_submission_packet`
   - `check_policy_context_present`
-  - `check_artifact_manifest_integrity`
-  - `check_evidence_references_present`
+  - temporary artifact-manifest integrity checker
+  - temporary evidence-reference checker
 - canonical artifact manifest hash helper
 - real Postgres-backed API and migration tests
 
@@ -83,14 +83,14 @@ Checker policy names must match registered checker names.
 
 If a locked checker policy references an unknown checker, Workstream rejects durable checker execution with a validation error and does not write fake checker results.
 
-The initial registered checker names are:
+The current registered checker names are:
 
 - `check_submission_packet`
 - `check_policy_context_present`
-- `check_artifact_manifest_integrity`
-- `check_evidence_references_present`
+- `check_evidence_integrity`
+- `check_evidence_present`
 
-These were the initial Chunk 7 names. Chunk 8 replaces the last two names in current policy-facing contracts.
+Chunk 8 replaces the temporary Chunk 7 artifact-manifest and evidence-reference checker names in current policy-facing contracts.
 
 ## Runner Behavior
 
@@ -176,5 +176,5 @@ Worker responses must not expose:
 Run from `backend/` against local Postgres:
 
 ```bash
-WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py -q
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py -q
 ```

--- a/docs/spec_chunk_8_evidence_policy_checkers.md
+++ b/docs/spec_chunk_8_evidence_policy_checkers.md
@@ -33,7 +33,7 @@ Chunk 8 does not prove artifact content safety, confidentiality truth, absence o
 - external object-store content reads
 - antivirus, secret-scanning engines, or external static-analysis adapters
 - model-based reviewer simulation
-- `check_preflight_evidence`, which needs the later readiness/pre-review record shape before it can be enforced correctly
+- preflight evidence checker support, which needs the later readiness/pre-review record shape before it can be enforced correctly
 
 ## Naming Contract
 
@@ -49,10 +49,7 @@ Canonical Chunk 8 checker names:
 - `check_confidentiality_attestation`
 - `check_low_quality_generated_artifacts`
 
-Chunk 8 performs a hard rename of Chunk 7's temporary public checker names:
-
-- replace `check_evidence_references_present` with `check_evidence_present`
-- replace `check_artifact_manifest_integrity` with `check_evidence_integrity`
+Chunk 8 performs a hard rename of Chunk 7's temporary public evidence-reference and artifact-manifest checker names to `check_evidence_present` and `check_evidence_integrity`.
 
 The old names are not aliases. If a checker policy still references the old names after Chunk 8, durable checker execution must reject the policy as invalid instead of silently mapping it.
 
@@ -304,8 +301,8 @@ Safe evidence references mean opaque Workstream evidence ids, sanitized labels, 
 
 ## Verification
 
-Run from `backend/` against local Postgres:
+Run from `backend/` against local async Postgres:
 
 ```bash
-.venv/bin/python -m pytest tests/test_checkers.py -q
+WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py -q
 ```

--- a/docs/template_checker_policy.md
+++ b/docs/template_checker_policy.md
@@ -18,19 +18,17 @@ Medium and low severities are visible to reviewers unless this policy overrides 
 
 | Checker | Severity | Blocks Review | Purpose |
 | --- | --- | --- | --- |
-| `check_project_guide_attached` | high | yes | Task must use a versioned project guide. |
-| `check_task_schema` | high | yes | Task must include required project fields. |
 | `check_acceptance_criteria_present` | high | yes | Task must include reviewable acceptance criteria. |
-| `check_ready_gate` | high | yes | Task must pass screening before release. |
 | `check_policy_context_present` | high | yes | Task must have locked checker, review, revision, and payment policy context. |
 | `check_submission_packet` | high | yes | Submission must include required packet fields. |
+| `check_required_files` | high | yes | Submission must include files required by the task. |
+| `check_forbidden_files` | high | yes | Submission must not include forbidden file paths. |
 | `check_evidence_present` | high | yes | Submission must include audit evidence. |
 | `check_evidence_integrity` | high | yes | Evidence and checker runs must bind to submitted artifacts. |
-| `check_prior_revision_closed` | high | yes | Resubmission must map prior findings to fixes. |
-| `check_forbidden_files` | high | yes | Submission must not include prohibited files or data. |
-| `check_confidentiality_attestation` | high | yes | Worker must attest no prohibited confidential material is present. |
-| `check_low_quality_generated_artifacts` | medium | no | Flags project-banned generated or boilerplate patterns. |
-| `check_preflight_evidence` | high | yes | Submission must include preflight evidence before review. |
+| `check_confidentiality_attestation` | high | yes | Worker attestation must address confidentiality and credential handling. |
+| `check_low_quality_generated_artifacts` | low | no | Low-quality generated artifact signals create warning results by default. |
+
+Revision closure, readiness, and lifecycle movement are lifecycle guards in v0.1. Do not add them as checker policy names unless they are present in the registered checker list.
 
 ## Checker Registry Fields
 

--- a/docs/template_project_guide.md
+++ b/docs/template_project_guide.md
@@ -106,12 +106,13 @@ Evidence must prove the submitted version, not an earlier local draft.
 
 Required checkers:
 
-- check_task_schema
-- check_project_guide_attached
+- check_acceptance_criteria_present
 - check_policy_context_present
 - check_submission_packet
 - check_evidence_present
 - check_evidence_integrity
+- check_required_files
+- check_forbidden_files
 - check_confidentiality_attestation
 - check_low_quality_generated_artifacts
 


### PR DESCRIPTION
## Summary
- update roadmap status from Week 2 implementation to Week 3 review/revision preparation
- add a real HTTP Week 2 API drill using Flow-compatible local tokens and Postgres
- document the full Week 2 validation gate and internal verifier evidence
- correct Day 10 visibility wording to project-manager/admin checker API visibility plus worker redaction

## Real API drill coverage
- clean packet -> review_pending
- missing file -> needs_revision
- missing evidence -> pre_submit_blocked / 422 submission contract block
- duplicate artifact integrity -> needs_revision
- weak confidentiality attestation -> needs_revision
- generated-output warning -> review_pending
- forbidden path -> needs_revision with worker redaction
- task setup defect -> task_setup_blocked -> trusted checker retry -> review_pending

## Validation
- cd backend && .venv/bin/python -m ruff check app tests scripts
- cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week1_api_e2e.py
- cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python scripts/week2_api_e2e.py
- cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py -q
- cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream .venv/bin/python -m pytest -q
- cd backend && .venv/bin/docstr-coverage --config .docstr.yaml
- stale wording scan passed
- Markdown relative links passed
- python3 scripts/check_internal_review_evidence.py

Open sub-agent sessions: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added real HTTP Week‑2 end‑to‑end drill (checker flows, routing, defect injection/repair, trusted retry, terminal-state validation) and expanded Week‑1 e2e checks; both refuse non‑local DBs unless explicitly allowed and run against a dedicated local test DB.
* **Documentation**
  * Added Week‑2 real API drill closeout, expanded roadmap/specs/checker contracts and visibility rules, and updated README local Postgres guidance.
* **Bug Fixes**
  * Guide activation now validates required checker names and resubmission state policies, blocking activation with clear errors.
* **Chores**
  * Strengthened test infra, assertions, deterministic validation, and CI test database isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->