### PR TITLE
Remove legacy task artifact fields

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,19 +4,16 @@
 
 - Active initiative: `WS-POL-001` - Submission Artifact Policy Foundation
 - Active planning chunk: none
-- Active implementation chunk: `WS-POL-001-06`
-- Branch: `codex/ws-pol-001-06-terminal-benchmark-drill`
-- Status: `WS-POL-001-05` is merged to `main`; `WS-POL-001-06` live manual API
-  proof exposed and fixed an OpenAI Agents SDK adapter issue, then this branch
-  removed stale project guide/payment construction-state contracts before
-  continuing pre-submit checker work. Local verification and internal review are
-  complete for implementation SHA `96792961c7cb74f31150df803c533fe4c6432636`.
-  PR #67 needs the new commits pushed so GitHub Actions and CodeRabbit can
-  rerun on the current head.
-- Last merged implementation SHA: `b20988ba79626e1edbc03953aba60f54f2fc94ab`
-- Last merge commit: `b20988ba79626e1edbc03953aba60f54f2fc94ab`
-- Current gate: `WS-POL-001-06` awaiting push, external checks, then human merge decision on PR #67
-- Next chunk: inactive until `WS-POL-001-06` is merged by the user
+- Active implementation chunk: `WS-POL-001-07`
+- Branch: `codex/ws-pol-001-07-task-contract-cleanup`
+- Status: `WS-POL-001-06` is merged to `main` through PR #67 as `3cce92c`.
+  `WS-POL-001-07` is active and removes the remaining task-owned
+  `required_files` / `required_evidence` artifact requirement fields from the
+  task API, ORM model, migration state, tests, scripts, and docs.
+- Last merged implementation SHA: `3cce92c`
+- Last merge commit: `3cce92c`
+- Current gate: `WS-POL-001-07` implementation in progress
+- Next chunk: inactive until `WS-POL-001-07` is merged by the user
 
 ## Operating Rule
 
@@ -33,14 +30,12 @@ not implement frontend behavior, payment, reputation, settlement, blockchain
 integrations, post-submit policy splitting, or revision resubmission drill
 behavior.
 
-The active `WS-POL-001-06` chunk uses real Terminal Benchmark reviewer fixture
-material to prove the current Workstream setup-agent route, project policy
-bundle, task locked context, pre-submit, submission versioning, post-submit
-checker, and fixed revision path through live manual API calls. It also fixes a
-narrow OpenAI Agents SDK adapter issue found by that live drill. It must not add
-Terminal Benchmark-specific product runtime code, human review decisions,
-payment, reputation, blockchain integrations, frontend behavior, or agent
-runtime redesign.
+The active `WS-POL-001-07` chunk removes stale task-owned artifact requirement
+fields after the project-guide/payment cleanup exposed the same request-body
+problem at task creation. It must not change project policy derivation, checker
+compilation, post-submit runtime, Terminal Benchmark example behavior,
+frontend behavior, payment, reputation, blockchain integrations, or agent
+runtime design.
 
 ## Last Review State
 
@@ -82,5 +77,6 @@ runtime redesign.
   payment-term authority.
 - `WS-POL-001-06` internal review evidence is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-06-internal-review-evidence.md`.
 - `WS-POL-001-06` PR trust bundle is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-06-pr-trust-bundle.md`.
-- `WS-POL-001-06` PR #67 is open and needs external checks rerun after the
-  latest commits are pushed.
+- PR #67 merged into `main` as `3cce92c`.
+- `WS-POL-001-07` started on branch `codex/ws-pol-001-07-task-contract-cleanup`
+  after the user's explicit start signal.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/CHUNK_MAP.md
@@ -589,3 +589,79 @@ Human review focus:
 The example remains proof harness code, uses current policy-bundle APIs, keeps
 fixture paths and secrets local, and does not add Terminal Benchmark behavior to
 Workstream runtime.
+
+### WS-POL-001-07: Task Contract Artifact Field Cleanup
+
+Goal:
+
+Remove task-owned `required_files` and `required_evidence` from task creation,
+task responses, and `workstream_tasks`. Submission artifact requirements are
+project-policy authority through `SubmissionArtifactPolicy`,
+`EffectiveProjectSubmissionArtifactPolicy`, and the project
+`PreSubmitCheckerPolicy`.
+
+Risk:
+
+L1
+
+Depends on:
+
+`WS-POL-001-06`
+
+Allowed files:
+
+```text
+backend/alembic/versions/**
+backend/app/modules/tasks/**
+backend/tests/test_tasks.py
+backend/tests/test_alembic.py
+backend/scripts/week1_dry_run.py
+backend/scripts/week2_api_e2e.py
+docs/architecture_data_model.md
+docs/operations_project_operating_manual.md
+docs/operations_queue_policy.md
+docs/product_first_user_flows.md
+docs/spec_chunk_4_task_queue_assignment.md
+docs/spec_chunk_8_submission_artifact_policy_checkers.md
+docs/template_task.md
+.agent-loop/LOOP_STATE.md
+.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/**
+```
+
+Not allowed:
+
+```text
+backend/app/modules/projects/**
+backend/app/modules/checkers/**
+backend/app/modules/submissions/**
+examples/terminal_benchmark/**
+demos/**
+frontend/**
+.github/workflows/**
+human review implementation
+payment/reputation/blockchain code
+project-agent runtime redesign
+new checker derivation or compilation per task
+```
+
+Acceptance criteria:
+
+- `TaskCreate` no longer exposes `required_files` or `required_evidence`.
+- `TaskResponse` no longer exposes `required_files` or `required_evidence`.
+- `WorkstreamTask` no longer maps `required_files` or `required_evidence`.
+- Alembic removes `workstream_tasks.required_files` and
+  `workstream_tasks.required_evidence`.
+- Task creation with either stale field returns 422.
+- Pre-submit required artifact/evidence behavior remains driven by locked
+  project policy and project `PreSubmitCheckerPolicy`.
+- Real API helper scripts create tasks using the current task request body.
+
+Required reviewers:
+
+senior engineering, QA/test, security/auth, product/ops, architecture, docs,
+reuse/dedup, test delta, CI integrity.
+
+Human review focus:
+
+Task contract cleanup without weakening project-policy driven submission
+intake.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -2,23 +2,20 @@
 
 ## Current Status
 
-`WS-POL-001-01`, `WS-POL-001-02`, `WS-POL-001-03`, `WS-POL-001-04`, and
-`WS-POL-001-05` are merged to `main`. `WS-POL-001-05` merged through PR #66 as
-`b20988ba79626e1edbc03953aba60f54f2fc94ab` after deterministic verification,
-internal reviewer fanout, GitHub Actions, and user merge approval.
+`WS-POL-001-01`, `WS-POL-001-02`, `WS-POL-001-03`, `WS-POL-001-04`,
+`WS-POL-001-05`, and `WS-POL-001-06` are merged to `main`. `WS-POL-001-06`
+merged through PR #67 as `3cce92c` after deterministic verification, internal
+reviewer fanout, GitHub Actions, CodeRabbit review, and user merge approval.
 
-`WS-POL-001-06` is active. It uses real Terminal Benchmark reviewer fixture
-material as an external-project proof for the current Workstream setup-agent,
-policy bundle, and submission/checker lifecycle. The branch now also removes
-stale construction-state project guide and payment request/body contracts before
-continuing pre-submit checker work. Local implementation and internal review
-are complete through implementation SHA
-`96792961c7cb74f31150df803c533fe4c6432636`; PR #67 needs the new commits
-pushed so GitHub Actions and CodeRabbit can rerun on the current head.
+`WS-POL-001-07` is active. It removes the remaining task-owned artifact
+requirement fields from the current backend task contract so `required_files`
+and `required_evidence` live only in `SubmissionArtifactPolicy` /
+`EffectiveProjectSubmissionArtifactPolicy` and the compiled project
+`PreSubmitCheckerPolicy`.
 
 ## Active Chunk
 
-`WS-POL-001-06` - Terminal Benchmark Real Fixture Drill
+`WS-POL-001-07` - Task Contract Artifact Field Cleanup
 
 ## Chunk Status
 
@@ -29,13 +26,14 @@ pushed so GitHub Actions and CodeRabbit can rerun on the current head.
 | `WS-POL-001-03` | Merged | `codex/ws-pol-001-03-task-locked-context` | 63 | Moves task locked-context and submission runtime to the effective policy and project checker bundle. |
 | `WS-POL-001-04` | Merged | `codex/ws-pol-001-04-post-submit-policy` | 65 | Splits post-submit checker policy provenance and locks durable checker runs to post-submit policy context. |
 | `WS-POL-001-05` | Merged | `codex/ws-pol-001-05-revision-resubmission` | 66 | Proves revision resubmission, real API drill, and `evaluation_pending` lifecycle status. |
-| `WS-POL-001-06` | Local verification complete; awaiting push and external checks | `codex/ws-pol-001-06-terminal-benchmark-drill` | 67 | Hardens the Terminal Benchmark proof harness and removes stale project guide/payment contracts before continuing pre-submit checker work. |
+| `WS-POL-001-06` | Merged | `codex/ws-pol-001-06-terminal-benchmark-drill` | 67 | Hardens the Terminal Benchmark proof harness and removes stale project guide/payment contracts before continuing pre-submit checker work. |
+| `WS-POL-001-07` | Active | `codex/ws-pol-001-07-task-contract-cleanup` | TBD | Removes task-owned `required_files`/`required_evidence` from request/response/model/migration and keeps artifact requirements project-policy driven. |
 
 ## Blockers
 
 | Blocker | Owner | Next action |
 |---|---|---|
-| New commits not yet externally checked | agent | Push evidence/status commit, then wait for GitHub Actions and CodeRabbit on PR #67. |
+| None | - | Continue bounded implementation for `WS-POL-001-07`. |
 
 ## Follow-Ups
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -7,11 +7,10 @@
 merged through PR #67 as `3cce92c` after deterministic verification, internal
 reviewer fanout, GitHub Actions, CodeRabbit review, and user merge approval.
 
-`WS-POL-001-07` is active. It removes the remaining task-owned artifact
-requirement fields from the current backend task contract so `required_files`
-and `required_evidence` live only in `SubmissionArtifactPolicy` /
-`EffectiveProjectSubmissionArtifactPolicy` and the compiled project
-`PreSubmitCheckerPolicy`.
+`WS-POL-001-07` is active. Implementation is committed at
+`55cc79a0b6b832519cf9258ad60722e49f2f4b4b`; deterministic checks, internal
+reviewer fanout, and evidence-gate validation have completed. The next gate is
+PR creation, GitHub Actions, CodeRabbit, and human review.
 
 ## Active Chunk
 
@@ -27,7 +26,7 @@ and `required_evidence` live only in `SubmissionArtifactPolicy` /
 | `WS-POL-001-04` | Merged | `codex/ws-pol-001-04-post-submit-policy` | 65 | Splits post-submit checker policy provenance and locks durable checker runs to post-submit policy context. |
 | `WS-POL-001-05` | Merged | `codex/ws-pol-001-05-revision-resubmission` | 66 | Proves revision resubmission, real API drill, and `evaluation_pending` lifecycle status. |
 | `WS-POL-001-06` | Merged | `codex/ws-pol-001-06-terminal-benchmark-drill` | 67 | Hardens the Terminal Benchmark proof harness and removes stale project guide/payment contracts before continuing pre-submit checker work. |
-| `WS-POL-001-07` | Active | `codex/ws-pol-001-07-task-contract-cleanup` | TBD | Removes task-owned `required_files`/`required_evidence` from request/response/model/migration and keeps artifact requirements project-policy driven. |
+| `WS-POL-001-07` | Internal review complete; PR next | `codex/ws-pol-001-07-task-contract-cleanup` | TBD | Removes task-owned `required_files`/`required_evidence` from request/response/model/migration and keeps artifact requirements project-policy driven. |
 
 ## Blockers
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-07-task-contract-artifact-field-cleanup.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-07-task-contract-artifact-field-cleanup.md
@@ -1,0 +1,147 @@
+# Chunk Contract: WS-POL-001-07 - Task Contract Artifact Field Cleanup
+
+## Parent Initiative
+
+WS-POL-001 - Submission Artifact Policy Foundation
+
+## Goal
+
+Remove the remaining task-owned artifact requirement fields from the current
+backend task contract.
+
+`required_files` and `required_evidence` belong to `SubmissionArtifactPolicy`
+and the compiled project `PreSubmitCheckerPolicy`. They must not be accepted on
+task creation, returned as task fields, or persisted on `workstream_tasks`.
+
+## Why This Chunk Exists
+
+Chunk 3 moved task readiness and submission creation onto the locked project
+guide-source snapshot, effective project submission artifact policy, and
+project pre-submit checker bundle.
+
+Chunk 6 removed stale project guide and project payment construction-state
+fields before the Terminal Benchmark drill continued. The next stale boundary
+is task creation: the API still accepts task-level `required_files` and
+`required_evidence`, even though those fields no longer define submission
+intake. Keeping them makes live API drills look fake because a task creator can
+appear to provide the same policy that Workstream should derive and approve at
+project scope.
+
+## Risk Class
+
+L1
+
+## SLA
+
+P1
+
+## Implementation Allowed Files
+
+```text
+backend/alembic/versions/**
+backend/app/modules/tasks/**
+backend/tests/test_tasks.py
+backend/tests/test_alembic.py
+backend/scripts/week1_dry_run.py
+backend/scripts/week2_api_e2e.py
+docs/architecture_data_model.md
+docs/operations_project_operating_manual.md
+docs/operations_queue_policy.md
+docs/product_first_user_flows.md
+docs/spec_chunk_4_task_queue_assignment.md
+docs/spec_chunk_8_submission_artifact_policy_checkers.md
+docs/template_task.md
+.agent-loop/LOOP_STATE.md
+.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/**
+```
+
+## Implementation Not Allowed
+
+```text
+backend/app/modules/projects/**
+backend/app/modules/checkers/**
+backend/app/modules/submissions/**
+examples/terminal_benchmark/**
+demos/**
+frontend/**
+.github/workflows/**
+human review implementation
+payment/reputation/blockchain code
+project-agent runtime redesign
+new checker derivation or compilation per task
+```
+
+## Implementation Boundaries
+
+- Task creation remains for task identity, source, description, difficulty,
+  skills, timing, acceptance criteria, rejection criteria, and deadline.
+- Task creation must reject unknown or stale artifact-policy fields through
+  Pydantic `extra="forbid"`.
+- Submission artifact requirements remain valid only inside
+  `SubmissionArtifactPolicy` / `EffectiveProjectSubmissionArtifactPolicy`.
+- The project `PreSubmitCheckerPolicy` remains the runtime pre-submit authority.
+- This chunk must not change product project guide setup, policy derivation,
+  checker compilation, or Terminal Benchmark example runtime behavior. Helper
+  scripts may remove stale project/guide request fields only when needed to keep
+  their task-creation drill aligned with the already-merged current API
+  contract.
+- There is no backward-compatibility alias for task-owned `required_files` or
+  `required_evidence`; Workstream is still in build phase and stale contracts
+  should be removed.
+
+## Acceptance Criteria
+
+- [ ] `TaskCreate` no longer exposes `required_files` or `required_evidence`.
+- [ ] `TaskResponse` no longer exposes `required_files` or `required_evidence`.
+- [ ] `WorkstreamTask` no longer maps `required_files` or `required_evidence`.
+- [ ] Alembic removes `workstream_tasks.required_files` and
+      `workstream_tasks.required_evidence`.
+- [ ] Task creation with either stale field returns 422 instead of silently
+      accepting the values.
+- [ ] Existing task lifecycle and submission tests still prove that pre-submit
+      required artifact/evidence checks come from the locked project policy.
+- [ ] Real API helper scripts create tasks using the current task request body.
+- [ ] Docs/templates no longer describe task-owned artifact requirement fields.
+
+## Verification Commands
+
+```bash
+git diff --check
+python3 scripts/check_stale_workstream_wording.py
+cd backend && .venv/bin/python -m ruff check app tests scripts
+cd backend && .venv/bin/python -m pytest tests/test_tasks.py tests/test_alembic.py
+cd backend && .venv/bin/docstr-coverage app scripts --config .docstr.yaml
+python3 scripts/check_markdown_links.py
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_loop_memory_state.py
+python3 scripts/workstream_agent_gate.py --base origin/main --head HEAD --format json
+```
+
+## Required Reviewers
+
+Every listed reviewer must end with one exact result value:
+
+- `PASS`
+- `PASS AFTER FIXES`
+- `PASS WITH LOW RISKS`
+- `N/A - with approved reason`
+
+Required:
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- docs
+- reuse/dedup
+- test delta
+- CI integrity
+
+## Human Review Focus
+
+- Task creation no longer accepts stale artifact-policy fields.
+- Required artifact/evidence checks remain project-policy driven.
+- Migration removes the stale columns without introducing compatibility aliases.
+- Real API scripts now reflect the same contract the live Terminal Benchmark
+  drill will use.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-external-review-response.md
@@ -32,15 +32,29 @@ None.
 
 ## Commands Rerun
 
-Pending after this response file is committed:
-
 ```bash
 python3 scripts/check_stale_workstream_wording.py
 python3 scripts/check_markdown_links.py
 git diff --check
+```
+
+Results:
+
+- stale wording scan: passed
+- Markdown link check: passed for 14 changed Markdown files
+- diff whitespace check: passed
+
+Evidence refresh commands rerun after the docs-delta review:
+
+```bash
 python3 scripts/check_internal_review_evidence.py
 python3 scripts/check_loop_memory_state.py
 ```
+
+Results:
+
+- internal review evidence gate: passed
+- loop memory state check: passed
 
 ## Remaining Risks
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-external-review-response.md
@@ -1,0 +1,48 @@
+# External Review Response: WS-POL-001-07
+
+## Source
+
+PR #68 CodeRabbit review on 2026-07-05.
+
+## Comments Addressed
+
+1. `docs/spec_chunk_8_submission_artifact_policy_checkers.md`
+   - Finding: `check_required_files` wording overstated runtime inputs by
+     naming both `SubmissionArtifactPolicy` and
+     `EffectiveProjectSubmissionArtifactPolicy`.
+   - Resolution: Updated the spec to state that the checker derives required
+     artifact paths from `context.effective_policy` and compares those paths to
+     `submission.artifact_hash_manifest[*].artifact`.
+
+2. `docs/template_task.md`
+   - Finding: The task template used a stamped `submission artifact policy
+     version` label that does not match the backend locked-context fields.
+   - Resolution: Replaced that label with the backend-aligned stamped context:
+     guide source snapshot id/hash, effective project submission artifact policy
+     id/hash, project pre-submit checker policy id, and project pre-submit
+     checker bundle hash.
+
+## Comments Deferred
+
+None.
+
+## Human Decisions Needed
+
+None.
+
+## Commands Rerun
+
+Pending after this response file is committed:
+
+```bash
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_loop_memory_state.py
+```
+
+## Remaining Risks
+
+None known. The comments were documentation consistency fixes and did not
+change runtime code.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-internal-review-evidence.md
@@ -10,11 +10,11 @@ valid findings addressed: yes
 
 ## Reviewed Revision
 
-Reviewed code SHA: 55cc79a0b6b832519cf9258ad60722e49f2f4b4b
+Reviewed code SHA: 4845f9891362caad479030d339e512dbe5924b46
 
-Reviewed at: 2026-07-05T16:24:54Z
+Reviewed at: 2026-07-05T16:49:33Z
 
-Reviewer run IDs: 019f32de-d755-7a11-aa0b-8c6fd43251c8, 019f32de-dfed-7510-9ede-44798d7fa35a, 019f32de-e9bb-7711-b976-cbde1f21d971, 019f32de-f304-7a01-bcf8-f589db625af7, 019f32de-ffff-7a21-8242-ce9154dfd660, 019f32df-4c04-7c90-9225-4630ca51ef1d, 019f3301-a155-7391-a160-9a6cf52bc6d3, 019f3301-ae4f-7e02-bb48-82d90e5c11fc, 019f3301-b9af-7c82-a753-69660c9519ab, 019f3301-c21b-7b21-832e-14b89807ffcb, 019f3301-c824-7fa2-b9e5-416e2cdb8183, 019f3301-ccf8-7a73-8bc1-c55743514284
+Reviewer run IDs: 019f32de-d755-7a11-aa0b-8c6fd43251c8, 019f32de-dfed-7510-9ede-44798d7fa35a, 019f32de-e9bb-7711-b976-cbde1f21d971, 019f32de-f304-7a01-bcf8-f589db625af7, 019f32de-ffff-7a21-8242-ce9154dfd660, 019f32df-4c04-7c90-9225-4630ca51ef1d, 019f3301-a155-7391-a160-9a6cf52bc6d3, 019f3301-ae4f-7e02-bb48-82d90e5c11fc, 019f3301-b9af-7c82-a753-69660c9519ab, 019f3301-c21b-7b21-832e-14b89807ffcb, 019f3301-c824-7fa2-b9e5-416e2cdb8183, 019f3301-ccf8-7a73-8bc1-c55743514284, 019f331a-c54e-7691-8222-bedc15db01d6, 019f331a-ca63-7cd1-9eff-74c35fe29c1c, 019f331d-e7e0-7161-a9d2-3bacf81b2c04, 019f331d-ec0c-7201-92eb-6716b23e4f7f, 019f332c-bd4c-7e31-be43-7bf4c150622f, 019f332c-c2e2-7d72-8718-8219d59c9d1f, 019f332c-c7ab-78f1-8419-9eecc882c154, 019f332c-cedf-7212-a528-50858e2f515a
 
 ## Reviewed Change
 
@@ -49,7 +49,7 @@ Scope:
 | security/auth | PASS | None | Confirmed stale client-supplied artifact policy fields are rejected, no policy-context spoofing was introduced, and the cleanup does not weaken auth or data boundaries. |
 | product/ops | PASS AFTER FIXES | None | Found stale project-shell payment fields in `week2_api_e2e.py`; commit `55cc79a0` removed them. Later evidence-missing process finding is addressed by this file. |
 | architecture | PASS | None | Confirmed artifact requirements remain project-policy authority and tasks do not own `required_files` / `required_evidence`. |
-| docs | PASS | None | Confirmed active docs/templates now point artifact requirements to `SubmissionArtifactPolicy`, `EffectiveProjectSubmissionArtifactPolicy`, and project `PreSubmitCheckerPolicy`. |
+| docs | PASS AFTER FIXES | None | Confirmed active docs/templates point artifact requirements to project policy authority. Later CodeRabbit docs comments were fixed at `4845f989` and the stale-evidence finding is addressed by this refresh. |
 | reuse/dedup | PASS | None | Confirmed no duplicate artifact-requirement path or missed shared helper was introduced. |
 | test delta | PASS | None | Confirmed tests were not weakened; task stale-field rejection and direct migration assertions were added. |
 | ci integrity | PASS AFTER FIXES | None | Found missing internal-review evidence before this file existed. This evidence file, status update, and rerun close that process finding. |
@@ -78,6 +78,11 @@ Scope:
 - Updated active docs and task template wording so task records describe work,
   source, acceptance, and rejection, while machine-enforced artifact and
   evidence requirements stay under project policy.
+- Addressed CodeRabbit docs feedback by clarifying that `check_required_files`
+  reads required artifact paths from `context.effective_policy`.
+- Updated the task template stamped submission artifact policy context to use
+  backend-aligned locked guide-source, effective-policy, and pre-submit-checker
+  id/hash labels.
 
 ## Verification
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-internal-review-evidence.md
@@ -1,0 +1,127 @@
+# Internal Review Evidence: WS-POL-001-07
+
+## Chunk
+
+WS-POL-001-07
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: 55cc79a0b6b832519cf9258ad60722e49f2f4b4b
+
+Reviewed at: 2026-07-05T16:24:54Z
+
+Reviewer run IDs: 019f32de-d755-7a11-aa0b-8c6fd43251c8, 019f32de-dfed-7510-9ede-44798d7fa35a, 019f32de-e9bb-7711-b976-cbde1f21d971, 019f32de-f304-7a01-bcf8-f589db625af7, 019f32de-ffff-7a21-8242-ce9154dfd660, 019f32df-4c04-7c90-9225-4630ca51ef1d, 019f3301-a155-7391-a160-9a6cf52bc6d3, 019f3301-ae4f-7e02-bb48-82d90e5c11fc, 019f3301-b9af-7c82-a753-69660c9519ab, 019f3301-c21b-7b21-832e-14b89807ffcb, 019f3301-c824-7fa2-b9e5-416e2cdb8183, 019f3301-ccf8-7a73-8bc1-c55743514284
+
+## Reviewed Change
+
+Branch: `codex/ws-pol-001-07-task-contract-cleanup`
+
+Scope:
+
+- `.agent-loop/LOOP_STATE.md`
+- `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/**`
+- `backend/alembic/versions/0011_remove_legacy_task_artifact_fields.py`
+- `backend/app/modules/tasks/models.py`
+- `backend/app/modules/tasks/schemas.py`
+- `backend/app/modules/tasks/service.py`
+- `backend/scripts/week1_dry_run.py`
+- `backend/scripts/week2_api_e2e.py`
+- `backend/tests/test_alembic.py`
+- `backend/tests/test_tasks.py`
+- `docs/architecture_data_model.md`
+- `docs/operations_project_operating_manual.md`
+- `docs/operations_queue_policy.md`
+- `docs/product_first_user_flows.md`
+- `docs/spec_chunk_4_task_queue_assignment.md`
+- `docs/spec_chunk_8_submission_artifact_policy_checkers.md`
+- `docs/template_task.md`
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS AFTER FIXES | None | Initial pass found dirty-worktree review, missing direct Alembic assertion, and an unclear helper-script exception. Commit `55cc79a0` fixed those and the rerun found no remaining issues. |
+| qa/test | PASS AFTER FIXES | None | Initial pass found the untracked migration and missing direct schema assertion. Commit `55cc79a0` tracks the migration and asserts removed task columns are absent after `head`. |
+| security/auth | PASS | None | Confirmed stale client-supplied artifact policy fields are rejected, no policy-context spoofing was introduced, and the cleanup does not weaken auth or data boundaries. |
+| product/ops | PASS AFTER FIXES | None | Found stale project-shell payment fields in `week2_api_e2e.py`; commit `55cc79a0` removed them. Later evidence-missing process finding is addressed by this file. |
+| architecture | PASS | None | Confirmed artifact requirements remain project-policy authority and tasks do not own `required_files` / `required_evidence`. |
+| docs | PASS | None | Confirmed active docs/templates now point artifact requirements to `SubmissionArtifactPolicy`, `EffectiveProjectSubmissionArtifactPolicy`, and project `PreSubmitCheckerPolicy`. |
+| reuse/dedup | PASS | None | Confirmed no duplicate artifact-requirement path or missed shared helper was introduced. |
+| test delta | PASS | None | Confirmed tests were not weakened; task stale-field rejection and direct migration assertions were added. |
+| ci integrity | PASS AFTER FIXES | None | Found missing internal-review evidence before this file existed. This evidence file, status update, and rerun close that process finding. |
+
+## Valid Findings Addressed
+
+- Tracked `backend/alembic/versions/0011_remove_legacy_task_artifact_fields.py`
+  so the migration is part of the branch and PR diff.
+- Added direct Alembic assertions that `workstream_tasks.required_files` and
+  `workstream_tasks.required_evidence` are absent after upgrading to `head`.
+- Removed task-owned `required_files` and `required_evidence` from `TaskCreate`,
+  `TaskResponse`, `WorkstreamTask`, and task creation service code.
+- Added task API coverage proving stale artifact requirement fields now return
+  422 instead of being accepted.
+- Preserved required artifact/evidence runtime behavior through the locked
+  project `PreSubmitCheckerPolicy` and effective project submission artifact
+  policy.
+- Removed stale task artifact fields from Week 1/Week 2 helper task payloads.
+- Removed stale project-shell payment fields from the Week 2 helper project
+  payload; payment terms remain in `PaymentPolicy`.
+- Removed stale project/guide request fields from `week1_dry_run.py` so that
+  helper script remains aligned with the already-merged current project API
+  contract.
+- Clarified the chunk contract to allow helper-script request-body cleanup while
+  keeping product project guide setup out of scope.
+- Updated active docs and task template wording so task records describe work,
+  source, acceptance, and rejection, while machine-enforced artifact and
+  evidence requirements stay under project policy.
+
+## Verification
+
+Passed locally before reviewer fanout:
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py tests/test_alembic.py
+git diff --check
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+cd backend && .venv/bin/docstr-coverage app scripts --config .docstr.yaml
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests
+```
+
+Results:
+
+- ruff: passed
+- `tests/test_tasks.py tests/test_alembic.py`: 67 passed in 0:11:01
+- stale wording scan: passed
+- Markdown link check: passed for 11 changed Markdown files
+- docstring coverage: 100.0%
+- full backend suite: 330 passed in 0:43:00
+
+Post-fix verification after reviewer findings:
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_alembic.py tests/test_tasks.py
+```
+
+Results:
+
+- ruff: passed
+- stale wording scan: passed
+- Markdown link check: passed for 11 changed Markdown files
+- diff whitespace check: passed
+- `tests/test_alembic.py tests/test_tasks.py`: 67 passed in 0:11:28
+
+## External Review Status
+
+External GitHub Actions and CodeRabbit have not run for this branch yet. They
+must run after the PR is opened. This internal evidence does not replace
+external review.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-pr-trust-bundle.md
@@ -170,9 +170,10 @@ Reviewer summary:
 
 ## External Review
 
-GitHub Actions and CodeRabbit have not run for this branch yet. They must run
-after the PR is opened, and any actionable external comments must be handled in
-a separate external review response file.
+GitHub Actions passed on PR #68. CodeRabbit posted two actionable documentation
+comments, both addressed in:
+
+`.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-external-review-response.md`
 
 ## Remaining Risks
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-pr-trust-bundle.md
@@ -1,0 +1,193 @@
+# PR Trust Bundle: WS-POL-001-07
+
+## Chunk
+
+`WS-POL-001-07` - Task Contract Artifact Field Cleanup
+
+## Goal
+
+Remove the remaining task-owned artifact requirement fields from the current
+backend task contract.
+
+`required_files` and `required_evidence` now belong only to
+`SubmissionArtifactPolicy`, `EffectiveProjectSubmissionArtifactPolicy`, and the
+compiled project `PreSubmitCheckerPolicy`. Task creation describes the work; it
+does not author submission artifact policy.
+
+## Human-Approved Intent
+
+The user explicitly pushed back that:
+
+- request bodies must hard-fail fields that no longer belong there;
+- no backward-compatibility alias is needed while Workstream is still in build
+  phase;
+- project owners provide project material and business terms, but Workstream
+  derives and approves internal artifact-intake policy;
+- tasks must not fake project policy by accepting `required_files` or
+  `required_evidence`;
+- the next Terminal Benchmark drill should use real current APIs one step at a
+  time.
+
+## What Changed
+
+- Added `0011_remove_legacy_task_artifact_fields.py`.
+- Dropped `workstream_tasks.required_files` and
+  `workstream_tasks.required_evidence`.
+- Removed both fields from `WorkstreamTask`, `TaskCreate`, `TaskResponse`, and
+  task creation service assignment.
+- Added API coverage proving task creation with stale artifact requirement
+  fields returns 422.
+- Added Alembic coverage proving the removed task columns are absent at
+  migration head.
+- Updated Week 1/Week 2 helper scripts so task creation uses the current task
+  request body.
+- Removed stale project-shell payment fields from the Week 2 helper script.
+- Removed stale project/guide request fields from `week1_dry_run.py` so the
+  helper stays aligned with the current API.
+- Updated active docs and templates so task records describe source, work,
+  acceptance, rejection, and locked policy snapshots, while machine-enforced
+  artifact and evidence rules are project-policy owned.
+- Updated WS-POL status/chunk map/loop state for Chunk 7.
+
+## Design Chosen
+
+Current authority is:
+
+```text
+ProjectGuide = human-facing project material
+SubmissionArtifactPolicy = Workstream-derived artifact-intake contract
+EffectiveProjectSubmissionArtifactPolicy = default + project policy merge
+Project PreSubmitCheckerPolicy = deterministic compiled checker bundle
+Task = locks the active project policy/checker context
+```
+
+Task fields can describe source, title, description, difficulty, skill tags,
+estimated time, acceptance criteria, rejection criteria, and deadline. They do
+not define required artifacts, evidence, hashes, packaging, or forbidden
+artifacts.
+
+## Scope
+
+Runtime/backend:
+
+- `backend/alembic/versions/0011_remove_legacy_task_artifact_fields.py`
+- `backend/app/modules/tasks/models.py`
+- `backend/app/modules/tasks/schemas.py`
+- `backend/app/modules/tasks/service.py`
+
+Tests/scripts:
+
+- `backend/tests/test_alembic.py`
+- `backend/tests/test_tasks.py`
+- `backend/scripts/week1_dry_run.py`
+- `backend/scripts/week2_api_e2e.py`
+
+Docs/process:
+
+- `.agent-loop/LOOP_STATE.md`
+- `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/**`
+- `docs/architecture_data_model.md`
+- `docs/operations_project_operating_manual.md`
+- `docs/operations_queue_policy.md`
+- `docs/product_first_user_flows.md`
+- `docs/spec_chunk_4_task_queue_assignment.md`
+- `docs/spec_chunk_8_submission_artifact_policy_checkers.md`
+- `docs/template_task.md`
+
+## Product Behavior
+
+- Task create rejects `required_files` and `required_evidence` through
+  `extra="forbid"`.
+- Task responses no longer show stale artifact requirement snapshots.
+- Tasks still lock guide/source/effective-policy/pre-submit-checker context
+  before entering the worker pipeline.
+- Pre-submit required artifact/evidence checks continue to come from the locked
+  project policy and project `PreSubmitCheckerPolicy`.
+- Payment values on tasks remain locked snapshots from `PaymentPolicy`.
+
+## Verification
+
+Passed locally:
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py tests/test_alembic.py
+git diff --check
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+cd backend && .venv/bin/docstr-coverage app scripts --config .docstr.yaml
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests
+```
+
+Results:
+
+- ruff: passed
+- focused task/Alembic suite: 67 passed
+- stale wording scan: passed
+- Markdown link check: passed
+- docstring coverage: 100.0%
+- full backend suite: 330 passed
+
+Post-review repair verification:
+
+```bash
+cd backend && .venv/bin/python -m ruff check app tests scripts
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_alembic.py tests/test_tasks.py
+```
+
+Results:
+
+- ruff: passed
+- stale wording scan: passed
+- Markdown link check: passed
+- diff whitespace check: passed
+- focused task/Alembic suite: 67 passed
+
+## Internal Review
+
+Evidence:
+
+`.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-internal-review-evidence.md`
+
+Reviewed implementation SHA:
+
+`55cc79a0b6b832519cf9258ad60722e49f2f4b4b`
+
+Reviewer summary:
+
+- senior engineering: PASS AFTER FIXES
+- QA/test: PASS AFTER FIXES
+- security/auth: PASS
+- product/ops: PASS AFTER FIXES
+- architecture: PASS
+- docs: PASS
+- reuse/dedup: PASS
+- test delta: PASS
+- CI integrity: PASS AFTER FIXES
+
+## External Review
+
+GitHub Actions and CodeRabbit have not run for this branch yet. They must run
+after the PR is opened, and any actionable external comments must be handled in
+a separate external review response file.
+
+## Remaining Risks
+
+- The full backend suite passed before the final direct Alembic assertion and
+  helper-script cleanup. The post-fix focused task/Alembic suite and ruff/docs
+  checks passed after those repairs.
+- Historical review evidence still mentions old construction-state fields
+  because it records earlier chunks; active docs and runtime contracts now use
+  the project-policy authority model.
+
+## Human Review Focus
+
+- Confirm task creation should no longer accept artifact requirement fields.
+- Confirm there is no compatibility alias for `required_files` /
+  `required_evidence` on tasks.
+- Confirm required artifact/evidence checks remain project-policy driven.
+- Confirm the helper-script cleanup is acceptable as request-body alignment for
+  live drills, not a product setup redesign.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-pr-trust-bundle.md
@@ -154,7 +154,7 @@ Evidence:
 
 Reviewed implementation SHA:
 
-`55cc79a0b6b832519cf9258ad60722e49f2f4b4b`
+`4845f9891362caad479030d339e512dbe5924b46`
 
 Reviewer summary:
 
@@ -163,7 +163,7 @@ Reviewer summary:
 - security/auth: PASS
 - product/ops: PASS AFTER FIXES
 - architecture: PASS
-- docs: PASS
+- docs: PASS AFTER FIXES
 - reuse/dedup: PASS
 - test delta: PASS
 - CI integrity: PASS AFTER FIXES

--- a/backend/alembic/versions/0011_remove_legacy_task_artifact_fields.py
+++ b/backend/alembic/versions/0011_remove_legacy_task_artifact_fields.py
@@ -1,0 +1,37 @@
+"""remove legacy task artifact requirement fields
+
+Revision ID: 0011_task_artifact_cleanup
+Revises: 0010_guide_cleanup
+Create Date: 2026-07-05
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0011_task_artifact_cleanup"
+down_revision = "0010_guide_cleanup"
+branch_labels = None
+depends_on = None
+
+
+LEGACY_TASK_ARTIFACT_COLUMNS = ("required_files", "required_evidence")
+
+
+def upgrade() -> None:
+    """Remove task-owned artifact requirement fields."""
+    for column_name in LEGACY_TASK_ARTIFACT_COLUMNS:
+        op.drop_column("workstream_tasks", column_name)
+
+
+def downgrade() -> None:
+    """Restore the previous construction-state task artifact columns."""
+    op.add_column(
+        "workstream_tasks",
+        sa.Column("required_files", sa.JSON(), nullable=False, server_default="[]"),
+    )
+    op.add_column(
+        "workstream_tasks",
+        sa.Column("required_evidence", sa.JSON(), nullable=False, server_default="[]"),
+    )

--- a/backend/app/modules/tasks/models.py
+++ b/backend/app/modules/tasks/models.py
@@ -244,8 +244,6 @@ class WorkstreamTask(Base):
     status: Mapped[str] = mapped_column(String(30), nullable=False, default="draft", index=True)
     acceptance_criteria: Mapped[str | None] = mapped_column(Text)
     rejection_criteria: Mapped[str | None] = mapped_column(Text)
-    required_files: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
-    required_evidence: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     deadline_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_by: Mapped[str] = mapped_column(String(100), nullable=False)
     assigned_to: Mapped[str | None] = mapped_column(String(100), index=True)

--- a/backend/app/modules/tasks/schemas.py
+++ b/backend/app/modules/tasks/schemas.py
@@ -85,8 +85,6 @@ class TaskCreate(BaseModel):
     external_task_id: str | None = None
     acceptance_criteria: str | None = None
     rejection_criteria: str | None = None
-    required_files: list[str] = Field(default_factory=list)
-    required_evidence: list[str] = Field(default_factory=list)
     deadline_at: datetime | None = None
 
 
@@ -181,8 +179,6 @@ class TaskResponse(BaseModel):
     status: str
     acceptance_criteria: str | None
     rejection_criteria: str | None
-    required_files: list[str]
-    required_evidence: list[str]
     deadline_at: datetime | None
     created_by: str
     assigned_to: str | None

--- a/backend/app/modules/tasks/service.py
+++ b/backend/app/modules/tasks/service.py
@@ -217,8 +217,6 @@ class TaskService:
             status=TASK_STATUS_DRAFT,
             acceptance_criteria=payload.acceptance_criteria,
             rejection_criteria=payload.rejection_criteria,
-            required_files=payload.required_files,
-            required_evidence=payload.required_evidence,
             deadline_at=payload.deadline_at,
             created_by=actor.actor_id,
         )
@@ -889,7 +887,7 @@ class TaskService:
         )
 
     def _validate_task_contract_fields(self, task: WorkstreamTask) -> None:
-        """Validate task-owned contract fields before screening.
+        """Validate task source and reviewability fields before screening.
 
         Args:
             task: Task being screened.

--- a/backend/scripts/week1_dry_run.py
+++ b/backend/scripts/week1_dry_run.py
@@ -217,8 +217,6 @@ async def main() -> None:
                 "name": f"Week 1 Dry Run {run_id}",
                 "slug": f"week1-dry-run-{run_id}",
                 "description": "Week 1 backend closure dry run",
-                "base_amount": "25.00",
-                "currency": "USD",
             },
         )
         guide = await post_ok(
@@ -227,25 +225,6 @@ async def main() -> None:
             {
                 "version": "v1",
                 "content_markdown": "# Week 1 Dry Run Guide",
-                "required_task_fields": [
-                    "title",
-                    "description",
-                    "acceptance_criteria",
-                    "required_evidence",
-                ],
-                "required_submission_fields": ["summary", "evidence", "worker_attestation"],
-                "task_instructions": "Complete the dry-run task.",
-                "output_requirements": "Submit an artifact manifest and evidence item.",
-                "acceptance_criteria": "The packet is complete.",
-                "rejection_criteria": "The packet is missing evidence.",
-                "reviewer_rubric": "Review packet completeness.",
-                "forbidden_actions": "No credentials or private source data.",
-                "required_skills": ["stem"],
-                "difficulty_scale": {"medium": 2},
-                "estimated_time_policy": {"default_minutes": 45},
-                "common_rejection_reasons": ["missing evidence"],
-                "evidence_policy": {"required": ["log"]},
-                "unacceptable_work_policy": "Copied or unverifiable work.",
                 "change_summary": "Initial dry-run guide",
                 "post_submit_checker_policy": {
                     "required_checkers": ["check_policy_context_present"],
@@ -292,8 +271,6 @@ async def main() -> None:
                 "source_payload_hash": f"sha256:source-{run_id}",
                 "acceptance_criteria": "The submission packet is complete.",
                 "rejection_criteria": "Evidence is missing.",
-                "required_files": ["answer.md"],
-                "required_evidence": ["checker log"],
             },
         )
         await post_ok(

--- a/backend/scripts/week2_api_e2e.py
+++ b/backend/scripts/week2_api_e2e.py
@@ -239,8 +239,6 @@ def task_payload(run_id: str, suffix: str) -> dict:
         "source_payload_hash": sha256_token(f"source:{suffix}:{run_id}"),
         "acceptance_criteria": "Submission packet is complete and reviewable.",
         "rejection_criteria": "Evidence or required output is missing.",
-        "required_files": ["answer.md"],
-        "required_evidence": ["checker log"],
     }
 
 
@@ -340,8 +338,6 @@ async def create_project_with_guide(
             "name": f"Week 2 API {suffix} {run_id}",
             "slug": f"week2-api-{suffix}-{run_id}",
             "description": "Real Week 2 checker API lifecycle QA",
-            "base_amount": "25.00",
-            "currency": "USD",
         },
         201,
     )

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -29,7 +29,7 @@ def test_guide_cleanup_migration_removes_legacy_columns(
     isolated_database_env: str,
     migration_lock,
 ) -> None:
-    """Prove current schema removes old guide fields and project payment duplicates."""
+    """Prove current schema removes old guide, project, and task shortcuts."""
     project_root = Path(__file__).resolve().parents[1]
     config = Config(str(project_root / "alembic.ini"))
     config.set_main_option("script_location", str(project_root / "alembic"))
@@ -44,6 +44,8 @@ def test_guide_cleanup_migration_removes_legacy_columns(
 
     assert "projects.base_amount" not in columns
     assert "projects.currency" not in columns
+    assert "workstream_tasks.required_files" not in columns
+    assert "workstream_tasks.required_evidence" not in columns
     assert "project_guides.approved_by" in columns
     assert "project_guides.effective_at" in columns
     for column in (

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -296,8 +296,6 @@ def complete_task_payload() -> dict:
         "source_payload_hash": "hash-123",
         "acceptance_criteria": "Proof is correct and evidence is present.",
         "rejection_criteria": "Proof is unsupported.",
-        "required_files": ["answer.md"],
-        "required_evidence": ["checker log"],
     }
 
 
@@ -704,6 +702,28 @@ async def test_task_can_be_created_in_draft(task_client: AsyncClient) -> None:
     assert "locked_guide_version" not in task
     assert task["skill_tags"] == ["stem", "proofs"]
     assert task["source_ref"] == "local-ticket-1"
+    assert "required_files" not in task
+    assert "required_evidence" not in task
+
+
+async def test_task_create_rejects_legacy_artifact_requirement_fields(
+    task_client: AsyncClient,
+) -> None:
+    project = await create_active_project(task_client)
+    payload = complete_task_payload()
+    payload["required_files"] = ["answer.md"]
+    payload["required_evidence"] = ["checker log"]
+
+    response = await task_client.post(
+        f"/api/v1/projects/{project['id']}/tasks",
+        headers=auth_headers(),
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    error_text = response.text
+    assert "required_files" in error_text
+    assert "required_evidence" in error_text
 
 
 async def test_task_create_and_transitions_reject_client_supplied_policy_context(
@@ -1034,16 +1054,13 @@ async def test_submission_runtime_uses_locked_project_policy_not_task_required_f
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     project = await create_active_project(task_client)
-    conflicting_task_payload = complete_task_payload()
-    conflicting_task_payload["required_files"] = ["legacy-only.md"]
-    conflicting_task_payload["required_evidence"] = ["legacy evidence"]
 
     project_policy_task = await create_started_task(
         task_client,
         project["id"],
         monkeypatch,
         "worker-one",
-        conflicting_task_payload,
+        complete_task_payload(),
     )
     project_policy_response = await task_client.post(
         f"/api/v1/tasks/{project_policy_task['id']}/submissions",
@@ -1057,7 +1074,7 @@ async def test_submission_runtime_uses_locked_project_policy_not_task_required_f
         project["id"],
         monkeypatch,
         "worker-two",
-        conflicting_task_payload,
+        complete_task_payload(),
     )
     legacy_only_payload = complete_submission_payload("sha256:legacy-package")
     legacy_only_payload["artifact_hash_manifest"] = [
@@ -1089,7 +1106,7 @@ async def test_submission_runtime_uses_locked_project_policy_not_task_required_f
         project["id"],
         monkeypatch,
         "worker-three",
-        conflicting_task_payload,
+        complete_task_payload(),
     )
     legacy_evidence_payload = complete_submission_payload("sha256:legacy-evidence-package")
     legacy_evidence_payload["artifact_hash_manifest"][0]["hash"] = "sha256:answer-legacy-evidence"
@@ -2769,7 +2786,5 @@ async def test_json_and_numeric_fields_round_trip_under_postgres(task_client: As
 
     assert task is not None
     assert task.skill_tags == ["stem", "proofs"]
-    assert task.required_files == ["answer.md"]
-    assert task.required_evidence == ["checker log"]
     assert task.source_payload_hash == "hash-123"
     assert task.base_amount == Decimal("25.00")

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -773,8 +773,6 @@ Fields:
 - `status`
 - `acceptance_criteria`
 - `rejection_criteria`
-- `required_files` (legacy display snapshot)
-- `required_evidence` (legacy display snapshot)
 - `deadline_at`
 - `created_by`
 - `assigned_to`

--- a/docs/operations_project_operating_manual.md
+++ b/docs/operations_project_operating_manual.md
@@ -32,7 +32,7 @@ Before releasing tasks:
 - payment policy base amount configured
 - payment policy currency configured
 - allowed task types listed
-- task-owned contract fields listed
+- task source, description, acceptance, and rejection fields listed
 - guide sufficiency report passed or warnings acknowledged by `admin` or `project_manager`
 - submission artifact policy derived by Workstream and approved by `admin` or `project_manager`
 - effective project submission artifact policy hash persisted

--- a/docs/operations_queue_policy.md
+++ b/docs/operations_queue_policy.md
@@ -213,7 +213,7 @@ Every operating day starts with:
 
 | Transition | Required Records |
 | --- | --- |
-| `DRAFT -> SCREENING` | project id, locked guide candidate, task-owned contract fields, payment policy |
+| `DRAFT -> SCREENING` | project id, locked guide candidate, task source/description fields, acceptance and rejection criteria, payment policy |
 | `SCREENING -> READY` | screening decision, guide version lock, guide source snapshot id/hash lock, acceptance criteria, effective project submission artifact policy hash lock, project `PreSubmitCheckerPolicy` compiled bundle hash lock, post-submit checker policy, review policy, revision policy, payment policy |
 | `IN_PROGRESS -> SUBMITTED` | blocking pre-submit checks passed, submission packet, artifact hash manifest, evidence references, worker attestation |
 | `SUBMITTED -> EVALUATION_PENDING` | immutable submission version, locked post-submit checker policy id/version/hash/body copied from the task context |

--- a/docs/product_first_user_flows.md
+++ b/docs/product_first_user_flows.md
@@ -30,8 +30,8 @@ Acceptance:
 ## Flow 2: Operator Creates A Task
 
 1. Operator selects active project.
-2. Operator creates task with title, description, expected output, acceptance criteria, deadline, and difficulty.
-3. Workstream validates the task-owned contract fields and confirms the task fits the active project guide and policy bundle.
+2. Operator creates task with title, description, source reference, acceptance criteria, rejection criteria, deadline, and difficulty.
+3. Workstream validates the task source and reviewability fields, then confirms the task fits the active project guide and policy bundle.
 4. Task enters `SCREENING`.
 5. Screening locks the guide source snapshot id/hash, effective project submission artifact policy hash, and project pre-submit checker bundle hash, then confirms task contract, post-submit checker policy, review policy, revision policy, payment policy, and reviewability.
 6. Task enters `READY`.

--- a/docs/spec_chunk_4_task_queue_assignment.md
+++ b/docs/spec_chunk_4_task_queue_assignment.md
@@ -105,7 +105,7 @@ CLAIMED -> IN_PROGRESS
 
 Rules:
 
-- `DRAFT -> SCREENING` requires active project guide context and complete task-owned contract fields, then locks guide and policy versions on the task.
+- `DRAFT -> SCREENING` requires active project guide context and complete task source, description, acceptance, and rejection fields, then locks guide and policy versions on the task.
 - `SCREENING -> READY` requires that guide, checker, review, revision, and payment policy context be locked.
 - `READY -> CLAIMED` creates an active assignment and blocks a second active assignment.
 - `CLAIMED -> IN_PROGRESS` requires an active assignment for the actor or an authorized operator role.

--- a/docs/spec_chunk_8_submission_artifact_policy_checkers.md
+++ b/docs/spec_chunk_8_submission_artifact_policy_checkers.md
@@ -117,7 +117,9 @@ The checker reads:
 - locked project `PreSubmitCheckerPolicy` required artifacts
 - `submission.artifact_hash_manifest[*].artifact`
 
-`task.required_files` is legacy/transitional storage. It is not the policy source of truth once `SubmissionArtifactPolicy` is implemented.
+Task records do not define required files. Required artifact rules come from
+`SubmissionArtifactPolicy`, `EffectiveProjectSubmissionArtifactPolicy`, and the
+locked project `PreSubmitCheckerPolicy`.
 
 Matching is exact after path normalization. Chunk 8 does not implement glob matching.
 

--- a/docs/spec_chunk_8_submission_artifact_policy_checkers.md
+++ b/docs/spec_chunk_8_submission_artifact_policy_checkers.md
@@ -114,12 +114,12 @@ Fails when required artifacts are not represented in the artifact manifest.
 
 The checker reads:
 
-- locked project `PreSubmitCheckerPolicy` required artifacts
+- required artifact paths from `context.effective_policy`
 - `submission.artifact_hash_manifest[*].artifact`
 
 Task records do not define required files. Required artifact rules come from
-`SubmissionArtifactPolicy`, `EffectiveProjectSubmissionArtifactPolicy`, and the
-locked project `PreSubmitCheckerPolicy`.
+the locked effective project submission artifact policy loaded into
+`context.effective_policy`.
 
 Matching is exact after path normalization. Chunk 8 does not implement glob matching.
 

--- a/docs/template_task.md
+++ b/docs/template_task.md
@@ -43,9 +43,13 @@
 
 Describe the work to be done.
 
-## Required Output
+## Output Notes
 
-List exactly what must be submitted.
+Describe task-specific work in human terms when the description needs more
+detail. Machine-enforced required files, evidence, hashes, packaging, and
+forbidden artifacts are defined by the active project
+`SubmissionArtifactPolicy` and locked project `PreSubmitCheckerPolicy`, not by
+task fields.
 
 ## Acceptance Criteria
 
@@ -57,12 +61,15 @@ List exactly what must be submitted.
 
 - Criterion 1
 
-## Required Evidence
+## Submission Artifact Policy Context
 
-- checker logs
-- output files
-- summary
-- screenshots or hashes when applicable
+These values are stamped from the active project policy bundle during
+screening. Task creators do not provide submission artifact requirement fields
+directly.
+
+- submission artifact policy version:
+- effective project submission artifact policy hash:
+- project pre-submit checker bundle hash:
 
 ## Locked Payment Policy Snapshot
 

--- a/docs/template_task.md
+++ b/docs/template_task.md
@@ -67,8 +67,11 @@ These values are stamped from the active project policy bundle during
 screening. Task creators do not provide submission artifact requirement fields
 directly.
 
-- submission artifact policy version:
+- guide source snapshot id:
+- guide source snapshot hash:
+- effective project submission artifact policy id:
 - effective project submission artifact policy hash:
+- project pre-submit checker policy id:
 - project pre-submit checker bundle hash:
 
 ## Locked Payment Policy Snapshot


### PR DESCRIPTION
# PR Trust Bundle: WS-POL-001-07

## Chunk

`WS-POL-001-07` - Task Contract Artifact Field Cleanup

## Goal

Remove the remaining task-owned artifact requirement fields from the current
backend task contract.

`required_files` and `required_evidence` now belong only to
`SubmissionArtifactPolicy`, `EffectiveProjectSubmissionArtifactPolicy`, and the
compiled project `PreSubmitCheckerPolicy`. Task creation describes the work; it
does not author submission artifact policy.

## Human-Approved Intent

The user explicitly pushed back that:

- request bodies must hard-fail fields that no longer belong there;
- no backward-compatibility alias is needed while Workstream is still in build
  phase;
- project owners provide project material and business terms, but Workstream
  derives and approves internal artifact-intake policy;
- tasks must not fake project policy by accepting `required_files` or
  `required_evidence`;
- the next Terminal Benchmark drill should use real current APIs one step at a
  time.

## What Changed

- Added `0011_remove_legacy_task_artifact_fields.py`.
- Dropped `workstream_tasks.required_files` and
  `workstream_tasks.required_evidence`.
- Removed both fields from `WorkstreamTask`, `TaskCreate`, `TaskResponse`, and
  task creation service assignment.
- Added API coverage proving task creation with stale artifact requirement
  fields returns 422.
- Added Alembic coverage proving the removed task columns are absent at
  migration head.
- Updated Week 1/Week 2 helper scripts so task creation uses the current task
  request body.
- Removed stale project-shell payment fields from the Week 2 helper script.
- Removed stale project/guide request fields from `week1_dry_run.py` so the
  helper stays aligned with the current API.
- Updated active docs and templates so task records describe source, work,
  acceptance, rejection, and locked policy snapshots, while machine-enforced
  artifact and evidence rules are project-policy owned.
- Updated WS-POL status/chunk map/loop state for Chunk 7.

## Design Chosen

Current authority is:

```text
ProjectGuide = human-facing project material
SubmissionArtifactPolicy = Workstream-derived artifact-intake contract
EffectiveProjectSubmissionArtifactPolicy = default + project policy merge
Project PreSubmitCheckerPolicy = deterministic compiled checker bundle
Task = locks the active project policy/checker context
```

Task fields can describe source, title, description, difficulty, skill tags,
estimated time, acceptance criteria, rejection criteria, and deadline. They do
not define required artifacts, evidence, hashes, packaging, or forbidden
artifacts.

## Scope

Runtime/backend:

- `backend/alembic/versions/0011_remove_legacy_task_artifact_fields.py`
- `backend/app/modules/tasks/models.py`
- `backend/app/modules/tasks/schemas.py`
- `backend/app/modules/tasks/service.py`

Tests/scripts:

- `backend/tests/test_alembic.py`
- `backend/tests/test_tasks.py`
- `backend/scripts/week1_dry_run.py`
- `backend/scripts/week2_api_e2e.py`

Docs/process:

- `.agent-loop/LOOP_STATE.md`
- `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/**`
- `docs/architecture_data_model.md`
- `docs/operations_project_operating_manual.md`
- `docs/operations_queue_policy.md`
- `docs/product_first_user_flows.md`
- `docs/spec_chunk_4_task_queue_assignment.md`
- `docs/spec_chunk_8_submission_artifact_policy_checkers.md`
- `docs/template_task.md`

## Product Behavior

- Task create rejects `required_files` and `required_evidence` through
  `extra="forbid"`.
- Task responses no longer show stale artifact requirement snapshots.
- Tasks still lock guide/source/effective-policy/pre-submit-checker context
  before entering the worker pipeline.
- Pre-submit required artifact/evidence checks continue to come from the locked
  project policy and project `PreSubmitCheckerPolicy`.
- Payment values on tasks remain locked snapshots from `PaymentPolicy`.

## Verification

Passed locally:

```bash
cd backend && .venv/bin/python -m ruff check app tests scripts
cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_tasks.py tests/test_alembic.py
git diff --check
python3 scripts/check_stale_workstream_wording.py
python3 scripts/check_markdown_links.py
cd backend && .venv/bin/docstr-coverage app scripts --config .docstr.yaml
cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests
```

Results:

- ruff: passed
- focused task/Alembic suite: 67 passed
- stale wording scan: passed
- Markdown link check: passed
- docstring coverage: 100.0%
- full backend suite: 330 passed

Post-review repair verification:

```bash
cd backend && .venv/bin/python -m ruff check app tests scripts
python3 scripts/check_stale_workstream_wording.py
python3 scripts/check_markdown_links.py
git diff --check
cd backend && WORKSTREAM_TEST_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python -m pytest tests/test_alembic.py tests/test_tasks.py
```

Results:

- ruff: passed
- stale wording scan: passed
- Markdown link check: passed
- diff whitespace check: passed
- focused task/Alembic suite: 67 passed

## Internal Review

Evidence:

`.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-internal-review-evidence.md`

Reviewed implementation SHA:

`4845f9891362caad479030d339e512dbe5924b46`

Reviewer summary:

- senior engineering: PASS AFTER FIXES
- QA/test: PASS AFTER FIXES
- security/auth: PASS
- product/ops: PASS AFTER FIXES
- architecture: PASS
- docs: PASS AFTER FIXES
- reuse/dedup: PASS
- test delta: PASS
- CI integrity: PASS AFTER FIXES

## External Review

GitHub Actions passed on PR #68. CodeRabbit posted two actionable documentation
comments, both addressed in:

`.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-external-review-response.md`

## Remaining Risks

- The full backend suite passed before the final direct Alembic assertion and
  helper-script cleanup. The post-fix focused task/Alembic suite and ruff/docs
  checks passed after those repairs.
- Historical review evidence still mentions old construction-state fields
  because it records earlier chunks; active docs and runtime contracts now use
  the project-policy authority model.

## Human Review Focus

- Confirm task creation should no longer accept artifact requirement fields.
- Confirm there is no compatibility alias for `required_files` /
  `required_evidence` on tasks.
- Confirm required artifact/evidence checks remain project-policy driven.
- Confirm the helper-script cleanup is acceptable as request-body alignment for
  live drills, not a product setup redesign.
