### PR TITLE
Implement post-submit checker policy provenance

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,13 +4,13 @@
 
 - Active initiative: `WS-POL-001` - Submission Artifact Policy Foundation
 - Active planning chunk: none
-- Active implementation chunk: none
-- Branch: `main`
-- Status: `WS-POL-001-03` merged through PR #63 on 2026-07-03; post-merge memory is current
-- Merged implementation SHA: `d1e80e3903038cb9c99aec9e83faf164a010c46d`
-- Merge commit: `a73be67bf6c3c2ac0194f8aecbda89d748baa92c`
-- Current gate: stop after memory update
-- Next chunk: `WS-POL-001-04` is inactive until the user gives an explicit start signal
+- Active implementation chunk: `WS-POL-001-04`
+- Branch: `codex/ws-pol-001-04-post-submit-policy`
+- Status: `WS-POL-001-04` implementation and internal reviewer fanout are complete; evidence and PR trust artifacts are being prepared
+- Last merged implementation SHA: `d1e80e3903038cb9c99aec9e83faf164a010c46d`
+- Last merge commit: `a73be67bf6c3c2ac0194f8aecbda89d748baa92c`
+- Current gate: evidence and PR trust bundle before PR
+- Next chunk: inactive until `WS-POL-001-04` is reviewed and merged by the user
 
 ## Operating Rule
 
@@ -27,6 +27,11 @@ not implement frontend behavior, payment, reputation, settlement, blockchain
 integrations, post-submit policy splitting, or revision resubmission drill
 behavior.
 
+The active `WS-POL-001-04` chunk splits post-submit checker policy provenance
+from pre-submit checker policy provenance. It must not implement human review
+decisions, revision resubmission, payment, reputation, blockchain integrations,
+frontend behavior, or agent runtime redesign.
+
 ## Last Review State
 
 - Last completed initiative: `WS-ENG-001` Codex zero-trust engineering loop bootstrap.
@@ -41,3 +46,5 @@ behavior.
 - Internal review evidence for `WS-POL-001-03` is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-03-internal-review-evidence.md`.
 - PR trust bundle for `WS-POL-001-03` is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-03-pr-trust-bundle.md`.
 - External review response for `WS-POL-001-03` is tracked separately at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-03-external-review-response.md`.
+- `WS-POL-001-04` started on branch `codex/ws-pol-001-04-post-submit-policy` after the user's explicit start signal.
+- `WS-POL-001-04` internal reviewer fanout completed with no open sub-agent sessions. Evidence and PR trust artifacts must be committed before PR.

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -6,10 +6,10 @@
 - Active planning chunk: none
 - Active implementation chunk: `WS-POL-001-04`
 - Branch: `codex/ws-pol-001-04-post-submit-policy`
-- Status: `WS-POL-001-04` implementation, internal reviewer fanout, evidence, and PR trust artifacts are complete; PR #65 is open
+- Status: `WS-POL-001-04` implementation, internal reviewer fanout, evidence, PR trust artifacts, external review, and CI are complete on PR #65
 - Last merged implementation SHA: `d1e80e3903038cb9c99aec9e83faf164a010c46d`
 - Last merge commit: `a73be67bf6c3c2ac0194f8aecbda89d748baa92c`
-- Current gate: external review and CI on PR #65
+- Current gate: user review of PR #65
 - Next chunk: inactive until `WS-POL-001-04` is reviewed and merged by the user
 
 ## Operating Rule
@@ -50,3 +50,4 @@ frontend behavior, or agent runtime redesign.
 - `WS-POL-001-04` internal reviewer fanout completed with no open sub-agent sessions.
 - `WS-POL-001-04` internal review evidence is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-internal-review-evidence.md`.
 - `WS-POL-001-04` PR trust bundle is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-pr-trust-bundle.md`.
+- `WS-POL-001-04` external review response is tracked separately at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-external-review-response.md`.

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -6,10 +6,10 @@
 - Active planning chunk: none
 - Active implementation chunk: `WS-POL-001-04`
 - Branch: `codex/ws-pol-001-04-post-submit-policy`
-- Status: `WS-POL-001-04` implementation and internal reviewer fanout are complete; evidence and PR trust artifacts are being prepared
+- Status: `WS-POL-001-04` implementation, internal reviewer fanout, evidence, and PR trust artifacts are complete
 - Last merged implementation SHA: `d1e80e3903038cb9c99aec9e83faf164a010c46d`
 - Last merge commit: `a73be67bf6c3c2ac0194f8aecbda89d748baa92c`
-- Current gate: evidence and PR trust bundle before PR
+- Current gate: PR creation and external review
 - Next chunk: inactive until `WS-POL-001-04` is reviewed and merged by the user
 
 ## Operating Rule
@@ -47,4 +47,6 @@ frontend behavior, or agent runtime redesign.
 - PR trust bundle for `WS-POL-001-03` is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-03-pr-trust-bundle.md`.
 - External review response for `WS-POL-001-03` is tracked separately at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-03-external-review-response.md`.
 - `WS-POL-001-04` started on branch `codex/ws-pol-001-04-post-submit-policy` after the user's explicit start signal.
-- `WS-POL-001-04` internal reviewer fanout completed with no open sub-agent sessions. Evidence and PR trust artifacts must be committed before PR.
+- `WS-POL-001-04` internal reviewer fanout completed with no open sub-agent sessions.
+- `WS-POL-001-04` internal review evidence is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-internal-review-evidence.md`.
+- `WS-POL-001-04` PR trust bundle is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-pr-trust-bundle.md`.

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -6,10 +6,10 @@
 - Active planning chunk: none
 - Active implementation chunk: `WS-POL-001-04`
 - Branch: `codex/ws-pol-001-04-post-submit-policy`
-- Status: `WS-POL-001-04` implementation, internal reviewer fanout, evidence, and PR trust artifacts are complete
+- Status: `WS-POL-001-04` implementation, internal reviewer fanout, evidence, and PR trust artifacts are complete; PR #65 is open
 - Last merged implementation SHA: `d1e80e3903038cb9c99aec9e83faf164a010c46d`
 - Last merge commit: `a73be67bf6c3c2ac0194f8aecbda89d748baa92c`
-- Current gate: PR creation and external review
+- Current gate: external review and CI on PR #65
 - Next chunk: inactive until `WS-POL-001-04` is reviewed and merged by the user
 
 ## Operating Rule

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-POL-001-04` | Post-Submit Checker Policy Provenance | L1 | Planned; inactive until the user gives an explicit start signal |
+| `WS-POL-001-04` | Post-Submit Checker Policy Provenance | L1 | Review complete; evidence preparation on `codex/ws-pol-001-04-post-submit-policy` |
 
 ## Completed
 
@@ -19,9 +19,9 @@
 
 ## Proposed Next
 
-`WS-POL-001-04` is the next Workstream product implementation chunk. It splits
-post-submit checker policy provenance from pre-submit intake and must start on a
-new branch only after the user's explicit start signal.
+`WS-POL-001-04` has completed deterministic verification and internal reviewer
+fanout. Evidence and PR trust artifacts must be committed before PR, then the
+chunk stops for user review.
 
 ## Blocked
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -9,7 +9,7 @@ CodeRabbit, and GitHub Actions completed.
 `WS-POL-001-03` owns the task locked-context and submission creation runtime
 migration. `WS-POL-001-04` has started after the user's explicit start signal
 and completed deterministic verification, internal reviewer fanout, evidence,
-and PR trust artifacts. PR #65 is open.
+PR trust artifacts, external review, and CI on PR #65.
 
 ## Active Chunk
 
@@ -22,14 +22,14 @@ and PR trust artifacts. PR #65 is open.
 | `WS-POL-001-01` | Merged | `codex/ws-pol-001-01-submission-artifact-policy` | 28 | Implements guide-source snapshots, guide sufficiency reports, submission artifact policy, effective project policy, project pre-submit checker contract, activation guards, and key-based artifact policy merge. |
 | `WS-POL-001-02` | Merged | `codex/ws-pol-001-02-agent-runtime-compiler` | 61 | Adds async guide sufficiency / derivation agents, runtime port, OpenAI Agents SDK adapter boundary, trusted compiler path, and server-owned provenance guards. |
 | `WS-POL-001-03` | Merged | `codex/ws-pol-001-03-task-locked-context` | 63 | Moves task locked-context and submission runtime to the effective policy and project checker bundle. |
-| `WS-POL-001-04` | PR open | `codex/ws-pol-001-04-post-submit-policy` | 65 | Waiting for external review and CI. |
+| `WS-POL-001-04` | User review | `codex/ws-pol-001-04-post-submit-policy` | 65 | External review and CI passed. |
 | `WS-POL-001-05` | Planned | - | - | Proves revision resubmission and real API drill. |
 
 ## Blockers
 
 | Blocker | Owner | Next action |
 |---|---|---|
-| None | - | Wait for external review and CI on PR #65. |
+| None | - | User reviews PR #65. |
 
 ## Follow-Ups
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -7,9 +7,9 @@
 CodeRabbit, and GitHub Actions completed.
 
 `WS-POL-001-03` owns the task locked-context and submission creation runtime
-migration. `WS-POL-001-04` has started after the user's explicit start signal,
-completed deterministic verification, and completed internal reviewer fanout.
-Evidence and PR trust artifacts are being prepared before PR.
+migration. `WS-POL-001-04` has started after the user's explicit start signal
+and completed deterministic verification, internal reviewer fanout, evidence,
+and PR trust artifacts.
 
 ## Active Chunk
 
@@ -22,14 +22,14 @@ Evidence and PR trust artifacts are being prepared before PR.
 | `WS-POL-001-01` | Merged | `codex/ws-pol-001-01-submission-artifact-policy` | 28 | Implements guide-source snapshots, guide sufficiency reports, submission artifact policy, effective project policy, project pre-submit checker contract, activation guards, and key-based artifact policy merge. |
 | `WS-POL-001-02` | Merged | `codex/ws-pol-001-02-agent-runtime-compiler` | 61 | Adds async guide sufficiency / derivation agents, runtime port, OpenAI Agents SDK adapter boundary, trusted compiler path, and server-owned provenance guards. |
 | `WS-POL-001-03` | Merged | `codex/ws-pol-001-03-task-locked-context` | 63 | Moves task locked-context and submission runtime to the effective policy and project checker bundle. |
-| `WS-POL-001-04` | Review complete | `codex/ws-pol-001-04-post-submit-policy` | - | Evidence and PR trust artifacts are being prepared before PR. |
+| `WS-POL-001-04` | Evidence complete | `codex/ws-pol-001-04-post-submit-policy` | - | Ready for PR creation and external review. |
 | `WS-POL-001-05` | Planned | - | - | Proves revision resubmission and real API drill. |
 
 ## Blockers
 
 | Blocker | Owner | Next action |
 |---|---|---|
-| None | - | Complete evidence gate and PR for `WS-POL-001-04`. |
+| None | - | Create PR and wait for external review on `WS-POL-001-04`. |
 
 ## Follow-Ups
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -9,7 +9,7 @@ CodeRabbit, and GitHub Actions completed.
 `WS-POL-001-03` owns the task locked-context and submission creation runtime
 migration. `WS-POL-001-04` has started after the user's explicit start signal
 and completed deterministic verification, internal reviewer fanout, evidence,
-and PR trust artifacts.
+and PR trust artifacts. PR #65 is open.
 
 ## Active Chunk
 
@@ -22,14 +22,14 @@ and PR trust artifacts.
 | `WS-POL-001-01` | Merged | `codex/ws-pol-001-01-submission-artifact-policy` | 28 | Implements guide-source snapshots, guide sufficiency reports, submission artifact policy, effective project policy, project pre-submit checker contract, activation guards, and key-based artifact policy merge. |
 | `WS-POL-001-02` | Merged | `codex/ws-pol-001-02-agent-runtime-compiler` | 61 | Adds async guide sufficiency / derivation agents, runtime port, OpenAI Agents SDK adapter boundary, trusted compiler path, and server-owned provenance guards. |
 | `WS-POL-001-03` | Merged | `codex/ws-pol-001-03-task-locked-context` | 63 | Moves task locked-context and submission runtime to the effective policy and project checker bundle. |
-| `WS-POL-001-04` | Evidence complete | `codex/ws-pol-001-04-post-submit-policy` | - | Ready for PR creation and external review. |
+| `WS-POL-001-04` | PR open | `codex/ws-pol-001-04-post-submit-policy` | 65 | Waiting for external review and CI. |
 | `WS-POL-001-05` | Planned | - | - | Proves revision resubmission and real API drill. |
 
 ## Blockers
 
 | Blocker | Owner | Next action |
 |---|---|---|
-| None | - | Create PR and wait for external review on `WS-POL-001-04`. |
+| None | - | Wait for external review and CI on PR #65. |
 
 ## Follow-Ups
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -7,12 +7,13 @@
 CodeRabbit, and GitHub Actions completed.
 
 `WS-POL-001-03` owns the task locked-context and submission creation runtime
-migration. `WS-POL-001-04` is the next planned chunk, but it is inactive until
-the user gives an explicit start signal.
+migration. `WS-POL-001-04` has started after the user's explicit start signal,
+completed deterministic verification, and completed internal reviewer fanout.
+Evidence and PR trust artifacts are being prepared before PR.
 
 ## Active Chunk
 
-None.
+`WS-POL-001-04` - Post-Submit Checker Policy Provenance
 
 ## Chunk Status
 
@@ -21,14 +22,14 @@ None.
 | `WS-POL-001-01` | Merged | `codex/ws-pol-001-01-submission-artifact-policy` | 28 | Implements guide-source snapshots, guide sufficiency reports, submission artifact policy, effective project policy, project pre-submit checker contract, activation guards, and key-based artifact policy merge. |
 | `WS-POL-001-02` | Merged | `codex/ws-pol-001-02-agent-runtime-compiler` | 61 | Adds async guide sufficiency / derivation agents, runtime port, OpenAI Agents SDK adapter boundary, trusted compiler path, and server-owned provenance guards. |
 | `WS-POL-001-03` | Merged | `codex/ws-pol-001-03-task-locked-context` | 63 | Moves task locked-context and submission runtime to the effective policy and project checker bundle. |
-| `WS-POL-001-04` | Planned | - | - | Splits post-submit checker policy provenance. |
+| `WS-POL-001-04` | Review complete | `codex/ws-pol-001-04-post-submit-policy` | - | Evidence and PR trust artifacts are being prepared before PR. |
 | `WS-POL-001-05` | Planned | - | - | Proves revision resubmission and real API drill. |
 
 ## Blockers
 
 | Blocker | Owner | Next action |
 |---|---|---|
-| None | - | Stop after post-merge memory update; wait for the user to start `WS-POL-001-04`. |
+| None | - | Complete evidence gate and PR for `WS-POL-001-04`. |
 
 ## Follow-Ups
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-04-post-submit-checker-policy-provenance.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-04-post-submit-checker-policy-provenance.md
@@ -1,0 +1,248 @@
+# Chunk Contract: WS-POL-001-04 - Post-Submit Checker Policy Provenance
+
+## Parent Initiative
+
+WS-POL-001 - Submission Artifact Policy Foundation
+
+## Goal
+
+Separate post-submit checker policy naming and provenance from project
+pre-submit checker policy and from the transitional
+`locked_checker_policy_version` field.
+
+This chunk keeps pre-submit intake stable from `WS-POL-001-03`: pre-submit
+checks run before submission creation and do not create durable checker runs.
+It makes post-submit/internal checker runs explicitly bind to locked
+post-submit checker policy context after a valid submission exists.
+
+## Why This Chunk Exists
+
+Chunks 1 through 3 established the project guide/source/policy foundation,
+async agent and compiler runtime, task locked context, and pre-submit execution
+before submission creation.
+
+The remaining checker provenance gap is that durable checker runs still use
+broad checker-policy naming that can be confused with pre-submit checker
+policy. Workstream needs deterministic audit records that say exactly which
+post-submit checker policy governed each internal checker run, while keeping
+worker-facing pre-submit feedback separate from review decisions and durable
+post-submit checks.
+
+## Approved Plan Reference
+
+- INTENT: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/INTENT.md`
+- DISCOVERY: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/DISCOVERY.md`
+- PLAN: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/PLAN.md`
+- CHUNK_MAP: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/CHUNK_MAP.md`
+
+## Risk Class
+
+L1
+
+## SLA
+
+P1
+
+## Implementation Allowed Files
+
+```text
+backend/alembic/versions/**
+backend/app/db/models.py
+backend/app/modules/projects/**
+backend/app/modules/tasks/**
+backend/app/modules/checkers/**
+backend/scripts/week1_dry_run.py
+backend/scripts/week1_api_e2e.py
+backend/scripts/week2_api_e2e.py
+backend/tests/**
+docs/spec_chunk_3_project_guide_foundation.md
+docs/spec_chunk_5_submission_packet_foundation.md
+docs/spec_chunk_8_submission_artifact_policy_checkers.md
+docs/spec_chunk_9_pre_review_gate.md
+docs/architecture_checker_framework.md
+docs/architecture_data_model.md
+docs/operations_queue_policy.md
+docs/product_first_user_flows.md
+docs/roadmap_status.md
+docs/template_checker_policy.md
+docs/template_submission_packet.md
+.agent-loop/LOOP_STATE.md
+.agent-loop/WORK_QUEUE.md
+.agent-loop/REVIEW_LOG.md
+.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/**
+```
+
+The chunk map lists the product docs required for the post-submit checker split.
+This contract also allows architecture/checker template docs and loop files
+because this chunk is a naming and provenance correction. Those files may only
+be changed to align authoritative `PostSubmitCheckerPolicy` wording, loop
+status, evidence, and PR trust artifacts for this chunk.
+
+## Implementation Not Allowed
+
+```text
+human review decision implementation
+revision resubmission workflow implementation
+payment/reputation/blockchain code
+frontend or demo UI changes
+object-storage implementation
+auth provider changes
+agent runtime redesign
+pre-submit checker derivation redesign
+per-task checker compilation
+new worker-facing task outcome values
+Workstream-owned login, signup, password, auth session, or API key auth
+```
+
+## Implementation Boundaries
+
+- Pre-submit checker policy remains project scoped and compiled from the
+  effective project submission artifact policy.
+- Pre-submit feedback remains draft-packet intake feedback. It must not create
+  durable `CheckerRun` records and must not store product review decision
+  values.
+- `PostSubmitCheckerPolicy` is the authoritative model/schema/service/API
+  naming for the durable checker policy used after a submission exists. The
+  current generic `CheckerPolicy`/`checker_policies` runtime authority must be
+  renamed or explicitly demoted to legacy non-authoritative compatibility.
+- The canonical lock path is task -> submission -> checker run: task screening
+  locks the active post-submit policy id, version, and immutable policy hash;
+  submission creation stamps that locked context from the task; a durable
+  `CheckerRun` records the submission-stamped post-submit policy context it
+  executed.
+- Durable checker runs must bind to locked post-submit checker policy context,
+  not to pre-submit checker bundle provenance and not to broad
+  `locked_checker_policy_version` authority.
+- Workers must not see internal-only checker routing fields or post-submit
+  route names through worker-facing APIs. Worker-facing task/submission status
+  may still be the canonical product status `needs_revision` when post-submit
+  checks find worker-fixable failures.
+- Stored product review decisions remain exactly `accept`, `needs_revision`,
+  and `reject`; this chunk must not add review decision states.
+- `WS-POL-001-05` owns revision resubmission and real API drill proof.
+
+## Acceptance Criteria
+
+- [ ] Pre-submit policy provenance and post-submit policy provenance are
+      distinct in schema, service code, tests, and docs.
+- [ ] Task screening locks explicit
+      `locked_post_submit_checker_policy_id`,
+      `locked_post_submit_checker_policy_version`, and
+      `locked_post_submit_checker_policy_hash` values plus the immutable
+      `locked_post_submit_checker_policy_body` from the active project
+      post-submit policy.
+- [ ] The locked post-submit checker policy body includes the complete durable
+      checker execution list, including Workstream default durable checkers,
+      project required checkers, warning checkers, and blocking severities.
+      Durable checker execution uses that locked body, not a live service
+      constant or mutable project setup row.
+- [ ] Submission creation stamps the post-submit policy context from the task,
+      and durable `CheckerRun` rows stamp the same post-submit policy context
+      from the submission.
+- [ ] Durable checker runs record the locked post-submit checker policy context
+      they used.
+- [ ] Later mutable project policy changes do not affect task, submission, or
+      checker-run provenance that was already locked.
+- [ ] Task readiness, submission creation, submission locking, checker-run
+      creation, and gate routing fail closed when locked post-submit policy
+      context is missing, mismatched, ambiguous, deleted, or unauthorized.
+- [ ] Missing or invalid locked post-submit policy context creates no fake
+      durable `CheckerRun`, no `CheckerResult`, no review-pending transition,
+      and no worker-revision transition; it returns a structured setup/policy
+      error.
+- [ ] Pre-submit feedback still creates no durable `CheckerRun` records.
+- [ ] Pre-submit feedback persistence cannot store review decision fields. If a
+      shared shape is unavoidable, review decision fields are enforced empty.
+- [ ] Worker-facing checker-run detail, checker-run list, task response,
+      submission response, and audit-event response surfaces do not expose
+      internal-only checker routes, post-submit routing internals, human review
+      decision records, review decision ids, `allow_review`, `checker_retry`,
+      `task_setup_blocked`, or locked post-submit policy provenance fields.
+- [ ] Worker-facing APIs may expose the canonical product task/submission
+      status `needs_revision`; that status is not treated as an internal route
+      field.
+- [ ] Existing `submission-precheck` and failed submission-create behavior from
+      `WS-POL-001-03` remains unchanged.
+- [ ] Migration names and ORM fields use `post_submit_checker_policy` wording,
+      not vague `checker_policy` wording for new provenance.
+- [ ] Transitional broad `locked_checker_policy_version` authority is removed
+      from durable checker-run provenance or retained only as admin-visible
+      legacy context with tests proving new code uses the
+      `locked_post_submit_checker_policy_*` fields.
+- [ ] Migration tests prove existing v0.1 rows are backfilled, renamed, or
+      rejected safely before explicit post-submit policy provenance is enforced.
+      Because there is no production data yet, a documented migration preflight
+      that blocks legacy non-draft task, submission, or checker-run rows is
+      acceptable when tested. Legacy checker policy definitions without hashes
+      may remain unauthoritative.
+
+## Required Proof Scenarios
+
+- Task screening stamps post-submit policy id, version, and hash.
+- Submission creation and checker-run creation preserve the same post-submit
+  policy id, version, and hash.
+- Project post-submit policy mutation after lock does not alter existing task,
+  submission, or checker-run provenance.
+- Client-supplied post-submit policy fields are rejected.
+- Missing or mismatched post-submit policy context fails closed without durable
+  checker-run/result rows or task routing.
+- Worker checker-run list/detail, task, submission, and audit responses omit
+  internal route fields and forbidden internal route tokens.
+
+## Verification Commands
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py tests/test_projects.py
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests
+cd backend && .venv/bin/docstr-coverage --config .docstr.yaml
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_loop_memory_state.py
+python3 scripts/workstream_agent_gate.py --base origin/main --head HEAD --format json
+git diff --check
+```
+
+## Required Reviewers
+
+Every listed reviewer must end with one exact result value:
+
+- `PASS`
+- `PASS AFTER FIXES`
+- `PASS WITH LOW RISKS`
+- `N/A - with approved reason`
+
+Required:
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- docs
+- reuse/dedup
+- test delta
+
+## Human Review Focus
+
+- New post-submit checker policy field names and migration safety.
+- Proof that durable checker runs use post-submit policy provenance.
+- Proof that pre-submit feedback still creates no durable checker runs.
+- Proof that worker-facing APIs do not expose internal checker routing or
+  review-decision-like values.
+- Assurance that revision resubmission and human review decisions remain out of
+  scope for this chunk.
+
+## Stop Conditions
+
+Stop and escalate if:
+
+- post-submit checker policy cannot be split without redesigning task or
+  project activation architecture
+- human review decision behavior must change
+- revision resubmission behavior must be implemented to satisfy this chunk
+- auth, payment, reputation, settlement, or frontend scope becomes necessary
+- CI/test weakening is required to pass
+- same blocker remains after 2 repair attempts
+- secrets or production data are needed

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-external-review-response.md
@@ -1,0 +1,30 @@
+# External Review Response: WS-POL-001-04
+
+## PR
+
+PR #65: https://github.com/Flow-Research/workstream/pull/65
+
+## Reviewed Implementation
+
+Internal evidence remains bound to reviewed implementation SHA
+`c2af838a2bef5a5504c43b7707d4d3248b1d8801`. This external response is a
+metadata-only record created after CodeRabbit and GitHub checks completed.
+
+## External Checks
+
+| Check | Result | Notes |
+|---|---:|---|
+| CodeRabbit | PASS | Review completed with no actionable comments reported in the PR check result. |
+| Agent Gates | PASS | GitHub workflow passed. |
+| Backend | PASS | GitHub workflow `test` passed in 4m35s. |
+| Week 1 API Demo UI | PASS | GitHub workflow `build-demo-ui` passed. |
+
+## Response
+
+No external review comments required code or documentation changes after PR
+creation. Internal reviewer evidence remains separate in
+`WS-POL-001-04-internal-review-evidence.md`.
+
+## Follow-Up
+
+No external-review follow-up is open for this PR.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-internal-review-evidence.md
@@ -1,0 +1,79 @@
+# Internal Review Evidence: WS-POL-001-04
+
+## Chunk
+
+WS-POL-001-04
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: c2af838a2bef5a5504c43b7707d4d3248b1d8801
+
+Reviewed at: 2026-07-03T22:36:35Z
+
+Reviewer run IDs: 019f2a0a-7a27-7131-8ceb-909a702d2010, 019f2a0a-b64d-7710-ad09-d3aececdb9ef, 019f2a0a-d6a5-79c1-95f8-fdd43bcd1297, 019f2a0a-fe3c-7a23-a4ef-3c9ca5005aac, 019f2a0b-2135-74e0-881e-989981a2824c, 019f2a0b-4d74-7cf1-8e80-0f981265ae79, 019f2a0e-73fe-7e70-81f6-fd58b104c044, 019f2a0e-9508-7f62-9539-9ed563d3abfe, 019f2a12-5bdf-7a03-a3c2-98622dc1a2c3, 019f2a12-7cc4-7d50-b5ec-9cc1dde06cb5, 019f2a12-a5be-7df2-b72b-761b88ff2560, 019f2a15-a9a3-7313-86f4-b6896907f6ae, 019f2a15-cc69-7bc3-bea2-c195aafcbc81, 019f2a17-be8e-7911-a9e8-6dc7c2685d3b, 019f2a17-e105-7960-81e4-091286d0716b, 019f2a1b-eb0d-79b2-937d-b4518a83094c, 019f2a1c-16e8-7c71-84e2-172fc227f96d, 019f2a1c-36fa-7ee2-a061-57fc13dd1d07, 019f2a1c-5a55-71e0-8682-56e7d8778ec8, 019f2a1c-8a86-7361-94f2-02cf17926c24, 019f2a1c-b921-7192-956b-fac88ed7ecf9, 019f2a1f-0c97-7ae1-ba1b-650a25fb077c, 019f2a1f-3c6d-7581-a092-66e969afecb0, 019f2a45-d4bc-7221-a97a-2686e83a67f8
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Confirmed post-submit policy provenance, migration preflight, worker redaction, and scope boundaries. |
+| qa/test | PASS AFTER FIXES | None | Verified acceptance coverage after task/submission redaction assertions were strengthened. |
+| security/auth | PASS | None | Confirmed client-supplied locked fields are rejected, worker surfaces hide internals, and checker execution fails closed before side effects. |
+| product/ops | PASS AFTER FIXES | None | Confirmed worker/operator wording after `pre_submission_checker_failed` cleanup and loop-state label clarification. |
+| architecture | PASS WITH LOW RISKS | None | Low residual: physical `checker_policies` storage and legacy admin-visible version remain compatibility context; new execution uses post-submit provenance. |
+| docs | PASS AFTER FIXES | None | Confirmed roadmap/status wording after canonical token and loop-state cleanup. |
+| reuse/dedup | PASS | None | Confirmed reuse of `post_submit_checker_policy_body`, `post_submit_checker_policy_hash`, parser, and canonical hashing helpers. |
+| test delta | PASS AFTER FIXES | None | Confirmed strengthened task/submission response redaction assertions and no weakened tests or skips. |
+| ci integrity | PASS WITH LOW RISKS | None | Confirmed no workflow/package/test gate weakening; deterministic agent gate correctly requires review for the large L1 migration/runtime diff. |
+
+## Valid Findings Addressed
+
+- Fixed worker-facing task response coverage after product/ops found the legacy `locked_checker_policy_version` risk. `TaskResponse` does not expose that field, and tests now assert it is absent.
+- Strengthened task and submission redaction tests to enumerate `locked_post_submit_checker_policy_id`, `locked_post_submit_checker_policy_version`, `locked_post_submit_checker_policy_hash`, and `locked_post_submit_checker_policy_body`.
+- Reused `post_submit_checker_policy_hash` in project service instead of leaving the shared helper unused.
+- Repaired roadmap wording so the real API drill uses canonical `pre_submission_checker_failed` for pre-submit intake blocking and preserves checker-caused `needs_revision` for worker-fixable post-submit failures.
+- Updated loop memory so `WS-POL-001-04` is review-complete but not merged, `WS-POL-001-05` remains inactive, and prior merge hashes are labeled as last-merged context.
+- Added CI-integrity review after the deterministic agent gate returned `REVIEW_REQUIRED` for the large migration/runtime/test diff.
+
+## Commands Run
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+cd backend && .venv/bin/docstr-coverage --config .docstr.yaml
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_loop_memory_state.py
+python3 scripts/workstream_agent_gate.py --base origin/main --head HEAD --format json
+git diff --check
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py::test_worker_task_response_redacts_locked_policy_hashes tests/test_tasks.py::test_assigned_worker_submits_v1_and_task_moves_to_submitted
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py::test_worker_task_response_redacts_locked_policy_hashes tests/test_tasks.py::test_screening_uses_persisted_post_submit_policy_body_after_default_drift tests/test_tasks.py::test_submission_uses_locked_post_submit_policy_body_after_setup_mutation tests/test_checkers.py::test_checker_run_uses_locked_post_submit_policy_body_after_setup_mutation tests/test_checkers.py::test_locked_post_submit_policy_parser_uses_persisted_body_hash
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py tests/test_projects.py
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests
+```
+
+## Results
+
+```text
+Ruff app/tests/scripts passed.
+Docstring coverage passed: 100.0% (542/542).
+Markdown link check passed for 15 changed Markdown files.
+Stale wording check passed.
+Loop memory state check passed.
+git diff --check passed.
+Focused redaction tests passed: 2 passed in 35.62s.
+Focused post-submit provenance tests passed: 5 passed in 86.67s.
+Module suite passed: 292 passed in 2790.99s.
+Full Postgres-backed backend suite passed on reviewed SHA: 323 passed in 2387.87s.
+Agent gate result: REVIEW_REQUIRED because this is a large L1 migration/runtime/test diff touching risk-sensitive paths.
+CI-integrity review accepted the REVIEW_REQUIRED result and found no bypass or gate weakening.
+```
+
+## Remaining Risks
+
+- The physical table remains `checker_policies` while code/API naming treats it as `PostSubmitCheckerPolicy` storage. This is contained compatibility for v0.1; future migrations should avoid re-promoting generic checker-policy naming.
+- `locked_checker_policy_version` remains admin-visible legacy context on durable checker-run provenance. New runtime authority uses `locked_post_submit_checker_policy_*`, and worker responses redact legacy/internal fields.
+- `WS-POL-001-05` still owns revision resubmission proof and public lifecycle coverage.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-pr-trust-bundle.md
@@ -136,9 +136,19 @@ Reviewer run IDs: see `WS-POL-001-04-internal-review-evidence.md`.
 
 ## External Review
 
-External review has not run yet for this PR. CodeRabbit and GitHub Actions must
-be tracked separately in `WS-POL-001-04-external-review-response.md` after the
-PR exists. Internal review evidence does not replace external review.
+External review is tracked separately in
+`WS-POL-001-04-external-review-response.md`.
+
+Result summary:
+
+```text
+CodeRabbit passed.
+Agent Gates passed.
+Backend passed.
+Week 1 API Demo UI passed.
+```
+
+Internal review evidence does not replace external review.
 
 ## Remaining Risks
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-pr-trust-bundle.md
@@ -1,0 +1,165 @@
+# PR Trust Bundle: WS-POL-001-04
+
+## Chunk
+
+`WS-POL-001-04` - Post-Submit Checker Policy Provenance
+
+## Goal
+
+Separate post-submit checker policy naming and provenance from project
+pre-submit checker policy and from the transitional
+`locked_checker_policy_version` field.
+
+## Human-Approved Intent
+
+- Intent: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/INTENT.md`
+- Plan: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/PLAN.md`
+- Chunk contract: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-04-post-submit-checker-policy-provenance.md`
+
+## What Changed
+
+- Added explicit locked post-submit checker policy id, version, hash, and body provenance to tasks, submissions, and durable checker runs.
+- Added post-submit policy body/hash generation and locked-body parsing helpers.
+- Made project activation and task readiness validate post-submit policy body/hash consistency.
+- Made task screening copy immutable post-submit policy body/hash from active project setup.
+- Made submission creation copy locked post-submit policy context from the task.
+- Made durable checker runs copy and execute the submission-stamped locked post-submit policy body.
+- Kept pre-submit checks non-durable: failed pre-submit intake still creates no submission and no durable checker run.
+- Hid internal post-submit provenance, route fields, trigger provenance, and legacy checker policy version from worker-facing task, submission, checker-run, and audit responses.
+- Added migration fail-closed preflight for legacy non-draft runtime rows before enforcing explicit post-submit provenance.
+- Updated Week 1/Week 2 scripts and docs to use the new post-submit policy provenance boundary.
+
+## Scope Control
+
+Allowed implementation surface:
+
+- `backend/alembic/versions/**`
+- `backend/app/db/models.py`
+- `backend/app/modules/projects/**`
+- `backend/app/modules/tasks/**`
+- `backend/app/modules/checkers/**`
+- `backend/scripts/week1_dry_run.py`
+- `backend/scripts/week1_api_e2e.py`
+- `backend/scripts/week2_api_e2e.py`
+- `backend/tests/**`
+- Chunk-approved docs and `.agent-loop/` files
+
+No frontend, human review decision implementation, revision resubmission,
+payment/reputation/blockchain code, object storage, auth provider changes,
+agent runtime redesign, pre-submit derivation redesign, or per-task checker
+compilation was added.
+
+## Product Behavior
+
+Task screening locks post-submit checker policy context from the active project
+guide-policy bundle:
+
+```text
+PostSubmitCheckerPolicy id
+PostSubmitCheckerPolicy version
+PostSubmitCheckerPolicy hash
+PostSubmitCheckerPolicy immutable body
+```
+
+Submission creation stamps that context from the task. Durable checker runs
+stamp the same context from the submission and execute the locked body.
+
+Worker-facing behavior remains stable:
+
+- pre-submit intake failure returns `pre_submission_checker_failed`
+- checker-caused worker-fixable post-submit failure may surface as `needs_revision`
+- setup/policy defects stay internal as `task_setup_blocked` or trusted checker retry
+- product review decisions remain only `accept`, `needs_revision`, and `reject`
+
+## Acceptance Criteria Proof
+
+- Distinct pre-submit and post-submit provenance: `backend/app/modules/projects/post_submit_policy.py`, task/checker models, schemas, and docs.
+- Task screening locks post-submit id/version/hash/body: `backend/app/modules/tasks/service.py`, `backend/tests/test_tasks.py`.
+- Submission and checker run preserve locked context: `backend/app/modules/tasks/service.py`, `backend/app/modules/checkers/service.py`, `backend/tests/test_checkers.py`.
+- Durable execution reads locked body, not live defaults or mutable setup rows: `backend/app/modules/checkers/service.py`, `backend/tests/test_checkers.py`.
+- Missing/mismatched/invalid context fails closed before durable side effects: `backend/app/modules/checkers/service.py`, `backend/tests/test_checkers.py`.
+- Pre-submit feedback remains non-durable: `backend/tests/test_tasks.py`, `backend/tests/test_checkers.py`.
+- Worker-facing redaction: `backend/app/modules/tasks/service.py`, `backend/app/modules/checkers/service.py`, `backend/tests/test_tasks.py`, `backend/tests/test_checkers.py`.
+- Migration safety: `backend/alembic/versions/0008_post_submit_checker_policy_provenance.py`, `backend/tests/test_alembic.py`.
+
+## Tests And Checks Run
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+cd backend && .venv/bin/docstr-coverage --config .docstr.yaml
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_loop_memory_state.py
+python3 scripts/workstream_agent_gate.py --base origin/main --head HEAD --format json
+git diff --check
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py::test_worker_task_response_redacts_locked_policy_hashes tests/test_tasks.py::test_assigned_worker_submits_v1_and_task_moves_to_submitted
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py::test_worker_task_response_redacts_locked_policy_hashes tests/test_tasks.py::test_screening_uses_persisted_post_submit_policy_body_after_default_drift tests/test_tasks.py::test_submission_uses_locked_post_submit_policy_body_after_setup_mutation tests/test_checkers.py::test_checker_run_uses_locked_post_submit_policy_body_after_setup_mutation tests/test_checkers.py::test_locked_post_submit_policy_parser_uses_persisted_body_hash
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py tests/test_projects.py
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests
+```
+
+Result summary:
+
+```text
+Ruff app/tests/scripts passed.
+Docstring coverage passed: 100.0% (542/542).
+Markdown link check passed for 15 changed Markdown files.
+Stale wording check passed.
+Loop memory state check passed.
+git diff --check passed.
+Focused redaction tests passed: 2 passed in 35.62s.
+Focused post-submit provenance tests passed: 5 passed in 86.67s.
+Module suite passed: 292 passed in 2790.99s.
+Full Postgres-backed backend suite passed on reviewed SHA: 323 passed in 2387.87s.
+Agent gate result: REVIEW_REQUIRED for L1 migration/runtime/test risk; reviewed by CI integrity.
+```
+
+## Reviewer Results
+
+Reviewed code SHA: `c2af838a2bef5a5504c43b7707d4d3248b1d8801`
+
+Reviewed at: `2026-07-03T22:36:35Z`
+
+Reviewer run IDs: see `WS-POL-001-04-internal-review-evidence.md`.
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Migration/runtime provenance reviewed. |
+| QA/test | PASS AFTER FIXES | None | Redaction assertions strengthened. |
+| security/auth | PASS | None | Worker surfaces and fail-closed behavior reviewed. |
+| product/ops | PASS AFTER FIXES | None | Status wording and worker/operator semantics reviewed. |
+| architecture | PASS WITH LOW RISKS | None | Legacy physical table naming remains contained. |
+| docs | PASS AFTER FIXES | None | Roadmap and loop-state wording cleaned. |
+| reuse/dedup | PASS | None | Shared helpers reused. |
+| test delta | PASS AFTER FIXES | None | Test coverage gap closed. |
+| CI integrity | PASS WITH LOW RISKS | None | Agent gate risk accepted; no CI weakening found. |
+
+## External Review
+
+External review has not run yet for this PR. CodeRabbit and GitHub Actions must
+be tracked separately in `WS-POL-001-04-external-review-response.md` after the
+PR exists. Internal review evidence does not replace external review.
+
+## Remaining Risks
+
+- Physical storage still uses `checker_policies` for v0.1 compatibility. New code should avoid treating generic checker policy naming as runtime authority.
+- Legacy `locked_checker_policy_version` remains admin-visible context on durable checker runs; worker surfaces redact it and runtime uses `locked_post_submit_checker_policy_*`.
+- Revision resubmission proof remains deferred to `WS-POL-001-05`.
+
+## Human Review Focus
+
+Please inspect:
+
+- Migration `0008` fail-closed preflight and post-submit provenance constraints.
+- Task -> submission -> checker-run locked policy propagation.
+- Locked policy body execution instead of live default constants or mutable setup rows.
+- Worker-facing API redaction of internal route/provenance fields.
+- Separation between `pre_submission_checker_failed`, internal setup routing, and user-facing `needs_revision`.
+
+## Human Ownership
+
+- [ ] I can explain what changed.
+- [ ] I can explain why it changed.
+- [ ] I know what could break.
+- [ ] I accept the remaining risks.
+- [ ] The user explicitly approved this specific PR for merge.

--- a/backend/alembic/versions/0008_post_submit_checker_policy_provenance.py
+++ b/backend/alembic/versions/0008_post_submit_checker_policy_provenance.py
@@ -1,0 +1,298 @@
+"""post submit checker policy provenance
+
+Revision ID: 0008_post_submit_checker_policy
+Revises: 0007_task_locked_context
+Create Date: 2026-07-03
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0008_post_submit_checker_policy"
+down_revision = "0007_task_locked_context"
+branch_labels = None
+depends_on = None
+
+
+def _preflight_no_legacy_runtime_rows() -> None:
+    """Stop before schema changes when legacy runtime rows cannot be backfilled."""
+    bind = op.get_bind()
+    counts = {
+        "non_draft_tasks": bind.scalar(
+            sa.text("select count(*) from workstream_tasks where status <> 'draft'")
+        ),
+        "submissions": bind.scalar(sa.text("select count(*) from submissions")),
+        "checker_runs": bind.scalar(sa.text("select count(*) from checker_runs")),
+    }
+    if any(counts.values()):
+        detail = ", ".join(f"{name}={count}" for name, count in counts.items())
+        raise RuntimeError(
+            "0008_post_submit_checker_policy cannot infer locked post-submit "
+            "checker policy provenance for existing v0.1 runtime rows. "
+            f"Found {detail}. Export or reset those runtime rows before upgrading."
+        )
+
+
+def upgrade() -> None:
+    """Add explicit post-submit checker policy provenance locks."""
+    _preflight_no_legacy_runtime_rows()
+
+    op.add_column(
+        "checker_policies",
+        sa.Column("policy_hash", sa.String(length=71), nullable=True),
+    )
+    op.add_column(
+        "checker_policies",
+        sa.Column("policy_body", sa.JSON(), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_checker_policies_id_version_hash",
+        "checker_policies",
+        ["id", "guide_version", "policy_hash"],
+    )
+    op.create_check_constraint(
+        "policy_hash_shape",
+        "checker_policies",
+        "policy_hash is null or policy_hash ~ '^sha256:[0-9a-f]{64}$'",
+    )
+
+    for table_name in ("workstream_tasks", "submissions", "checker_runs"):
+        op.add_column(
+            table_name,
+            sa.Column(
+                "locked_post_submit_checker_policy_id",
+                sa.String(length=36),
+                nullable=True,
+            ),
+        )
+        op.add_column(
+            table_name,
+            sa.Column(
+                "locked_post_submit_checker_policy_version",
+                sa.String(length=50),
+                nullable=True,
+            ),
+        )
+        op.add_column(
+            table_name,
+            sa.Column(
+                "locked_post_submit_checker_policy_hash",
+                sa.String(length=71),
+                nullable=True,
+            ),
+        )
+        op.add_column(
+            table_name,
+            sa.Column(
+                "locked_post_submit_checker_policy_body",
+                sa.JSON(),
+                nullable=True,
+            ),
+        )
+        op.create_foreign_key(
+            f"fk_{table_name}_locked_post_submit_policy_hash",
+            table_name,
+            "checker_policies",
+            [
+                "locked_post_submit_checker_policy_id",
+                "locked_post_submit_checker_policy_version",
+                "locked_post_submit_checker_policy_hash",
+            ],
+            ["id", "guide_version", "policy_hash"],
+        )
+        op.create_index(
+            f"ix_{table_name}_locked_post_submit_policy_hash",
+            table_name,
+            ["locked_post_submit_checker_policy_hash"],
+            unique=False,
+        )
+
+    op.create_check_constraint(
+        "post_submit_policy_lock_complete",
+        "workstream_tasks",
+        """
+        status = 'draft'
+        or (
+            locked_post_submit_checker_policy_id is not null
+            and locked_post_submit_checker_policy_version is not null
+            and locked_post_submit_checker_policy_hash is not null
+            and locked_post_submit_checker_policy_body is not null
+        )
+        """,
+    )
+    op.create_check_constraint(
+        "post_submit_policy_lock_complete",
+        "submissions",
+        """
+        locked_post_submit_checker_policy_id is not null
+        and locked_post_submit_checker_policy_version is not null
+        and locked_post_submit_checker_policy_hash is not null
+        and locked_post_submit_checker_policy_body is not null
+        """,
+    )
+    op.create_check_constraint(
+        "post_submit_policy_lock_complete",
+        "checker_runs",
+        """
+        locked_post_submit_checker_policy_id is not null
+        and locked_post_submit_checker_policy_version is not null
+        and locked_post_submit_checker_policy_hash is not null
+        and locked_post_submit_checker_policy_body is not null
+        """,
+    )
+
+    op.create_unique_constraint(
+        "uq_workstream_tasks_id_locked_post_submit_policy_hash",
+        "workstream_tasks",
+        [
+            "id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+    )
+    op.create_foreign_key(
+        "fk_submissions_task_locked_post_submit_policy_hash",
+        "submissions",
+        "workstream_tasks",
+        [
+            "task_id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+        [
+            "id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+    )
+    op.create_unique_constraint(
+        "uq_submissions_id_locked_post_submit_policy_hash",
+        "submissions",
+        [
+            "id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+    )
+    op.create_foreign_key(
+        "fk_checker_runs_submission_locked_post_submit_policy_hash",
+        "checker_runs",
+        "submissions",
+        [
+            "submission_id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+        [
+            "id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Remove explicit post-submit checker policy provenance locks."""
+    op.drop_constraint(
+        "post_submit_policy_lock_complete",
+        "checker_runs",
+        type_="check",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "ck_checker_runs_post_submit_policy_lock_complete",
+        "checker_runs",
+        type_="check",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "post_submit_policy_lock_complete",
+        "submissions",
+        type_="check",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "ck_submissions_post_submit_policy_lock_complete",
+        "submissions",
+        type_="check",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "post_submit_policy_lock_complete",
+        "workstream_tasks",
+        type_="check",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "ck_workstream_tasks_post_submit_policy_lock_complete",
+        "workstream_tasks",
+        type_="check",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "fk_checker_runs_submission_locked_post_submit_policy_hash",
+        "checker_runs",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "uq_submissions_id_locked_post_submit_policy_hash",
+        "submissions",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "fk_submissions_task_locked_post_submit_policy_hash",
+        "submissions",
+        type_="foreignkey",
+    )
+    op.drop_constraint(
+        "uq_workstream_tasks_id_locked_post_submit_policy_hash",
+        "workstream_tasks",
+        type_="unique",
+    )
+    for table_name in ("checker_runs", "submissions", "workstream_tasks"):
+        op.drop_index(
+            f"ix_{table_name}_locked_post_submit_policy_hash",
+            table_name=table_name,
+        )
+        op.drop_constraint(
+            f"fk_{table_name}_locked_post_submit_policy_hash",
+            table_name,
+            type_="foreignkey",
+        )
+        op.execute(
+            sa.text(
+                f"alter table {table_name} "
+                "drop column if exists locked_post_submit_checker_policy_body"
+            )
+        )
+        op.drop_column(table_name, "locked_post_submit_checker_policy_hash")
+        op.drop_column(table_name, "locked_post_submit_checker_policy_version")
+        op.drop_column(table_name, "locked_post_submit_checker_policy_id")
+
+    op.drop_constraint(
+        "policy_hash_shape",
+        "checker_policies",
+        type_="check",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "ck_checker_policies_policy_hash_shape",
+        "checker_policies",
+        type_="check",
+        if_exists=True,
+    )
+    op.drop_constraint(
+        "uq_checker_policies_id_version_hash",
+        "checker_policies",
+        type_="unique",
+    )
+    op.execute(sa.text("alter table checker_policies drop column if exists policy_body"))
+    op.drop_column("checker_policies", "policy_hash")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -2,12 +2,12 @@
 
 from app.modules.checkers.models import CheckerResult, CheckerRun  # noqa: F401
 from app.modules.projects.models import (  # noqa: F401
-    CheckerPolicy,
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
     GuideSourceSnapshotItem,
     GuideSufficiencyReport,
     PaymentPolicy,
+    PostSubmitCheckerPolicy,
     PreSubmitCheckerPolicy,
     Project,
     ProjectGuide,

--- a/backend/app/modules/checkers/models.py
+++ b/backend/app/modules/checkers/models.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
@@ -39,6 +40,15 @@ class CheckerRun(Base):
             name="fk_checker_runs_task_locked_checker_policy",
         ),
         ForeignKeyConstraint(
+            [
+                "locked_post_submit_checker_policy_id",
+                "locked_post_submit_checker_policy_version",
+                "locked_post_submit_checker_policy_hash",
+            ],
+            ["checker_policies.id", "checker_policies.guide_version", "checker_policies.policy_hash"],
+            name="fk_checker_runs_locked_post_submit_policy_hash",
+        ),
+        ForeignKeyConstraint(
             ["task_id", "locked_review_policy_version"],
             ["workstream_tasks.id", "workstream_tasks.locked_review_policy_version"],
             name="fk_checker_runs_task_locked_review_policy",
@@ -58,16 +68,44 @@ class CheckerRun(Base):
             ["submissions.id", "submissions.version"],
             name="fk_checker_runs_submission_version",
         ),
+        ForeignKeyConstraint(
+            [
+                "submission_id",
+                "locked_post_submit_checker_policy_id",
+                "locked_post_submit_checker_policy_version",
+                "locked_post_submit_checker_policy_hash",
+            ],
+            [
+                "submissions.id",
+                "submissions.locked_post_submit_checker_policy_id",
+                "submissions.locked_post_submit_checker_policy_version",
+                "submissions.locked_post_submit_checker_policy_hash",
+            ],
+            name="fk_checker_runs_submission_locked_post_submit_policy_hash",
+        ),
         UniqueConstraint(
             "submission_id",
             "attempt_number",
             name="uq_checker_runs_submission_attempt",
+        ),
+        CheckConstraint(
+            """
+            locked_post_submit_checker_policy_id is not null
+            and locked_post_submit_checker_policy_version is not null
+            and locked_post_submit_checker_policy_hash is not null
+            and locked_post_submit_checker_policy_body is not null
+            """,
+            name="post_submit_policy_lock_complete",
         ),
         Index(
             "uq_checker_runs_current_per_submission",
             "submission_id",
             unique=True,
             postgresql_where=text("is_current_for_submission = true"),
+        ),
+        Index(
+            "ix_checker_runs_locked_post_submit_policy_hash",
+            "locked_post_submit_checker_policy_hash",
         ),
     )
 
@@ -98,6 +136,13 @@ class CheckerRun(Base):
     is_current_for_submission: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     locked_guide_version: Mapped[str] = mapped_column(String(50), nullable=False)
     locked_checker_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_post_submit_checker_policy_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    locked_post_submit_checker_policy_version: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+    )
+    locked_post_submit_checker_policy_hash: Mapped[str] = mapped_column(String(71), nullable=False)
+    locked_post_submit_checker_policy_body: Mapped[dict] = mapped_column(JSON, nullable=False)
     locked_review_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
     locked_revision_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
     locked_payment_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/backend/app/modules/checkers/router.py
+++ b/backend/app/modules/checkers/router.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps.auth import get_current_actor
@@ -12,6 +14,7 @@ from app.core.permissions import PermissionDenied
 from app.db.session import get_db_session
 from app.modules.checkers.schemas import (
     CheckerRunRequest,
+    CheckerRunPublicResponse,
     CheckerRunResponse,
     PreSubmitCheckRequest,
     PreSubmitCheckResponse,
@@ -20,6 +23,17 @@ from app.modules.checkers.service import CheckerService, CheckerServiceError
 from app.schemas.auth import ActorContext
 
 router = APIRouter(tags=["checkers"])
+
+CHECKER_RUN_PUBLIC_RESPONSE = {
+    200: {
+        "model": CheckerRunPublicResponse,
+        "description": (
+            "Role-sensitive checker run response. Worker-readable OpenAPI "
+            "documents only the public subset; admin and project_manager actors "
+            "may receive additional internal routing and provenance fields."
+        ),
+    }
+}
 
 
 def checker_http_error(exc: CheckerServiceError) -> HTTPException:
@@ -46,6 +60,11 @@ def permission_http_error(exc: PermissionDenied) -> HTTPException:
     return HTTPException(status_code=403, detail=str(exc))
 
 
+def checker_run_response(payload: CheckerRunResponse | list[CheckerRunResponse]) -> JSONResponse:
+    """Serialize role-sensitive checker-run responses without null hidden fields."""
+    return JSONResponse(content=jsonable_encoder(payload, exclude_none=True))
+
+
 @router.post("/tasks/{task_id}/submission-precheck", response_model=PreSubmitCheckResponse)
 async def pre_submit_check(
     task_id: str,
@@ -62,52 +81,75 @@ async def pre_submit_check(
         raise checker_http_error(exc) from exc
 
 
-@router.post("/submissions/{submission_id}/checker-runs", response_model=CheckerRunResponse)
+@router.post(
+    "/submissions/{submission_id}/checker-runs",
+    response_model=None,
+    responses=CHECKER_RUN_PUBLIC_RESPONSE,
+)
 async def run_submission_checkers(
     submission_id: str,
     payload: CheckerRunRequest,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
-) -> CheckerRunResponse:
+) -> JSONResponse:
     """Trigger a durable internal checker run for a locked submission."""
     try:
-        return await CheckerService(session).run_submission_checkers(
+        result = await CheckerService(session).run_submission_checkers(
             actor,
             submission_id,
             payload.trigger_reason,
         )
+        return checker_run_response(result)
     except PermissionDenied as exc:
         raise permission_http_error(exc) from exc
     except CheckerServiceError as exc:
         raise checker_http_error(exc) from exc
 
 
-@router.get("/submissions/{submission_id}/checker-runs", response_model=list[CheckerRunResponse])
+@router.get(
+    "/submissions/{submission_id}/checker-runs",
+    response_model=None,
+    responses={
+        200: {
+            "model": list[CheckerRunPublicResponse],
+            "description": (
+                "Role-sensitive checker run list. Worker-readable OpenAPI "
+                "documents only the public subset; admin and project_manager "
+                "actors may receive additional internal routing and provenance fields."
+            ),
+        }
+    },
+)
 async def list_submission_checker_runs(
     submission_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
-) -> list[CheckerRunResponse]:
+) -> JSONResponse:
     """Return checker runs for one visible submission."""
     try:
-        return await CheckerService(session).list_submission_checker_runs(actor, submission_id)
+        result = await CheckerService(session).list_submission_checker_runs(actor, submission_id)
+        return checker_run_response(result)
     except PermissionDenied as exc:
         raise permission_http_error(exc) from exc
     except CheckerServiceError as exc:
         raise checker_http_error(exc) from exc
 
 
-@router.get("/checker-runs/{checker_run_id}", response_model=CheckerRunResponse)
+@router.get(
+    "/checker-runs/{checker_run_id}",
+    response_model=None,
+    responses=CHECKER_RUN_PUBLIC_RESPONSE,
+)
 async def get_checker_run(
     checker_run_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
-) -> CheckerRunResponse:
+) -> JSONResponse:
     """Return one visible checker run."""
     try:
-        return await CheckerService(session).get_checker_run(actor, checker_run_id)
+        result = await CheckerService(session).get_checker_run(actor, checker_run_id)
+        return checker_run_response(result)
     except PermissionDenied as exc:
         raise permission_http_error(exc) from exc
     except CheckerServiceError as exc:
         raise checker_http_error(exc) from exc
-

--- a/backend/app/modules/checkers/runner.py
+++ b/backend/app/modules/checkers/runner.py
@@ -844,6 +844,15 @@ async def check_policy_context_present(context: CheckerContext) -> CheckerOutcom
         for name, value in {
             "locked_guide_version": context.submission.locked_guide_version,
             "locked_checker_policy_version": context.submission.locked_checker_policy_version,
+            "locked_post_submit_checker_policy_id": (
+                context.submission.locked_post_submit_checker_policy_id
+            ),
+            "locked_post_submit_checker_policy_version": (
+                context.submission.locked_post_submit_checker_policy_version
+            ),
+            "locked_post_submit_checker_policy_hash": (
+                context.submission.locked_post_submit_checker_policy_hash
+            ),
             "locked_review_policy_version": context.submission.locked_review_policy_version,
             "locked_revision_policy_version": context.submission.locked_revision_policy_version,
             "locked_payment_policy_version": context.submission.locked_payment_policy_version,

--- a/backend/app/modules/checkers/schemas.py
+++ b/backend/app/modules/checkers/schemas.py
@@ -106,10 +106,10 @@ class CheckerRunResponse(BaseModel):
     task_id: str
     submission_id: str
     submission_version: int
-    trigger_source: str
+    trigger_source: str | None = None
     status: CheckerStatus
-    routing_recommendation: CheckerRoutingRecommendation
-    outcome_source: CheckerOutcomeSource
+    routing_recommendation: CheckerRoutingRecommendation | None = None
+    outcome_source: CheckerOutcomeSource | None = None
     triggered_by: str | None
     triggered_by_subject: str | None
     triggered_by_issuer: str | None
@@ -121,6 +121,9 @@ class CheckerRunResponse(BaseModel):
     is_current_for_submission: bool
     locked_guide_version: str | None
     locked_checker_policy_version: str | None
+    locked_post_submit_checker_policy_id: str | None = None
+    locked_post_submit_checker_policy_version: str | None = None
+    locked_post_submit_checker_policy_hash: str | None = None
     locked_review_policy_version: str | None
     locked_revision_policy_version: str | None
     locked_payment_policy_version: str | None
@@ -136,5 +139,36 @@ class CheckerRunResponse(BaseModel):
     completed_at: datetime | None
     failure_code: str | None
     failure_message: str | None
+    created_at: datetime
+    results: list[CheckerResultResponse] = Field(default_factory=list)
+
+
+class CheckerRunPublicResponse(BaseModel):
+    """Conservative public schema for worker-readable checker run endpoints.
+
+    Runtime responses are role-sensitive. Actors with checker-operation roles
+    may receive additional internal audit and provenance fields from
+    ``CheckerRunResponse``; worker-readable OpenAPI surfaces advertise only this
+    safe subset.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    task_id: str
+    submission_id: str
+    submission_version: int
+    status: CheckerStatus
+    attempt_number: int
+    supersedes_checker_run_id: str | None
+    is_current_for_submission: bool
+    artifact_hash_manifest: list[dict[str, Any]]
+    passed_count: int
+    warning_count: int
+    failed_count: int
+    blocking_count: int
+    queued_at: datetime
+    started_at: datetime | None
+    completed_at: datetime | None
     created_at: datetime
     results: list[CheckerResultResponse] = Field(default_factory=list)

--- a/backend/app/modules/checkers/service.py
+++ b/backend/app/modules/checkers/service.py
@@ -37,6 +37,10 @@ from app.modules.projects.models import (
     EffectiveProjectSubmissionArtifactPolicy,
     PreSubmitCheckerPolicy,
 )
+from app.modules.projects.post_submit_policy import (
+    LockedPostSubmitCheckerPolicy,
+    parse_locked_post_submit_checker_policy_body,
+)
 from app.modules.projects.repository import ProjectRepository
 from app.modules.tasks.lifecycle import (
     InvalidTaskTransition,
@@ -66,16 +70,6 @@ INTERNAL_ROUTING_RECOMMENDATIONS = {
     ROUTING_CHECKER_RETRY,
     ROUTING_TASK_SETUP_BLOCKED,
 }
-DEFAULT_DURABLE_CHECKERS = [
-    "check_submission_packet",
-    "check_policy_context_present",
-    "check_evidence_present",
-    "check_evidence_integrity",
-    "check_required_files",
-    "check_forbidden_files",
-    "check_confidentiality_attestation",
-    "check_low_quality_generated_artifacts",
-]
 
 
 class CheckerServiceError(Exception):
@@ -312,6 +306,64 @@ class CheckerService:
             ) from exc
         return effective_policy, pre_submit_checker_policy
 
+    async def _load_locked_post_submit_policy(
+        self,
+        task: WorkstreamTask,
+        submission: Submission,
+    ) -> LockedPostSubmitCheckerPolicy:
+        """Load and validate the locked post-submit checker policy.
+
+        Args:
+            task: Task whose locked context must match the submission.
+            submission: Locked submission stamped from the task context.
+
+        Returns:
+            The parsed locked post-submit checker policy body.
+
+        Raises:
+            CheckerPolicyInvalid: If the post-submit policy lock is missing,
+                mismatched, deleted, or stale.
+        """
+        locked_id = submission.locked_post_submit_checker_policy_id
+        locked_version = submission.locked_post_submit_checker_policy_version
+        locked_hash = submission.locked_post_submit_checker_policy_hash
+        if not all([locked_id, locked_version, locked_hash]):
+            raise CheckerPolicyInvalid("locked post-submit checker policy context is incomplete")
+        if (
+            task.locked_post_submit_checker_policy_id != locked_id
+            or task.locked_post_submit_checker_policy_version != locked_version
+            or task.locked_post_submit_checker_policy_hash != locked_hash
+            or task.locked_post_submit_checker_policy_body
+            != submission.locked_post_submit_checker_policy_body
+        ):
+            raise CheckerPolicyInvalid(
+                "submission post-submit checker policy context does not match task lock"
+            )
+        policy = await self._project_repo.get_post_submit_checker_policy_by_id(locked_id)
+        if (
+            policy is None
+            or policy.project_id != task.project_id
+            or policy.guide_version != locked_version
+            or policy.policy_hash != locked_hash
+        ):
+            raise CheckerPolicyInvalid("locked post-submit checker policy is invalid")
+        try:
+            locked_policy = parse_locked_post_submit_checker_policy_body(
+                submission.locked_post_submit_checker_policy_body,
+                project_id=task.project_id,
+                guide_version=locked_version,
+                policy_hash=locked_hash,
+            )
+        except ValueError as exc:
+            raise CheckerPolicyInvalid("locked post-submit checker policy hash is invalid") from exc
+        try:
+            self._registry.require_registered(set(locked_policy.execution_checkers))
+        except UnknownChecker as exc:
+            raise CheckerPolicyInvalid(
+                "locked post-submit checker policy references unregistered checker"
+            ) from exc
+        return locked_policy
+
     @staticmethod
     def _effective_policy_shape_is_valid(effective_policy: Any) -> bool:
         """Return whether a locked effective policy can be safely executed."""
@@ -427,28 +479,13 @@ class CheckerService:
         if latest_submission is None or latest_submission.id != submission.id:
             raise CheckerExecutionBlocked("only latest submission version can be checked")
 
-        checker_policy = await self._project_repo.get_checker_policy(
-            task.project_id,
-            submission.locked_checker_policy_version,
-        )
-        if checker_policy is None:
-            raise CheckerPolicyInvalid("locked checker policy not found")
+        checker_policy = await self._load_locked_post_submit_policy(task, submission)
         effective_policy, _ = await self._load_locked_pre_submit_context(
             task,
             submission,
         )
 
-        required_names = list(checker_policy.required_checkers or [])
-        warning_names = list(checker_policy.warning_checkers or [])
-        checker_names = list(
-            dict.fromkeys(
-                [
-                    *DEFAULT_DURABLE_CHECKERS,
-                    *required_names,
-                    *warning_names,
-                ]
-            )
-        )
+        checker_names = list(checker_policy.execution_checkers or [])
         try:
             self._registry.require_registered(set(checker_names))
         except UnknownChecker as exc:
@@ -475,8 +512,8 @@ class CheckerService:
         context = CheckerContext(
             task=task,
             submission=submission,
-            required_checker_names=frozenset(required_names),
-            warning_checker_names=frozenset(warning_names),
+            required_checker_names=frozenset(checker_policy.required_checkers),
+            warning_checker_names=frozenset(checker_policy.warning_checkers),
             blocking_severities=frozenset(checker_policy.blocking_severities or []),
             effective_policy=effective_policy.effective_policy,
         )
@@ -650,6 +687,16 @@ class CheckerService:
             is_current_for_submission=True,
             locked_guide_version=submission.locked_guide_version,
             locked_checker_policy_version=submission.locked_checker_policy_version,
+            locked_post_submit_checker_policy_id=submission.locked_post_submit_checker_policy_id,
+            locked_post_submit_checker_policy_version=(
+                submission.locked_post_submit_checker_policy_version
+            ),
+            locked_post_submit_checker_policy_hash=(
+                submission.locked_post_submit_checker_policy_hash
+            ),
+            locked_post_submit_checker_policy_body=(
+                submission.locked_post_submit_checker_policy_body
+            ),
             locked_review_policy_version=submission.locked_review_policy_version,
             locked_revision_policy_version=submission.locked_revision_policy_version,
             locked_payment_policy_version=submission.locked_payment_policy_version,
@@ -842,6 +889,15 @@ class CheckerService:
             "submission_version": submission.version,
             "locked_guide_version": submission.locked_guide_version,
             "locked_checker_policy_version": submission.locked_checker_policy_version,
+            "locked_post_submit_checker_policy_id": (
+                submission.locked_post_submit_checker_policy_id
+            ),
+            "locked_post_submit_checker_policy_version": (
+                submission.locked_post_submit_checker_policy_version
+            ),
+            "locked_post_submit_checker_policy_hash": (
+                submission.locked_post_submit_checker_policy_hash
+            ),
             "locked_review_policy_version": submission.locked_review_policy_version,
             "locked_revision_policy_version": submission.locked_revision_policy_version,
             "locked_payment_policy_version": submission.locked_payment_policy_version,
@@ -915,6 +971,15 @@ class CheckerService:
                     "trigger_source": trigger_source,
                     "locked_guide_version": submission.locked_guide_version,
                     "locked_checker_policy_version": submission.locked_checker_policy_version,
+                    "locked_post_submit_checker_policy_id": (
+                        submission.locked_post_submit_checker_policy_id
+                    ),
+                    "locked_post_submit_checker_policy_version": (
+                        submission.locked_post_submit_checker_policy_version
+                    ),
+                    "locked_post_submit_checker_policy_hash": (
+                        submission.locked_post_submit_checker_policy_hash
+                    ),
                     "locked_review_policy_version": submission.locked_review_policy_version,
                     "locked_revision_policy_version": submission.locked_revision_policy_version,
                     "locked_payment_policy_version": submission.locked_payment_policy_version,
@@ -1031,13 +1096,9 @@ class CheckerService:
                 )
             )
         routing_recommendation = (
-            "not_evaluated"
-            if hide_internal_route_from_worker
-            else checker_run.routing_recommendation
+            checker_run.routing_recommendation if has_checker_admin_access else None
         )
-        outcome_source = (
-            "none" if hide_internal_route_from_worker else checker_run.outcome_source
-        )
+        outcome_source = checker_run.outcome_source if has_checker_admin_access else None
         passed_count = 0 if hide_internal_route_from_worker else checker_run.passed_count
         warning_count = 0 if hide_internal_route_from_worker else checker_run.warning_count
         failed_count = 0 if hide_internal_route_from_worker else checker_run.failed_count
@@ -1047,7 +1108,7 @@ class CheckerService:
             task_id=checker_run.task_id,
             submission_id=checker_run.submission_id,
             submission_version=checker_run.submission_version,
-            trigger_source=checker_run.trigger_source,
+            trigger_source=checker_run.trigger_source if has_checker_admin_access else None,
             status=checker_run.status,
             routing_recommendation=routing_recommendation,
             outcome_source=outcome_source,
@@ -1071,6 +1132,21 @@ class CheckerService:
             ),
             locked_checker_policy_version=(
                 checker_run.locked_checker_policy_version if has_checker_admin_access else None
+            ),
+            locked_post_submit_checker_policy_id=(
+                checker_run.locked_post_submit_checker_policy_id
+                if has_checker_admin_access
+                else None
+            ),
+            locked_post_submit_checker_policy_version=(
+                checker_run.locked_post_submit_checker_policy_version
+                if has_checker_admin_access
+                else None
+            ),
+            locked_post_submit_checker_policy_hash=(
+                checker_run.locked_post_submit_checker_policy_hash
+                if has_checker_admin_access
+                else None
             ),
             locked_review_policy_version=(
                 checker_run.locked_review_policy_version if has_checker_admin_access else None

--- a/backend/app/modules/projects/models.py
+++ b/backend/app/modules/projects/models.py
@@ -103,8 +103,8 @@ class ProjectGuide(Base):
     project: Mapped[Project] = relationship(back_populates="guides")
 
 
-class CheckerPolicy(Base):
-    """Checker requirements attached to a project guide version."""
+class PostSubmitCheckerPolicy(Base):
+    """Post-submit checker requirements attached to a project guide version."""
 
     __tablename__ = "checker_policies"
     __table_args__ = (
@@ -113,7 +113,17 @@ class CheckerPolicy(Base):
             ["project_guides.project_id", "project_guides.version"],
             name="fk_checker_policies_project_guide",
         ),
+        CheckConstraint(
+            "policy_hash is null or policy_hash ~ '^sha256:[0-9a-f]{64}$'",
+            name="policy_hash_shape",
+        ),
         UniqueConstraint("project_id", "guide_version", name="uq_checker_policies_project_version"),
+        UniqueConstraint(
+            "id",
+            "guide_version",
+            "policy_hash",
+            name="uq_checker_policies_id_version_hash",
+        ),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
@@ -122,7 +132,14 @@ class CheckerPolicy(Base):
     required_checkers: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     warning_checkers: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     blocking_severities: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    policy_hash: Mapped[str | None] = mapped_column(String(71), index=True)
+    policy_body: Mapped[dict | None] = mapped_column(JSON)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+
+# Legacy alias for older module imports. New runtime authority uses
+# PostSubmitCheckerPolicy naming.
+CheckerPolicy = PostSubmitCheckerPolicy
 
 
 class ReviewPolicy(Base):

--- a/backend/app/modules/projects/post_submit_policy.py
+++ b/backend/app/modules/projects/post_submit_policy.py
@@ -1,0 +1,172 @@
+"""Helpers for durable post-submit checker policy identity."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.hashing import canonical_json_hash
+
+POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION = "post_submit_checker_policy.v1"
+POST_SUBMIT_CHECKER_POLICY_BODY_KEYS = {
+    "schema_version",
+    "project_id",
+    "guide_version",
+    "default_checkers",
+    "required_checkers",
+    "warning_checkers",
+    "execution_checkers",
+    "blocking_severities",
+}
+DEFAULT_DURABLE_CHECKERS = [
+    "check_submission_packet",
+    "check_policy_context_present",
+    "check_evidence_present",
+    "check_evidence_integrity",
+    "check_required_files",
+    "check_forbidden_files",
+    "check_confidentiality_attestation",
+    "check_low_quality_generated_artifacts",
+]
+
+
+@dataclass(frozen=True)
+class LockedPostSubmitCheckerPolicy:
+    """Validated locked post-submit checker policy body."""
+
+    default_checkers: list[str]
+    required_checkers: list[str]
+    warning_checkers: list[str]
+    execution_checkers: list[str]
+    blocking_severities: list[str]
+
+
+def post_submit_checker_policy_body(
+    *,
+    project_id: str,
+    guide_version: str,
+    required_checkers: Sequence[str],
+    warning_checkers: Sequence[str],
+    blocking_severities: Sequence[str],
+) -> dict[str, Any]:
+    """Build the canonical body for a post-submit checker policy.
+
+    Args:
+        project_id: Project that owns the guide version.
+        guide_version: Guide version the policy belongs to.
+        required_checkers: Checker names that can block review on failure.
+        warning_checkers: Checker names that produce non-blocking findings.
+        blocking_severities: Severities that force a failed checker to block review.
+
+    Returns:
+        Canonical JSON-compatible policy body.
+    """
+    return {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "project_id": project_id,
+        "guide_version": guide_version,
+        "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
+        "required_checkers": list(required_checkers),
+        "warning_checkers": list(warning_checkers),
+        "execution_checkers": list(
+            dict.fromkeys(
+                [
+                    *DEFAULT_DURABLE_CHECKERS,
+                    *required_checkers,
+                    *warning_checkers,
+                ]
+            )
+        ),
+        "blocking_severities": list(blocking_severities),
+    }
+
+
+def post_submit_checker_policy_hash(
+    *,
+    project_id: str,
+    guide_version: str,
+    required_checkers: Sequence[str],
+    warning_checkers: Sequence[str],
+    blocking_severities: Sequence[str],
+) -> str:
+    """Return the server-owned hash for a post-submit checker policy.
+
+    Args:
+        project_id: Project that owns the guide version.
+        guide_version: Guide version the policy belongs to.
+        required_checkers: Checker names that can block review on failure.
+        warning_checkers: Checker names that produce non-blocking findings.
+        blocking_severities: Severities that force a failed checker to block review.
+
+    Returns:
+        Canonical SHA-256 hash for the durable policy contract.
+    """
+    return canonical_json_hash(
+        post_submit_checker_policy_body(
+            project_id=project_id,
+            guide_version=guide_version,
+            required_checkers=required_checkers,
+            warning_checkers=warning_checkers,
+            blocking_severities=blocking_severities,
+        )
+    )
+
+
+def parse_locked_post_submit_checker_policy_body(
+    body: Any,
+    *,
+    project_id: str,
+    guide_version: str,
+    policy_hash: str,
+) -> LockedPostSubmitCheckerPolicy:
+    """Validate and parse a locked post-submit checker policy body.
+
+    Args:
+        body: JSON body stamped when the task locked project context.
+        project_id: Expected project id from the locked task.
+        guide_version: Expected guide version from the locked task.
+        policy_hash: Expected hash stamped with the locked body.
+
+    Returns:
+        Parsed checker policy lists.
+
+    Raises:
+        ValueError: If the body is malformed or does not match the locked hash.
+    """
+    if not isinstance(body, dict):
+        raise ValueError("locked post-submit checker policy body is missing")
+    required_checkers = body.get("required_checkers")
+    warning_checkers = body.get("warning_checkers")
+    default_checkers = body.get("default_checkers")
+    execution_checkers = body.get("execution_checkers")
+    blocking_severities = body.get("blocking_severities")
+    if (
+        set(body) != POST_SUBMIT_CHECKER_POLICY_BODY_KEYS
+        or body.get("schema_version") != POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION
+        or body.get("project_id") != project_id
+        or body.get("guide_version") != guide_version
+        or not _string_list(default_checkers)
+        or not _string_list(required_checkers)
+        or not _string_list(warning_checkers)
+        or not _string_list(execution_checkers)
+        or not _string_list(blocking_severities)
+        or not required_checkers
+        or execution_checkers
+        != list(dict.fromkeys([*default_checkers, *required_checkers, *warning_checkers]))
+    ):
+        raise ValueError("locked post-submit checker policy body is invalid")
+    if canonical_json_hash(body) != policy_hash:
+        raise ValueError("locked post-submit checker policy hash is invalid")
+    return LockedPostSubmitCheckerPolicy(
+        default_checkers=list(default_checkers),
+        required_checkers=list(required_checkers),
+        warning_checkers=list(warning_checkers),
+        execution_checkers=list(execution_checkers),
+        blocking_severities=list(blocking_severities),
+    )
+
+
+def _string_list(value: Any) -> bool:
+    """Return whether a value is a list containing only strings."""
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)

--- a/backend/app/modules/projects/repository.py
+++ b/backend/app/modules/projects/repository.py
@@ -9,12 +9,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.projects.models import (
-    CheckerPolicy,
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
     GuideSourceSnapshotItem,
     GuideSufficiencyReport,
     PaymentPolicy,
+    PostSubmitCheckerPolicy,
     PreSubmitCheckerPolicy,
     Project,
     ProjectGuide,
@@ -534,16 +534,22 @@ class ProjectRepository:
         )
         return result.scalars().all()
 
-    async def upsert_checker_policy(self, policy: CheckerPolicy) -> CheckerPolicy:
-        """Create or replace a checker policy for one guide version.
+    async def upsert_post_submit_checker_policy(
+        self,
+        policy: PostSubmitCheckerPolicy,
+    ) -> PostSubmitCheckerPolicy:
+        """Create or replace a post-submit checker policy for one guide version.
 
         Args:
-            policy: Checker policy model carrying the desired values.
+            policy: Post-submit checker policy model carrying the desired values.
 
         Returns:
-            Persisted checker policy model.
+            Persisted post-submit checker policy model.
         """
-        existing = await self.get_checker_policy(policy.project_id, policy.guide_version)
+        existing = await self.get_post_submit_checker_policy(
+            policy.project_id,
+            policy.guide_version,
+        )
         if existing is None:
             self._session.add(policy)
             await self._session.flush()
@@ -552,27 +558,55 @@ class ProjectRepository:
         existing.required_checkers = policy.required_checkers
         existing.warning_checkers = policy.warning_checkers
         existing.blocking_severities = policy.blocking_severities
+        existing.policy_hash = policy.policy_hash
+        existing.policy_body = policy.policy_body
         await self._session.flush()
         await self._session.refresh(existing)
         return existing
 
-    async def get_checker_policy(self, project_id: str, guide_version: str) -> CheckerPolicy | None:
-        """Load a checker policy by project and guide version.
+    async def upsert_checker_policy(
+        self,
+        policy: PostSubmitCheckerPolicy,
+    ) -> PostSubmitCheckerPolicy:
+        """Legacy wrapper for creating a post-submit checker policy."""
+        return await self.upsert_post_submit_checker_policy(policy)
+
+    async def get_post_submit_checker_policy(
+        self,
+        project_id: str,
+        guide_version: str,
+    ) -> PostSubmitCheckerPolicy | None:
+        """Load a post-submit checker policy by project and guide version.
 
         Args:
             project_id: Project id that owns the policy.
             guide_version: Guide version the policy applies to.
 
         Returns:
-            Checker policy when found; otherwise ``None``.
+            Post-submit checker policy when found; otherwise ``None``.
         """
         result = await self._session.execute(
-            select(CheckerPolicy).where(
-                CheckerPolicy.project_id == project_id,
-                CheckerPolicy.guide_version == guide_version,
+            select(PostSubmitCheckerPolicy).where(
+                PostSubmitCheckerPolicy.project_id == project_id,
+                PostSubmitCheckerPolicy.guide_version == guide_version,
             )
         )
         return result.scalar_one_or_none()
+
+    async def get_checker_policy(
+        self,
+        project_id: str,
+        guide_version: str,
+    ) -> PostSubmitCheckerPolicy | None:
+        """Legacy wrapper for loading a post-submit checker policy."""
+        return await self.get_post_submit_checker_policy(project_id, guide_version)
+
+    async def get_post_submit_checker_policy_by_id(
+        self,
+        policy_id: str,
+    ) -> PostSubmitCheckerPolicy | None:
+        """Load a post-submit checker policy by id."""
+        return await self._session.get(PostSubmitCheckerPolicy, policy_id)
 
     async def upsert_review_policy(self, policy: ReviewPolicy) -> ReviewPolicy:
         """Create or replace a review policy for one guide version.

--- a/backend/app/modules/projects/schemas.py
+++ b/backend/app/modules/projects/schemas.py
@@ -23,8 +23,8 @@ def reject_non_finite_json_numbers(value: Any) -> Any:
     return value
 
 
-class CheckerPolicyInput(BaseModel):
-    """Input schema for checker requirements on a guide version."""
+class PostSubmitCheckerPolicyInput(BaseModel):
+    """Input schema for post-submit checker requirements on a guide version."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -440,7 +440,7 @@ class ProjectGuideCreate(BaseModel):
     evidence_policy: dict[str, Any] | None = None
     unacceptable_work_policy: str | None = None
     change_summary: str | None = None
-    checker_policy: CheckerPolicyInput | None = None
+    post_submit_checker_policy: PostSubmitCheckerPolicyInput | None = None
     review_policy: ReviewPolicyInput | None = None
     revision_policy: RevisionPolicyInput | None = None
     payment_policy: PaymentPolicyInput | None = None
@@ -473,7 +473,7 @@ class ProjectGuideUpdate(BaseModel):
     evidence_policy: dict[str, Any] | None = None
     unacceptable_work_policy: str | None = None
     change_summary: str | None = None
-    checker_policy: CheckerPolicyInput | None = None
+    post_submit_checker_policy: PostSubmitCheckerPolicyInput | None = None
     review_policy: ReviewPolicyInput | None = None
     revision_policy: RevisionPolicyInput | None = None
     payment_policy: PaymentPolicyInput | None = None
@@ -518,8 +518,8 @@ class ProjectGuideResponse(BaseModel):
     superseded_at: datetime | None
 
 
-class CheckerPolicyResponse(BaseModel):
-    """Response schema for checker policy records."""
+class PostSubmitCheckerPolicyResponse(BaseModel):
+    """Response schema for post-submit checker policy records."""
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -529,6 +529,7 @@ class CheckerPolicyResponse(BaseModel):
     required_checkers: list[str]
     warning_checkers: list[str]
     blocking_severities: list[str]
+    policy_hash: str | None
     created_at: datetime
 
 
@@ -589,7 +590,7 @@ class ActiveGuideResponse(BaseModel):
     submission_artifact_policy: SubmissionArtifactPolicyResponse
     effective_submission_artifact_policy: EffectiveProjectSubmissionArtifactPolicyResponse
     pre_submit_checker_policy: PreSubmitCheckerPolicySummaryResponse
-    checker_policy: CheckerPolicyResponse
+    post_submit_checker_policy: PostSubmitCheckerPolicyResponse
     review_policy: ReviewPolicyResponse
     revision_policy: RevisionPolicyResponse
     payment_policy: PaymentPolicyResponse

--- a/backend/app/modules/projects/service.py
+++ b/backend/app/modules/projects/service.py
@@ -31,12 +31,12 @@ from app.modules.checkers.compiler import (
 )
 from app.modules.checkers.runner import UnknownChecker, default_checker_registry
 from app.modules.projects.models import (
-    CheckerPolicy,
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
     GuideSourceSnapshotItem,
     GuideSufficiencyReport,
     PaymentPolicy,
+    PostSubmitCheckerPolicy,
     PreSubmitCheckerPolicy,
     Project,
     ProjectGuide,
@@ -44,11 +44,14 @@ from app.modules.projects.models import (
     ReviewPolicy,
     SubmissionArtifactPolicy,
 )
+from app.modules.projects.post_submit_policy import (
+    parse_locked_post_submit_checker_policy_body,
+    post_submit_checker_policy_body,
+    post_submit_checker_policy_hash,
+)
 from app.modules.projects.repository import ProjectRepository, ProjectRepositoryIntegrityError
 from app.modules.projects.schemas import (
     ActiveGuideResponse,
-    CheckerPolicyInput,
-    CheckerPolicyResponse,
     EffectiveProjectSubmissionArtifactPolicyResponse,
     GuideSourceSnapshotCreate,
     GuideSourceSnapshotItemResponse,
@@ -58,6 +61,8 @@ from app.modules.projects.schemas import (
     GuideSufficiencyReportResponse,
     PaymentPolicyInput,
     PaymentPolicyResponse,
+    PostSubmitCheckerPolicyInput,
+    PostSubmitCheckerPolicyResponse,
     PreSubmitCheckerPolicySummaryResponse,
     ProjectCreate,
     ProjectGuideCreate,
@@ -512,7 +517,12 @@ class ProjectService:
                     "guide source material cannot change after a source snapshot exists"
                 )
         for field, value in changes.items():
-            if field in {"checker_policy", "review_policy", "revision_policy", "payment_policy"}:
+            if field in {
+                "post_submit_checker_policy",
+                "review_policy",
+                "revision_policy",
+                "payment_policy",
+            }:
                 continue
             setattr(guide, field, value)
         await self._upsert_optional_policies(project_id, guide.version, payload)
@@ -1206,7 +1216,10 @@ class ProjectService:
         if guide.status != "draft":
             raise GuideActivationBlocked("only draft guides can be activated")
 
-        checker_policy = await self._repo.get_checker_policy(project_id, guide.version)
+        post_submit_checker_policy = await self._repo.get_post_submit_checker_policy(
+            project_id,
+            guide.version,
+        )
         review_policy = await self._repo.get_review_policy(project_id, guide.version)
         revision_policy = await self._repo.get_revision_policy(project_id, guide.version)
         payment_policy = await self._repo.get_payment_policy(project_id, guide.version)
@@ -1251,7 +1264,7 @@ class ProjectService:
             submission_artifact_policy,
             effective_policy,
             pre_submit_checker_policy,
-            checker_policy,
+            post_submit_checker_policy,
             review_policy,
             revision_policy,
             payment_policy,
@@ -1287,7 +1300,7 @@ class ProjectService:
         await self._session.refresh(submission_artifact_policy)
         await self._session.refresh(effective_policy)
         await self._session.refresh(pre_submit_checker_policy)
-        await self._session.refresh(checker_policy)
+        await self._session.refresh(post_submit_checker_policy)
         await self._session.refresh(review_policy)
         await self._session.refresh(revision_policy)
         await self._session.refresh(payment_policy)
@@ -1298,7 +1311,7 @@ class ProjectService:
             submission_artifact_policy,
             effective_policy,
             pre_submit_checker_policy,
-            checker_policy,
+            post_submit_checker_policy,
             review_policy,
             revision_policy,
             payment_policy,
@@ -1323,7 +1336,10 @@ class ProjectService:
         guide = await self._repo.get_active_guide(project_id)
         if guide is None:
             raise GuideNotFound("active guide not found")
-        checker_policy = await self._repo.get_checker_policy(project_id, guide.version)
+        post_submit_checker_policy = await self._repo.get_post_submit_checker_policy(
+            project_id,
+            guide.version,
+        )
         review_policy = await self._repo.get_review_policy(project_id, guide.version)
         revision_policy = await self._repo.get_revision_policy(project_id, guide.version)
         payment_policy = await self._repo.get_payment_policy(project_id, guide.version)
@@ -1362,7 +1378,7 @@ class ProjectService:
         except ProjectRepositoryIntegrityError as exc:
             raise GuideActivationBlocked("active guide policy context is ambiguous") from exc
         if (
-            checker_policy is None
+            post_submit_checker_policy is None
             or review_policy is None
             or revision_policy is None
             or payment_policy is None
@@ -1378,7 +1394,7 @@ class ProjectService:
             submission_artifact_policy,
             effective_policy,
             pre_submit_checker_policy,
-            checker_policy,
+            post_submit_checker_policy,
             review_policy,
             revision_policy,
             payment_policy,
@@ -1390,7 +1406,7 @@ class ProjectService:
             submission_artifact_policy,
             effective_policy,
             pre_submit_checker_policy,
-            checker_policy,
+            post_submit_checker_policy,
             review_policy,
             revision_policy,
             payment_policy,
@@ -1438,9 +1454,13 @@ class ProjectService:
             guide_version: Guide version the policies apply to.
             payload: Guide create or update payload carrying optional policies.
         """
-        if payload.checker_policy is not None:
-            await self._repo.upsert_checker_policy(
-                self._checker_policy_model(project_id, guide_version, payload.checker_policy)
+        if payload.post_submit_checker_policy is not None:
+            await self._repo.upsert_post_submit_checker_policy(
+                self._post_submit_checker_policy_model(
+                    project_id,
+                    guide_version,
+                    payload.post_submit_checker_policy,
+                )
             )
         if payload.review_policy is not None:
             await self._repo.upsert_review_policy(
@@ -2348,7 +2368,7 @@ class ProjectService:
         submission_artifact_policy: SubmissionArtifactPolicy,
         effective_policy: EffectiveProjectSubmissionArtifactPolicy | None,
         pre_submit_checker_policy: PreSubmitCheckerPolicy | None,
-        checker_policy: CheckerPolicy | None,
+        post_submit_checker_policy: PostSubmitCheckerPolicy | None,
         review_policy: ReviewPolicy | None,
         revision_policy: RevisionPolicy | None,
         payment_policy: PaymentPolicy | None,
@@ -2362,7 +2382,7 @@ class ProjectService:
             submission_artifact_policy: Approved submission artifact policy.
             effective_policy: Effective policy produced from default + project policy.
             pre_submit_checker_policy: Project pre-submit checker bundle contract.
-            checker_policy: Checker policy for the guide version.
+            post_submit_checker_policy: Post-submit checker policy for the guide version.
             review_policy: Review policy for the guide version.
             revision_policy: Revision policy for the guide version.
             payment_policy: Payment policy for the guide version.
@@ -2474,11 +2494,27 @@ class ProjectService:
             != pre_submit_checker_policy.compiled_bundle_hash
         ):
             raise GuideActivationBlocked("pre-submit checker compiled bundle hash mismatch")
-        if checker_policy is None or not checker_policy.required_checkers:
-            raise GuideActivationBlocked("checker policy with required checkers is required")
-        checker_names = set(checker_policy.required_checkers or []).union(
-            checker_policy.warning_checkers or []
-        )
+        if post_submit_checker_policy is None or not post_submit_checker_policy.required_checkers:
+            raise GuideActivationBlocked("post-submit checker policy with required checkers is required")
+        try:
+            parsed_post_submit_policy = parse_locked_post_submit_checker_policy_body(
+                post_submit_checker_policy.policy_body,
+                project_id=post_submit_checker_policy.project_id,
+                guide_version=post_submit_checker_policy.guide_version,
+                policy_hash=post_submit_checker_policy.policy_hash or "",
+            )
+        except ValueError as exc:
+            raise GuideActivationBlocked("post-submit checker policy hash is invalid") from exc
+        if (
+            parsed_post_submit_policy.required_checkers
+            != post_submit_checker_policy.required_checkers
+            or parsed_post_submit_policy.warning_checkers
+            != post_submit_checker_policy.warning_checkers
+            or parsed_post_submit_policy.blocking_severities
+            != post_submit_checker_policy.blocking_severities
+        ):
+            raise GuideActivationBlocked("post-submit checker policy hash is invalid")
+        checker_names = set(parsed_post_submit_policy.execution_checkers)
         try:
             default_checker_registry().require_registered(checker_names)
         except UnknownChecker as exc:
@@ -2526,29 +2562,45 @@ class ProjectService:
                 f"guide sufficiency warnings require admin/project_manager acknowledgement {action}"
             )
 
-    def _checker_policy_model(
+    def _post_submit_checker_policy_model(
         self,
         project_id: str,
         guide_version: str,
-        payload: CheckerPolicyInput,
-    ) -> CheckerPolicy:
-        """Build a checker policy model from API input.
+        payload: PostSubmitCheckerPolicyInput,
+    ) -> PostSubmitCheckerPolicy:
+        """Build a post-submit checker policy model from API input.
 
         Args:
             project_id: Project that owns the policy.
             guide_version: Guide version the policy applies to.
-            payload: Validated checker policy input.
+            payload: Validated post-submit checker policy input.
 
         Returns:
-            Unsaved checker policy model.
+            Unsaved post-submit checker policy model.
         """
-        return CheckerPolicy(
+        policy_body = post_submit_checker_policy_body(
+            project_id=project_id,
+            guide_version=guide_version,
+            required_checkers=payload.required_checkers,
+            warning_checkers=payload.warning_checkers,
+            blocking_severities=payload.blocking_severities,
+        )
+        policy_hash = post_submit_checker_policy_hash(
+            project_id=project_id,
+            guide_version=guide_version,
+            required_checkers=payload.required_checkers,
+            warning_checkers=payload.warning_checkers,
+            blocking_severities=payload.blocking_severities,
+        )
+        return PostSubmitCheckerPolicy(
             id=str(uuid4()),
             project_id=project_id,
             guide_version=guide_version,
             required_checkers=payload.required_checkers,
             warning_checkers=payload.warning_checkers,
             blocking_severities=payload.blocking_severities,
+            policy_hash=policy_hash,
+            policy_body=policy_body,
         )
 
     def _review_policy_model(
@@ -2640,7 +2692,7 @@ class ProjectService:
         submission_artifact_policy: SubmissionArtifactPolicy,
         effective_policy: EffectiveProjectSubmissionArtifactPolicy,
         pre_submit_checker_policy: PreSubmitCheckerPolicy,
-        checker_policy: CheckerPolicy,
+        post_submit_checker_policy: PostSubmitCheckerPolicy,
         review_policy: ReviewPolicy,
         revision_policy: RevisionPolicy,
         payment_policy: PaymentPolicy,
@@ -2654,7 +2706,8 @@ class ProjectService:
             submission_artifact_policy: Approved project submission artifact policy.
             effective_policy: Effective project policy bound to the snapshot.
             pre_submit_checker_policy: Project pre-submit checker bundle contract.
-            checker_policy: Checker policy attached to the active guide version.
+            post_submit_checker_policy: Post-submit checker policy attached to
+                the active guide version.
             review_policy: Review policy attached to the active guide version.
             revision_policy: Revision policy attached to the active guide version.
             payment_policy: Payment policy attached to the active guide version.
@@ -2678,7 +2731,9 @@ class ProjectService:
             pre_submit_checker_policy=PreSubmitCheckerPolicySummaryResponse.model_validate(
                 pre_submit_checker_policy
             ),
-            checker_policy=CheckerPolicyResponse.model_validate(checker_policy),
+            post_submit_checker_policy=PostSubmitCheckerPolicyResponse.model_validate(
+                post_submit_checker_policy
+            ),
             review_policy=ReviewPolicyResponse.model_validate(review_policy),
             revision_policy=RevisionPolicyResponse.model_validate(revision_policy),
             payment_policy=PaymentPolicyResponse.model_validate(payment_policy),

--- a/backend/app/modules/tasks/models.py
+++ b/backend/app/modules/tasks/models.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 
 from sqlalchemy import (
     Boolean,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
@@ -83,6 +84,15 @@ class WorkstreamTask(Base):
             name="fk_workstream_tasks_locked_checker_policy",
         ),
         ForeignKeyConstraint(
+            [
+                "locked_post_submit_checker_policy_id",
+                "locked_post_submit_checker_policy_version",
+                "locked_post_submit_checker_policy_hash",
+            ],
+            ["checker_policies.id", "checker_policies.guide_version", "checker_policies.policy_hash"],
+            name="fk_workstream_tasks_locked_post_submit_policy_hash",
+        ),
+        ForeignKeyConstraint(
             ["project_id", "locked_review_policy_version"],
             ["review_policies.project_id", "review_policies.guide_version"],
             name="fk_workstream_tasks_locked_review_policy",
@@ -126,6 +136,13 @@ class WorkstreamTask(Base):
         ),
         UniqueConstraint(
             "id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+            name="uq_workstream_tasks_id_locked_post_submit_policy_hash",
+        ),
+        UniqueConstraint(
+            "id",
             "locked_review_policy_version",
             name="uq_workstream_tasks_id_locked_review_policy",
         ),
@@ -157,6 +174,18 @@ class WorkstreamTask(Base):
             "locked_pre_submit_checker_bundle_hash",
             name="uq_workstream_tasks_id_locked_pre_submit_checker_hash",
         ),
+        CheckConstraint(
+            """
+            status = 'draft'
+            or (
+                locked_post_submit_checker_policy_id is not null
+                and locked_post_submit_checker_policy_version is not null
+                and locked_post_submit_checker_policy_hash is not null
+                and locked_post_submit_checker_policy_body is not null
+            )
+            """,
+            name="post_submit_policy_lock_complete",
+        ),
         Index(
             "ix_workstream_tasks_locked_source_snapshot",
             "locked_guide_source_snapshot_id",
@@ -169,12 +198,20 @@ class WorkstreamTask(Base):
             "ix_workstream_tasks_locked_pre_submit_checker_hash",
             "locked_pre_submit_checker_bundle_hash",
         ),
+        Index(
+            "ix_workstream_tasks_locked_post_submit_policy_hash",
+            "locked_post_submit_checker_policy_hash",
+        ),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     project_id: Mapped[str] = mapped_column(ForeignKey("projects.id"), nullable=False, index=True)
     locked_guide_version: Mapped[str | None] = mapped_column(String(50))
     locked_checker_policy_version: Mapped[str | None] = mapped_column(String(50))
+    locked_post_submit_checker_policy_id: Mapped[str | None] = mapped_column(String(36))
+    locked_post_submit_checker_policy_version: Mapped[str | None] = mapped_column(String(50))
+    locked_post_submit_checker_policy_hash: Mapped[str | None] = mapped_column(String(71))
+    locked_post_submit_checker_policy_body: Mapped[dict | None] = mapped_column(JSON)
     locked_review_policy_version: Mapped[str | None] = mapped_column(String(50))
     locked_revision_policy_version: Mapped[str | None] = mapped_column(String(50))
     locked_payment_policy_version: Mapped[str | None] = mapped_column(String(50))
@@ -275,6 +312,21 @@ class Submission(Base):
             name="fk_submissions_task_locked_checker_policy",
         ),
         ForeignKeyConstraint(
+            [
+                "task_id",
+                "locked_post_submit_checker_policy_id",
+                "locked_post_submit_checker_policy_version",
+                "locked_post_submit_checker_policy_hash",
+            ],
+            [
+                "workstream_tasks.id",
+                "workstream_tasks.locked_post_submit_checker_policy_id",
+                "workstream_tasks.locked_post_submit_checker_policy_version",
+                "workstream_tasks.locked_post_submit_checker_policy_hash",
+            ],
+            name="fk_submissions_task_locked_post_submit_policy_hash",
+        ),
+        ForeignKeyConstraint(
             ["task_id", "locked_review_policy_version"],
             ["workstream_tasks.id", "workstream_tasks.locked_review_policy_version"],
             name="fk_submissions_task_locked_review_policy",
@@ -341,8 +393,33 @@ class Submission(Base):
             ["pre_submit_checker_policies.id", "pre_submit_checker_policies.compiled_bundle_hash"],
             name="fk_submissions_locked_pre_submit_checker_hash",
         ),
+        ForeignKeyConstraint(
+            [
+                "locked_post_submit_checker_policy_id",
+                "locked_post_submit_checker_policy_version",
+                "locked_post_submit_checker_policy_hash",
+            ],
+            ["checker_policies.id", "checker_policies.guide_version", "checker_policies.policy_hash"],
+            name="fk_submissions_locked_post_submit_policy_hash",
+        ),
         UniqueConstraint("task_id", "version", name="uq_submissions_task_version"),
         UniqueConstraint("id", "version", name="uq_submissions_id_version"),
+        UniqueConstraint(
+            "id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+            name="uq_submissions_id_locked_post_submit_policy_hash",
+        ),
+        CheckConstraint(
+            """
+            locked_post_submit_checker_policy_id is not null
+            and locked_post_submit_checker_policy_version is not null
+            and locked_post_submit_checker_policy_hash is not null
+            and locked_post_submit_checker_policy_body is not null
+            """,
+            name="post_submit_policy_lock_complete",
+        ),
         Index(
             "ix_submissions_locked_source_snapshot",
             "locked_guide_source_snapshot_id",
@@ -354,6 +431,10 @@ class Submission(Base):
         Index(
             "ix_submissions_locked_pre_submit_checker_hash",
             "locked_pre_submit_checker_bundle_hash",
+        ),
+        Index(
+            "ix_submissions_locked_post_submit_policy_hash",
+            "locked_post_submit_checker_policy_hash",
         ),
     )
 
@@ -369,6 +450,13 @@ class Submission(Base):
     worker_attestation: Mapped[str] = mapped_column(Text, nullable=False)
     locked_guide_version: Mapped[str] = mapped_column(String(50), nullable=False)
     locked_checker_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
+    locked_post_submit_checker_policy_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    locked_post_submit_checker_policy_version: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+    )
+    locked_post_submit_checker_policy_hash: Mapped[str] = mapped_column(String(71), nullable=False)
+    locked_post_submit_checker_policy_body: Mapped[dict] = mapped_column(JSON, nullable=False)
     locked_review_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
     locked_revision_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)
     locked_payment_policy_version: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/backend/app/modules/tasks/router.py
+++ b/backend/app/modules/tasks/router.py
@@ -79,7 +79,12 @@ def permission_http_error(exc: PermissionDenied) -> HTTPException:
     return HTTPException(status_code=403, detail=str(exc))
 
 
-@router.post("/projects/{project_id}/tasks", response_model=TaskResponse, status_code=201)
+@router.post(
+    "/projects/{project_id}/tasks",
+    response_model=TaskResponse,
+    response_model_exclude_none=True,
+    status_code=201,
+)
 async def create_task(
     project_id: str,
     payload: TaskCreate,
@@ -95,7 +100,7 @@ async def create_task(
         raise task_http_error(exc) from exc
 
 
-@router.get("/tasks/{task_id}", response_model=TaskResponse)
+@router.get("/tasks/{task_id}", response_model=TaskResponse, response_model_exclude_none=True)
 async def get_task(
     task_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
@@ -110,7 +115,11 @@ async def get_task(
         raise task_http_error(exc) from exc
 
 
-@router.post("/tasks/{task_id}/screen", response_model=TaskResponse)
+@router.post(
+    "/tasks/{task_id}/screen",
+    response_model=TaskResponse,
+    response_model_exclude_none=True,
+)
 async def screen_task(
     task_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
@@ -130,7 +139,11 @@ async def screen_task(
         raise task_http_error(exc) from exc
 
 
-@router.post("/tasks/{task_id}/release", response_model=TaskResponse)
+@router.post(
+    "/tasks/{task_id}/release",
+    response_model=TaskResponse,
+    response_model_exclude_none=True,
+)
 async def release_task(
     task_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
@@ -150,7 +163,11 @@ async def release_task(
         raise task_http_error(exc) from exc
 
 
-@router.post("/tasks/{task_id}/claim", response_model=TaskWithAssignmentResponse)
+@router.post(
+    "/tasks/{task_id}/claim",
+    response_model=TaskWithAssignmentResponse,
+    response_model_exclude_none=True,
+)
 async def claim_task(
     task_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
@@ -170,7 +187,11 @@ async def claim_task(
         raise task_http_error(exc) from exc
 
 
-@router.post("/tasks/{task_id}/start", response_model=TaskResponse)
+@router.post(
+    "/tasks/{task_id}/start",
+    response_model=TaskResponse,
+    response_model_exclude_none=True,
+)
 async def start_task(
     task_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
@@ -193,6 +214,7 @@ async def start_task(
 @router.post(
     "/tasks/{task_id}/submissions",
     response_model=SubmissionResponse,
+    response_model_exclude_none=True,
     status_code=201,
     responses={
         422: {
@@ -222,7 +244,11 @@ async def create_submission(
         raise task_http_error(exc) from exc
 
 
-@router.get("/tasks/{task_id}/submissions", response_model=list[SubmissionResponse])
+@router.get(
+    "/tasks/{task_id}/submissions",
+    response_model=list[SubmissionResponse],
+    response_model_exclude_none=True,
+)
 async def list_task_submissions(
     task_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
@@ -237,7 +263,11 @@ async def list_task_submissions(
         raise task_http_error(exc) from exc
 
 
-@router.get("/submissions/{submission_id}", response_model=SubmissionResponse)
+@router.get(
+    "/submissions/{submission_id}",
+    response_model=SubmissionResponse,
+    response_model_exclude_none=True,
+)
 async def get_submission(
     submission_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],
@@ -252,7 +282,11 @@ async def get_submission(
         raise task_http_error(exc) from exc
 
 
-@router.post("/submissions/{submission_id}/lock", response_model=SubmissionResponse)
+@router.post(
+    "/submissions/{submission_id}/lock",
+    response_model=SubmissionResponse,
+    response_model_exclude_none=True,
+)
 async def lock_submission(
     submission_id: str,
     actor: Annotated[ActorContext, Depends(get_current_actor)],

--- a/backend/app/modules/tasks/schemas.py
+++ b/backend/app/modules/tasks/schemas.py
@@ -70,6 +70,8 @@ def validate_storage_reference(value: str | None) -> str | None:
 class TaskCreate(BaseModel):
     """Request schema for creating a draft task."""
 
+    model_config = ConfigDict(extra="forbid")
+
     title: str
     description: str
     task_type: str | None = None
@@ -90,6 +92,8 @@ class TaskCreate(BaseModel):
 
 class TaskTransitionRequest(BaseModel):
     """Optional request body for task lifecycle transitions."""
+
+    model_config = ConfigDict(extra="forbid")
 
     reason: str | None = None
 
@@ -151,7 +155,6 @@ class TaskResponse(BaseModel):
     id: str
     project_id: str
     locked_guide_version: str | None
-    locked_checker_policy_version: str | None
     locked_review_policy_version: str | None
     locked_revision_policy_version: str | None
     locked_payment_policy_version: str | None
@@ -242,14 +245,13 @@ class SubmissionResponse(BaseModel):
     status: str
     summary: str
     package_uri: str | None
-    package_hash: str
-    artifact_hash_manifest: list[dict[str, Any]]
-    worker_attestation: str
-    locked_guide_version: str
-    locked_checker_policy_version: str
-    locked_review_policy_version: str
-    locked_revision_policy_version: str
-    locked_payment_policy_version: str
+    package_hash: str | None
+    artifact_hash_manifest: list[dict[str, Any]] | None
+    worker_attestation: str | None
+    locked_guide_version: str | None
+    locked_review_policy_version: str | None
+    locked_revision_policy_version: str | None
+    locked_payment_policy_version: str | None
     locked_guide_source_snapshot_id: str | None
     locked_guide_source_snapshot_hash: str | None
     locked_effective_project_submission_artifact_policy_id: str | None

--- a/backend/app/modules/tasks/service.py
+++ b/backend/app/modules/tasks/service.py
@@ -10,14 +10,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.permissions import require_any_role
 from app.modules.projects.models import (
-    CheckerPolicy,
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
     PaymentPolicy,
+    PostSubmitCheckerPolicy,
     PreSubmitCheckerPolicy,
     ProjectGuide,
     RevisionPolicy,
     ReviewPolicy,
+)
+from app.modules.projects.post_submit_policy import (
+    parse_locked_post_submit_checker_policy_body,
 )
 from app.modules.projects.repository import ProjectRepository, ProjectRepositoryIntegrityError
 from app.modules.tasks.lifecycle import (
@@ -62,17 +65,9 @@ SUBMISSION_LOCK_ROLES = {"admin", "project_manager"}
 WORKER_VISIBLE_AUDIT_PAYLOAD_KEYS = {
     "assignment_id",
     "locked_guide_version",
-    "locked_checker_policy_version",
     "locked_review_policy_version",
     "locked_revision_policy_version",
     "locked_payment_policy_version",
-    "locked_guide_source_snapshot_id",
-    "locked_guide_source_snapshot_hash",
-    "locked_effective_project_submission_artifact_policy_id",
-    "locked_effective_project_submission_artifact_policy_hash",
-    "locked_pre_submit_checker_policy_id",
-    "locked_pre_submit_checker_bundle_hash",
-    "package_hash",
     "source_type",
     "submission_id",
     "submission_version",
@@ -239,7 +234,7 @@ class TaskService:
         )
         await self._session.commit()
         await self._session.refresh(task)
-        return TaskResponse.model_validate(task)
+        return self._task_response(actor, task)
 
     async def get_task(self, actor: ActorContext, task_id: str) -> TaskResponse:
         """Return one task visible to authorized workflow actors.
@@ -258,7 +253,7 @@ class TaskService:
         require_any_role(actor, TASK_VIEW_ROLES)
         task = await self._get_task(task_id)
         await self._ensure_task_visible(actor, task)
-        return TaskResponse.model_validate(task)
+        return self._task_response(actor, task)
 
     async def move_to_screening(
         self,
@@ -311,7 +306,7 @@ class TaskService:
         await self._change_task_status(actor, task, TASK_STATUS_SCREENING, reason)
         await self._session.commit()
         await self._session.refresh(task)
-        return TaskResponse.model_validate(task)
+        return self._task_response(actor, task)
 
     async def release_to_ready(
         self,
@@ -339,10 +334,11 @@ class TaskService:
         if reason is None or not reason.strip():
             raise TaskValidationError("release decision reason is required")
         self._ensure_locked_context(task)
+        await self._validate_locked_post_submit_policy_context(task)
         await self._change_task_status(actor, task, TASK_STATUS_READY, reason)
         await self._session.commit()
         await self._session.refresh(task)
-        return TaskResponse.model_validate(task)
+        return self._task_response(actor, task)
 
     async def claim_task(
         self,
@@ -396,7 +392,7 @@ class TaskService:
         await self._session.refresh(task)
         await self._session.refresh(assignment)
         return TaskWithAssignmentResponse(
-            task=TaskResponse.model_validate(task),
+            task=self._task_response(actor, task),
             assignment=AssignmentResponse.model_validate(assignment),
         )
 
@@ -447,7 +443,7 @@ class TaskService:
         )
         await self._session.commit()
         await self._session.refresh(task)
-        return TaskResponse.model_validate(task)
+        return self._task_response(actor, task)
 
     async def create_submission(
         self,
@@ -467,6 +463,7 @@ class TaskService:
 
         Raises:
             PermissionDenied: If the actor cannot create worker submissions.
+            TaskProjectNotReady: If locked project policy context is invalid.
             TaskTransitionBlocked: If task state or assignment does not allow submission.
             TaskValidationError: If required submission fields are missing.
             SubmissionVersionConflict: If concurrent version allocation conflicts.
@@ -487,6 +484,7 @@ class TaskService:
                 "task must be in progress or needs revision before submission"
             )
         self._ensure_locked_context(task)
+        await self._validate_locked_post_submit_policy_context(task)
 
         from app.modules.checkers.service import CheckerService, CheckerServiceError
 
@@ -520,6 +518,12 @@ class TaskService:
             worker_attestation=payload.worker_attestation,
             locked_guide_version=task.locked_guide_version,
             locked_checker_policy_version=task.locked_checker_policy_version,
+            locked_post_submit_checker_policy_id=task.locked_post_submit_checker_policy_id,
+            locked_post_submit_checker_policy_version=(
+                task.locked_post_submit_checker_policy_version
+            ),
+            locked_post_submit_checker_policy_hash=task.locked_post_submit_checker_policy_hash,
+            locked_post_submit_checker_policy_body=task.locked_post_submit_checker_policy_body,
             locked_review_policy_version=task.locked_review_policy_version,
             locked_revision_policy_version=task.locked_revision_policy_version,
             locked_payment_policy_version=task.locked_payment_policy_version,
@@ -577,7 +581,7 @@ class TaskService:
         persisted = await self._repo.get_submission(submission.id)
         if persisted is None:
             raise SubmissionNotFound("submission not found")
-        return SubmissionResponse.model_validate(persisted)
+        return self._submission_response(actor, persisted)
 
     async def list_task_submissions(
         self,
@@ -597,7 +601,7 @@ class TaskService:
         task = await self._get_task(task_id)
         await self._ensure_task_visible(actor, task)
         submissions = await self._repo.list_submissions_for_task(task.id)
-        return [SubmissionResponse.model_validate(submission) for submission in submissions]
+        return [self._submission_response(actor, submission) for submission in submissions]
 
     async def get_submission(
         self,
@@ -617,7 +621,7 @@ class TaskService:
         submission = await self._get_submission(submission_id)
         task = await self._get_task(submission.task_id)
         await self._ensure_task_visible(actor, task)
-        return SubmissionResponse.model_validate(submission)
+        return self._submission_response(actor, submission)
 
     async def lock_submission(
         self,
@@ -644,7 +648,7 @@ class TaskService:
         if latest_submission is None or latest_submission.id != submission.id:
             raise TaskTransitionBlocked("only latest submission version can be locked")
         if submission.locked_at is not None:
-            return SubmissionResponse.model_validate(submission)
+            return self._submission_response(actor, submission)
         if task.status != TASK_STATUS_SUBMITTED:
             raise TaskTransitionBlocked("task must be submitted before locking submission")
 
@@ -675,7 +679,7 @@ class TaskService:
         persisted = await self._repo.get_submission(submission.id)
         if persisted is None:
             raise SubmissionNotFound("submission not found")
-        return SubmissionResponse.model_validate(persisted)
+        return self._submission_response(actor, persisted)
 
     async def list_task_audit_events(
         self,
@@ -751,6 +755,15 @@ class TaskService:
             "locked_at": submission.locked_at.isoformat() if submission.locked_at else None,
             "locked_guide_source_snapshot_id": submission.locked_guide_source_snapshot_id,
             "locked_guide_source_snapshot_hash": submission.locked_guide_source_snapshot_hash,
+            "locked_post_submit_checker_policy_id": (
+                submission.locked_post_submit_checker_policy_id
+            ),
+            "locked_post_submit_checker_policy_version": (
+                submission.locked_post_submit_checker_policy_version
+            ),
+            "locked_post_submit_checker_policy_hash": (
+                submission.locked_post_submit_checker_policy_hash
+            ),
             "locked_effective_project_submission_artifact_policy_id": (
                 submission.locked_effective_project_submission_artifact_policy_id
             ),
@@ -768,7 +781,7 @@ class TaskService:
         project_id: str,
     ) -> tuple[
         ProjectGuide,
-        CheckerPolicy,
+        PostSubmitCheckerPolicy,
         ReviewPolicy,
         RevisionPolicy,
         PaymentPolicy,
@@ -791,7 +804,10 @@ class TaskService:
             guide = await self._project_repo.get_active_guide(project_id)
             if guide is None:
                 raise TaskProjectNotReady("project has no active guide")
-            checker_policy = await self._project_repo.get_checker_policy(project_id, guide.version)
+            checker_policy = await self._project_repo.get_post_submit_checker_policy(
+                project_id,
+                guide.version,
+            )
             review_policy = await self._project_repo.get_review_policy(project_id, guide.version)
             revision_policy = await self._project_repo.get_revision_policy(
                 project_id,
@@ -842,6 +858,23 @@ class TaskService:
             or not pre_submit_checker_policy.compiled_bundle_hash
         ):
             raise TaskProjectNotReady("active project pre-submit checker policy is incomplete")
+        if not checker_policy.policy_hash or not checker_policy.policy_body:
+            raise TaskProjectNotReady("active post-submit checker policy hash is incomplete")
+        try:
+            parsed_checker_policy = parse_locked_post_submit_checker_policy_body(
+                checker_policy.policy_body,
+                project_id=checker_policy.project_id,
+                guide_version=checker_policy.guide_version,
+                policy_hash=checker_policy.policy_hash,
+            )
+        except ValueError as exc:
+            raise TaskProjectNotReady("active post-submit checker policy hash is invalid") from exc
+        if (
+            parsed_checker_policy.required_checkers != checker_policy.required_checkers
+            or parsed_checker_policy.warning_checkers != checker_policy.warning_checkers
+            or parsed_checker_policy.blocking_severities != checker_policy.blocking_severities
+        ):
+            raise TaskProjectNotReady("active post-submit checker policy hash is invalid")
         return (
             guide,
             checker_policy,
@@ -908,7 +941,7 @@ class TaskService:
         self,
         task: WorkstreamTask,
         guide: ProjectGuide,
-        checker_policy: CheckerPolicy,
+        checker_policy: PostSubmitCheckerPolicy,
         review_policy: ReviewPolicy,
         revision_policy: RevisionPolicy,
         payment_policy: PaymentPolicy,
@@ -931,6 +964,10 @@ class TaskService:
         """
         task.locked_guide_version = guide.version
         task.locked_checker_policy_version = checker_policy.guide_version
+        task.locked_post_submit_checker_policy_id = checker_policy.id
+        task.locked_post_submit_checker_policy_version = checker_policy.guide_version
+        task.locked_post_submit_checker_policy_hash = checker_policy.policy_hash
+        task.locked_post_submit_checker_policy_body = dict(checker_policy.policy_body or {})
         task.locked_review_policy_version = review_policy.guide_version
         task.locked_revision_policy_version = revision_policy.guide_version
         task.locked_payment_policy_version = payment_policy.guide_version
@@ -962,6 +999,10 @@ class TaskService:
             for field in (
                 "locked_guide_version",
                 "locked_checker_policy_version",
+                "locked_post_submit_checker_policy_id",
+                "locked_post_submit_checker_policy_version",
+                "locked_post_submit_checker_policy_hash",
+                "locked_post_submit_checker_policy_body",
                 "locked_review_policy_version",
                 "locked_revision_policy_version",
                 "locked_payment_policy_version",
@@ -976,6 +1017,38 @@ class TaskService:
         ]
         if missing:
             raise TaskTransitionBlocked(f"task missing locked context: {', '.join(missing)}")
+
+    async def _validate_locked_post_submit_policy_context(self, task: WorkstreamTask) -> None:
+        """Validate the task's locked post-submit checker policy before submission.
+
+        Args:
+            task: Task whose locked post-submit policy context should be
+                verified before a submission row can be created.
+
+        Raises:
+            TaskProjectNotReady: If the locked post-submit policy row is
+                missing, mismatched, or no longer hashes to the stamped value.
+        """
+        policy = await self._project_repo.get_post_submit_checker_policy_by_id(
+            task.locked_post_submit_checker_policy_id or ""
+        )
+        if (
+            policy is None
+            or policy.project_id != task.project_id
+            or policy.guide_version != task.locked_post_submit_checker_policy_version
+            or policy.guide_version != task.locked_guide_version
+            or policy.policy_hash != task.locked_post_submit_checker_policy_hash
+        ):
+            raise TaskProjectNotReady("locked post-submit checker policy is invalid")
+        try:
+            parse_locked_post_submit_checker_policy_body(
+                task.locked_post_submit_checker_policy_body,
+                project_id=task.project_id,
+                guide_version=task.locked_post_submit_checker_policy_version or "",
+                policy_hash=task.locked_post_submit_checker_policy_hash or "",
+            )
+        except ValueError as exc:
+            raise TaskProjectNotReady("locked post-submit checker policy hash is invalid") from exc
 
     async def _require_active_worker_profile(
         self,
@@ -1082,6 +1155,11 @@ class TaskService:
         payload = {
             "locked_guide_version": task.locked_guide_version,
             "locked_checker_policy_version": task.locked_checker_policy_version,
+            "locked_post_submit_checker_policy_id": task.locked_post_submit_checker_policy_id,
+            "locked_post_submit_checker_policy_version": (
+                task.locked_post_submit_checker_policy_version
+            ),
+            "locked_post_submit_checker_policy_hash": task.locked_post_submit_checker_policy_hash,
             "locked_review_policy_version": task.locked_review_policy_version,
             "locked_revision_policy_version": task.locked_revision_policy_version,
             "locked_payment_policy_version": task.locked_payment_policy_version,
@@ -1137,6 +1215,62 @@ class TaskService:
                 return
         raise TaskNotFound("task not found")
 
+    def _task_response(self, actor: ActorContext, task: WorkstreamTask) -> TaskResponse:
+        """Build a role-sensitive task response.
+
+        Args:
+            actor: Verified actor reading the task.
+            task: Persisted task model.
+
+        Returns:
+            Task response with internal locked policy hashes hidden from workers.
+        """
+        response = TaskResponse.model_validate(task)
+        if not set(actor.roles).intersection(PROJECT_OPERATOR_ROLES):
+            response.locked_guide_source_snapshot_id = None
+            response.locked_guide_source_snapshot_hash = None
+            response.locked_effective_project_submission_artifact_policy_id = None
+            response.locked_effective_project_submission_artifact_policy_hash = None
+            response.locked_pre_submit_checker_policy_id = None
+            response.locked_pre_submit_checker_bundle_hash = None
+        return response
+
+    def _submission_response(
+        self,
+        actor: ActorContext,
+        submission: Submission,
+    ) -> SubmissionResponse:
+        """Build a role-sensitive submission response.
+
+        Args:
+            actor: Verified actor reading the submission.
+            submission: Persisted submission model.
+
+        Returns:
+            Submission response with artifact and policy provenance hidden from workers.
+        """
+        response = SubmissionResponse.model_validate(submission)
+        if not set(actor.roles).intersection(PROJECT_OPERATOR_ROLES):
+            response.package_uri = None
+            response.package_hash = None
+            response.artifact_hash_manifest = None
+            response.worker_attestation = None
+            response.locked_guide_version = None
+            response.locked_review_policy_version = None
+            response.locked_revision_policy_version = None
+            response.locked_payment_policy_version = None
+            response.locked_guide_source_snapshot_id = None
+            response.locked_guide_source_snapshot_hash = None
+            response.locked_effective_project_submission_artifact_policy_id = None
+            response.locked_effective_project_submission_artifact_policy_hash = None
+            response.locked_pre_submit_checker_policy_id = None
+            response.locked_pre_submit_checker_bundle_hash = None
+            for evidence_item in response.evidence_items:
+                evidence_item.uri = None
+                evidence_item.hash = None
+                evidence_item.metadata = {}
+        return response
+
     def _audit_response(self, actor: ActorContext, event: AuditEvent) -> AuditEventResponse:
         """Build a public audit response with claim snapshots redacted.
 
@@ -1156,6 +1290,9 @@ class TaskService:
                 if key in WORKER_VISIBLE_AUDIT_PAYLOAD_KEYS
             }
             if response.event_type in WORKER_REDACTED_AUDIT_EVENTS:
+                response.event_type = "post_submit_checks_processing"
+                response.from_status = None
+                response.to_status = None
                 response.reason = None
         return response
 

--- a/backend/scripts/week1_api_e2e.py
+++ b/backend/scripts/week1_api_e2e.py
@@ -25,11 +25,11 @@ from sqlalchemy import select
 from app.db import session as db_session
 from app.modules.checkers.models import CheckerResult, CheckerRun
 from app.modules.projects.models import (
-    CheckerPolicy,
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
     GuideSufficiencyReport,
     PaymentPolicy,
+    PostSubmitCheckerPolicy,
     PreSubmitCheckerPolicy,
     Project,
     ProjectGuide,
@@ -470,7 +470,7 @@ def guide_payload(run_id: str) -> dict:
         "evidence_policy": {"required": ["log"]},
         "unacceptable_work_policy": "Copied or unverifiable work.",
         "change_summary": "Initial real API guide",
-        "checker_policy": {
+        "post_submit_checker_policy": {
             "required_checkers": ["check_policy_context_present"],
             "warning_checkers": [],
             "blocking_severities": ["high"],
@@ -837,7 +837,6 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
         )
         assert {
             screened["locked_guide_version"],
-            screened["locked_checker_policy_version"],
             screened["locked_review_policy_version"],
             screened["locked_revision_policy_version"],
             screened["locked_payment_policy_version"],
@@ -930,13 +929,17 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
             },
             201,
         )
-        assert {
-            submission["locked_guide_version"],
-            submission["locked_checker_policy_version"],
-            submission["locked_review_policy_version"],
-            submission["locked_revision_policy_version"],
-            submission["locked_payment_policy_version"],
-        } == {"v1"}
+        for internal_field in (
+            "artifact_hash_manifest",
+            "package_hash",
+            "worker_attestation",
+            "locked_guide_version",
+            "locked_review_policy_version",
+            "locked_revision_policy_version",
+            "locked_payment_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ):
+            assert internal_field not in submission
         await request_json(
             client,
             "POST",
@@ -976,6 +979,12 @@ async def exercise_week1_api(base_url: str, env: dict[str, str]) -> None:
             manager_token,
         )
         assert locked["locked_at"] is not None
+        assert {
+            locked["locked_guide_version"],
+            locked["locked_review_policy_version"],
+            locked["locked_revision_policy_version"],
+            locked["locked_payment_policy_version"],
+        } == {"v1"}
         assert all(item["locked_at"] == locked["locked_at"] for item in locked["evidence_items"])
         checker_run = await wait_for_submission_checker_run(client, manager_token, submission["id"])
         assert checker_run["routing_recommendation"] == "allow_review"
@@ -1082,7 +1091,7 @@ async def assert_week1_database_invariants(
         ensure(guide.effective_at is not None, "active guide missing effective_at")
 
         for model, label in [
-            (CheckerPolicy, "checker policy"),
+            (PostSubmitCheckerPolicy, "post-submit checker policy"),
             (ReviewPolicy, "review policy"),
             (RevisionPolicy, "revision policy"),
             (PaymentPolicy, "payment policy"),
@@ -1151,6 +1160,17 @@ async def assert_week1_database_invariants(
             pre_submit_checker_policy.compiled_bundle_hash is not None,
             "pre-submit checker compiled bundle hash missing",
         )
+        post_submit_checker_policy = await session.scalar(
+            select(PostSubmitCheckerPolicy).where(
+                PostSubmitCheckerPolicy.project_id == project.id,
+                PostSubmitCheckerPolicy.guide_version == guide.version,
+            )
+        )
+        ensure(post_submit_checker_policy is not None, "post-submit checker policy missing")
+        ensure(
+            post_submit_checker_policy.policy_hash is not None,
+            "post-submit checker policy hash missing",
+        )
 
         locked_versions = {
             task.locked_guide_version,
@@ -1161,6 +1181,18 @@ async def assert_week1_database_invariants(
         }
         ensure(locked_versions == {"v1"}, f"task locked versions drifted: {locked_versions}")
         ensure(task.status == "review_pending", f"task status drifted: {task.status}")
+        ensure(
+            task.locked_post_submit_checker_policy_id == post_submit_checker_policy.id,
+            "task post-submit policy id drifted",
+        )
+        ensure(
+            task.locked_post_submit_checker_policy_version == post_submit_checker_policy.guide_version,
+            "task post-submit policy version drifted",
+        )
+        ensure(
+            task.locked_post_submit_checker_policy_hash == post_submit_checker_policy.policy_hash,
+            "task post-submit policy hash drifted",
+        )
         ensure(task.assigned_to == assignment.worker_id, "task assignment pointer drifted")
         ensure(assignment.status == "active", f"assignment status drifted: {assignment.status}")
         ensure(assignment.accepted_at is not None, "assignment missing accepted_at")
@@ -1178,6 +1210,21 @@ async def assert_week1_database_invariants(
             submission.locked_payment_policy_version,
         }
         ensure(submission_versions == {"v1"}, f"submission locked versions drifted: {submission_versions}")
+        ensure(
+            submission.locked_post_submit_checker_policy_id
+            == task.locked_post_submit_checker_policy_id,
+            "submission post-submit policy id drifted",
+        )
+        ensure(
+            submission.locked_post_submit_checker_policy_version
+            == task.locked_post_submit_checker_policy_version,
+            "submission post-submit policy version drifted",
+        )
+        ensure(
+            submission.locked_post_submit_checker_policy_hash
+            == task.locked_post_submit_checker_policy_hash,
+            "submission post-submit policy hash drifted",
+        )
 
         evidence_items = (
             await session.scalars(
@@ -1200,6 +1247,21 @@ async def assert_week1_database_invariants(
         ensure(checker_run.is_current_for_submission is True, "checker run is not current")
         ensure(checker_run.attempt_number == 1, "first checker attempt number drifted")
         ensure(checker_run.locked_guide_version == submission.locked_guide_version, "checker guide lock drifted")
+        ensure(
+            checker_run.locked_post_submit_checker_policy_id
+            == submission.locked_post_submit_checker_policy_id,
+            "checker post-submit policy id drifted",
+        )
+        ensure(
+            checker_run.locked_post_submit_checker_policy_version
+            == submission.locked_post_submit_checker_policy_version,
+            "checker post-submit policy version drifted",
+        )
+        ensure(
+            checker_run.locked_post_submit_checker_policy_hash
+            == submission.locked_post_submit_checker_policy_hash,
+            "checker post-submit policy hash drifted",
+        )
         ensure(checker_run.package_hash == submission.package_hash, "checker package hash drifted")
 
         results = (

--- a/backend/scripts/week1_dry_run.py
+++ b/backend/scripts/week1_dry_run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import os
 from pathlib import Path
 from uuid import uuid4
@@ -19,6 +20,12 @@ from app.modules.tasks.models import WorkerProfile
 
 TOKEN = "week1-dry-run-token"
 ISSUER = "flow-dry-run"
+STRONG_ATTESTATION = (
+    "I attest this is original dry run originality work with no confidential client data, "
+    "credentials, secrets, tokens, passwords, API keys, private source material, source code, "
+    "copied platform artifacts, or copied platform content. I confirm credential and secret "
+    "exclusion and accept human accountability for agent assisted work."
+)
 
 
 def set_actor(*, subject: str, roles: str) -> None:
@@ -99,8 +106,96 @@ async def post_ok(client: AsyncClient, url: str, payload: dict | None = None) ->
         Parsed JSON response.
     """
     response = await client.post(url, headers=auth_headers(), json=payload)
-    response.raise_for_status()
+    if response.status_code >= 400:
+        raise RuntimeError(f"POST {url} failed: {response.status_code} {response.text}")
     return response.json()
+
+
+def sha256_token(value: str) -> str:
+    """Return a Workstream sha256 token for deterministic dry-run fixtures."""
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def submission_artifact_policy_body() -> dict:
+    """Return a minimal project submission artifact policy for the dry run."""
+    return {
+        "required_artifacts": [
+            {
+                "key": "answer",
+                "path": "answer.md",
+                "hash_required": True,
+                "required": True,
+                "description": "Main answer artifact.",
+            }
+        ],
+        "required_evidence": [
+            {
+                "key": "checker_log",
+                "label": "checker log",
+                "hash_required": True,
+                "required": True,
+                "description": "Evidence item used by the reviewer.",
+            }
+        ],
+        "forbidden_artifacts": [],
+        "attestation_terms": ["dry_run_originality"],
+        "manifest_required": True,
+        "artifact_hash_required": True,
+        "artifact_hash_algorithm": "sha256",
+        "allowed_storage_schemes": ["local", "s3", "r2"],
+        "maximum_file_size_bytes": 1_000_000,
+        "maximum_package_size_bytes": 5_000_000,
+        "packaging": {"package_required": False},
+    }
+
+
+async def create_policy_bundle_for_guide(
+    client: AsyncClient,
+    project_id: str,
+    guide_id: str,
+    run_id: str,
+) -> None:
+    """Create the guide-source, sufficiency, and approved policy bundle."""
+    snapshot = await post_ok(
+        client,
+        f"/api/v1/projects/{project_id}/guides/{guide_id}/source-snapshots",
+        {
+            "items": [
+                {
+                    "source_kind": "inline_markdown",
+                    "durable_ref": f"inline:/guides/{guide_id}/{run_id}",
+                    "ingestion_adapter": "manual_import",
+                    "content_hash": sha256_token(f"{run_id}:guide"),
+                    "media_type": "text/markdown",
+                }
+            ]
+        },
+    )
+    await post_ok(
+        client,
+        f"/api/v1/projects/{project_id}/guides/{guide_id}/sufficiency-reports",
+        {
+            "source_snapshot_id": snapshot["id"],
+            "status": "passed",
+            "findings": [],
+            "summary": "Guide is sufficient for the Week 1 dry run.",
+        },
+    )
+    policy = await post_ok(
+        client,
+        f"/api/v1/projects/{project_id}/guides/{guide_id}/submission-artifact-policies",
+        {
+            "source_snapshot_id": snapshot["id"],
+            "policy_version": "v1",
+            "policy_body": submission_artifact_policy_body(),
+        },
+    )
+    await post_ok(
+        client,
+        f"/api/v1/projects/{project_id}/guides/{guide_id}/submission-artifact-policies/"
+        f"{policy['id']}/approve",
+        {"approval_note": "Approved for Week 1 dry run."},
+    )
 
 
 async def main() -> None:
@@ -152,7 +247,7 @@ async def main() -> None:
                 "evidence_policy": {"required": ["log"]},
                 "unacceptable_work_policy": "Copied or unverifiable work.",
                 "change_summary": "Initial dry-run guide",
-                "checker_policy": {
+                "post_submit_checker_policy": {
                     "required_checkers": ["check_policy_context_present"],
                     "warning_checkers": [],
                     "blocking_severities": ["high"],
@@ -180,6 +275,7 @@ async def main() -> None:
                 },
             },
         )
+        await create_policy_bundle_for_guide(client, project["id"], guide["id"], run_id)
         await post_ok(client, f"/api/v1/projects/{project['id']}/guides/{guide['id']}/activate")
         task = await post_ok(
             client,
@@ -238,7 +334,7 @@ async def main() -> None:
                         "notes": "dry-run artifact",
                     }
                 ],
-                "worker_attestation": "I confirm this dry-run packet follows the locked guide.",
+                "worker_attestation": STRONG_ATTESTATION,
                 "evidence_items": [
                     {
                         "type": "log",
@@ -246,7 +342,7 @@ async def main() -> None:
                         "uri": f"local://dry-run/{run_id}/evidence.log",
                         "hash": f"sha256:evidence-{run_id}",
                         "size_bytes": 256,
-                        "metadata": {"command": "week1_dry_run"},
+                        "metadata": {"command": "week1_dry_run", "policy_key": "checker_log"},
                     }
                 ],
             },

--- a/backend/scripts/week2_api_e2e.py
+++ b/backend/scripts/week2_api_e2e.py
@@ -20,12 +20,14 @@ from app.modules.tasks.models import AuditEvent, EvidenceItem, Submission, Works
 from week1_api_e2e import (
     alembic_config,
     api_environment,
+    create_policy_bundle_for_guide,
     find_free_port,
     flow_settings,
     guide_payload,
     issue_flow_token,
     project_root,
     request_json,
+    sha256_token,
     wait_for_health,
 )
 
@@ -46,6 +48,7 @@ EXPECTED_PRE_SUBMIT_CHECKERS = {
     "check_required_files",
     "check_forbidden_files",
     "check_confidentiality_attestation",
+    "check_low_quality_generated_artifacts",
 }
 LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
 LOCAL_DATABASE_NAMES = {"workstream_test", "test_workstream"}
@@ -54,7 +57,9 @@ NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
 STRONG_ATTESTATION = (
     "I attest this submission contains no confidential client data, credentials, "
     "secrets, tokens, passwords, API keys, private source material, source code, "
-    "copied platform artifacts, or copied platform content."
+    "copied platform artifacts, or copied platform content, and it satisfies "
+    "the original_work, credentials_and_secret_exclusion, real_api_originality, and "
+    "human_accountability_for_agent_assisted_work policy terms."
 )
 
 
@@ -219,7 +224,7 @@ def task_payload(run_id: str, suffix: str) -> dict:
         "estimated_time_minutes": 45,
         "source_type": "manual",
         "source_ref": f"week2-{suffix}-{run_id}",
-        "source_payload_hash": f"sha256:source-{suffix}-{run_id}",
+        "source_payload_hash": sha256_token(f"source:{suffix}:{run_id}"),
         "acceptance_criteria": "Submission packet is complete and reviewable.",
         "rejection_criteria": "Evidence or required output is missing.",
         "required_files": ["answer.md"],
@@ -240,11 +245,11 @@ def submission_payload(run_id: str, suffix: str) -> dict:
     return {
         "summary": f"Week 2 {suffix} packet completed.",
         "package_uri": f"local://week2/{run_id}/{suffix}/package.tar.zst",
-        "package_hash": f"sha256:package-{suffix}-{run_id}",
+        "package_hash": sha256_token(f"package:{suffix}:{run_id}"),
         "artifact_hash_manifest": [
             {
                 "artifact": "answer.md",
-                "hash": f"sha256:answer-{suffix}-{run_id}",
+                "hash": sha256_token(f"answer:{suffix}:{run_id}"),
                 "size_bytes": 128,
                 "notes": "main answer",
             }
@@ -255,9 +260,12 @@ def submission_payload(run_id: str, suffix: str) -> dict:
                 "type": "log",
                 "label": f"checker evidence {suffix}",
                 "uri": f"local://week2/{run_id}/{suffix}/checker.log",
-                "hash": f"sha256:evidence-{suffix}-{run_id}",
+                "hash": sha256_token(f"evidence:{suffix}:{run_id}"),
                 "size_bytes": 256,
-                "metadata": {"command": "week2_api_e2e"},
+                "metadata": {
+                    "command": "week2_api_e2e",
+                    "required_evidence_key": "checker_log",
+                },
             }
         ],
     }
@@ -327,7 +335,7 @@ async def create_project_with_guide(
     )
     payload = guide_payload(run_id)
     if required_checkers is not None:
-        payload["checker_policy"]["required_checkers"] = required_checkers
+        payload["post_submit_checker_policy"]["required_checkers"] = required_checkers
     guide = await request_json(
         client,
         "POST",
@@ -335,6 +343,13 @@ async def create_project_with_guide(
         manager_token,
         payload,
         201,
+    )
+    await create_policy_bundle_for_guide(
+        client,
+        manager_token,
+        project["id"],
+        guide["id"],
+        run_id,
     )
     await request_json(
         client,
@@ -473,7 +488,6 @@ def assert_locked_submission_response(submission: dict) -> None:
     ensure(submission["locked_at"] is not None, "locked submission missing locked_at")
     locked_versions = {
         submission["locked_guide_version"],
-        submission["locked_checker_policy_version"],
         submission["locked_review_policy_version"],
         submission["locked_revision_policy_version"],
         submission["locked_payment_policy_version"],
@@ -671,6 +685,12 @@ async def assert_week2_database_invariants(scenarios: list[dict]) -> None:
                 task.locked_payment_policy_version,
             }
             ensure(task_versions == {"v1"}, f"{scenario['name']} task context drifted")
+            ensure(
+                task.locked_post_submit_checker_policy_id is not None
+                and task.locked_post_submit_checker_policy_version == "v1"
+                and task.locked_post_submit_checker_policy_hash is not None,
+                f"{scenario['name']} task post-submit policy lock missing",
+            )
             submission_versions = {
                 submission.locked_guide_version,
                 submission.locked_checker_policy_version,
@@ -681,6 +701,21 @@ async def assert_week2_database_invariants(scenarios: list[dict]) -> None:
             ensure(
                 submission_versions == task_versions,
                 f"{scenario['name']} submission context drifted",
+            )
+            ensure(
+                submission.locked_post_submit_checker_policy_id
+                == task.locked_post_submit_checker_policy_id,
+                f"{scenario['name']} submission post-submit policy id drifted",
+            )
+            ensure(
+                submission.locked_post_submit_checker_policy_version
+                == task.locked_post_submit_checker_policy_version,
+                f"{scenario['name']} submission post-submit policy version drifted",
+            )
+            ensure(
+                submission.locked_post_submit_checker_policy_hash
+                == task.locked_post_submit_checker_policy_hash,
+                f"{scenario['name']} submission post-submit policy hash drifted",
             )
             ensure(submission.locked_at is not None, f"{scenario['name']} submission not locked")
             ensure(
@@ -732,6 +767,21 @@ async def assert_week2_database_invariants(scenarios: list[dict]) -> None:
                 checker_run.locked_payment_policy_version,
             }
             ensure(run_versions == submission_versions, f"{scenario['name']} checker context drifted")
+            ensure(
+                checker_run.locked_post_submit_checker_policy_id
+                == submission.locked_post_submit_checker_policy_id,
+                f"{scenario['name']} checker post-submit policy id drifted",
+            )
+            ensure(
+                checker_run.locked_post_submit_checker_policy_version
+                == submission.locked_post_submit_checker_policy_version,
+                f"{scenario['name']} checker post-submit policy version drifted",
+            )
+            ensure(
+                checker_run.locked_post_submit_checker_policy_hash
+                == submission.locked_post_submit_checker_policy_hash,
+                f"{scenario['name']} checker post-submit policy hash drifted",
+            )
 
             results = (
                 await session.scalars(
@@ -880,7 +930,10 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             {"submission": submission_payload(run_id, "clean")},
         )
         ensure(clean_precheck["authoritative"] is False, "precheck must be non-authoritative")
-        ensure(clean_precheck["eligible_to_submit"] is True, "clean precheck should pass")
+        ensure(
+            clean_precheck["eligible_to_submit"] is True,
+            f"clean precheck should pass: {clean_precheck}",
+        )
         assert_pre_submit_checker_set(clean_precheck)
         await assert_task_status(client, manager_token, clean_task["id"], "in_progress")
         clean_precheck_submissions = await request_json(
@@ -915,8 +968,14 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             clean_worker_token,
         )
         ensure(
-            worker_clean_run["routing_recommendation"] == "allow_review",
-            "worker clean route mismatch",
+            "routing_recommendation" not in worker_clean_run,
+            "worker saw internal routing recommendation",
+        )
+        ensure("outcome_source" not in worker_clean_run, "worker saw internal outcome source")
+        ensure("trigger_source" not in worker_clean_run, "worker saw internal trigger source")
+        ensure(
+            "locked_post_submit_checker_policy_hash" not in worker_clean_run,
+            "worker saw locked post-submit checker policy hash",
         )
         ensure(worker_clean_run["artifact_hash_manifest"] == [], "worker saw artifact manifest")
         manager_clean_runs = await request_json(
@@ -936,6 +995,14 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         ensure(
             worker_clean_runs[0]["artifact_hash_manifest"] == [],
             "worker checker-run list exposed artifact manifest",
+        )
+        ensure(
+            "routing_recommendation" not in worker_clean_runs[0],
+            "worker checker-run list exposed routing recommendation",
+        )
+        ensure(
+            "locked_post_submit_checker_policy_hash" not in worker_clean_runs[0],
+            "worker checker-run list exposed locked post-submit checker policy hash",
         )
         await request_json(
             client,
@@ -987,7 +1054,7 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         missing_file_payload["artifact_hash_manifest"] = [
             {
                 "artifact": "other.md",
-                "hash": f"sha256:other-{run_id}",
+                "hash": sha256_token(f"other:{run_id}"),
                 "size_bytes": 128,
                 "notes": "wrong artifact",
             }
@@ -1009,38 +1076,14 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             revision_worker_token,
         )
         ensure(revision_precheck_submissions == [], "failed precheck created a submission")
-        first_submission, first_locked, first_run = await submit_lock_and_get_run(
+        await request_json(
             client,
-            manager_token=manager_token,
-            worker_token=revision_worker_token,
-            task_id=revision_task["id"],
-            payload=missing_file_payload,
-        )
-        assert_default_checker_set(first_run)
-        ensure(first_run["routing_recommendation"] == "needs_revision", "missing file route drifted")
-        ensure(first_run["outcome_source"] == "auto_checker", "missing file source drifted")
-        await assert_task_status(client, manager_token, revision_task["id"], "needs_revision")
-        worker_revision_run = await request_json(
-            client,
-            "GET",
-            f"/api/v1/checker-runs/{first_run['id']}",
+            "POST",
+            f"/api/v1/tasks/{revision_task['id']}/submissions",
             revision_worker_token,
+            missing_file_payload,
+            422,
         )
-        required_file_result = checker_result(worker_revision_run, "check_required_files")
-        ensure(bool(required_file_result["worker_message"]), "required-file worker message missing")
-        ensure(required_file_result["metadata"] == {}, "worker saw required-file metadata")
-        second_submission, second_locked, second_run = await submit_lock_and_get_run(
-            client,
-            manager_token=manager_token,
-            worker_token=revision_worker_token,
-            task_id=revision_task["id"],
-            payload=submission_payload(run_id, "revision-v2"),
-        )
-        assert_default_checker_set(second_run)
-        ensure(first_submission["version"] == 1, "first submission version drifted")
-        ensure(second_submission["version"] == 2, "second submission version drifted")
-        ensure(second_run["routing_recommendation"] == "allow_review", "fixed v2 did not pass")
-        await assert_task_status(client, manager_token, revision_task["id"], "review_pending")
 
         missing_evidence_worker_subject = f"week2-worker-no-evidence-{run_id}"
         missing_evidence_worker_token = token_for(
@@ -1134,26 +1177,39 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         duplicate_artifact_payload["artifact_hash_manifest"].append(
             {
                 "artifact": "answer.md",
-                "hash": f"sha256:duplicate-{run_id}",
+                "hash": sha256_token(f"duplicate:{run_id}"),
                 "size_bytes": 128,
                 "notes": "duplicate artifact",
             }
         )
-        integrity_submission, integrity_locked, integrity_run = await submit_lock_and_get_run(
+        integrity_precheck = await request_json(
             client,
-            manager_token=manager_token,
-            worker_token=integrity_worker_token,
-            task_id=integrity_task["id"],
-            payload=duplicate_artifact_payload,
+            "POST",
+            f"/api/v1/tasks/{integrity_task['id']}/submission-precheck",
+            integrity_worker_token,
+            {"submission": duplicate_artifact_payload},
         )
-        assert_default_checker_set(integrity_run)
+        assert_pre_submit_checker_set(integrity_precheck)
         ensure(
-            integrity_run["routing_recommendation"] == "needs_revision",
-            "integrity failure did not route to needs_revision",
+            integrity_precheck["eligible_to_submit"] is False,
+            "duplicate artifact precheck should block submission",
         )
         ensure(
-            checker_result(integrity_run, "check_evidence_integrity")["status"] == "failed",
-            "evidence integrity checker did not fail",
+            next(
+                result
+                for result in integrity_precheck["results"]
+                if result["checker_name"] == "check_evidence_integrity"
+            )["status"]
+            == "failed",
+            "duplicate artifact precheck did not fail integrity",
+        )
+        await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{integrity_task['id']}/submissions",
+            integrity_worker_token,
+            duplicate_artifact_payload,
+            422,
         )
 
         attestation_worker_subject = f"week2-worker-attestation-{run_id}"
@@ -1182,22 +1238,34 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         )
         weak_attestation_payload = submission_payload(run_id, "attestation")
         weak_attestation_payload["worker_attestation"] = "ok"
-        attestation_submission, attestation_locked, attestation_run = await submit_lock_and_get_run(
+        attestation_precheck = await request_json(
             client,
-            manager_token=manager_token,
-            worker_token=attestation_worker_token,
-            task_id=attestation_task["id"],
-            payload=weak_attestation_payload,
+            "POST",
+            f"/api/v1/tasks/{attestation_task['id']}/submission-precheck",
+            attestation_worker_token,
+            {"submission": weak_attestation_payload},
         )
-        assert_default_checker_set(attestation_run)
+        assert_pre_submit_checker_set(attestation_precheck)
         ensure(
-            attestation_run["routing_recommendation"] == "needs_revision",
-            "weak attestation did not route to needs_revision",
+            attestation_precheck["eligible_to_submit"] is False,
+            "weak attestation precheck should block submission",
         )
         ensure(
-            checker_result(attestation_run, "check_confidentiality_attestation")["status"]
+            next(
+                result
+                for result in attestation_precheck["results"]
+                if result["checker_name"] == "check_confidentiality_attestation"
+            )["status"]
             == "failed",
-            "confidentiality attestation checker did not fail",
+            "weak attestation precheck did not fail confidentiality",
+        )
+        await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{attestation_task['id']}/submissions",
+            attestation_worker_token,
+            weak_attestation_payload,
+            422,
         )
 
         warning_worker_subject = f"week2-worker-warning-{run_id}"
@@ -1270,37 +1338,40 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
         forbidden_payload["artifact_hash_manifest"].append(
             {
                 "artifact": "secrets/.env",
-                "hash": f"sha256:forbidden-{run_id}",
+                "hash": sha256_token(f"forbidden:{run_id}"),
                 "size_bytes": 64,
                 "notes": "must be blocked",
             }
         )
-        forbidden_submission, forbidden_locked, forbidden_run = await submit_lock_and_get_run(
+        forbidden_precheck = await request_json(
             client,
-            manager_token=manager_token,
-            worker_token=forbidden_worker_token,
-            task_id=forbidden_task["id"],
-            payload=forbidden_payload,
-        )
-        assert_default_checker_set(forbidden_run)
-        ensure(
-            forbidden_run["routing_recommendation"] == "needs_revision",
-            "forbidden path did not route to needs_revision",
-        )
-        ensure(
-            checker_result(forbidden_run, "check_forbidden_files")["status"] == "failed",
-            "forbidden-file checker did not fail",
-        )
-        worker_forbidden_run = await request_json(
-            client,
-            "GET",
-            f"/api/v1/checker-runs/{forbidden_run['id']}",
+            "POST",
+            f"/api/v1/tasks/{forbidden_task['id']}/submission-precheck",
             forbidden_worker_token,
+            {"submission": forbidden_payload},
         )
-        serialized_forbidden = str(worker_forbidden_run)
-        ensure(".env" not in serialized_forbidden, "worker saw forbidden .env path")
-        ensure("secrets/" not in serialized_forbidden, "worker saw forbidden directory path")
-        ensure("local://" not in serialized_forbidden, "worker saw internal storage URI")
+        assert_pre_submit_checker_set(forbidden_precheck)
+        ensure(
+            forbidden_precheck["eligible_to_submit"] is False,
+            "forbidden path precheck should block submission",
+        )
+        ensure(
+            next(
+                result
+                for result in forbidden_precheck["results"]
+                if result["checker_name"] == "check_forbidden_files"
+            )["status"]
+            == "failed",
+            "forbidden path precheck did not fail forbidden-file checker",
+        )
+        await request_json(
+            client,
+            "POST",
+            f"/api/v1/tasks/{forbidden_task['id']}/submissions",
+            forbidden_worker_token,
+            forbidden_payload,
+            422,
+        )
 
         setup_worker_subject = f"week2-worker-setup-{run_id}"
         setup_worker_token = token_for(
@@ -1365,9 +1436,10 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
             setup_worker_token,
         )
         ensure(
-            worker_setup_run["routing_recommendation"] == "not_evaluated",
+            "routing_recommendation" not in worker_setup_run,
             "worker saw internal setup route",
         )
+        ensure("outcome_source" not in worker_setup_run, "worker saw internal setup outcome")
         ensure(worker_setup_run["results"] == [], "worker saw internal setup results")
         await repair_acceptance_criteria(setup_task["id"])
         retry = await request_json(
@@ -1439,70 +1511,6 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
                 "expected_gate_event": "pre_review_gate_passed",
             },
             {
-                "name": "missing_file_v1",
-                "task_id": revision_task["id"],
-                "submission_id": first_submission["id"],
-                "checker_run_id": first_run["id"],
-                "locked_at": first_locked["locked_at"],
-                "expected_route": "needs_revision",
-                "expected_task_status": "review_pending",
-                "expected_trigger_source": "submission_locked",
-                "expected_attempt": 1,
-                "expected_attempts": [1],
-                "expected_current": True,
-                "expected_current_run_id": first_run["id"],
-                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
-                "expected_gate_event": "pre_review_gate_needs_revision",
-            },
-            {
-                "name": "revision_v2",
-                "task_id": revision_task["id"],
-                "submission_id": second_submission["id"],
-                "checker_run_id": second_run["id"],
-                "locked_at": second_locked["locked_at"],
-                "expected_route": "allow_review",
-                "expected_task_status": "review_pending",
-                "expected_trigger_source": "submission_locked",
-                "expected_attempt": 1,
-                "expected_attempts": [1],
-                "expected_current": True,
-                "expected_current_run_id": second_run["id"],
-                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
-                "expected_gate_event": "pre_review_gate_passed",
-            },
-            {
-                "name": "integrity",
-                "task_id": integrity_task["id"],
-                "submission_id": integrity_submission["id"],
-                "checker_run_id": integrity_run["id"],
-                "locked_at": integrity_locked["locked_at"],
-                "expected_route": "needs_revision",
-                "expected_task_status": "needs_revision",
-                "expected_trigger_source": "submission_locked",
-                "expected_attempt": 1,
-                "expected_attempts": [1],
-                "expected_current": True,
-                "expected_current_run_id": integrity_run["id"],
-                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
-                "expected_gate_event": "pre_review_gate_needs_revision",
-            },
-            {
-                "name": "attestation",
-                "task_id": attestation_task["id"],
-                "submission_id": attestation_submission["id"],
-                "checker_run_id": attestation_run["id"],
-                "locked_at": attestation_locked["locked_at"],
-                "expected_route": "needs_revision",
-                "expected_task_status": "needs_revision",
-                "expected_trigger_source": "submission_locked",
-                "expected_attempt": 1,
-                "expected_attempts": [1],
-                "expected_current": True,
-                "expected_current_run_id": attestation_run["id"],
-                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
-                "expected_gate_event": "pre_review_gate_needs_revision",
-            },
-            {
                 "name": "warning",
                 "task_id": warning_task["id"],
                 "submission_id": warning_submission["id"],
@@ -1517,22 +1525,6 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
                 "expected_current_run_id": warning_run["id"],
                 "expected_checkers": EXPECTED_DURABLE_CHECKERS,
                 "expected_gate_event": "pre_review_gate_passed",
-            },
-            {
-                "name": "forbidden",
-                "task_id": forbidden_task["id"],
-                "submission_id": forbidden_submission["id"],
-                "checker_run_id": forbidden_run["id"],
-                "locked_at": forbidden_locked["locked_at"],
-                "expected_route": "needs_revision",
-                "expected_task_status": "needs_revision",
-                "expected_trigger_source": "submission_locked",
-                "expected_attempt": 1,
-                "expected_attempts": [1],
-                "expected_current": True,
-                "expected_current_run_id": forbidden_run["id"],
-                "expected_checkers": EXPECTED_DURABLE_CHECKERS,
-                "expected_gate_event": "pre_review_gate_needs_revision",
             },
             {
                 "name": "setup_blocked",
@@ -1572,18 +1564,16 @@ async def exercise_week2_api(base_url: str, env: dict[str, str]) -> None:
     print("Week 2 real API e2e passed")
     print("scenario_summary:")
     print("clean=review_pending")
-    print("missing_file=needs_revision")
+    print("missing_file=pre_submit_blocked")
     print("missing_evidence=pre_submit_blocked")
-    print("duplicate_artifact_integrity=needs_revision")
-    print("weak_attestation=needs_revision")
+    print("duplicate_artifact_integrity=pre_submit_blocked")
+    print("weak_attestation=pre_submit_blocked")
     print("generated_output_warning=review_pending")
-    print("forbidden_path=needs_revision")
+    print("forbidden_path=pre_submit_blocked")
     print("task_setup_blocked=auto_checking->review_pending")
     print(f"clean_task_id={clean_task['id']}")
     print(f"clean_submission_id={clean_submission['id']}")
-    print(f"revision_task_id={revision_task['id']}")
-    print(f"revision_v1_submission_id={first_submission['id']}")
-    print(f"revision_v2_submission_id={second_submission['id']}")
+    print(f"missing_file_task_id={revision_task['id']}")
     print(f"missing_evidence_task_id={missing_evidence_task['id']}")
     print(f"integrity_task_id={integrity_task['id']}")
     print(f"attestation_task_id={attestation_task['id']}")

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
+from uuid import uuid4
 
+import pytest
 from alembic import command
 from alembic.config import Config
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
 
 
 def test_alembic_upgrade_and_downgrade(isolated_database_env: str, migration_lock) -> None:
@@ -15,3 +20,507 @@ def test_alembic_upgrade_and_downgrade(isolated_database_env: str, migration_loc
         command.downgrade(config, "base")
         command.upgrade(config, "head")
         command.downgrade(config, "base")
+
+
+def test_post_submit_policy_upgrade_leaves_legacy_rows_fail_closed(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """Prove 0008 does not create fake post-submit policy authority for legacy rows."""
+    project_root = Path(__file__).resolve().parents[1]
+    config = Config(str(project_root / "alembic.ini"))
+    config.set_main_option("script_location", str(project_root / "alembic"))
+
+    legacy_project_id = str(uuid4())
+    legacy_guide_id = str(uuid4())
+    legacy_policy_id = str(uuid4())
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "0007_task_locked_context")
+            asyncio.run(
+                _seed_legacy_post_submit_policy(
+                    isolated_database_env,
+                    legacy_project_id,
+                    legacy_guide_id,
+                    legacy_policy_id,
+                )
+            )
+            command.upgrade(config, "0008_post_submit_checker_policy")
+            policy_hash = asyncio.run(
+                _fetch_legacy_post_submit_policy_hash(isolated_database_env, legacy_policy_id)
+            )
+        finally:
+            command.downgrade(config, "base")
+
+    assert policy_hash is None
+
+
+def test_post_submit_policy_upgrade_blocks_legacy_runtime_rows(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """Prove 0008 fails clearly when runtime rows cannot gain trusted provenance."""
+    project_root = Path(__file__).resolve().parents[1]
+    config = Config(str(project_root / "alembic.ini"))
+    config.set_main_option("script_location", str(project_root / "alembic"))
+
+    ids = {name: str(uuid4()) for name in ("project", "guide", "policy", "task", "submission", "run")}
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "0007_task_locked_context")
+            asyncio.run(_seed_legacy_runtime_rows(isolated_database_env, ids))
+
+            with pytest.raises(RuntimeError, match="cannot infer locked post-submit"):
+                command.upgrade(config, "0008_post_submit_checker_policy")
+
+            columns_exist = asyncio.run(
+                _post_submit_lock_columns_exist(isolated_database_env, "submissions")
+            )
+        finally:
+            command.downgrade(config, "base")
+
+    assert columns_exist is False
+
+
+async def _seed_legacy_post_submit_policy(
+    database_url: str,
+    project_id: str,
+    guide_id: str,
+    policy_id: str,
+) -> None:
+    """Seed a valid 0007 checker policy row before post-submit hashes exist."""
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    """
+                    insert into projects (
+                        id,
+                        name,
+                        slug,
+                        status,
+                        base_amount,
+                        currency
+                    )
+                    values (
+                        :project_id,
+                        'Legacy policy project',
+                        'legacy-policy-project',
+                        'draft',
+                        25.00,
+                        'USD'
+                    )
+                    """
+                ),
+                {"project_id": project_id},
+            )
+            await connection.execute(
+                text(
+                    """
+                    insert into project_guides (
+                        id,
+                        project_id,
+                        version,
+                        status,
+                        content_markdown,
+                        required_task_fields,
+                        required_submission_fields,
+                        required_skills,
+                        difficulty_scale,
+                        estimated_time_policy,
+                        common_rejection_reasons,
+                        created_by
+                    )
+                    values (
+                        :guide_id,
+                        :project_id,
+                        'v1',
+                        'draft',
+                        '# Legacy guide',
+                        '[]'::json,
+                        '[]'::json,
+                        '[]'::json,
+                        '{}'::json,
+                        '{}'::json,
+                        '[]'::json,
+                        'legacy-test'
+                    )
+                    """
+                ),
+                {"guide_id": guide_id, "project_id": project_id},
+            )
+            await connection.execute(
+                text(
+                    """
+                    insert into checker_policies (
+                        id,
+                        project_id,
+                        guide_version,
+                        required_checkers,
+                        warning_checkers,
+                        blocking_severities
+                    )
+                    values (
+                        :policy_id,
+                        :project_id,
+                        'v1',
+                        '["check_policy_context_present"]'::json,
+                        '[]'::json,
+                        '["high"]'::json
+                    )
+                    """
+                ),
+                {"policy_id": policy_id, "project_id": project_id},
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _seed_legacy_runtime_rows(database_url: str, ids: dict[str, str]) -> None:
+    """Seed 0007 runtime rows that cannot be trusted under 0008 provenance."""
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    """
+                    insert into projects (
+                        id,
+                        name,
+                        slug,
+                        status,
+                        base_amount,
+                        currency
+                    )
+                    values (
+                        :project_id,
+                        'Legacy runtime project',
+                        'legacy-runtime-project',
+                        'draft',
+                        25.00,
+                        'USD'
+                    )
+                    """
+                ),
+                {"project_id": ids["project"]},
+            )
+            await connection.execute(
+                text(
+                    """
+                    insert into project_guides (
+                        id,
+                        project_id,
+                        version,
+                        status,
+                        content_markdown,
+                        required_task_fields,
+                        required_submission_fields,
+                        required_skills,
+                        difficulty_scale,
+                        estimated_time_policy,
+                        common_rejection_reasons,
+                        created_by
+                    )
+                    values (
+                        :guide_id,
+                        :project_id,
+                        'v1',
+                        'active',
+                        '# Legacy runtime guide',
+                        '[]'::json,
+                        '[]'::json,
+                        '[]'::json,
+                        '{}'::json,
+                        '{}'::json,
+                        '[]'::json,
+                        'legacy-test'
+                    )
+                    """
+                ),
+                {"guide_id": ids["guide"], "project_id": ids["project"]},
+            )
+            await _seed_legacy_policies(connection, ids["project"], ids["policy"])
+            await connection.execute(
+                text(
+                    """
+                    insert into workstream_tasks (
+                        id,
+                        project_id,
+                        locked_guide_version,
+                        locked_checker_policy_version,
+                        locked_review_policy_version,
+                        locked_revision_policy_version,
+                        locked_payment_policy_version,
+                        source_type,
+                        title,
+                        description,
+                        skill_tags,
+                        status,
+                        required_files,
+                        required_evidence,
+                        created_by
+                    )
+                    values (
+                        :task_id,
+                        :project_id,
+                        'v1',
+                        'v1',
+                        'v1',
+                        'v1',
+                        'v1',
+                        'manual',
+                        'Legacy runtime task',
+                        'Already in progress before 0008.',
+                        '[]'::json,
+                        'in_progress',
+                        '[]'::json,
+                        '[]'::json,
+                        'legacy-test'
+                    )
+                    """
+                ),
+                {"task_id": ids["task"], "project_id": ids["project"]},
+            )
+            await connection.execute(
+                text(
+                    """
+                    insert into submissions (
+                        id,
+                        task_id,
+                        worker_id,
+                        version,
+                        status,
+                        summary,
+                        package_hash,
+                        artifact_hash_manifest,
+                        worker_attestation,
+                        locked_guide_version,
+                        locked_checker_policy_version,
+                        locked_review_policy_version,
+                        locked_revision_policy_version,
+                        locked_payment_policy_version
+                    )
+                    values (
+                        :submission_id,
+                        :task_id,
+                        'legacy-worker',
+                        1,
+                        'submitted',
+                        'Legacy submitted packet',
+                        'sha256:legacy-package',
+                        '[]'::json,
+                        'legacy attestation',
+                        'v1',
+                        'v1',
+                        'v1',
+                        'v1',
+                        'v1'
+                    )
+                    """
+                ),
+                {"submission_id": ids["submission"], "task_id": ids["task"]},
+            )
+            await connection.execute(
+                text(
+                    """
+                    insert into checker_runs (
+                        id,
+                        task_id,
+                        submission_id,
+                        submission_version,
+                        trigger_source,
+                        status,
+                        routing_recommendation,
+                        outcome_source,
+                        triggered_by,
+                        triggered_by_subject,
+                        triggered_by_issuer,
+                        trigger_auth_source,
+                        attempt_number,
+                        is_current_for_submission,
+                        locked_guide_version,
+                        locked_checker_policy_version,
+                        locked_review_policy_version,
+                        locked_revision_policy_version,
+                        locked_payment_policy_version,
+                        package_hash,
+                        artifact_hash_manifest,
+                        artifact_manifest_hash,
+                        passed_count,
+                        warning_count,
+                        failed_count,
+                        blocking_count
+                    )
+                    values (
+                        :run_id,
+                        :task_id,
+                        :submission_id,
+                        1,
+                        'submission_lock',
+                        'completed',
+                        'allow_review',
+                        'auto_checker',
+                        'legacy-test',
+                        'legacy-test',
+                        'flow-legacy',
+                        'flow',
+                        1,
+                        true,
+                        'v1',
+                        'v1',
+                        'v1',
+                        'v1',
+                        'v1',
+                        'sha256:legacy-package',
+                        '[]'::json,
+                        'sha256:legacy-manifest',
+                        1,
+                        0,
+                        0,
+                        0
+                    )
+                    """
+                ),
+                {
+                    "run_id": ids["run"],
+                    "task_id": ids["task"],
+                    "submission_id": ids["submission"],
+                },
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _seed_legacy_policies(connection, project_id: str, checker_policy_id: str) -> None:
+    """Seed v0.1 guide policies required by locked task foreign keys."""
+    await connection.execute(
+        text(
+            """
+            insert into checker_policies (
+                id,
+                project_id,
+                guide_version,
+                required_checkers,
+                warning_checkers,
+                blocking_severities
+            )
+            values (
+                :checker_policy_id,
+                :project_id,
+                'v1',
+                '["check_policy_context_present"]'::json,
+                '[]'::json,
+                '["high"]'::json
+            )
+            """
+        ),
+        {"checker_policy_id": checker_policy_id, "project_id": project_id},
+    )
+    await connection.execute(
+        text(
+            """
+            insert into review_policies (
+                id,
+                project_id,
+                guide_version,
+                requires_second_review,
+                allowed_decisions,
+                minimum_finding_fields
+            )
+            values (
+                :review_policy_id,
+                :project_id,
+                'v1',
+                false,
+                '["accept", "needs_revision", "reject"]'::json,
+                '[]'::json
+            )
+            """
+        ),
+        {"review_policy_id": str(uuid4()), "project_id": project_id},
+    )
+    await connection.execute(
+        text(
+            """
+            insert into revision_policies (
+                id,
+                project_id,
+                guide_version,
+                max_revision_rounds,
+                revision_deadline_hours,
+                auto_reject_after_limit,
+                allowed_resubmission_states
+            )
+            values (
+                :revision_policy_id,
+                :project_id,
+                'v1',
+                7,
+                48,
+                true,
+                '["needs_revision"]'::json
+            )
+            """
+        ),
+        {"revision_policy_id": str(uuid4()), "project_id": project_id},
+    )
+    await connection.execute(
+        text(
+            """
+            insert into payment_policies (
+                id,
+                project_id,
+                guide_version,
+                base_amount,
+                currency,
+                payout_type
+            )
+            values (
+                :payment_policy_id,
+                :project_id,
+                'v1',
+                25.00,
+                'USD',
+                'fixed'
+            )
+            """
+        ),
+        {"payment_policy_id": str(uuid4()), "project_id": project_id},
+    )
+
+
+async def _post_submit_lock_columns_exist(database_url: str, table_name: str) -> bool:
+    """Return whether a post-submit lock column was added to a table."""
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            count = await connection.scalar(
+                text(
+                    """
+                    select count(*)
+                    from information_schema.columns
+                    where table_name = :table_name
+                      and column_name = 'locked_post_submit_checker_policy_id'
+                    """
+                ),
+                {"table_name": table_name},
+            )
+            return bool(count)
+    finally:
+        await engine.dispose()
+
+
+async def _fetch_legacy_post_submit_policy_hash(database_url: str, policy_id: str) -> str | None:
+    """Return the post-submit policy hash created by the 0008 migration, if any."""
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            return await connection.scalar(
+                text("select policy_hash from checker_policies where id = :policy_id"),
+                {"policy_id": policy_id},
+            )
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_checkers.py
+++ b/backend/tests/test_checkers.py
@@ -11,6 +11,7 @@ from httpx import ASGITransport, AsyncClient
 from pydantic import TypeAdapter, ValidationError
 from sqlalchemy import inspect, select
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.schema import CreateIndex
 
 from app.core.config import get_settings
@@ -29,6 +30,11 @@ from app.modules.checkers.compiler import (
 from app.modules.checkers.models import CheckerResult, CheckerRun
 from app.modules.checkers.runner import canonical_artifact_manifest_hash
 from app.modules.checkers.schemas import CheckerRoutingRecommendation
+from app.modules.projects.models import PostSubmitCheckerPolicy
+from app.modules.projects.post_submit_policy import (
+    POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+    parse_locked_post_submit_checker_policy_body,
+)
 from app.modules.tasks.models import AuditEvent, EvidenceItem, Submission, WorkstreamTask
 from tests.test_tasks import (
     auth_headers,
@@ -37,6 +43,7 @@ from tests.test_tasks import (
     create_active_project,
     create_policy_bundle_for_guide,
     create_started_task,
+    load_post_submit_checker_policy,
     seed_worker_profile,
     set_dev_actor,
 )
@@ -80,6 +87,33 @@ def alembic_config() -> Config:
     return config
 
 
+def test_locked_post_submit_policy_parser_uses_persisted_body_hash() -> None:
+    body = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "default_checkers": ["legacy_default_checker"],
+        "required_checkers": ["project_required_checker"],
+        "warning_checkers": [],
+        "execution_checkers": ["legacy_default_checker", "project_required_checker"],
+        "blocking_severities": ["high"],
+    }
+    policy_hash = canonical_json_hash(body)
+
+    parsed = parse_locked_post_submit_checker_policy_body(
+        body,
+        project_id="project-id",
+        guide_version="v1",
+        policy_hash=policy_hash,
+    )
+
+    assert parsed.default_checkers == ["legacy_default_checker"]
+    assert parsed.execution_checkers == [
+        "legacy_default_checker",
+        "project_required_checker",
+    ]
+
+
 def test_checker_models_are_registered_for_alembic_metadata() -> None:
     expected_tables = {"checker_runs", "checker_results"}
 
@@ -95,6 +129,35 @@ def test_checker_routing_recommendation_schema_uses_canonical_routing_tokens() -
     assert adapter.validate_python("task_setup_blocked") == "task_setup_blocked"
     with pytest.raises(ValidationError):
         adapter.validate_python("operator" + "_retry")
+
+
+def test_checker_run_openapi_documents_worker_safe_public_response_schema() -> None:
+    schema = create_app().openapi()
+    public_schema = schema["components"]["schemas"]["CheckerRunPublicResponse"]
+    public_properties = set(public_schema["properties"])
+    forbidden_properties = {
+        "trigger_source",
+        "routing_recommendation",
+        "outcome_source",
+        "triggered_by",
+        "trigger_reason",
+        "audit_event_id",
+        "locked_post_submit_checker_policy_id",
+        "locked_post_submit_checker_policy_version",
+        "locked_post_submit_checker_policy_hash",
+        "locked_post_submit_checker_policy_body",
+        "failure_message",
+    }
+
+    assert forbidden_properties.isdisjoint(public_properties)
+    detail_schema = schema["paths"]["/api/v1/checker-runs/{checker_run_id}"]["get"][
+        "responses"
+    ]["200"]["content"]["application/json"]["schema"]
+    list_schema = schema["paths"]["/api/v1/submissions/{submission_id}/checker-runs"]["get"][
+        "responses"
+    ]["200"]["content"]["application/json"]["schema"]
+    assert detail_schema["$ref"] == "#/components/schemas/CheckerRunPublicResponse"
+    assert list_schema["items"]["$ref"] == "#/components/schemas/CheckerRunPublicResponse"
 
 
 async def test_checker_migration_creates_expected_tables(checker_database_env: str) -> None:
@@ -116,6 +179,33 @@ def test_checker_run_current_partial_unique_index_metadata_compiles() -> None:
     postgres_compiled = str(CreateIndex(index).compile(dialect=postgresql.dialect()))
 
     assert "is_current_for_submission = true" in postgres_compiled
+
+
+def test_checker_run_binds_to_locked_post_submit_policy_context() -> None:
+    expected_constraints = {
+        "fk_checker_runs_locked_post_submit_policy_hash": [
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+        "fk_checker_runs_submission_locked_post_submit_policy_hash": [
+            "submission_id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+    }
+
+    for constraint_name, local_columns in expected_constraints.items():
+        constraint = next(
+            constraint
+            for constraint in CheckerRun.__table__.foreign_key_constraints
+            if constraint.name == constraint_name
+        )
+        assert [column.name for column in constraint.columns] == local_columns
+    assert "ck_checker_runs_post_submit_policy_lock_complete" in {
+        constraint.name for constraint in CheckerRun.__table__.constraints
+    }
 
 
 def test_artifact_manifest_hash_is_stable_and_rejects_duplicates() -> None:
@@ -472,7 +562,7 @@ async def create_checker_trial_project(
 
     guide_payload = complete_guide_payload()
     if required_checkers is not None:
-        guide_payload["checker_policy"]["required_checkers"] = required_checkers
+        guide_payload["post_submit_checker_policy"]["required_checkers"] = required_checkers
     guide_response = await client.post(
         f"/api/v1/projects/{project['id']}/guides",
         headers=auth_headers(),
@@ -594,6 +684,10 @@ async def test_locked_submission_checker_run_persists_results_and_allows_review(
     assert body["outcome_source"] == "none"
     assert body["submission_version"] == 1
     assert body["locked_checker_policy_version"] == "v1"
+    expected_post_submit_policy = await load_post_submit_checker_policy(project["id"])
+    assert body["locked_post_submit_checker_policy_id"] == expected_post_submit_policy["id"]
+    assert body["locked_post_submit_checker_policy_version"] == "v1"
+    assert body["locked_post_submit_checker_policy_hash"] == expected_post_submit_policy["policy_hash"]
     assert body["artifact_manifest_hash"].startswith("sha256:")
     assert body["audit_event_id"]
     assert body["passed_count"] >= 8
@@ -619,14 +713,31 @@ async def test_locked_submission_checker_run_persists_results_and_allows_review(
     async with db_session.get_session_factory()() as session:
         audit = await session.get(AuditEvent, body["audit_event_id"])
         task = await session.get(WorkstreamTask, started_task["id"])
+        submission = await session.get(Submission, created.json()["id"])
+        checker_run = await session.get(CheckerRun, body["id"])
     assert audit is not None
     assert audit.event_type == "checker_run_triggered"
     assert audit.entity_id == created.json()["id"]
     assert audit.reason == "submission locked pre-review gate"
     assert audit.event_payload["submission_version"] == 1
     assert audit.event_payload["trigger_source"] == "submission_locked"
+    assert (
+        audit.event_payload["locked_post_submit_checker_policy_hash"]
+        == expected_post_submit_policy["policy_hash"]
+    )
     assert task is not None
     assert task.status == "review_pending"
+    assert submission is not None
+    assert checker_run is not None
+    assert task.locked_post_submit_checker_policy_id == expected_post_submit_policy["id"]
+    assert submission.locked_post_submit_checker_policy_id == expected_post_submit_policy["id"]
+    assert checker_run.locked_post_submit_checker_policy_id == expected_post_submit_policy["id"]
+    assert (
+        task.locked_post_submit_checker_policy_hash
+        == submission.locked_post_submit_checker_policy_hash
+        == checker_run.locked_post_submit_checker_policy_hash
+        == expected_post_submit_policy["policy_hash"]
+    )
     audit_response = await checker_client.get(
         f"/api/v1/tasks/{started_task['id']}/audit-events",
         headers=auth_headers(),
@@ -641,6 +752,226 @@ async def test_locked_submission_checker_run_persists_results_and_allows_review(
     assert audit_events["pre_review_gate_passed"]["event_payload"]["trigger_source"] == (
         "submission_locked"
     )
+
+
+async def test_database_rejects_missing_submission_post_submit_policy_context(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+
+    async with db_session.get_session_factory()() as session:
+        submission = await session.get(Submission, created.json()["id"])
+        assert submission is not None
+        submission.locked_post_submit_checker_policy_id = None
+        submission.locked_post_submit_checker_policy_version = None
+        submission.locked_post_submit_checker_policy_hash = None
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        submission = await session.get(Submission, created.json()["id"])
+        runs = (
+            await session.execute(
+                select(CheckerRun).where(CheckerRun.submission_id == created.json()["id"])
+            )
+        ).scalars().all()
+        results = (
+            await session.execute(
+                select(CheckerResult).where(CheckerResult.submission_id == created.json()["id"])
+            )
+        ).scalars().all()
+    assert task is not None
+    assert task.status == "submitted"
+    assert submission is not None
+    assert submission.locked_at is None
+    assert runs == []
+    assert results == []
+
+
+async def test_checker_run_uses_locked_post_submit_policy_body_after_setup_mutation(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+
+    async with db_session.get_session_factory()() as session:
+        submission = await session.get(Submission, created.json()["id"])
+        assert submission is not None
+        locked_body = dict(submission.locked_post_submit_checker_policy_body or {})
+        policy = await session.scalar(
+            select(PostSubmitCheckerPolicy).where(
+                PostSubmitCheckerPolicy.project_id == project["id"],
+                PostSubmitCheckerPolicy.guide_version == "v1",
+            )
+        )
+        assert policy is not None
+        policy.required_checkers = [
+            "check_policy_context_present",
+            "check_acceptance_criteria_present",
+        ]
+        await session.commit()
+
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+
+    assert locked.status_code == 200, locked.text
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        submission = await session.get(Submission, created.json()["id"])
+        runs = (
+            await session.execute(
+                select(CheckerRun).where(CheckerRun.submission_id == created.json()["id"])
+            )
+        ).scalars().all()
+        results = (
+            await session.execute(
+                select(CheckerResult).where(CheckerResult.submission_id == created.json()["id"])
+            )
+        ).scalars().all()
+    assert task is not None
+    assert task.status == "review_pending"
+    assert submission is not None
+    assert submission.locked_at is not None
+    assert submission.locked_post_submit_checker_policy_body == locked_body
+    assert len(runs) == 1
+    assert runs[0].locked_post_submit_checker_policy_body == locked_body
+    assert "check_acceptance_criteria_present" not in locked_body["required_checkers"]
+    assert "check_acceptance_criteria_present" not in locked_body["execution_checkers"]
+    assert "check_evidence_present" in locked_body["default_checkers"]
+    assert "check_evidence_present" in locked_body["execution_checkers"]
+    assert "check_required_files" in locked_body["execution_checkers"]
+    assert "check_acceptance_criteria_present" not in {
+        result.checker_name for result in results
+    }
+    assert results != []
+
+
+async def test_lock_submission_rejects_malformed_locked_post_submit_policy_body_without_side_effects(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        submission = await session.get(Submission, created.json()["id"])
+        assert task is not None
+        assert submission is not None
+        corrupted_body = dict(submission.locked_post_submit_checker_policy_body or {})
+        corrupted_body["required_checkers"] = [
+            "check_policy_context_present",
+            "check_evidence_present",
+        ]
+        task.locked_post_submit_checker_policy_body = corrupted_body
+        submission.locked_post_submit_checker_policy_body = corrupted_body
+        await session.commit()
+
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    locked = await checker_client.post(
+        f"/api/v1/submissions/{created.json()['id']}/lock",
+        headers=auth_headers(),
+    )
+
+    assert locked.status_code == 422
+    assert "locked post-submit checker policy" in locked.json()["detail"]
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        submission = await session.get(Submission, created.json()["id"])
+        runs = (
+            await session.execute(
+                select(CheckerRun).where(CheckerRun.submission_id == created.json()["id"])
+            )
+        ).scalars().all()
+        results = (
+            await session.execute(
+                select(CheckerResult).where(CheckerResult.submission_id == created.json()["id"])
+            )
+        ).scalars().all()
+        audit_events = (
+            await session.execute(
+                select(AuditEvent).where(
+                    AuditEvent.entity_id.in_([started_task["id"], created.json()["id"]])
+                )
+            )
+        ).scalars().all()
+
+    assert task is not None
+    assert task.status == "submitted"
+    assert submission is not None
+    assert submission.locked_at is None
+    assert runs == []
+    assert results == []
+    assert "submission_locked" not in {event.event_type for event in audit_events}
+    assert "checker_run_triggered" not in {event.event_type for event in audit_events}
+
+
+async def test_database_rejects_mismatched_submission_post_submit_policy_context(
+    checker_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(checker_client)
+    started_task = await create_started_task(checker_client, project["id"], monkeypatch)
+    created = await checker_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert created.status_code == 201, created.text
+
+    async with db_session.get_session_factory()() as session:
+        submission = await session.get(Submission, created.json()["id"])
+        assert submission is not None
+        submission.locked_post_submit_checker_policy_hash = "sha256:" + "0" * 64
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        submission = await session.get(Submission, created.json()["id"])
+        runs = (
+            await session.execute(
+                select(CheckerRun).where(CheckerRun.submission_id == created.json()["id"])
+            )
+        ).scalars().all()
+        results = (
+            await session.execute(
+                select(CheckerResult).where(CheckerResult.submission_id == created.json()["id"])
+            )
+        ).scalars().all()
+    assert task is not None
+    assert task.status == "submitted"
+    assert submission is not None
+    assert submission.locked_at is None
+    assert submission.locked_post_submit_checker_policy_hash != "sha256:" + "0" * 64
+    assert runs == []
+    assert results == []
 
 
 async def test_locked_submission_checker_run_enforces_required_evidence_key(
@@ -840,8 +1171,8 @@ async def test_chunk8_default_blocking_checker_survives_empty_blocking_severitie
     assert project_response.status_code == 201, project_response.text
     project = project_response.json()
     guide_payload = complete_guide_payload()
-    guide_payload["checker_policy"]["required_checkers"] = ["check_policy_context_present"]
-    guide_payload["checker_policy"]["blocking_severities"] = []
+    guide_payload["post_submit_checker_policy"]["required_checkers"] = ["check_policy_context_present"]
+    guide_payload["post_submit_checker_policy"]["blocking_severities"] = []
     guide_response = await checker_client.post(
         f"/api/v1/projects/{project['id']}/guides",
         headers=auth_headers(),
@@ -992,7 +1323,7 @@ async def test_chunk8_task_setup_blocked_takes_priority_over_worker_revision(
     assert project_response.status_code == 201, project_response.text
     project = project_response.json()
     guide_payload = complete_guide_payload()
-    guide_payload["checker_policy"]["required_checkers"] = [
+    guide_payload["post_submit_checker_policy"]["required_checkers"] = [
         "check_acceptance_criteria_present"
     ]
     guide_response = await checker_client.post(
@@ -1037,7 +1368,7 @@ async def test_chunk8_task_setup_blocked_takes_priority_over_worker_revision(
     assert setup_result["status"] == "failed"
     assert setup_result["blocks_review"] is True
     assert setup_result["worker_visible"] is False
-    assert setup_result["worker_message"] is None
+    assert "worker_message" not in setup_result
     async with db_session.get_session_factory()() as session:
         task = await session.get(WorkstreamTask, started_task["id"])
     assert task is not None
@@ -1063,8 +1394,8 @@ async def test_chunk8_task_setup_blocked_takes_priority_over_worker_revision(
     )
     assert worker_read.status_code == 200, worker_read.text
     worker_body = worker_read.json()
-    assert worker_body["routing_recommendation"] == "not_evaluated"
-    assert worker_body["outcome_source"] == "none"
+    assert "routing_recommendation" not in worker_body
+    assert "outcome_source" not in worker_body
     assert worker_body["passed_count"] == 0
     assert worker_body["warning_count"] == 0
     assert worker_body["failed_count"] == 0
@@ -1237,7 +1568,8 @@ async def test_chunk10_checker_trial_runs_sample_submissions_through_real_api(
         )
         assert worker_read.status_code == 200, worker_read.text
         worker_body = worker_read.json()
-        assert worker_body["routing_recommendation"] == case["worker_route"]
+        assert "routing_recommendation" not in worker_body
+        assert "outcome_source" not in worker_body
         worker_result = next(
             result
             for result in worker_body["results"]
@@ -1303,9 +1635,14 @@ async def test_chunk10_checker_trial_runs_sample_submissions_through_real_api(
         headers=auth_headers(),
     )
     assert worker_blocked_read.status_code == 200, worker_blocked_read.text
-    assert worker_blocked_read.json()["routing_recommendation"] == "not_evaluated"
-    assert worker_blocked_read.json()["results"] == []
+    worker_blocked_body = worker_blocked_read.json()
+    assert "trigger_source" not in worker_blocked_body
+    assert "routing_recommendation" not in worker_blocked_body
+    assert "outcome_source" not in worker_blocked_body
+    assert worker_blocked_body["results"] == []
     assert "task_setup_blocked" not in worker_blocked_read.text
+    assert "submission_locked" not in worker_blocked_read.text
+    assert "manual_checker_trigger" not in worker_blocked_read.text
     assert "acceptance_criteria" not in worker_blocked_read.text
 
     async with db_session.get_session_factory()() as session:
@@ -1355,25 +1692,57 @@ async def test_worker_can_read_only_worker_visible_checker_result_fields(
 
     assert read.status_code == 200, read.text
     body = read.json()
-    assert body["failure_message"] is None
-    assert body["triggered_by"] is None
-    assert body["triggered_by_subject"] is None
-    assert body["triggered_by_issuer"] is None
-    assert body["trigger_auth_source"] is None
-    assert body["trigger_reason"] is None
-    assert body["audit_event_id"] is None
-    assert body["locked_guide_version"] is None
-    assert body["locked_checker_policy_version"] is None
-    assert body["locked_review_policy_version"] is None
-    assert body["locked_revision_policy_version"] is None
-    assert body["locked_payment_policy_version"] is None
-    assert body["package_hash"] is None
+    assert "trigger_source" not in body
+    assert "routing_recommendation" not in body
+    assert "outcome_source" not in body
+    assert "failure_message" not in body
+    assert "triggered_by" not in body
+    assert "triggered_by_subject" not in body
+    assert "triggered_by_issuer" not in body
+    assert "trigger_auth_source" not in body
+    assert "trigger_reason" not in body
+    assert "audit_event_id" not in body
+    assert "locked_guide_version" not in body
+    assert "locked_checker_policy_version" not in body
+    assert "locked_post_submit_checker_policy_id" not in body
+    assert "locked_post_submit_checker_policy_version" not in body
+    assert "locked_post_submit_checker_policy_hash" not in body
+    assert "locked_post_submit_checker_policy_body" not in body
+    assert "locked_review_policy_version" not in body
+    assert "locked_revision_policy_version" not in body
+    assert "locked_payment_policy_version" not in body
+    assert "package_hash" not in body
     assert body["artifact_hash_manifest"] == []
-    assert body["artifact_manifest_hash"] is None
+    assert "artifact_manifest_hash" not in body
+    assert "submission_locked" not in read.text
+    assert "manual_checker_trigger" not in read.text
     assert body["results"]
-    assert all(result["message"] is None for result in body["results"])
+    assert all("message" not in result for result in body["results"])
     assert all(result["metadata"] == {} for result in body["results"])
     assert all(result["worker_visible"] is True for result in body["results"])
+
+    listed = await checker_client.get(
+        f"/api/v1/submissions/{created.json()['id']}/checker-runs",
+        headers=auth_headers(),
+    )
+    assert listed.status_code == 200, listed.text
+    listed_body = listed.json()
+    assert len(listed_body) == 1
+    listed_run = listed_body[0]
+    assert listed_run["id"] == run["id"]
+    assert "trigger_source" not in listed_run
+    assert "routing_recommendation" not in listed_run
+    assert "outcome_source" not in listed_run
+    assert "failure_message" not in listed_run
+    assert "triggered_by" not in listed_run
+    assert "trigger_reason" not in listed_run
+    assert "audit_event_id" not in listed_run
+    assert "locked_post_submit_checker_policy_id" not in listed_run
+    assert "locked_post_submit_checker_policy_version" not in listed_run
+    assert "locked_post_submit_checker_policy_hash" not in listed_run
+    assert "locked_post_submit_checker_policy_body" not in listed_run
+    assert "submission_locked" not in listed.text
+    assert "manual_checker_trigger" not in listed.text
 
 
 async def test_worker_cannot_see_hidden_checker_results(
@@ -1599,7 +1968,7 @@ async def test_old_checker_name_blocks_guide_activation_without_alias(
     assert project_response.status_code == 201, project_response.text
     project = project_response.json()
     guide_payload = complete_guide_payload()
-    guide_payload["checker_policy"]["required_checkers"] = [old_checker_name]
+    guide_payload["post_submit_checker_policy"]["required_checkers"] = [old_checker_name]
     guide_response = await checker_client.post(
         f"/api/v1/projects/{project['id']}/guides",
         headers=auth_headers(),

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -36,12 +36,12 @@ from app.interfaces.project_agents import (
     SubmissionArtifactPolicyDerivationResult,
 )
 from app.modules.projects.models import (
-    CheckerPolicy,
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
     GuideSourceSnapshotItem,
     GuideSufficiencyReport,
     PaymentPolicy,
+    PostSubmitCheckerPolicy,
     PreSubmitCheckerPolicy,
     ProjectGuide,
     RevisionPolicy,
@@ -165,7 +165,7 @@ def test_setup_mutations_use_locked_guide_helper() -> None:
 
 def test_policy_models_have_project_guide_foreign_keys() -> None:
     expected_constraints = {
-        CheckerPolicy: "fk_checker_policies_project_guide",
+        PostSubmitCheckerPolicy: "fk_checker_policies_project_guide",
         ReviewPolicy: "fk_review_policies_project_guide",
         RevisionPolicy: "fk_revision_policies_project_guide",
         PaymentPolicy: "fk_payment_policies_project_guide",
@@ -261,6 +261,7 @@ def test_policy_models_bind_to_denormalized_policy_hashes() -> None:
 
 def test_policy_hash_pairs_are_unique_fk_targets() -> None:
     expected_constraints = {
+        PostSubmitCheckerPolicy: "uq_checker_policies_id_version_hash",
         SubmissionArtifactPolicy: "uq_submission_artifact_policies_id_hash",
         EffectiveProjectSubmissionArtifactPolicy: (
             "uq_effective_project_submission_artifact_policies_id_hash"
@@ -276,6 +277,7 @@ def test_policy_hash_pairs_are_unique_fk_targets() -> None:
         )
 
         assert [column.name for column in constraint.columns] in (
+            ["id", "guide_version", "policy_hash"],
             ["id", "policy_hash"],
             ["id", "effective_policy_hash"],
             ["id", "compiled_bundle_hash"],
@@ -336,7 +338,7 @@ def complete_guide_payload(version: str = "v1") -> dict:
         "evidence_policy": {"required": ["log"]},
         "unacceptable_work_policy": "Copied or unverifiable work.",
         "change_summary": f"Initial {version}",
-        "checker_policy": {
+        "post_submit_checker_policy": {
             "required_checkers": ["check_policy_context_present"],
             "warning_checkers": [],
             "blocking_severities": ["high"],
@@ -3588,7 +3590,7 @@ async def test_activation_does_not_require_legacy_evidence_policy(
 async def test_activation_requires_all_policies(project_client: AsyncClient) -> None:
     project = await create_project(project_client)
     payload = complete_guide_payload()
-    payload["checker_policy"] = None
+    payload["post_submit_checker_policy"] = None
     guide = await create_guide(project_client, project["id"], payload)
     await create_approved_policy_bundle(project_client, project["id"], guide["id"])
 
@@ -3720,7 +3722,7 @@ async def test_activation_rejects_unregistered_checker_names(
 ) -> None:
     project = await create_project(project_client)
     payload = complete_guide_payload()
-    payload["checker_policy"]["required_checkers"] = ["missing_checker"]
+    payload["post_submit_checker_policy"]["required_checkers"] = ["missing_checker"]
     guide = await create_guide(project_client, project["id"], payload)
     await create_approved_policy_bundle(project_client, project["id"], guide["id"])
 
@@ -3926,7 +3928,7 @@ async def test_guide_activation_and_active_guide_retrieval(project_client: Async
     assert active.status_code == 200, active.text
     assert active.json()["guide"]["status"] == "active"
     assert active.json()["guide"]["version"] == "v1"
-    assert active.json()["checker_policy"]["required_checkers"] == [
+    assert active.json()["post_submit_checker_policy"]["required_checkers"] == [
         "check_policy_context_present"
     ]
     assert active.json()["guide_source_snapshot"]["bundle_hash"] == (

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -27,6 +27,7 @@ from app.main import create_app
 from app.modules.tasks.lifecycle import InvalidTaskTransition, ensure_allowed_transition
 from app.modules.projects.models import (
     EffectiveProjectSubmissionArtifactPolicy,
+    PostSubmitCheckerPolicy,
     PreSubmitCheckerPolicy,
     SubmissionArtifactPolicy,
 )
@@ -131,7 +132,7 @@ def complete_guide_payload(version: str = "v1") -> dict:
         "evidence_policy": {"required": ["log"]},
         "unacceptable_work_policy": "Copied or unverifiable work.",
         "change_summary": f"Initial {version}",
-        "checker_policy": {
+        "post_submit_checker_policy": {
             "required_checkers": ["check_policy_context_present"],
             "warning_checkers": [],
             "blocking_severities": ["high"],
@@ -177,6 +178,26 @@ async def load_pre_submit_checker_policy(effective_policy: dict) -> dict:
         return {
             "compiled_bundle": pre_submit_checker_policy.compiled_bundle,
             "compiled_bundle_hash": pre_submit_checker_policy.compiled_bundle_hash,
+        }
+
+
+async def load_post_submit_checker_policy(project_id: str, guide_version: str = "v1") -> dict:
+    """Load the project post-submit checker policy attached to a guide version."""
+    async with db_session.get_session_factory()() as session:
+        policy = await session.scalar(
+            select(PostSubmitCheckerPolicy).where(
+                PostSubmitCheckerPolicy.project_id == project_id,
+                PostSubmitCheckerPolicy.guide_version == guide_version,
+            )
+        )
+        assert policy is not None
+        assert policy.policy_hash is not None
+        assert policy.policy_body is not None
+        return {
+            "id": policy.id,
+            "guide_version": policy.guide_version,
+            "policy_hash": policy.policy_hash,
+            "policy_body": policy.policy_body,
         }
 
 
@@ -537,6 +558,11 @@ def test_task_locked_context_constraints_bind_task_submission_and_hashes() -> No
             "locked_pre_submit_checker_policy_id",
             "locked_pre_submit_checker_bundle_hash",
         ],
+        "fk_workstream_tasks_locked_post_submit_policy_hash": [
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
     }
     for constraint_name, local_columns in expected_task_constraints.items():
         constraint = next(
@@ -566,6 +592,17 @@ def test_task_locked_context_constraints_bind_task_submission_and_hashes() -> No
             "locked_pre_submit_checker_policy_id",
             "locked_pre_submit_checker_bundle_hash",
         ],
+        "fk_submissions_task_locked_post_submit_policy_hash": [
+            "task_id",
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
+        "fk_submissions_locked_post_submit_policy_hash": [
+            "locked_post_submit_checker_policy_id",
+            "locked_post_submit_checker_policy_version",
+            "locked_post_submit_checker_policy_hash",
+        ],
     }
     for constraint_name, local_columns in expected_submission_constraints.items():
         constraint = next(
@@ -579,12 +616,20 @@ def test_task_locked_context_constraints_bind_task_submission_and_hashes() -> No
         "ix_workstream_tasks_locked_source_snapshot",
         "ix_workstream_tasks_locked_effective_policy_hash",
         "ix_workstream_tasks_locked_pre_submit_checker_hash",
+        "ix_workstream_tasks_locked_post_submit_policy_hash",
     }.issubset({index.name for index in WorkstreamTask.__table__.indexes})
     assert {
         "ix_submissions_locked_source_snapshot",
         "ix_submissions_locked_effective_policy_hash",
         "ix_submissions_locked_pre_submit_checker_hash",
+        "ix_submissions_locked_post_submit_policy_hash",
     }.issubset({index.name for index in Submission.__table__.indexes})
+    assert "ck_workstream_tasks_post_submit_policy_lock_complete" in {
+        constraint.name for constraint in WorkstreamTask.__table__.constraints
+    }
+    assert "ck_submissions_post_submit_policy_lock_complete" in {
+        constraint.name for constraint in Submission.__table__.constraints
+    }
 
 
 async def test_profile_upserts_update_existing_actor_rows(task_database_env: str) -> None:
@@ -672,9 +717,52 @@ async def test_task_can_be_created_in_draft(task_client: AsyncClient) -> None:
     task = await create_draft_task(task_client, project["id"])
 
     assert task["status"] == "draft"
-    assert task["locked_guide_version"] is None
+    assert "locked_guide_version" not in task
     assert task["skill_tags"] == ["stem", "proofs"]
     assert task["source_ref"] == "local-ticket-1"
+
+
+async def test_task_create_and_transitions_reject_client_supplied_policy_context(
+    task_client: AsyncClient,
+) -> None:
+    project = await create_active_project(task_client)
+    locked_context_payload = {
+        "locked_post_submit_checker_policy_id": "malicious",
+        "locked_post_submit_checker_policy_version": "malicious",
+        "locked_post_submit_checker_policy_hash": "sha256:" + "0" * 64,
+        "locked_post_submit_checker_policy_body": {"required_checkers": []},
+    }
+
+    create_payload = complete_task_payload()
+    create_payload.update(locked_context_payload)
+    create_response = await task_client.post(
+        f"/api/v1/projects/{project['id']}/tasks",
+        headers=auth_headers(),
+        json=create_payload,
+    )
+    assert create_response.status_code == 422
+
+    task = await create_draft_task(task_client, project["id"])
+    screen_response = await task_client.post(
+        f"/api/v1/tasks/{task['id']}/screen",
+        headers=auth_headers(),
+        json={"reason": "screen", **locked_context_payload},
+    )
+    assert screen_response.status_code == 422
+
+    valid_screen = await task_client.post(
+        f"/api/v1/tasks/{task['id']}/screen",
+        headers=auth_headers(),
+        json={"reason": "screen"},
+    )
+    assert valid_screen.status_code == 200, valid_screen.text
+
+    release_response = await task_client.post(
+        f"/api/v1/tasks/{task['id']}/release",
+        headers=auth_headers(),
+        json={"reason": "release", **locked_context_payload},
+    )
+    assert release_response.status_code == 422
 
 
 async def test_screening_requires_active_guide_context(task_client: AsyncClient) -> None:
@@ -776,7 +864,7 @@ async def test_screening_locks_guide_policy_context_and_payment_fields(
     body = response.json()
     assert body["status"] == "screening"
     assert body["locked_guide_version"] == "v1"
-    assert body["locked_checker_policy_version"] == "v1"
+    assert "locked_checker_policy_version" not in body
     assert body["locked_review_policy_version"] == "v1"
     assert body["locked_revision_policy_version"] == "v1"
     assert body["locked_payment_policy_version"] == "v1"
@@ -786,9 +874,148 @@ async def test_screening_locks_guide_policy_context_and_payment_fields(
     assert body["locked_effective_project_submission_artifact_policy_hash"].startswith("sha256:")
     assert body["locked_pre_submit_checker_policy_id"]
     assert body["locked_pre_submit_checker_bundle_hash"].startswith("sha256:")
+    expected_post_submit_policy = await load_post_submit_checker_policy(project["id"])
+    async with db_session.get_session_factory()() as session:
+        persisted_task = await session.get(WorkstreamTask, task["id"])
+    assert persisted_task is not None
+    assert persisted_task.locked_post_submit_checker_policy_id == expected_post_submit_policy["id"]
+    assert persisted_task.locked_post_submit_checker_policy_version == "v1"
+    assert (
+        persisted_task.locked_post_submit_checker_policy_hash
+        == expected_post_submit_policy["policy_hash"]
+    )
     assert body["base_amount"] == "25.00"
     assert body["currency"] == "USD"
     assert body["payout_type"] == "fixed"
+
+
+async def test_screening_uses_persisted_post_submit_policy_body_after_default_drift(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.modules.projects import post_submit_policy as post_submit_policy_module
+
+    project = await create_active_project(task_client)
+    async with db_session.get_session_factory()() as session:
+        source_policy = await session.scalar(
+            select(PostSubmitCheckerPolicy).where(
+                PostSubmitCheckerPolicy.project_id == project["id"],
+                PostSubmitCheckerPolicy.guide_version == "v1",
+            )
+        )
+        assert source_policy is not None
+        persisted_body = dict(source_policy.policy_body or {})
+
+    monkeypatch.setattr(
+        post_submit_policy_module,
+        "DEFAULT_DURABLE_CHECKERS",
+        [
+            *post_submit_policy_module.DEFAULT_DURABLE_CHECKERS,
+            "check_acceptance_criteria_present",
+        ],
+    )
+    task = await create_draft_task(task_client, project["id"])
+
+    response = await task_client.post(
+        f"/api/v1/tasks/{task['id']}/screen",
+        headers=auth_headers(),
+        json={"reason": "screen"},
+    )
+
+    assert response.status_code == 200, response.text
+    async with db_session.get_session_factory()() as session:
+        persisted_task = await session.get(WorkstreamTask, task["id"])
+    assert persisted_task is not None
+    assert persisted_task.locked_post_submit_checker_policy_body == persisted_body
+    assert "check_acceptance_criteria_present" not in (
+        persisted_task.locked_post_submit_checker_policy_body or {}
+    )["execution_checkers"]
+
+
+async def test_release_uses_locked_post_submit_policy_body_after_setup_mutation(
+    task_client: AsyncClient,
+) -> None:
+    project = await create_active_project(task_client)
+    task = await create_draft_task(task_client, project["id"])
+    screen = await task_client.post(
+        f"/api/v1/tasks/{task['id']}/screen",
+        headers=auth_headers(),
+        json={"reason": "screening checklist passed"},
+    )
+    assert screen.status_code == 200, screen.text
+    async with db_session.get_session_factory()() as session:
+        persisted_task = await session.get(WorkstreamTask, task["id"])
+        assert persisted_task is not None
+        locked_body = dict(persisted_task.locked_post_submit_checker_policy_body or {})
+        post_submit_policy = await session.get(
+            PostSubmitCheckerPolicy,
+            persisted_task.locked_post_submit_checker_policy_id,
+        )
+        assert post_submit_policy is not None
+        post_submit_policy.required_checkers = [
+            *post_submit_policy.required_checkers,
+            "check_acceptance_criteria_present",
+        ]
+        await session.commit()
+
+    release = await task_client.post(
+        f"/api/v1/tasks/{task['id']}/release",
+        headers=auth_headers(),
+        json={"reason": "release decision recorded"},
+    )
+
+    assert release.status_code == 200, release.text
+    assert release.json()["status"] == "ready"
+    async with db_session.get_session_factory()() as session:
+        persisted_task = await session.get(WorkstreamTask, task["id"])
+    assert persisted_task is not None
+    assert persisted_task.status == "ready"
+    assert persisted_task.locked_post_submit_checker_policy_body == locked_body
+    assert "check_acceptance_criteria_present" not in locked_body["required_checkers"]
+    assert "check_acceptance_criteria_present" not in locked_body["execution_checkers"]
+    assert "check_required_files" in locked_body["default_checkers"]
+    assert "check_required_files" in locked_body["execution_checkers"]
+
+
+async def test_worker_task_response_redacts_locked_policy_hashes(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    ready_task = await create_ready_task(task_client, project["id"])
+    operator_response = await task_client.get(
+        f"/api/v1/tasks/{ready_task['id']}",
+        headers=auth_headers(),
+    )
+
+    assert operator_response.status_code == 200, operator_response.text
+    assert "locked_checker_policy_version" not in operator_response.json()
+
+    await seed_worker_profile("worker-one")
+    set_dev_actor(monkeypatch, roles="worker", subject="worker-one")
+
+    response = await task_client.get(
+        f"/api/v1/tasks/{ready_task['id']}",
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["status"] == "ready"
+    assert "locked_checker_policy_version" not in body
+    for internal_field in (
+        "locked_guide_source_snapshot_id",
+        "locked_guide_source_snapshot_hash",
+        "locked_effective_project_submission_artifact_policy_id",
+        "locked_effective_project_submission_artifact_policy_hash",
+        "locked_pre_submit_checker_policy_id",
+        "locked_pre_submit_checker_bundle_hash",
+        "locked_post_submit_checker_policy_id",
+        "locked_post_submit_checker_policy_version",
+        "locked_post_submit_checker_policy_hash",
+        "locked_post_submit_checker_policy_body",
+    ):
+        assert internal_field not in body
 
 
 async def test_tasks_under_same_active_guide_share_project_pre_submit_checker(
@@ -987,7 +1214,7 @@ async def test_full_task_claim_start_flow_writes_audit_events(
     release_event = next(event for event in events if event["to_status"] == "ready")
     for event in (screening_event, release_event):
         assert event["event_payload"]["locked_guide_version"] == "v1"
-        assert event["event_payload"]["locked_checker_policy_version"] == "v1"
+        assert "locked_checker_policy_version" not in event["event_payload"]
         assert event["event_payload"]["locked_review_policy_version"] == "v1"
         assert event["event_payload"]["locked_revision_policy_version"] == "v1"
         assert event["event_payload"]["locked_payment_policy_version"] == "v1"
@@ -1141,24 +1368,48 @@ async def test_assigned_worker_submits_v1_and_task_moves_to_submitted(
     assert submission["worker_id"] == worker_actor_id
     assert submission["version"] == 1
     assert submission["status"] == "submitted"
-    assert submission["locked_guide_version"] == "v1"
-    assert submission["locked_checker_policy_version"] == "v1"
-    assert submission["locked_review_policy_version"] == "v1"
-    assert submission["locked_revision_policy_version"] == "v1"
-    assert submission["locked_payment_policy_version"] == "v1"
-    assert submission["locked_guide_source_snapshot_id"]
-    assert submission["locked_guide_source_snapshot_hash"].startswith("sha256:")
-    assert submission["locked_effective_project_submission_artifact_policy_id"]
-    assert submission["locked_effective_project_submission_artifact_policy_hash"].startswith(
-        "sha256:"
+    assert "locked_checker_policy_version" not in submission
+    for internal_field in (
+        "package_uri",
+        "package_hash",
+        "artifact_hash_manifest",
+        "worker_attestation",
+        "locked_guide_version",
+        "locked_review_policy_version",
+        "locked_revision_policy_version",
+        "locked_payment_policy_version",
+        "locked_guide_source_snapshot_id",
+        "locked_guide_source_snapshot_hash",
+        "locked_effective_project_submission_artifact_policy_id",
+        "locked_effective_project_submission_artifact_policy_hash",
+        "locked_pre_submit_checker_policy_id",
+        "locked_pre_submit_checker_bundle_hash",
+        "locked_post_submit_checker_policy_id",
+        "locked_post_submit_checker_policy_version",
+        "locked_post_submit_checker_policy_hash",
+        "locked_post_submit_checker_policy_body",
+    ):
+        assert internal_field not in submission
+    assert submission["evidence_items"][0]["metadata"] == {}
+    assert "uri" not in submission["evidence_items"][0]
+    assert "hash" not in submission["evidence_items"][0]
+    async with db_session.get_session_factory()() as session:
+        persisted_submission = await session.get(Submission, submission["id"])
+        persisted_task = await session.get(WorkstreamTask, started_task["id"])
+    assert persisted_submission is not None
+    assert persisted_task is not None
+    assert (
+        persisted_submission.locked_post_submit_checker_policy_id
+        == persisted_task.locked_post_submit_checker_policy_id
     )
-    assert submission["locked_pre_submit_checker_policy_id"]
-    assert submission["locked_pre_submit_checker_bundle_hash"].startswith("sha256:")
-    assert submission["artifact_hash_manifest"][0]["artifact"] == "answer.md"
-    assert submission["evidence_items"][0]["metadata"] == {
-        "command": "pytest",
-        "policy_key": "checker_log",
-    }
+    assert (
+        persisted_submission.locked_post_submit_checker_policy_version
+        == persisted_task.locked_post_submit_checker_policy_version
+    )
+    assert (
+        persisted_submission.locked_post_submit_checker_policy_hash
+        == persisted_task.locked_post_submit_checker_policy_hash
+    )
 
     task = await task_client.get(f"/api/v1/tasks/{started_task['id']}", headers=auth_headers())
     assert task.status_code == 200, task.text
@@ -1175,17 +1426,29 @@ async def test_assigned_worker_submits_v1_and_task_moves_to_submitted(
     assert submission_event["to_status"] == "submitted"
     assert submission_event["event_payload"]["submission_id"] == submission["id"]
     assert submission_event["event_payload"]["submission_version"] == 1
-    assert submission_event["event_payload"]["package_hash"] == "sha256:package-v1"
-    assert submission_event["event_payload"]["locked_guide_source_snapshot_id"]
-    assert submission_event["event_payload"]["locked_guide_source_snapshot_hash"].startswith(
-        "sha256:"
+    assert "package_hash" not in submission_event["event_payload"]
+    assert "artifact_hash_manifest" not in submission_event["event_payload"]
+    assert "locked_guide_source_snapshot_id" not in submission_event["event_payload"]
+    assert "locked_guide_source_snapshot_hash" not in submission_event["event_payload"]
+    assert "locked_effective_project_submission_artifact_policy_hash" not in (
+        submission_event["event_payload"]
     )
-    assert submission_event["event_payload"][
-        "locked_effective_project_submission_artifact_policy_hash"
-    ].startswith("sha256:")
-    assert submission_event["event_payload"]["locked_pre_submit_checker_bundle_hash"].startswith(
-        "sha256:"
+    assert "locked_pre_submit_checker_bundle_hash" not in submission_event["event_payload"]
+    assert "locked_post_submit_checker_policy_hash" not in submission_event["event_payload"]
+
+    async with db_session.get_session_factory()() as session:
+        stored_submission_event = await session.scalar(
+            select(AuditEvent).where(
+                AuditEvent.entity_id == started_task["id"],
+                AuditEvent.event_type == "submission_created",
+            )
+        )
+    assert stored_submission_event is not None
+    assert (
+        stored_submission_event.event_payload["locked_post_submit_checker_policy_hash"]
+        == persisted_submission.locked_post_submit_checker_policy_hash
     )
+    assert stored_submission_event.event_payload["package_hash"] == "sha256:package-v1"
     assert "package_uri" not in submission_event["event_payload"]
 
 
@@ -1203,6 +1466,10 @@ async def test_submission_schema_rejects_worker_supplied_locked_context(
             "status": "submitted",
             "locked_guide_version": "malicious",
             "locked_checker_policy_version": "malicious",
+            "locked_post_submit_checker_policy_id": "malicious",
+            "locked_post_submit_checker_policy_version": "malicious",
+            "locked_post_submit_checker_policy_hash": "sha256:" + "0" * 64,
+            "locked_post_submit_checker_policy_body": {"required_checkers": []},
             "locked_review_policy_version": "malicious",
             "locked_revision_policy_version": "malicious",
             "locked_payment_policy_version": "malicious",
@@ -1716,6 +1983,174 @@ async def test_submission_pre_submit_checker_setup_error_is_controlled(
     assert submissions == []
 
 
+async def test_submission_uses_locked_post_submit_policy_body_after_setup_mutation(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        assert task is not None
+        locked_body = dict(task.locked_post_submit_checker_policy_body or {})
+        post_submit_policy = await session.get(
+            PostSubmitCheckerPolicy,
+            task.locked_post_submit_checker_policy_id,
+        )
+        assert post_submit_policy is not None
+        post_submit_policy.required_checkers = [
+            *post_submit_policy.required_checkers,
+            "check_acceptance_criteria_present",
+        ]
+        await session.commit()
+
+    response = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+
+    assert response.status_code == 201, response.text
+
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        submissions = (
+            await session.execute(select(Submission).where(Submission.task_id == started_task["id"]))
+        ).scalars().all()
+        checker_runs = (await session.execute(select(db_models.CheckerRun))).scalars().all()
+    assert task is not None
+    assert task.status == "submitted"
+    assert len(submissions) == 1
+    assert submissions[0].locked_post_submit_checker_policy_body == locked_body
+    assert "check_acceptance_criteria_present" not in locked_body["required_checkers"]
+    assert "check_acceptance_criteria_present" not in locked_body["execution_checkers"]
+    assert "check_required_files" in locked_body["default_checkers"]
+    assert "check_required_files" in locked_body["execution_checkers"]
+    assert checker_runs == []
+
+
+async def test_database_rejects_null_post_submit_context_on_non_draft_task(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        assert task is not None
+        task.locked_post_submit_checker_policy_id = None
+        task.locked_post_submit_checker_policy_version = None
+        task.locked_post_submit_checker_policy_hash = None
+        with pytest.raises(IntegrityError):
+            await session.commit()
+        await session.rollback()
+
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        submissions = (
+            await session.execute(select(Submission).where(Submission.task_id == started_task["id"]))
+        ).scalars().all()
+        checker_runs = (await session.execute(select(db_models.CheckerRun))).scalars().all()
+    assert task is not None
+    assert task.status == "in_progress"
+    assert submissions == []
+    assert checker_runs == []
+
+
+async def test_database_rejects_submission_without_post_submit_policy_context(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        assert task is not None
+        submission = Submission(
+            id=str(uuid4()),
+            task_id=task.id,
+            worker_id=actor_id("worker-one"),
+            version=1,
+            status="submitted",
+            summary="Bypass submission without post-submit policy provenance.",
+            package_hash="sha256:package-bypass",
+            artifact_hash_manifest=[{"artifact": "answer.md", "hash": "sha256:answer-bypass"}],
+            worker_attestation="Bypass attestation.",
+            locked_guide_version=task.locked_guide_version,
+            locked_checker_policy_version=task.locked_checker_policy_version,
+            locked_post_submit_checker_policy_id=None,
+            locked_post_submit_checker_policy_version=None,
+            locked_post_submit_checker_policy_hash=None,
+            locked_post_submit_checker_policy_body=None,
+            locked_review_policy_version=task.locked_review_policy_version,
+            locked_revision_policy_version=task.locked_revision_policy_version,
+            locked_payment_policy_version=task.locked_payment_policy_version,
+            locked_guide_source_snapshot_id=task.locked_guide_source_snapshot_id,
+            locked_guide_source_snapshot_hash=task.locked_guide_source_snapshot_hash,
+            locked_effective_project_submission_artifact_policy_id=(
+                task.locked_effective_project_submission_artifact_policy_id
+            ),
+            locked_effective_project_submission_artifact_policy_hash=(
+                task.locked_effective_project_submission_artifact_policy_hash
+            ),
+            locked_pre_submit_checker_policy_id=task.locked_pre_submit_checker_policy_id,
+            locked_pre_submit_checker_bundle_hash=task.locked_pre_submit_checker_bundle_hash,
+        )
+        session.add(submission)
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+async def test_database_rejects_checker_run_without_post_submit_policy_context(
+    task_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project = await create_active_project(task_client)
+    started_task = await create_started_task(task_client, project["id"], monkeypatch)
+    submission_response = await task_client.post(
+        f"/api/v1/tasks/{started_task['id']}/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+    assert submission_response.status_code == 201, submission_response.text
+    async with db_session.get_session_factory()() as session:
+        task = await session.get(WorkstreamTask, started_task["id"])
+        submission = await session.get(Submission, submission_response.json()["id"])
+        assert task is not None
+        assert submission is not None
+        checker_run = db_models.CheckerRun(
+            id=str(uuid4()),
+            task_id=task.id,
+            submission_id=submission.id,
+            submission_version=submission.version,
+            trigger_source="submission_locked",
+            status="queued",
+            routing_recommendation="not_evaluated",
+            outcome_source="none",
+            triggered_by="project-manager",
+            triggered_by_subject="project-manager-subject",
+            triggered_by_issuer="flow-test",
+            trigger_auth_source="dev_mock",
+            attempt_number=1,
+            is_current_for_submission=True,
+            locked_guide_version=submission.locked_guide_version,
+            locked_checker_policy_version=submission.locked_checker_policy_version,
+            locked_post_submit_checker_policy_id=None,
+            locked_post_submit_checker_policy_version=None,
+            locked_post_submit_checker_policy_hash=None,
+            locked_post_submit_checker_policy_body=None,
+            locked_review_policy_version=submission.locked_review_policy_version,
+            locked_revision_policy_version=submission.locked_revision_policy_version,
+            locked_payment_policy_version=submission.locked_payment_policy_version,
+            package_hash=submission.package_hash,
+            artifact_hash_manifest=submission.artifact_hash_manifest,
+            artifact_manifest_hash=canonical_json_hash(submission.artifact_hash_manifest),
+        )
+        session.add(checker_run)
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
 async def test_submission_versioning_creates_new_rows_and_preserves_v1(
     task_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -1749,8 +2184,13 @@ async def test_submission_versioning_creates_new_rows_and_preserves_v1(
     second = v2.json()
     assert second["version"] == 2
     assert second["supersedes_submission_id"] == first["id"]
-    assert first["package_hash"] == "sha256:package-v1"
-    assert first["artifact_hash_manifest"][0]["hash"] == "sha256:answer-v1"
+    assert "package_hash" not in first
+    assert "artifact_hash_manifest" not in first
+    async with db_session.get_session_factory()() as session:
+        persisted_v1 = await session.get(Submission, first["id"])
+    assert persisted_v1 is not None
+    assert persisted_v1.package_hash == "sha256:package-v1"
+    assert persisted_v1.artifact_hash_manifest[0]["hash"] == "sha256:answer-v1"
 
     listed = await task_client.get(
         f"/api/v1/tasks/{started_task['id']}/submissions",
@@ -1758,6 +2198,8 @@ async def test_submission_versioning_creates_new_rows_and_preserves_v1(
     )
     assert listed.status_code == 200, listed.text
     assert [submission["version"] for submission in listed.json()] == [1, 2]
+    assert all("package_hash" not in submission for submission in listed.json())
+    assert all("artifact_hash_manifest" not in submission for submission in listed.json())
 
     set_dev_actor(monkeypatch, roles="worker", subject="worker-two")
     await seed_worker_profile("worker-two")
@@ -1799,11 +2241,19 @@ async def test_submission_uses_task_locked_context_after_new_guide_activation(
 
     assert response.status_code == 201, response.text
     submission = response.json()
-    assert submission["locked_guide_version"] == "v1"
-    assert submission["locked_checker_policy_version"] == "v1"
+    assert "locked_checker_policy_version" not in submission
+    assert "locked_guide_version" not in submission
+    async with db_session.get_session_factory()() as session:
+        persisted_submission = await session.get(Submission, submission["id"])
+        persisted_task = await session.get(WorkstreamTask, started_task["id"])
+    assert persisted_submission is not None
+    assert persisted_task is not None
+    assert persisted_submission.locked_guide_version == "v1"
+    assert persisted_task.locked_guide_version == "v1"
     task = await task_client.get(f"/api/v1/tasks/{started_task['id']}", headers=auth_headers())
     assert task.status_code == 200, task.text
     assert task.json()["locked_guide_version"] == "v1"
+    assert "locked_guide_source_snapshot_hash" not in task.json()
 
 
 async def test_locked_submission_can_only_be_replaced_by_new_version(
@@ -1851,8 +2301,13 @@ async def test_locked_submission_can_only_be_replaced_by_new_version(
     )
     assert fetched_v1.status_code == 200, fetched_v1.text
     assert fetched_v1.json()["locked_at"] == locked_v1.json()["locked_at"]
-    assert fetched_v1.json()["package_hash"] == "sha256:package-v1"
-    assert fetched_v1.json()["artifact_hash_manifest"][0]["hash"] == "sha256:answer-v1"
+    assert "package_hash" not in fetched_v1.json()
+    assert "artifact_hash_manifest" not in fetched_v1.json()
+    async with db_session.get_session_factory()() as session:
+        persisted_v1 = await session.get(Submission, v1.json()["id"])
+    assert persisted_v1 is not None
+    assert persisted_v1.package_hash == "sha256:package-v1"
+    assert persisted_v1.artifact_hash_manifest[0]["hash"] == "sha256:answer-v1"
 
 
 async def test_project_manager_cannot_submit_as_worker(
@@ -2180,6 +2635,8 @@ async def test_database_enforces_unique_submission_version(
     body = created.json()
 
     async with db_session.get_session_factory()() as session:
+        persisted = await session.get(Submission, body["id"])
+        assert persisted is not None
         session.add(
             Submission(
                 id=str(uuid4()),
@@ -2188,14 +2645,26 @@ async def test_database_enforces_unique_submission_version(
                 version=body["version"],
                 status="submitted",
                 summary="duplicate",
-                package_hash="sha256:duplicate",
-                artifact_hash_manifest=body["artifact_hash_manifest"],
-                worker_attestation="duplicate",
-                locked_guide_version=body["locked_guide_version"],
-                locked_checker_policy_version=body["locked_checker_policy_version"],
-                locked_review_policy_version=body["locked_review_policy_version"],
-                locked_revision_policy_version=body["locked_revision_policy_version"],
-                locked_payment_policy_version=body["locked_payment_policy_version"],
+                package_hash=persisted.package_hash,
+                artifact_hash_manifest=persisted.artifact_hash_manifest,
+                worker_attestation=persisted.worker_attestation,
+                locked_guide_version=persisted.locked_guide_version,
+                locked_checker_policy_version=persisted.locked_checker_policy_version,
+                locked_post_submit_checker_policy_id=(
+                    persisted.locked_post_submit_checker_policy_id
+                ),
+                locked_post_submit_checker_policy_version=(
+                    persisted.locked_post_submit_checker_policy_version
+                ),
+                locked_post_submit_checker_policy_hash=(
+                    persisted.locked_post_submit_checker_policy_hash
+                ),
+                locked_post_submit_checker_policy_body=(
+                    persisted.locked_post_submit_checker_policy_body
+                ),
+                locked_review_policy_version=persisted.locked_review_policy_version,
+                locked_revision_policy_version=persisted.locked_revision_policy_version,
+                locked_payment_policy_version=persisted.locked_payment_policy_version,
             )
         )
         with pytest.raises(IntegrityError):

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -273,8 +273,8 @@ Draft packet
 -> create Submission only when blocking pre-submit checks pass
 -> lock submission
 -> create CheckerRun
--> load locked PostSubmitCheckerPolicy
--> run required checkers
+-> validate locked PostSubmitCheckerPolicy id/version/hash/body
+-> execute locked PostSubmitCheckerPolicy execution_checkers
 -> store CheckerResult records
 -> calculate blocking status
 -> if no blocking failures remain: store readiness proof on CheckerRun and move to REVIEW_PENDING
@@ -298,7 +298,8 @@ When all blocking checks pass, the checker service stores readiness proof on the
 The checker run records:
 
 - submission id
-- post-submit checker policy version derived from the locked task context
+- post-submit checker policy id, version, hash, and internal locked body
+  stamped from the locked submission context
 - artifact hash manifest
 - blocking failure count
 - warning count
@@ -316,6 +317,10 @@ Workers see:
 - severity
 - message
 - suggested fix when safe
+
+Worker-facing checker-run responses do not expose `routing_recommendation`,
+`outcome_source`, internal route tokens, post-submit policy provenance fields,
+locked post-submit policy body, or hidden task setup details.
 
 Reviewers see:
 

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -589,22 +589,88 @@ Fields:
 - `required_checkers`
 - `warning_checkers`
 - `blocking_severities`
+- `policy_hash`
+- `policy_body`
 - `created_at`
+
+`policy_body` is the canonical source for post-submit checker execution. The
+hash is `sha256(canonical_json(policy_body))`. `required_checkers`,
+`warning_checkers`, and `blocking_severities` are query projections and must
+match `policy_body`.
+
+When a task locks its project context, Workstream stamps
+`locked_post_submit_checker_policy_body` by copying the persisted project
+`PostSubmitCheckerPolicy.policy_body`. Submissions copy that body from the task,
+and durable checker runs copy it from the submission. Checker execution
+validates the body against the stamped hash and executes from that locked body,
+not from mutable project setup rows or the current default-checker constant.
+Later project policy edits therefore cannot change already locked task,
+submission, or checker-run behavior.
+
+The policy body includes:
+
+- `schema_version`
+- `project_id`
+- `guide_version`
+- `default_checkers`
+- `required_checkers`
+- `warning_checkers`
+- `execution_checkers`
+- `blocking_severities`
+
+`execution_checkers` is the complete ordered durable checker list. It is
+computed from Workstream default durable checkers plus project required and
+warning checkers, and it is covered by `policy_hash`.
 
 Example:
 
 ```json
 {
+  "schema_version": "post_submit_checker_policy.v1",
+  "project_id": "project-id",
+  "guide_version": "v1",
+  "default_checkers": [
+    "check_submission_packet",
+    "check_policy_context_present",
+    "check_evidence_present",
+    "check_evidence_integrity",
+    "check_required_files",
+    "check_forbidden_files",
+    "check_confidentiality_attestation",
+    "check_low_quality_generated_artifacts"
+  ],
   "required_checkers": [
     "check_policy_context_present",
     "check_submission_packet",
     "check_evidence_present"
+  ],
+  "warning_checkers": [],
+  "execution_checkers": [
+    "check_submission_packet",
+    "check_policy_context_present",
+    "check_evidence_present",
+    "check_evidence_integrity",
+    "check_required_files",
+    "check_forbidden_files",
+    "check_confidentiality_attestation",
+    "check_low_quality_generated_artifacts"
   ],
   "blocking_severities": ["high"]
 }
 ```
 
 Post-submit checker policy governs durable internal checker runs after a submission is locked. It does not replace the generated project pre-submit checker policy.
+
+Migration note: the `0008_post_submit_checker_policy` migration adds explicit
+post-submit policy hash, body, and lock columns. Existing local v0.1 checker
+policy rows without policy hashes are intentionally not backfilled into
+authority. They must be recreated or repaired through the project setup
+lifecycle. Existing non-draft task, submission, or checker-run rows from the
+construction database block the migration with an explicit preflight error
+because Workstream cannot truthfully infer which post-submit policy body and
+hash governed those runtime records. After the migration, runtime records fail
+closed when a task, submission, or checker run lacks valid
+`locked_post_submit_checker_policy_*` context.
 
 ## ReviewPolicy
 
@@ -699,6 +765,10 @@ Fields:
 - `locked_pre_submit_checker_policy_id`
 - `locked_pre_submit_checker_bundle_hash`
 - `locked_checker_policy_version`
+- `locked_post_submit_checker_policy_id`
+- `locked_post_submit_checker_policy_version`
+- `locked_post_submit_checker_policy_hash`
+- `locked_post_submit_checker_policy_body`
 - `locked_review_policy_version`
 - `locked_revision_policy_version`
 - `locked_payment_policy_version`
@@ -753,14 +823,18 @@ External origin adapters are later work. When added, they normalize into this ta
 The task id points to the locked task contract. That contract includes the guide
 version, guide source snapshot id/hash, effective project submission artifact
 policy id/hash, generated project pre-submit checker policy id/bundle hash,
-current checker policy version, review policy version, revision policy
-version, payment policy version, acceptance criteria, derived display summaries,
-base payout, and skill tags. Workers submit against the task id; they do not
-restate policy versions.
+legacy checker policy version, post-submit checker policy id/version/hash,
+review policy version, revision policy version, payment policy version,
+acceptance criteria, derived display summaries, base payout, and skill tags.
+Workers submit against the task id; they do not restate policy versions.
 
-Implementation note: current v0.1 code uses `locked_checker_policy_version`
-for current checker-policy provenance. The later post-submit split adds
-explicit post-submit checker provenance.
+Implementation note: `locked_checker_policy_version` is retained only as
+legacy/admin-visible context. Durable post-submit checker execution uses
+`locked_post_submit_checker_policy_id`,
+`locked_post_submit_checker_policy_version`, and
+`locked_post_submit_checker_policy_hash`.
+Worker-facing task responses omit the legacy checker-policy version and
+post-submit checker policy internals.
 
 ## Assignment
 
@@ -797,6 +871,10 @@ Fields:
 - `locked_pre_submit_checker_policy_id`
 - `locked_pre_submit_checker_bundle_hash`
 - `locked_checker_policy_version`
+- `locked_post_submit_checker_policy_id`
+- `locked_post_submit_checker_policy_version`
+- `locked_post_submit_checker_policy_hash`
+- `locked_post_submit_checker_policy_body`
 - `locked_review_policy_version`
 - `locked_revision_policy_version`
 - `locked_payment_policy_version`
@@ -812,10 +890,15 @@ checker, review, revision, and payment policy provenance from trusted
 task/project state. The worker does not provide submission version, evidence
 ids, checker results, checker run ids, guide versions, source snapshots,
 effective project policy ids/hashes, pre-submit checker ids/bundle hashes,
-current checker policy versions, review policy versions, revision policy
-versions, or payment policy versions.
+legacy checker policy versions, post-submit checker policy ids/versions/hashes,
+review policy versions, revision policy versions, or payment policy versions.
 
-Implementation note: current v0.1 code stamps explicit effective project submission artifact policy and pre-submit checker provenance on submissions. `locked_checker_policy_version` remains the v0.1 post-submit checker policy reference until `WS-POL-001-04` splits post-submit checker provenance into a dedicated `PostSubmitCheckerPolicy`.
+Implementation note: submissions stamp explicit post-submit checker provenance
+from the task. Durable `CheckerRun` creation uses those
+`locked_post_submit_checker_policy_*` fields and fails closed when they are
+missing, mismatched, deleted, stale, or unauthorized.
+Worker-facing submission responses omit the legacy checker-policy version and
+post-submit checker policy internals.
 
 Status:
 
@@ -872,6 +955,10 @@ Fields:
 - `runner_version`
 - `locked_guide_version`
 - `locked_checker_policy_version`
+- `locked_post_submit_checker_policy_id`
+- `locked_post_submit_checker_policy_version`
+- `locked_post_submit_checker_policy_hash`
+- `locked_post_submit_checker_policy_body`
 - `locked_review_policy_version`
 - `locked_revision_policy_version`
 - `locked_payment_policy_version`

--- a/docs/operations_queue_policy.md
+++ b/docs/operations_queue_policy.md
@@ -216,7 +216,7 @@ Every operating day starts with:
 | `DRAFT -> SCREENING` | project id, locked guide candidate, required task fields, payment policy |
 | `SCREENING -> READY` | screening decision, guide version lock, guide source snapshot id/hash lock, acceptance criteria, effective project submission artifact policy hash lock, project `PreSubmitCheckerPolicy` compiled bundle hash lock, post-submit checker policy, review policy, revision policy, payment policy |
 | `IN_PROGRESS -> SUBMITTED` | blocking pre-submit checks passed, submission packet, artifact hash manifest, evidence references, worker attestation |
-| `SUBMITTED -> AUTO_CHECKING` | immutable submission version, post-submit checker policy version derived from the locked task context |
+| `SUBMITTED -> AUTO_CHECKING` | immutable submission version, locked post-submit checker policy id/version/hash/body copied from the task context |
 | `AUTO_CHECKING -> REVIEW_PENDING` | checker run for exact submission version, readiness certificate, no blocking failures |
 | `AUTO_CHECKING -> NEEDS_REVISION` | checker run id, outcome source `auto_checker`, worker-visible checker failures with severity, message, suggested fix |
 | `REVIEW_PENDING -> NEEDS_REVISION` | review decision, at least one structured finding, revision policy still permits revision |

--- a/docs/product_first_user_flows.md
+++ b/docs/product_first_user_flows.md
@@ -62,11 +62,12 @@ Acceptance:
 
 ## Flow 4: Automated Checks Run
 
-1. Checker runner loads project policy.
-2. Runner executes enabled checks.
+1. Checker runner validates the submission-stamped locked `PostSubmitCheckerPolicy` id/version/hash/body.
+2. Runner executes enabled checks from that locked policy body.
 3. Results are saved with `passed`, `warning`, or `failed`, plus severity, message, and evidence.
-4. If high-severity failures exist, task enters `NEEDS_REVISION`.
-5. If no high-severity failures exist, task enters `REVIEW_PENDING`.
+4. If worker-fixable blocking failures exist, task enters `NEEDS_REVISION`.
+5. If setup or provenance defects exist, the task stays in the internal operations queue.
+6. If no blocking failures exist, task enters `REVIEW_PENDING`.
 
 Acceptance:
 

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -40,9 +40,9 @@ Current phase: Week 3 review and revision preparation.
 - Chunk 6 checker contract and records specification.
 - Chunk 7 checker runner, registry, structural checkers, durable checker records, and API tests.
 - Chunk 8 evidence, policy, forbidden-file, confidentiality, and generated-artifact checkers.
-- Chunk 9 automatic pre-review gate with checker-caused `needs_revision`, internal `task_setup_blocked`, trusted checker retry, and worker redaction.
+- Chunk 9 automatic pre-review gate with pre-submit intake blocking, internal `task_setup_blocked`, trusted checker retry, and worker redaction.
 - Chunk 10 checker trial with the expanded real API sample matrix, failure catalog, false-positive notes, missing-checker notes, and internal verifier evidence.
-- Week 2 real HTTP API drill through Flow-token auth, project/guide/task/submission lifecycle, pre-submit checks, automatic checker runs, checker-caused `needs_revision`, worker redaction, internal `task_setup_blocked`, and trusted checker retry.
+- Week 2 real HTTP API drill through Flow-token auth, project/guide/task/submission lifecycle, pre-submit checks, automatic checker runs, `pre_submission_checker_failed` intake failures, worker redaction, internal `task_setup_blocked`, and trusted checker retry.
 
 ## Review Tracks Closed
 
@@ -92,7 +92,7 @@ WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:543
 
 The script starts a real local API server, issues local Flow-compatible tokens, runs migrations forward, and exercises:
 
-`Project -> Guide -> Task -> Screening -> Ready -> Claim -> Start -> Pre-submit checks -> Submit -> Lock submission -> Automatic checker run -> review_pending | needs_revision | internal task_setup_blocked -> trusted checker retry`
+`Project -> Guide -> Task -> Screening -> Ready -> Claim -> Start -> Pre-submit checks -> pre_submission_checker_failed | Submit -> Lock submission -> Automatic checker run -> review_pending | checker-caused needs_revision | internal task_setup_blocked -> trusted checker retry`
 
 ## Deterministic Week 2 Closeout Gate
 

--- a/docs/spec_chunk_3_project_guide_foundation.md
+++ b/docs/spec_chunk_3_project_guide_foundation.md
@@ -176,7 +176,7 @@ setup bundle:
 - `submission_artifact_policy`
 - `effective_submission_artifact_policy`
 - `pre_submit_checker_policy`
-- `checker_policy`
+- `post_submit_checker_policy`
 - `review_policy`
 - `revision_policy`
 - `payment_policy`

--- a/docs/spec_chunk_5_submission_packet_foundation.md
+++ b/docs/spec_chunk_5_submission_packet_foundation.md
@@ -51,7 +51,10 @@ Chunk 5 stores package and evidence references. Actual file storage still belong
 - `locked_effective_project_submission_artifact_policy_hash`
 - `locked_pre_submit_checker_policy_id`
 - `locked_pre_submit_checker_bundle_hash`
-- `locked_checker_policy_version`
+- `locked_post_submit_checker_policy_id`
+- `locked_post_submit_checker_policy_version`
+- `locked_post_submit_checker_policy_hash`
+- `locked_post_submit_checker_policy_body`
 - `locked_review_policy_version`
 - `locked_revision_policy_version`
 - `locked_payment_policy_version`
@@ -59,9 +62,13 @@ Chunk 5 stores package and evidence references. Actual file storage still belong
 - `locked_at`
 - `supersedes_submission_id`
 
-Submissions intentionally reference the task's locked guide and policy fields, including guide-source snapshot provenance, effective project submission artifact policy provenance, and project pre-submit checker compiled bundle hash provenance. This prevents task-owned locked context from changing silently after a submission has been recorded.
-
-Implementation note: current v0.1 code uses `locked_checker_policy_version` for post-submit checker policy provenance. `WS-POL-001-04` splits post-submit checker provenance into an explicit `PostSubmitCheckerPolicy`.
+Submissions intentionally reference the task's locked guide and policy fields,
+including guide-source snapshot provenance, effective project submission
+artifact policy provenance, project pre-submit checker compiled bundle hash
+provenance, and explicit post-submit checker policy provenance. The locked
+post-submit checker policy body is internal runtime provenance, copied from the
+task and hidden from worker-facing responses. This prevents task-owned locked
+context from changing silently after a submission has been recorded.
 
 `evidence_items`
 
@@ -130,7 +137,9 @@ Returns one visible submission packet.
 
 POST `/api/v1/submissions/{submission_id}/lock`
 
-Locks a submission packet and triggers the current post-submit checker gate. Locking makes the packet immutable in place. This uses the existing checker gate behavior; defining the dedicated post-submit checker policy model remains separate scope.
+Locks a submission packet and triggers the current post-submit checker gate.
+Locking makes the packet immutable in place and binds durable checker runs to
+the locked `PostSubmitCheckerPolicy` id, version, hash, and body.
 
 ## Versioning Rules
 
@@ -170,7 +179,7 @@ Locks a submission packet and triggers the current post-submit checker gate. Loc
 - only the assigned worker can create a submission for the task
 - project managers and admins can read and lock submissions for operational flow
 - workers can read their own task submissions
-- response payloads return server-stamped locked guide source snapshot ids/hashes, effective project submission artifact policy ids/hashes, project pre-submit checker policy ids/bundle hashes, and guide/checker/review/revision/payment policy versions
+- response payloads are role-sensitive: operators can inspect server-stamped locked provenance for source snapshots and policy context, while worker-facing payloads hide internal policy ids, hashes, and bodies
 - package and evidence URIs are stored as object references, not signed URLs or credentials
 - persisted storage references are Workstream-issued opaque object references or validated object-storage adapter references
 - raw signed URLs, credential-bearing URLs, query strings, local filesystem paths, bucket secrets, and token-bearing references are rejected before persistence

--- a/docs/spec_chunk_8_submission_artifact_policy_checkers.md
+++ b/docs/spec_chunk_8_submission_artifact_policy_checkers.md
@@ -221,7 +221,13 @@ pass/fail/warning details, create no submission row, no submission version, no
 task transition to `submitted`, and no submission-created audit event. They do
 not return review decision values: `accept`, `needs_revision`, or `reject`.
 
-Durable post-submit checker runs run the canonical default submission-quality checks plus locked checker-policy names:
+Durable post-submit checker runs execute the complete `execution_checkers` list
+from the submission-stamped locked `PostSubmitCheckerPolicy` body. That locked
+body includes Workstream default durable checkers, project required checkers,
+warning checkers, and blocking severities. The durable run records the locked
+post-submit checker policy id, version, hash, and internal policy body stamped
+on the submission. Worker-facing responses do not expose those provenance
+fields.
 
 - `check_submission_packet`
 - `check_policy_context_present`
@@ -234,7 +240,10 @@ Durable post-submit checker runs run the canonical default submission-quality ch
 - additional locked `required_checkers`
 - additional locked `warning_checkers`
 
-`check_acceptance_criteria_present` is registered in Chunk 8, but it is a locked task setup checker. It is not part of the default durable submission-quality list. If a locked post-submit checker policy requires it and it fails, the run must use task setup routing, not worker revision routing.
+`check_acceptance_criteria_present` is registered in Chunk 8, but it is a
+locked task setup checker. It is not part of the default durable
+submission-quality list. If a locked `PostSubmitCheckerPolicy` requires it and
+it fails, the run must use task setup routing, not worker revision routing.
 
 ## Routing Boundary
 
@@ -318,6 +327,9 @@ Safe evidence references mean opaque Workstream evidence ids, sanitized labels, 
 - clean submissions keep `routing_recommendation = allow_review`
 - worker-fixable submission failures keep `routing_recommendation = needs_revision` and `outcome_source = auto_checker`
 - task setup failures keep `routing_recommendation = task_setup_blocked` and do not create worker revision outcomes
+- worker-facing checker-run responses omit `routing_recommendation`,
+  `outcome_source`, and internal route tokens such as `allow_review`,
+  `checker_retry`, and `task_setup_blocked`
 - tests use real FastAPI calls and Postgres-backed persistence, not monkeypatch-only unit tests
 - senior engineering, QA/test, security/auth, and product/ops reviewer tracks pass before PR completion
 

--- a/docs/spec_chunk_9_pre_review_gate.md
+++ b/docs/spec_chunk_9_pre_review_gate.md
@@ -64,14 +64,22 @@ If a worker submits a new version after `needs_revision`, older locked versions 
 The automatic run uses the policy context already stamped on the locked submission:
 
 - locked guide version
+- locked post-submit checker policy id
 - locked post-submit checker policy version
+- locked post-submit checker policy hash
+- locked post-submit checker policy body
 - locked review policy version
 - locked revision policy version
 - locked payment policy version
 
 The worker does not provide or restate these policy versions.
 
-The checker service loads required checker names and blocking severities from the locked post-submit checker policy. Unregistered checker names are policy errors and block the lock/gate path with a structured API error.
+The checker service validates the locked `PostSubmitCheckerPolicy`
+id/version/hash/body stamped on the submission, then executes from that locked
+body. Missing, mismatched, deleted, stale, malformed, or unregistered
+post-submit policy context blocks the lock/gate path with a structured setup or
+post-submit checker policy API error before a durable `CheckerRun` or
+`CheckerResult` is created.
 
 ## Revision Boundary
 
@@ -112,7 +120,9 @@ Each event records actor identity, auth source, task id, submission id, submissi
 - clean submission moves task to `review_pending`
 - worker-fixable blocking result moves task to `needs_revision`
 - task setup defect produces `task_setup_blocked` and keeps task internal in `auto_checking`
-- worker-visible checker responses do not leak internal `task_setup_blocked` details
+- worker-visible checker responses do not expose `routing_recommendation`,
+  `outcome_source`, internal `task_setup_blocked` details, or other internal
+  route tokens
 - manual checker retry supersedes the prior current run and increments attempt number
 - older submission versions cannot receive checker runs after a newer submission exists
 - checker-caused revision does not create a human review decision

--- a/docs/template_checker_policy.md
+++ b/docs/template_checker_policy.md
@@ -30,7 +30,7 @@ Task setup and post-submit checks must stay separated from worker-fixable submis
 
 | Checker | Severity | Blocks Review | Purpose |
 | --- | --- | --- | --- |
-| `check_policy_context_present` | high | yes | Task must have locked guide snapshot, effective project submission artifact policy hash, pre-submit checker bundle hash, post-submit checker, review, revision, and payment policy context. |
+| `check_policy_context_present` | high | yes | Task must have locked guide snapshot, effective project submission artifact policy hash, pre-submit checker bundle hash, post-submit checker policy id/version/hash, review, revision, and payment policy context. |
 | `check_submission_packet` | high | yes | Submission must include required packet fields. |
 | `check_required_files` | high | yes | Submission must include artifacts required by the locked effective project policy and project pre-submit checker bundle. |
 | `check_forbidden_files` | high | yes | Submission must not include forbidden file paths. |
@@ -97,6 +97,9 @@ Workers must not see:
 - hidden evaluator logic
 - private reviewer notes
 - confidential source metadata
+- internal checker routing tokens such as `allow_review`, `checker_retry`, or
+  `task_setup_blocked`
+- post-submit checker policy provenance fields
 
 ## Admin Override
 

--- a/docs/template_submission_packet.md
+++ b/docs/template_submission_packet.md
@@ -28,10 +28,11 @@ List files, links, packages, or deliverables.
 
 Workstream derives the locked project guide version, locked guide-source
 snapshot id/hash, effective project submission artifact policy id/hash,
-generated project pre-submit checker policy id/bundle hash, current checker
-policy version, review policy version, revision policy version, and payment
-policy version from the task and server-side project policy records. The worker
-does not provide those ids, versions, or hashes in the submission packet.
+generated project pre-submit checker policy id/bundle hash, post-submit
+checker policy context, review policy version, revision policy version, and
+payment policy version from the task's locked context. The worker does not
+provide those ids, versions, hashes, or internal policy bodies in the
+submission packet.
 
 Workstream runs pre-submit checks from the locked project pre-submit checker policy before creating the submission.
 Preflight failures return `PreSubmitCheckResponse` with structured


### PR DESCRIPTION
# PR Trust Bundle: WS-POL-001-04

## Chunk

`WS-POL-001-04` - Post-Submit Checker Policy Provenance

## Goal

Separate post-submit checker policy naming and provenance from project
pre-submit checker policy and from the transitional
`locked_checker_policy_version` field.

## Human-Approved Intent

- Intent: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/INTENT.md`
- Plan: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/PLAN.md`
- Chunk contract: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-04-post-submit-checker-policy-provenance.md`

## What Changed

- Added explicit locked post-submit checker policy id, version, hash, and body provenance to tasks, submissions, and durable checker runs.
- Added post-submit policy body/hash generation and locked-body parsing helpers.
- Made project activation and task readiness validate post-submit policy body/hash consistency.
- Made task screening copy immutable post-submit policy body/hash from active project setup.
- Made submission creation copy locked post-submit policy context from the task.
- Made durable checker runs copy and execute the submission-stamped locked post-submit policy body.
- Kept pre-submit checks non-durable: failed pre-submit intake still creates no submission and no durable checker run.
- Hid internal post-submit provenance, route fields, trigger provenance, and legacy checker policy version from worker-facing task, submission, checker-run, and audit responses.
- Added migration fail-closed preflight for legacy non-draft runtime rows before enforcing explicit post-submit provenance.
- Updated Week 1/Week 2 scripts and docs to use the new post-submit policy provenance boundary.

## Scope Control

Allowed implementation surface:

- `backend/alembic/versions/**`
- `backend/app/db/models.py`
- `backend/app/modules/projects/**`
- `backend/app/modules/tasks/**`
- `backend/app/modules/checkers/**`
- `backend/scripts/week1_dry_run.py`
- `backend/scripts/week1_api_e2e.py`
- `backend/scripts/week2_api_e2e.py`
- `backend/tests/**`
- Chunk-approved docs and `.agent-loop/` files

No frontend, human review decision implementation, revision resubmission,
payment/reputation/blockchain code, object storage, auth provider changes,
agent runtime redesign, pre-submit derivation redesign, or per-task checker
compilation was added.

## Product Behavior

Task screening locks post-submit checker policy context from the active project
guide-policy bundle:

```text
PostSubmitCheckerPolicy id
PostSubmitCheckerPolicy version
PostSubmitCheckerPolicy hash
PostSubmitCheckerPolicy immutable body
```

Submission creation stamps that context from the task. Durable checker runs
stamp the same context from the submission and execute the locked body.

Worker-facing behavior remains stable:

- pre-submit intake failure returns `pre_submission_checker_failed`
- checker-caused worker-fixable post-submit failure may surface as `needs_revision`
- setup/policy defects stay internal as `task_setup_blocked` or trusted checker retry
- product review decisions remain only `accept`, `needs_revision`, and `reject`

## Acceptance Criteria Proof

- Distinct pre-submit and post-submit provenance: `backend/app/modules/projects/post_submit_policy.py`, task/checker models, schemas, and docs.
- Task screening locks post-submit id/version/hash/body: `backend/app/modules/tasks/service.py`, `backend/tests/test_tasks.py`.
- Submission and checker run preserve locked context: `backend/app/modules/tasks/service.py`, `backend/app/modules/checkers/service.py`, `backend/tests/test_checkers.py`.
- Durable execution reads locked body, not live defaults or mutable setup rows: `backend/app/modules/checkers/service.py`, `backend/tests/test_checkers.py`.
- Missing/mismatched/invalid context fails closed before durable side effects: `backend/app/modules/checkers/service.py`, `backend/tests/test_checkers.py`.
- Pre-submit feedback remains non-durable: `backend/tests/test_tasks.py`, `backend/tests/test_checkers.py`.
- Worker-facing redaction: `backend/app/modules/tasks/service.py`, `backend/app/modules/checkers/service.py`, `backend/tests/test_tasks.py`, `backend/tests/test_checkers.py`.
- Migration safety: `backend/alembic/versions/0008_post_submit_checker_policy_provenance.py`, `backend/tests/test_alembic.py`.

## Tests And Checks Run

```bash
cd backend && .venv/bin/python -m ruff check app tests scripts
cd backend && .venv/bin/docstr-coverage --config .docstr.yaml
python3 scripts/check_markdown_links.py
python3 scripts/check_stale_workstream_wording.py
python3 scripts/check_loop_memory_state.py
python3 scripts/workstream_agent_gate.py --base origin/main --head HEAD --format json
git diff --check
cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py::test_worker_task_response_redacts_locked_policy_hashes tests/test_tasks.py::test_assigned_worker_submits_v1_and_task_moves_to_submitted
cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py::test_worker_task_response_redacts_locked_policy_hashes tests/test_tasks.py::test_screening_uses_persisted_post_submit_policy_body_after_default_drift tests/test_tasks.py::test_submission_uses_locked_post_submit_policy_body_after_setup_mutation tests/test_checkers.py::test_checker_run_uses_locked_post_submit_policy_body_after_setup_mutation tests/test_checkers.py::test_locked_post_submit_policy_parser_uses_persisted_body_hash
cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_checkers.py tests/test_tasks.py tests/test_projects.py
cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests
```

Result summary:

```text
Ruff app/tests/scripts passed.
Docstring coverage passed: 100.0% (542/542).
Markdown link check passed for 15 changed Markdown files.
Stale wording check passed.
Loop memory state check passed.
git diff --check passed.
Focused redaction tests passed: 2 passed in 35.62s.
Focused post-submit provenance tests passed: 5 passed in 86.67s.
Module suite passed: 292 passed in 2790.99s.
Full Postgres-backed backend suite passed on reviewed SHA: 323 passed in 2387.87s.
Agent gate result: REVIEW_REQUIRED for L1 migration/runtime/test risk; reviewed by CI integrity.
```

## Reviewer Results

Reviewed code SHA: `c2af838a2bef5a5504c43b7707d4d3248b1d8801`

Reviewed at: `2026-07-03T22:36:35Z`

Reviewer run IDs: see `WS-POL-001-04-internal-review-evidence.md`.

| Reviewer | Result | Blocking findings | Notes |
|---|---:|---|---|
| senior engineering | PASS | None | Migration/runtime provenance reviewed. |
| QA/test | PASS AFTER FIXES | None | Redaction assertions strengthened. |
| security/auth | PASS | None | Worker surfaces and fail-closed behavior reviewed. |
| product/ops | PASS AFTER FIXES | None | Status wording and worker/operator semantics reviewed. |
| architecture | PASS WITH LOW RISKS | None | Legacy physical table naming remains contained. |
| docs | PASS AFTER FIXES | None | Roadmap and loop-state wording cleaned. |
| reuse/dedup | PASS | None | Shared helpers reused. |
| test delta | PASS AFTER FIXES | None | Test coverage gap closed. |
| CI integrity | PASS WITH LOW RISKS | None | Agent gate risk accepted; no CI weakening found. |

## External Review

External review is tracked separately in
`WS-POL-001-04-external-review-response.md`.

Result summary:

```text
CodeRabbit passed.
Agent Gates passed.
Backend passed.
Week 1 API Demo UI passed.
```

Internal review evidence does not replace external review.

## Remaining Risks

- Physical storage still uses `checker_policies` for v0.1 compatibility. New code should avoid treating generic checker policy naming as runtime authority.
- Legacy `locked_checker_policy_version` remains admin-visible context on durable checker runs; worker surfaces redact it and runtime uses `locked_post_submit_checker_policy_*`.
- Revision resubmission proof remains deferred to `WS-POL-001-05`.

## Human Review Focus

Please inspect:

- Migration `0008` fail-closed preflight and post-submit provenance constraints.
- Task -> submission -> checker-run locked policy propagation.
- Locked policy body execution instead of live default constants or mutable setup rows.
- Worker-facing API redaction of internal route/provenance fields.
- Separation between `pre_submission_checker_failed`, internal setup routing, and user-facing `needs_revision`.

## Human Ownership

- [x] I can explain what changed.
- [x] I can explain why it changed.
- [x] I know what could break.
- [x] I accept the remaining risks.
- [x] The user explicitly approved this specific PR for merge.
