### PR TITLE
[codex] Update WS-POL post-merge memory

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -3,13 +3,13 @@
 ## Current State
 
 - Active initiative: `WS-POL-001` - Submission Artifact Policy Foundation
-- Active planning chunk: `WS-POL-001-01` - Submission Artifact Policy Foundation
-- Branch: `codex/submission-artifact-policy-loop-plan`
-- Status: planning review ready; implementation has not started
-- Merge commit: none for this initiative
+- Active planning chunk: none
+- Branch: `main`
+- Status: WS-POL-001 planning approved and merged; implementation has not started
+- Merge commit: `acf2bcf62a7af391c506c960769268c393aefdab`
 - Reviewed code SHA: `8b51a84b1bede193bbafe0b1eeb7b7981a271a0e`
-- Current gate: awaiting human planning approval and PR merge decision; backend implementation is not approved
-- Next chunk: inactive until `WS-POL-001-01` is approved and completed
+- Current gate: ready to open the `WS-POL-001-01` implementation branch when the user says to start
+- Next chunk: `WS-POL-001-01` implementation
 
 ## Operating Rule
 
@@ -19,8 +19,8 @@ Workstream engineering chunks move through:
 Intent -> Discovery -> Plan -> Chunk Map -> Chunk Contract -> Implementation -> Evidence -> Internal Review -> PR -> Human Checkpoint -> Memory Update -> Stop
 ```
 
-The current initiative is Workstream product planning for submission intake
-policy. The current branch changes loop planning artifacts only; it does not
+The current initiative is Workstream product implementation planning for
+submission intake policy. PR #26 approved the planning contract only; it did not
 change Workstream product behavior, database schema, API behavior, or frontend
 behavior.
 
@@ -30,5 +30,6 @@ behavior.
 - PR #23 merged into `main` on 2026-06-20.
 - PR #24 updated post-merge loop memory on `main`.
 - PR #25 added Terminal Benchmark example material under `examples/`.
-- Current planning branch has internal review evidence at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-01-internal-review-evidence.md`.
+- PR #26 approved and merged WS-POL-001 planning into `main` on 2026-06-27.
+- Internal review evidence is at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-01-internal-review-evidence.md`.
 - External review response is tracked separately at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-01-external-review-response.md`.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -23,3 +23,34 @@ Result: PASS after fixes; external review addressed; GitHub checks passed.
 Evidence: `.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/reviews/WS-ENG-001-01-internal-review-evidence.md`
 
 External review response: `.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/reviews/WS-ENG-001-01-external-review-response.md`
+
+## WS-POL-001-PLAN
+
+Status: merged through PR #26 on 2026-06-27.
+
+Merge commit: `acf2bcf62a7af391c506c960769268c393aefdab`
+
+Reviewed code SHA: `8b51a84b1bede193bbafe0b1eeb7b7981a271a0e`
+
+Required reviewer tracks:
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- CI integrity
+- docs
+- reuse/dedup
+- test delta
+
+Result: PASS with low risks; external review addressed; GitHub checks passed.
+
+Scope: planning approval only. No runtime product behavior, database schema, API
+behavior, or frontend behavior changed.
+
+Next chunk: `WS-POL-001-01` implementation on a new branch.
+
+Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-01-internal-review-evidence.md`
+
+External review response: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-01-external-review-response.md`

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -1,10 +1,10 @@
 # Work Queue
 
-## Active Planning
+## Ready For Implementation
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-POL-001-01` | Submission Artifact Policy Foundation | L1 | Draft contract; awaiting human approval before implementation |
+| `WS-POL-001-01` | Submission Artifact Policy Foundation | L1 | Planning approved through PR #26; waiting for implementation branch |
 
 ## Completed
 
@@ -12,12 +12,13 @@
 |---|---|---:|---|
 | `WS-ENG-001-01` | Codex-native zero-trust loop bootstrap | L1 | Merged through PR #23 on 2026-06-20 |
 | `EXAMPLE-TERMINAL-BENCHMARK` | Terminal Benchmark example drill | L3 | Merged through PR #25 on 2026-06-21 |
+| `WS-POL-001-PLAN` | Submission Artifact Policy Foundation planning | L1 | Merged through PR #26 on 2026-06-27 |
 
 ## Proposed Next
 
-`WS-POL-001-01` is the proposed next Workstream product implementation chunk.
-Only planning is active. Backend implementation must not start until the user
-approves the chunk contract.
+`WS-POL-001-01` is the next Workstream product implementation chunk. The
+planning contract is approved. Backend implementation must start on a new branch
+and must not start automatically without the user's start signal.
 
 ## Blocked
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -2,19 +2,19 @@
 
 ## Current Status
 
-Planning review is ready, and latest internal and external review feedback has
-been addressed.
+Planning review was approved and merged through PR #26.
 Implementation has not started.
 
 ## Active Chunk
 
-`WS-POL-001-01` is pending human planning approval. Implementation has not started.
+`WS-POL-001-01` planning contract is approved for future implementation.
+Implementation has not started.
 
 ## Chunk Status
 
 | Chunk | Status | Branch | PR | Notes |
 |---|---|---|---:|---|
-| `WS-POL-001-01` | Awaiting human planning approval | `codex/submission-artifact-policy-loop-plan` | 26 | Internal review complete; external review response is recorded separately from internal review evidence. |
+| `WS-POL-001-01` | Ready for implementation | - | - | Planning merged through PR #26 at `acf2bcf62a7af391c506c960769268c393aefdab`; start on a new implementation branch. |
 | `WS-POL-001-02` | Planned | - | - | Starts after policy foundation lands. |
 | `WS-POL-001-03` | Planned | - | - | Moves submission creation to effective policy. |
 | `WS-POL-001-04` | Planned | - | - | Splits post-submit checker policy provenance. |
@@ -24,7 +24,7 @@ Implementation has not started.
 
 | Blocker | Owner | Next action |
 |---|---|---|
-| Human approval of chunk sequence and first contract | User | Review PR #26 and decide whether to merge. |
+| Implementation start signal | User | Confirm when to open the implementation branch for `WS-POL-001-01`. |
 
 ## Follow-Ups
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-post-merge-memory-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-post-merge-memory-internal-review-evidence.md
@@ -1,0 +1,67 @@
+# Internal Review Evidence: WS-POL-001 post-merge memory
+
+## Chunk
+
+WS-POL-001-POST-MERGE-MEMORY
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: d2eac0a4df066592fe457f57bb9dc3f1d98ead59
+
+Reviewed at: 2026-06-27T07:34:29Z
+
+Reviewer run IDs: 019f07fb-550d-7e63-a095-5e2a10dde31c, 019f07fb-631b-7a32-bf50-3f71b793695d, 019f07fb-6ad7-7fc3-a2af-6dda4b2791a4, 019f07fb-7920-7e00-b0b2-476a2d6b724a, 019f07fb-92dd-7d70-833a-349abcc94f1e, 019f07fb-b00d-7fa2-9dac-b553cfcf19e2
+
+After reviewed SHA `d2eac0a4df066592fe457f57bb9dc3f1d98ead59`, only review evidence changed.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS AFTER FIXES | None remaining | Initially blocked on missing evidence. Content was correct; this evidence file resolves the gate requirement. |
+| QA/test | PASS | None | Confirmed no stale pre-merge approval wording remains and implementation is not marked started. |
+| security/auth | PASS AFTER FIXES | None remaining | Initially blocked on missing evidence and ambiguous status wording. Status wording now says the planning contract is approved for future implementation and still awaits a new branch plus user start signal. |
+| product/ops | PASS WITH LOW RISKS | None | Confirmed PR #26 is merged, implementation has not started, and `WS-POL-001-01` is next. Low risk: `Blocked: None` is acceptable because the start signal is a gate, not a blocker. |
+| architecture | PASS WITH LOW RISKS | None | Confirmed the memory update changes only `.agent-loop` files and does not imply runtime/schema/API/frontend changes. Low wording risk was fixed. |
+| docs | PASS WITH LOW RISKS | None | Confirmed durable memory docs are updated consistently and referenced review files/SHAs exist. |
+
+## Valid Findings Addressed
+
+- Recorded PR #26 as merged into `main` on 2026-06-27.
+- Recorded merge commit `acf2bcf62a7af391c506c960769268c393aefdab`.
+- Updated loop state so it no longer says planning approval is pending.
+- Updated work queue so `WS-POL-001-01` is ready for implementation on a new branch.
+- Updated initiative status so implementation remains not started and waits for
+  the user's start signal.
+- Added review log entry for the WS-POL planning merge.
+- Reworded status to say the planning contract is approved for future
+  implementation, avoiding any implication that implementation has already
+  started.
+
+## Commands Run
+
+```bash
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_loop_memory_state.py
+git diff --check
+```
+
+## Results
+
+```text
+Stale wording check passed.
+Markdown link check passed for 4 changed Markdown files.
+Loop memory state check passed.
+git diff --check passed.
+```
+
+## Remaining Risks
+
+- This is a post-merge memory update only. It does not start implementation.
+- `WS-POL-001-01` implementation must still begin on a separate branch after the
+  user gives the start signal.


### PR DESCRIPTION
## Summary
- record PR #26 as merged into main
- update loop state, work queue, review log, and WS-POL status for post-merge reality
- add internal review evidence for this memory-only process update

## Verification
- python3 scripts/check_internal_review_evidence.py
- python3 scripts/check_stale_workstream_wording.py
- python3 scripts/check_markdown_links.py
- python3 scripts/check_loop_memory_state.py
- git diff --check
- python3 scripts/workstream_agent_gate.py --base origin/main --head HEAD --format json (returns REVIEW_REQUIRED for .agent-loop risk-sensitive files, covered by internal evidence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status notes to show the planning phase has been merged and implementation has not started yet.
  * Marked the next work item as ready for implementation, with a reminder that it should only begin after an explicit start signal.
  * Added a new review record summarizing the merged planning approval, scope, and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->