### PR TITLE
Update WS-POL post-merge memory

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,17 +4,17 @@
 
 - Active initiative: `WS-POL-001` - Submission Artifact Policy Foundation
 - Active planning chunk: none
-- Active implementation chunk: `WS-POL-001-08`
-- Branch: `codex/ws-pol-001-08-celery-project-setup`
-- Status: `WS-POL-001-07` is merged to `main` through PR #68 as `3dc6a95`.
-  `WS-POL-001-08` is active and moves automatic pre-submit project setup onto
-  Celery: guide/source capture enqueues sufficiency analysis, blocked
-  sufficiency stops derivation, and passed or warning sufficiency creates only
-  a draft `SubmissionArtifactPolicy` for human Workstream approval.
-- Last merged implementation SHA: `3dc6a95`
-- Last merge commit: `3dc6a95`
-- Current gate: `WS-POL-001-08` implementation in progress
-- Next chunk: inactive until `WS-POL-001-08` is merged by the user
+- Active implementation chunk: none
+- Branch: `main`
+- Status: `WS-POL-001-08` is merged to `main` through PR #69 as `aea7024`.
+  Automatic pre-submit project setup now runs through Celery from guide/source
+  capture: sufficiency analysis runs first, blocked sufficiency stops policy
+  derivation, and passed or warning sufficiency creates only a draft
+  `SubmissionArtifactPolicy` for human Workstream approval.
+- Last merged implementation SHA: `0c32c97`
+- Last merge commit: `aea7024`
+- Current gate: post-merge memory update for `WS-POL-001-08`
+- Next chunk: inactive until the user gives an explicit start signal
 
 ## Operating Rule
 
@@ -31,9 +31,9 @@ not implement frontend behavior, payment, reputation, settlement, blockchain
 integrations, post-submit policy splitting, or revision resubmission drill
 behavior.
 
-The active `WS-POL-001-08` chunk corrects the project setup orchestration path:
+The merged `WS-POL-001-08` chunk corrected the project setup orchestration path:
 normal guide/source capture starts the pre-submit setup pipeline automatically
-through Celery. It must not redesign post-submit policy, review, revision,
+through Celery. It did not redesign post-submit policy, review, revision,
 payment, reputation, blockchain integrations, frontend behavior, or task
 submission runtime.
 
@@ -84,3 +84,7 @@ submission runtime.
 - `WS-POL-001-08` started on branch `codex/ws-pol-001-08-celery-project-setup`
   after the user's explicit correction that project setup must run
   automatically from guide/source capture through Celery.
+- `WS-POL-001-08` internal review evidence is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-08-internal-review-evidence.md`.
+- `WS-POL-001-08` external review response is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-08-external-review-response.md`.
+- `WS-POL-001-08` PR trust bundle is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-08-pr-trust-bundle.md`.
+- PR #69 merged into `main` as `aea7024`.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -137,3 +137,94 @@ explicit start signal.
 Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-03-internal-review-evidence.md`
 
 External review response: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-03-external-review-response.md`
+
+## WS-POL-001-04
+
+Status: merged through PR #65.
+
+Required reviewer tracks:
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- docs
+- reuse/dedup
+- test delta
+
+Result: PASS after fixes; external review addressed; GitHub checks passed.
+
+Scope: post-submit checker policy provenance, durable checker-run policy locks,
+and separation of post-submit/internal checks from pre-submit intake.
+
+Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-internal-review-evidence.md`
+
+External review response: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-04-external-review-response.md`
+
+## WS-POL-001-05
+
+Status: merged through PR #66.
+
+Result: PASS after fixes; external review addressed; GitHub checks passed.
+
+Scope: revision resubmission proof, real API drill, and `evaluation_pending`
+lifecycle status.
+
+Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-05-internal-review-evidence.md`
+
+External review response: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-05-external-review-response.md`
+
+## WS-POL-001-06
+
+Status: merged through PR #67.
+
+Result: PASS after fixes; GitHub checks passed.
+
+Scope: Terminal Benchmark fixture proof harness, OpenAI Agents SDK strict-schema
+fix, and cleanup of stale project guide/payment contracts.
+
+Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-06-internal-review-evidence.md`
+
+## WS-POL-001-07
+
+Status: merged through PR #68.
+
+Result: PASS after fixes; external review addressed; GitHub checks passed.
+
+Scope: removed task-owned artifact fields and kept artifact requirements driven
+by project submission artifact policy.
+
+Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-internal-review-evidence.md`
+
+External review response: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-07-external-review-response.md`
+
+## WS-POL-001-08
+
+Status: merged through PR #69 on 2026-07-06.
+
+Merge commit: `aea7024`
+
+Reviewed implementation SHA: `0c32c97a3895f0435b7602698730b5d40b1bacbd`
+
+Required reviewer tracks:
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- CI integrity
+- docs
+- reuse/dedup
+- test delta
+
+Result: PASS after fixes; external review addressed; GitHub checks passed.
+
+Scope: Celery-backed automatic project setup from guide/source capture,
+sufficiency-first pipeline ordering, draft submission artifact policy creation,
+and removal of remaining construction-state compatibility surfaces.
+
+Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-08-internal-review-evidence.md`
+
+External review response: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-08-external-review-response.md`

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-POL-001-05` | Revision Resubmission And Real API Drill | L1 | Active on `codex/ws-pol-001-05-revision-resubmission`; implementation proof complete, internal reviewer repair/re-review in progress |
+| TBD | Next WS-POL-001 bounded chunk | L1 | Inactive until explicit user start signal and chunk contract |
 
 ## Completed
 
@@ -17,12 +17,17 @@
 | `WS-POL-001-02` | Async Guide Analysis And Policy Derivation | L1 | Merged through PR #61 |
 | `WS-POL-001-03` | Task Locked Context And Submission Creation | L1 | Merged through PR #63 on 2026-07-03 |
 | `WS-POL-001-04` | Post-Submit Checker Policy Provenance | L1 | Merged through PR #65 |
+| `WS-POL-001-05` | Revision Resubmission And Real API Drill | L1 | Merged through PR #66 |
+| `WS-POL-001-06` | Terminal Benchmark Real Fixture Drill | L1 | Merged through PR #67 |
+| `WS-POL-001-07` | Task Contract Artifact Field Cleanup | L1 | Merged through PR #68 |
+| `WS-POL-001-08` | Celery Project Setup Pipeline | L1 | Merged through PR #69 |
 
 ## Proposed Next
 
-`WS-POL-001-05` must prove checker-caused revision resubmission with real
-Postgres-backed API calls and replace the legacy evaluation lifecycle status
-with `evaluation_pending`.
+No chunk is active. The next likely step is a new bounded chunk to prove the
+automatic Celery project setup path against the Terminal Benchmark example with
+real API calls, but it must receive an explicit chunk contract before
+implementation starts.
 
 ## Blocked
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/DECISIONS.md
@@ -40,8 +40,14 @@
 - Worker-facing task outcomes remain simple; internal routes stay internal.
 - Stored review decision values remain exactly `accept`, `needs_revision`, and
   `reject`. Display wording must not create new persisted tokens.
-- `evidence_policy`, `required_files`, and `required_evidence` are transitional
-  fields to replace, not compatibility contracts to preserve.
+- `evidence_policy`, task-owned `required_files`, task-owned
+  `required_evidence`, and generic checker-policy version locks are discarded
+  construction-state fields. They are not compatibility contracts and must not
+  be restored in current v0.1 APIs or migrations.
+- Guide/source capture starts automatic project setup through Celery. The
+  pipeline runs guide sufficiency first, stops on blocking sufficiency, and
+  creates only a draft `SubmissionArtifactPolicy` after sufficiency passes or
+  passes with warnings.
 
 ## Accepted Defaults
 
@@ -62,5 +68,5 @@
 - Final review of persisted provenance field names for guide sufficiency
   reports, project submission artifact policies, effective project submission artifact policy hashes, and
   generated project pre-submit checker compiled bundle hashes.
-- Final confirmation that Chunk 1 implements records/contracts/activation guard
-  only, while full async agent execution comes later.
+- Confirm the next chunk contract before resuming the real Terminal Benchmark
+  drill through the automatic Celery setup path.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/RISKS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/RISKS.md
@@ -7,6 +7,7 @@
 | Project owner schema burden | High | Project owners provide plain-language material; Workstream derives policy and actors with the `admin` or `project_manager` role approve it. |
 | Naming drift | High | Human review field names before migrations. |
 | Worker-facing internal route leakage | Medium | Keep `task_setup_blocked` and `checker_retry` internal; expose `needs_revision` only when worker action is needed. |
-| Stale transitional field drift | Medium | Replace guide-field artifact rules and task-level artifact/evidence shortcuts; do not preserve them as v0.1 compatibility aliases. |
-| Agent scope creep | Medium | Chunk 1 models records/contracts/activation guards; full async agent execution is a later chunk. |
+| Stale construction-state field drift | Medium | Removed guide-field artifact rules, task-level artifact/evidence shortcuts, and generic checker-policy version locks; keep stale wording scans and request-body tests fail-closed. |
+| Worker enqueue durability gap | Medium | Current Celery enqueue semantics are honest after commit; add a durable outbox later if guaranteed eventual enqueue is required. |
+| Agent scope creep | Medium | Project setup agent execution is now isolated behind Celery; future agent expansion must stay behind chunk contracts and must not run inline in request handlers. |
 | Insufficient real API proof | High | Require Postgres-backed API tests and real API drill before closing the initiative. |

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -3,18 +3,17 @@
 ## Current Status
 
 `WS-POL-001-01`, `WS-POL-001-02`, `WS-POL-001-03`, `WS-POL-001-04`,
-`WS-POL-001-05`, `WS-POL-001-06`, and `WS-POL-001-07` are merged to `main`.
-`WS-POL-001-07` merged through PR #68 as `3dc6a95` after deterministic
-verification, internal reviewer fanout, GitHub Actions, CodeRabbit review, and
-user merge approval.
+`WS-POL-001-05`, `WS-POL-001-06`, `WS-POL-001-07`, and `WS-POL-001-08` are
+merged to `main`. `WS-POL-001-08` merged through PR #69 as `aea7024` after
+deterministic verification, internal reviewer fanout, GitHub Actions,
+CodeRabbit review, external review response, and user merge approval.
 
-`WS-POL-001-08` is active. Implementation is in progress on
-`codex/ws-pol-001-08-celery-project-setup` and moves automatic pre-submit
-project setup onto Celery.
+No implementation chunk is active. The next chunk must start only after an
+explicit user signal and a new chunk contract.
 
 ## Active Chunk
 
-`WS-POL-001-08` - Celery Project Setup Pipeline
+None.
 
 ## Chunk Status
 
@@ -27,13 +26,13 @@ project setup onto Celery.
 | `WS-POL-001-05` | Merged | `codex/ws-pol-001-05-revision-resubmission` | 66 | Proves revision resubmission, real API drill, and `evaluation_pending` lifecycle status. |
 | `WS-POL-001-06` | Merged | `codex/ws-pol-001-06-terminal-benchmark-drill` | 67 | Hardens the Terminal Benchmark proof harness and removes stale project guide/payment contracts before continuing pre-submit checker work. |
 | `WS-POL-001-07` | Merged | `codex/ws-pol-001-07-task-contract-cleanup` | 68 | Removes task-owned `required_files`/`required_evidence` from request/response/model/migration and keeps artifact requirements project-policy driven. |
-| `WS-POL-001-08` | Implementation in progress | `codex/ws-pol-001-08-celery-project-setup` | TBD | Makes guide/source capture enqueue Celery pre-submit setup automatically: sufficiency first, blocked stops, draft submission artifact policy next. |
+| `WS-POL-001-08` | Merged | `codex/ws-pol-001-08-celery-project-setup` | 69 | Makes guide/source capture enqueue Celery pre-submit setup automatically: sufficiency first, blocked stops, draft submission artifact policy next; removes remaining construction-state compatibility surfaces. |
 
 ## Blockers
 
 | Blocker | Owner | Next action |
 |---|---|---|
-| None | - | Continue bounded implementation for `WS-POL-001-08`. |
+| None | - | Await explicit user start signal for the next bounded chunk. |
 
 ## Follow-Ups
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-08-post-merge-memory-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-08-post-merge-memory-internal-review-evidence.md
@@ -1,0 +1,62 @@
+# Internal Review Evidence: WS-POL-001-08 Post-Merge Memory
+
+## Chunk
+
+WS-POL-001-08 post-merge memory update
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: d85a32bce78ba6eb0697db481b2616501e9f55aa
+
+Reviewed at: 2026-07-06T02:45:29Z
+
+Reviewer run ids: local-senior-engineering-review-20260706T024529Z, local-qa-test-review-20260706T024529Z, local-security-auth-review-20260706T024529Z, local-product-ops-review-20260706T024529Z, local-architecture-review-20260706T024529Z, local-docs-review-20260706T024529Z
+
+## Reviewed Change
+
+Branch: `codex/ws-pol-001-post-merge-memory`
+
+Scope:
+
+- Marks `WS-POL-001-08` as merged through PR #69.
+- Updates `.agent-loop/LOOP_STATE.md`, `.agent-loop/WORK_QUEUE.md`, and
+  `.agent-loop/REVIEW_LOG.md`.
+- Updates the WS-POL-001 initiative status, decisions, and risks to reflect the
+  Celery project setup merge and discarded construction-state compatibility
+  fields.
+- Leaves product/runtime code untouched.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Memory update is bounded to loop/status/log files and does not alter runtime behavior. |
+| qa/test | PASS | None | Loop memory, stale wording, Markdown links, and diff whitespace checks passed before PR. |
+| security/auth | PASS | None | No auth, secret, permission, worker, or deployment behavior changed. |
+| product/ops | PASS | None | Durable state now matches the user-approved merge: no active chunk, next chunk inactive until explicit start signal. |
+| architecture | PASS | None | Process memory now reflects the Celery setup boundary without changing architecture contracts. |
+| docs | PASS | None | Updated memory docs remove stale active-branch wording and add PR #69 evidence links. |
+
+## Commands Run
+
+```bash
+python3 scripts/check_loop_memory_state.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+Results:
+
+- Loop memory state check: passed.
+- Stale wording check: passed.
+- Markdown link check: passed for 6 changed Markdown files.
+- Diff whitespace check: passed.
+
+## Remaining Risks
+
+None for this memory-only update.


### PR DESCRIPTION
## Summary

Updates durable loop memory after PR #69 merged:

- marks WS-POL-001-08 as merged through PR #69
- records review/evidence links and merge SHA
- clears active chunk state
- updates work queue, decisions, and risks for the Celery project setup merge

## Validation

- python3 scripts/check_loop_memory_state.py
- python3 scripts/check_stale_workstream_wording.py
- python3 scripts/check_markdown_links.py
- git diff --check

No product/runtime code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the setup and submission workflow, including when project setup starts automatically and what happens before a draft policy is created.
  * Updated status notes to show the latest work items as merged and that no implementation chunk is currently active.

* **Chores**
  * Refined internal tracking for review history, risks, and next-step guidance to better reflect the current release state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->