### PR TITLE
Update WS-POL-001-13 post-merge memory

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,16 +4,16 @@
 
 - Active initiative: `WS-POL-001` - Submission Artifact Policy Foundation
 - Active planning chunk: none
-- Active implementation chunk: `WS-POL-001-13`
-- Branch: `codex/ws-pol-001-13-task-context-apis`
-- Status: `WS-POL-001-13` is implementing worker-safe task work context,
-  exact submission requirements, and operator-only locked task provenance APIs
-  after PR #76 merged to `main`.
-- Last merged implementation SHA: `46e74de`
-- Last merge commit: `46e74de`
-- Current gate: implement Chunk 13, run deterministic proof, run required
-  internal reviewer tracks, then open a PR for human review.
-- Next chunk: inactive until `WS-POL-001-13` receives human review and merge.
+- Active implementation chunk: none
+- Branch: `main`
+- Status: `WS-POL-001-13` merged through PR #77. Worker-safe task work
+  context, exact submission requirements, and operator-only locked task
+  provenance APIs are now on `main`.
+- Last merged implementation SHA: `b567bac`
+- Last merge commit: `b567bac`
+- Current gate: post-merge memory update, then stop.
+- Next chunk: `WS-POL-001-14` is inactive until the user gives an explicit
+  start signal.
 
 ## Operating Rule
 
@@ -117,3 +117,10 @@ blockchain, frontend, or agent-runtime behavior.
   project setup-run and policy visibility APIs.
 - `WS-POL-001-13` started on branch `codex/ws-pol-001-13-task-context-apis`
   after the user's explicit start signal.
+- PR #77 merged into `main` as `b567bac`; it implemented `WS-POL-001-13`
+  task work-context, submission-requirements, and operator-only locked-context APIs.
+- `WS-POL-001-13` internal review evidence is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-13-internal-review-evidence.md`.
+- `WS-POL-001-13` external review response is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-13-external-review-response.md`.
+- `WS-POL-001-13` PR trust bundle is tracked at `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-13-pr-trust-bundle.md`.
+- `WS-POL-001-14` remains inactive. It should address submission finalize/no-DB
+  proof semantics before the next Terminal Benchmark accepted drill.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -337,3 +337,44 @@ no-backward-compatibility chunk decision.
 Next gate: rerun the Terminal Benchmark live API drill through real HTTP calls
 using `POST /api/v1/workers/me/profile`, then review findings before starting
 the next product chunk.
+
+## WS-POL-001-13
+
+Status: merged through PR #77 on 2026-07-08.
+
+Merge commit: `b567bac`
+
+Branch: `codex/ws-pol-001-13-task-context-apis`
+
+Reviewed implementation SHA: `f533f1a`
+
+Required reviewer tracks:
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- docs
+- reuse/dedup
+- test delta
+
+Result: PASS after fixes from internal review and CodeRabbit. GitHub Agent
+Gates, Backend, and CodeRabbit passed before merge.
+
+Scope: worker-safe task work context, exact submission requirements, existing
+worker task-read redaction, fail-closed locked-context validation, and
+operator-only locked task provenance APIs.
+
+Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-13-internal-review-evidence.md`
+
+External review response: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-13-external-review-response.md`
+
+External review status: CodeRabbit comments triaged; the valid test
+maintainability nitpick was fixed; PR description warning was fixed by updating
+the trust bundle and PR body.
+
+Next gate: `WS-POL-001-14` remains inactive until the user explicitly starts it.
+It should replace public submission lock wording with finalize semantics,
+define system actor audit behavior, and rerun the Terminal Benchmark proof
+without DB inspection.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,8 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `TERMINAL-BENCHMARK-LIVE-DRILL` | Post-Actor-Registry Real API Drill | L1 | Next gate; use real HTTP calls and canonical `POST /api/v1/workers/me/profile` |
+| `WS-POL-001-14` | Submission Finalize And No-DB Terminal Benchmark Proof | L1 | Inactive; start only after explicit user signal |
+| `TERMINAL-BENCHMARK-LIVE-DRILL` | Accepted No-DB Terminal Benchmark Drill | L1 | Blocked behind `WS-POL-001-14`; use real HTTP calls only after finalize/system actor semantics are implemented |
 
 ## Completed
 
@@ -24,14 +25,18 @@
 | `WS-POL-001-09` | OpenAI Agents SDK Runtime Only | L1 | Merged through PR #71 |
 | `WS-POL-001-10` | Pre-Submit Live Drill Hardening | L1 | Merged through PR #72 |
 | `WS-POL-001-11` | Actor Identity And Profile Registry | L1 | Merged through PR #74 on 2026-07-07 |
+| `WS-POL-001-12` | Project Setup And Policy Visibility APIs | L1 | Merged through PR #76 as `46e74de` |
+| `WS-POL-001-13` | Task Context And Submission Requirement APIs | L1 | Merged through PR #77 as `b567bac` on 2026-07-08 |
 
 ## Proposed Next
 
-After the Terminal Benchmark live API drill passes, decide whether the next
-product chunk should address drill findings or continue from the approved
-WS-POL chunk map. Do not start another implementation chunk before the drill
-result is reviewed.
+`WS-POL-001-14` should replace public submission lock wording with finalize
+semantics, define system actor audit behavior, and enable the accepted
+Terminal Benchmark proof without DB inspection. Do not start it until the user
+explicitly asks.
 
 ## Blocked
 
-None.
+| Chunk | Blocker | Next action |
+|---|---|---|
+| `TERMINAL-BENCHMARK-LIVE-DRILL` | Accepted no-DB proof requires submission finalize semantics and system actor audit behavior. | Complete and review `WS-POL-001-14`, then rerun the drill through real HTTP calls. |

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -4,22 +4,17 @@
 
 `WS-POL-001-01`, `WS-POL-001-02`, `WS-POL-001-03`, `WS-POL-001-04`,
 `WS-POL-001-05`, `WS-POL-001-06`, `WS-POL-001-07`, `WS-POL-001-08`,
-`WS-POL-001-09`, `WS-POL-001-10`, `WS-POL-001-11`, and `WS-POL-001-12` are
-merged to `main`.
+`WS-POL-001-09`, `WS-POL-001-10`, `WS-POL-001-11`, `WS-POL-001-12`, and
+`WS-POL-001-13` are merged to `main`.
 The post-actor-registry Terminal Benchmark live API drill passed through real
-HTTP calls, but it still needs task context visibility, submission finalize
-wording, and system-actor audit semantics before being accepted as a no-DB
-proof. `WS-POL-001-13` is active to expose worker-safe task context, exact
-submission requirements, and operator-only locked provenance. `WS-POL-001-14`
-remains the finalize/no-DB proof chunk before rerunning the Terminal Benchmark
-drill as accepted evidence.
+HTTP calls, and task context visibility is now exposed through APIs. The drill
+still needs submission finalize wording and system actor audit semantics before
+being accepted as a no-DB proof. `WS-POL-001-14` remains the finalize/no-DB
+proof chunk before rerunning the Terminal Benchmark drill as accepted evidence.
 
 ## Active Chunk
 
-`WS-POL-001-13` is active on branch
-`codex/ws-pol-001-13-task-context-apis`. It adds task work-context,
-submission-requirements, and operator locked-context APIs before the next
-Terminal Benchmark drill.
+None. `WS-POL-001-14` is inactive until the user gives an explicit start signal.
 
 ## Chunk Status
 
@@ -37,14 +32,13 @@ Terminal Benchmark drill.
 | `WS-POL-001-10` | Merged | `codex/ws-pol-001-10-pre-submit-hardening` | 72 | Hardens duplicate guide-version conflicts, guide-create source snapshots, active-guide checker summaries, worker self-profile onboarding, and failed pre-submit audit evidence. |
 | `WS-POL-001-11` | Merged | `codex/ws-pol-001-11-actor-profile-registry-impl` | 74 | Implements local Workstream actor identity and actor profile registries for verified Flow actors before the next live API drill. |
 | `WS-POL-001-12` | Merged | `codex/ws-pol-001-12-project-setup-policy-visibility` | 76 | Adds project setup-run and project policy visibility APIs for setup runs, sufficiency reports, submission artifact policies, effective policy, and compiled project pre-submit checker policy. |
-| `WS-POL-001-13` | Active | `codex/ws-pol-001-13-task-context-apis` | - | Add task work-context, worker submission-requirements, and operator locked-context APIs. |
+| `WS-POL-001-13` | Merged | `codex/ws-pol-001-13-task-context-apis` | 77 | Adds task work-context, worker submission-requirements, and operator-only locked-context APIs. |
 | `WS-POL-001-14` | Proposed | - | - | Replace public submission lock with finalize, define system actor audit semantics, and rerun the Terminal Benchmark proof without DB inspection. |
 
 ## Blockers
 
 | Blocker | Owner | Next action |
 |---|---|---|
-| Missing task context visibility APIs | Workstream | Implement and review `WS-POL-001-13`. |
 | Public lock wording and no-DB drill proof | Workstream | Implement `WS-POL-001-14` before rerunning Terminal Benchmark as accepted proof. |
 
 ## Follow-Ups

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-13-post-merge-memory-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-13-post-merge-memory-internal-review-evidence.md
@@ -1,0 +1,70 @@
+# Internal Review Evidence: WS-POL-001-13 Post-Merge Memory
+
+## Chunk
+
+WS-POL-001-13-post-merge-memory
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: c5f88dff111457c341c8afceda468c29f3ee4fa6
+
+Reviewed at: 2026-07-08T02:39:53Z
+
+Reviewer run IDs: senior-engineering-initial-019f3f93-7d4d-7ce3-8440-589038ff9d6f, qa-test-019f3f93-7f3e-7151-9429-cdf9106747a1, security-auth-019f3f93-8195-7371-b175-331784b611d2, product-ops-initial-019f3f93-83f4-7180-81b3-ff480ea75157, architecture-019f3f93-867c-72d3-8b3e-2ff7c2a6bf75, docs-019f3f93-8c12-7272-9ea3-4f74e412eea2, senior-engineering-final-019f3f96-75ff-7400-af32-559befff9c93, product-ops-final-019f3f96-7813-78e0-8ddf-05301188d7d4
+
+After the reviewed SHA, only evidence files changed.
+
+## Reviewed Change
+
+Scope:
+
+- Marks `WS-POL-001-13` as merged through PR #77 at merge commit `b567bac`.
+- Sets the active implementation chunk to none.
+- Keeps `WS-POL-001-14` inactive until an explicit user start signal.
+- Records that the accepted no-DB Terminal Benchmark drill remains blocked
+  behind submission finalize semantics and system actor audit behavior.
+- Updates the Work Queue, loop state, initiative status, roadmap status, and
+  review log without starting the next implementation chunk.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS AFTER FIXES | None | Initial pass found the Work Queue Blocked section contradicted the planned blocker. The final recheck passed after the blocker table was added. |
+| QA/test | PASS | None | Confirmed PR #77 is merged at `b567bac`, Chunk 13 is complete, no active chunk remains, and the stale task-context blocker is gone. |
+| security/auth | PASS | None | Confirmed no secrets, tokens, private operational data, or security-confusing wording was introduced. |
+| product/ops | PASS AFTER FIXES | None | Initial pass found the same Work Queue contradiction. The final recheck confirmed the Terminal Benchmark drill remains blocked behind `WS-POL-001-14`. |
+| architecture | PASS | None | Confirmed the engineering loop remains separate from the Workstream product lifecycle and Chunk 14 is not accidentally activated. |
+| docs | PASS | None | Confirmed wording consistency for the final memory diff. |
+
+## Valid Findings Addressed
+
+- Replaced the stale `Blocked: None` Work Queue section with a blocker table for
+  `TERMINAL-BENCHMARK-LIVE-DRILL`.
+- Kept `WS-POL-001-14` inactive while documenting that it must complete before
+  the accepted no-DB Terminal Benchmark drill resumes.
+
+## Commands Run
+
+```bash
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+rg -n 'system-actor|operator locked-context|Missing task context visibility APIs|Active \|.*WS-POL-001-13|Active implementation chunk: `WS-POL-001-13`' .agent-loop docs/roadmap_status.md
+```
+
+Results:
+
+- Stale wording scan: passed.
+- Markdown link check: passed for 5 changed Markdown files.
+- Diff whitespace check: passed.
+- Stale active-chunk and stale wording scan: no matches.
+
+## Remaining Risks
+
+- None for the memory update. `WS-POL-001-14` remains inactive and must be
+  planned and reviewed before implementation.

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -45,6 +45,7 @@ Current phase: Week 3 review and revision preparation.
 - Week 2 real HTTP API drill through Flow-token auth, project/guide/task/submission lifecycle, pre-submit checks, automatic checker runs, `pre_submission_checker_failed` intake failures, worker redaction, internal `task_setup_blocked`, and trusted checker retry.
 - Chunk 11 actor identity/profile registry for verified Flow actors.
 - Chunk 12 project setup-run and project policy visibility APIs for setup runs, sufficiency reports, submission artifact policies, effective policy, and compiled project pre-submit checker policy.
+- Chunk 13 task work-context, worker submission-requirements, and operator-only locked-context APIs.
 
 ## Review Tracks Closed
 
@@ -64,9 +65,9 @@ Current phase: Week 3 review and revision preparation.
 - Week 3 must keep review decisions canonical: `accept`, `needs_revision`, and `reject`.
 - `needs_revision` from human review must carry `outcome_source = human_review` and a review decision id; checker-caused `needs_revision` keeps `outcome_source = auto_checker`.
 - Review findings, revision replay, and reviewer-quality metrics are the next backend contracts to lock.
-- Chunk 13 task context APIs are in progress to expose worker-safe work
-  context, exact submission requirements, and operator-only locked provenance
-  before rerunning the Terminal Benchmark drill.
+- Chunk 14 remains before the accepted no-DB Terminal Benchmark drill. It must
+  replace public submission lock wording with finalize semantics and define
+  system actor audit behavior.
 
 ## Pending Before Pilot
 


### PR DESCRIPTION
## Summary

Updates the durable loop memory after PR #77 merged to `main` as `b567bac`.

## What Changed

- Marks `WS-POL-001-13` as merged and clears the active implementation chunk.
- Records `WS-POL-001-14` as inactive until explicit user start.
- Blocks the accepted no-DB Terminal Benchmark drill behind `WS-POL-001-14` finalize/system actor semantics.
- Adds reviewed-revision-bound internal review evidence for this memory-only cleanup.

## Evidence

Internal evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-13-post-merge-memory-internal-review-evidence.md`

Reviewed memory commit: `c5f88dff111457c341c8afceda468c29f3ee4fa6`

## Checks

- `python3 scripts/check_stale_workstream_wording.py`
- `python3 scripts/check_markdown_links.py`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_internal_review_evidence.py`

## Internal Review

- senior engineering: PASS after Work Queue blocker fix
- QA/test: PASS
- security/auth: PASS
- product/ops: PASS after Work Queue blocker fix
- architecture: PASS
- docs: PASS

## Human Review Focus

Confirm this is only post-merge memory state and does not start `WS-POL-001-14`.
