### PR TITLE
Harden project policy derivation prompt

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,16 +4,21 @@
 
 - Active initiative: `WS-POL-001` - Submission Artifact Policy Foundation
 - Active planning chunk: none
-- Active implementation chunk: none
-- Branch: `main`
-- Status: `WS-POL-001-14` merged through PR #79. Submission finalization,
-  system actor pre-review gate audit semantics, scoped operator visibility, and
-  HTTP-visible Terminal Benchmark proof are now on `main`.
+- Active implementation chunk: `WS-POL-001-15` - Agent Derivation Policy
+  Conflict Hardening
+- Branch: `codex/ws-pol-001-15-agent-derivation-hardening`
+- Status: The accepted no-DB Terminal Benchmark live API drill from `main`
+  reached project/guide/snapshot/sufficiency, then failed during
+  agent-derived submission artifact policy creation because the agent emitted a
+  required artifact and forbidden artifact pattern that matched each other.
 - Last merged implementation SHA: `ebf9d1d`
 - Last merge commit: `53a57c3`
-- Current gate: run the accepted no-DB Terminal Benchmark live API drill from
-  `main`, then decide the next chunk.
-- Next chunk: inactive until the user explicitly starts it.
+- Current gate: write internal review evidence, run the evidence gate, and open
+  a PR for human review after the derivation contract hardening, full project
+  tests, internal reviewers, and accepted no-DB Terminal Benchmark live API
+  drill passed on this branch.
+- Next chunk: inactive until this corrective chunk is merged and the user
+  explicitly starts it.
 
 ## Operating Rule
 

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -418,5 +418,8 @@ External review response: `.agent-loop/initiatives/WS-POL-001-submission-artifac
 External review status: CodeRabbit comments triaged; valid findings fixed;
 GitHub checks and CodeRabbit passed before merge.
 
-Next gate: rerun the accepted no-DB Terminal Benchmark live API drill from
-`main` using real HTTP calls, then decide the next chunk.
+Next gate update: the accepted no-DB Terminal Benchmark live API drill from
+`main` exposed an agent-derived submission artifact policy self-conflict during
+policy derivation. Corrective chunk `WS-POL-001-15` is now active to harden the
+derivation contract before any next implementation chunk starts. The corrective
+branch has rerun that live API drill successfully after hardening.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `TERMINAL-BENCHMARK-LIVE-DRILL` | Accepted No-DB Terminal Benchmark Drill | L1 | Ready on `main`; use real HTTP calls only |
+| `WS-POL-001-15` | Agent Derivation Policy Conflict Hardening | L1 | Active on `codex/ws-pol-001-15-agent-derivation-hardening` |
 
 ## Completed
 
@@ -30,10 +30,10 @@
 
 ## Proposed Next
 
-Run the accepted no-DB Terminal Benchmark live API drill from `main`, using
-real HTTP calls and the HTTP-visible setup, task context, finalization,
-checker-run, audit, and revision responses. Do not start the next implementation
-chunk until the user explicitly approves it.
+Complete `WS-POL-001-15` after the accepted no-DB Terminal Benchmark live API
+drill exposed an agent-derived submission artifact policy self-conflict. Do not
+start the next implementation chunk until this corrective PR is merged and the
+user explicitly approves the next chunk.
 
 ## Blocked
 

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/CHUNK_MAP.md
@@ -1248,3 +1248,72 @@ Human review focus:
 
 Public `finalize` wording, operator-only authorization, system actor audit
 provenance, and whether the live drill is genuinely API-only.
+
+### WS-POL-001-15: Agent Derivation Policy Conflict Hardening
+
+Goal:
+
+Harden the project setup derivation contract after the accepted no-DB Terminal
+Benchmark drill exposed that the agent can emit a required artifact and a
+forbidden artifact pattern that match each other.
+
+Risk:
+
+L1
+
+Depends on:
+
+`WS-POL-001-14`
+
+Allowed files:
+
+```text
+backend/app/adapters/project_agents/openai_agent_sdk.py
+backend/tests/test_projects.py
+examples/terminal_benchmark/terminal_benchmark_api_e2e.py
+docs/roadmap_status.md
+.agent-loop/LOOP_STATE.md
+.agent-loop/WORK_QUEUE.md
+.agent-loop/REVIEW_LOG.md
+.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/**
+```
+
+Not allowed:
+
+```text
+backend/alembic/versions/**
+backend/app/adapters/auth/**
+backend/app/modules/tasks/**
+backend/app/modules/checkers/**
+backend/app/modules/projects/models.py
+backend/app/modules/projects/router.py
+backend/app/modules/projects/repository.py
+payment/reputation/blockchain settlement
+frontend/demo UI work
+new agent runtime providers
+weakening Workstream default forbidden artifact rules
+```
+
+Acceptance criteria:
+
+- `SubmissionArtifactPolicyDerivationAgent` instructions prohibit
+  self-conflicting policies where forbidden artifact rules match required
+  artifact paths/keys or required evidence keys/labels.
+- The instructions distinguish worker-submitted artifacts from guide source,
+  reviewer-only, and example material.
+- The instructions prefer deterministic project-level artifact intake contracts
+  over overfitting to one representative task.
+- Tests pin the prompt contract and preserve fail-closed rejection for unsafe
+  required artifact paths and keys.
+- The accepted Terminal Benchmark no-DB live API drill proceeds past policy
+  derivation and through the HTTP-visible proof path.
+
+Required reviewers:
+
+senior engineering, QA/test, security/auth, product/ops, architecture, docs,
+reuse/dedup, test delta.
+
+Human review focus:
+
+Whether the derivation contract prevents real setup-agent self-conflicts without
+weakening default forbidden artifact enforcement.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md
@@ -8,12 +8,15 @@ HTTP calls, and task context visibility is now exposed through APIs.
 `WS-POL-001-14` replaced public submission lock wording with finalization,
 defined system actor audit semantics, and merged PR #79's HTTP-visible Terminal
 Benchmark proof evidence. The accepted post-merge no-DB Terminal Benchmark
-drill still needs to rerun from `main`.
+drill from `main` exposed a self-conflicting agent-derived submission artifact
+policy, now tracked as corrective chunk `WS-POL-001-15`.
+The corrective branch now reruns that accepted drill successfully after
+hardening the derivation contract.
 
 ## Active Chunk
 
-None. The next gate is the accepted no-DB Terminal Benchmark live API drill from
-`main`.
+`WS-POL-001-15` on branch
+`codex/ws-pol-001-15-agent-derivation-hardening`.
 
 ## Chunk Status
 
@@ -33,6 +36,7 @@ None. The next gate is the accepted no-DB Terminal Benchmark live API drill from
 | `WS-POL-001-12` | Merged | `codex/ws-pol-001-12-project-setup-policy-visibility` | 76 | Adds project setup-run and project policy visibility APIs for setup runs, sufficiency reports, submission artifact policies, effective policy, and compiled project pre-submit checker policy. |
 | `WS-POL-001-13` | Merged | `codex/ws-pol-001-13-task-context-apis` | 77 | Adds task work-context, worker submission-requirements, and operator-only locked-context APIs. |
 | `WS-POL-001-14` | Merged | `codex/ws-pol-001-14-submission-finalize` | 79 | Replaces public submission lock with finalize, defines system actor audit semantics, scopes operator visibility, and proves the Terminal Benchmark flow through HTTP-visible lifecycle responses. |
+| `WS-POL-001-15` | Active | `codex/ws-pol-001-15-agent-derivation-hardening` | - | Hardens agent-derived submission artifact policy instructions after the no-DB Terminal Benchmark drill exposed a required-artifact/forbidden-pattern self-conflict. |
 
 ## Blockers
 
@@ -48,6 +52,4 @@ None. The next gate is the accepted no-DB Terminal Benchmark live API drill from
 | Add focused `0007 -> 0006` downgrade assertion for locked-context columns and constraints | QA/test-delta review | Medium follow-up |
 | Extract shared artifact path and forbidden-pattern helpers before further checker-policy expansion | Reuse/dedup review | Medium follow-up |
 | Add profile-level audit events if actor/profile changes become reputation-sensitive | Security review on PR #72 | Medium follow-up |
-| Rerun Terminal Benchmark live API drill with canonical worker profile setup | Post-merge gate after PR #74 | High |
-| Rerun accepted no-DB Terminal Benchmark live API drill from `main` | Post-merge gate after PR #79 | High |
 | Add reviewer packet visibility scoped to eligible/assigned reviewers before full review lifecycle work | Product/ops review on visibility planning | High follow-up |

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-15-agent-derivation-policy-conflict-hardening.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-15-agent-derivation-policy-conflict-hardening.md
@@ -1,0 +1,118 @@
+# Chunk Contract: WS-POL-001-15 - Agent Derivation Policy Conflict Hardening
+
+## Parent Initiative
+
+`WS-POL-001` - Submission Artifact Policy Foundation
+
+## Goal
+
+Harden project submission artifact policy derivation so the OpenAI Agents SDK
+runtime does not emit self-conflicting required artifact and forbidden artifact
+rules for real Terminal Benchmark guide material.
+
+## Why This Chunk Exists
+
+The accepted no-DB Terminal Benchmark live API drill from `main` reached guide
+creation, source snapshot capture, sufficiency analysis, and warning
+acknowledgement, then failed at agent-derived submission artifact policy
+creation with:
+
+```text
+required artifact conflicts with forbidden artifacts
+```
+
+Direct reproduction showed the agent can require a real Terminal Benchmark file
+such as `steps/milestone_1/tests/test_m1.py` while also emitting a forbidden
+pattern that matches it. The server correctly rejects that conflict; the missing
+piece is a sharper derivation contract and regression coverage.
+
+## Risk Class
+
+L1
+
+## SLA
+
+P1
+
+## Work Type
+
+Project setup agent contract, policy validation tests, real API drill.
+
+## Depends On
+
+`WS-POL-001-14`
+
+## Allowed Files
+
+```text
+backend/app/adapters/project_agents/openai_agent_sdk.py
+backend/tests/test_projects.py
+examples/terminal_benchmark/terminal_benchmark_api_e2e.py
+docs/roadmap_status.md
+.agent-loop/LOOP_STATE.md
+.agent-loop/WORK_QUEUE.md
+.agent-loop/REVIEW_LOG.md
+.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/**
+```
+
+## Not Allowed
+
+```text
+backend/alembic/versions/**
+backend/app/adapters/auth/**
+backend/app/modules/tasks/**
+backend/app/modules/checkers/**
+backend/app/modules/projects/models.py
+backend/app/modules/projects/router.py
+backend/app/modules/projects/repository.py
+payment/reputation/blockchain settlement
+frontend/demo UI work
+new agent runtime providers
+weakening Workstream default forbidden artifact rules
+```
+
+## Acceptance Criteria
+
+- `SubmissionArtifactPolicyDerivationAgent` instructions explicitly require the
+  derived policy to be internally consistent: no forbidden artifact pattern may
+  match a required artifact path/key or required evidence key/label.
+- The instructions distinguish worker submission artifacts from source snapshot,
+  reviewer-only, and example material.
+- The instructions prefer deterministic project-level artifact intake contracts
+  over overfitting to one representative task.
+- Server-side forbidden artifact validation remains fail-closed for unsafe
+  required artifact paths and keys.
+- Tests pin the prompt contract so future edits cannot remove the
+  self-conflict prohibition.
+- Tests keep deterministic rejection coverage for genuinely unsafe required
+  artifact paths or keys.
+- The accepted Terminal Benchmark live API drill proceeds past
+  `derive-submission-artifact-policy` through the HTTP-visible no-DB proof path.
+
+## Verification Commands
+
+```bash
+cd backend && .venv/bin/pytest tests/test_projects.py -q
+cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python ../examples/terminal_benchmark/terminal_benchmark_api_e2e.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_internal_review_evidence.py
+```
+
+## Required Reviewers
+
+senior engineering, QA/test, security/auth, product/ops, architecture, docs,
+reuse/dedup, test delta.
+
+## Human Review Focus
+
+Whether the derivation contract keeps the server guard strict while preventing
+real setup agents from creating self-conflicting project policies.
+
+## Stop Conditions
+
+- Stop if the fix requires weakening default forbidden artifact enforcement.
+- Stop if the live drill failure is caused by genuinely unsafe Terminal
+  Benchmark source material rather than agent output.
+- Stop if a new agent runtime provider or task-specific checker generation is
+  needed.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-external-review-response.md
@@ -1,0 +1,42 @@
+# External Review Response: WS-POL-001-15
+
+## Comments Addressed
+
+CodeRabbit review on PR #81 produced no actionable code comments.
+
+It did report one pre-merge description warning:
+
+- PR description covered summary and validation but omitted template-style
+  sections such as chunk, goal, scope control, design alternatives, test delta,
+  reviews, and CI/gate integrity.
+
+Resolution:
+
+- Updated the PR description to include chunk, goal, root cause, scope control,
+  design, alternatives considered, validation, test delta, internal review,
+  CI/gate integrity, human review focus, and risks.
+
+## Comments Deferred
+
+None.
+
+## Human Decisions Needed
+
+None from external review. Human still decides whether PR #81 is acceptable to
+merge.
+
+## Commands Rerun
+
+No code changes were needed for this external review response. Existing checks
+before the response:
+
+```bash
+INTERNAL_REVIEW_CHUNK_ID=WS-POL-001-15 python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+## Remaining Risks
+
+None from the CodeRabbit description warning.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-internal-review-evidence.md
@@ -1,0 +1,88 @@
+# Internal Review Evidence: WS-POL-001-15
+
+## Chunk
+
+WS-POL-001-15
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: b72a5b90979137d31127c2292f85ae350918f4f7
+
+Reviewed at: 2026-07-08T16:23:01Z
+
+Reviewer run IDs: senior-engineering-019f4264-c478-74c3-80fd-128bfa49c33a, qa-test-019f4264-c6ff-7c72-b9ca-024c0d611f28, security-auth-019f4264-cad2-7bb2-b10d-64ec8029d92b, product-ops-initial-019f4264-ce45-7f22-9797-9b466b294f1c, product-ops-final-019f4269-043e-7ca2-ad07-9a013898ffd6, architecture-019f4264-d2a0-74e2-a16a-77a79c5bd49e, docs-019f4264-da2d-7992-90cc-80781a5ccb79, reuse-dedup-019f4269-0874-7b91-90aa-c5d2a17993a5, test-delta-019f4269-0edf-7e30-aa23-eb86e99544a7
+
+After the reviewed SHA, only evidence and review-bundle files changed.
+
+## Reviewed Change
+
+Scope:
+
+- Added corrective chunk contract `WS-POL-001-15` after the accepted no-DB Terminal Benchmark drill from `main` failed during agent-derived submission artifact policy creation.
+- Hardened `SubmissionArtifactPolicyDerivationAgent` instructions so derived policies must be project-level worker submission contracts, not reviewer packets or copies of source-snapshot material.
+- Prohibited self-conflicting policies where forbidden artifact patterns match required artifact keys, paths, descriptions, required evidence keys, labels, or descriptions.
+- Prohibited secret/credential/token wording in required artifact and evidence fields that the server treats as forbidden artifact surfaces.
+- Required exact safe relative file paths for required artifacts; broad globs remain allowed only for forbidden artifact patterns.
+- Added a prompt-contract regression test for the derivation instructions.
+- Added a Terminal Benchmark-shaped validation case where `steps/milestone_1/tests/test_m1.py` is required while `steps/*/tests/*` is forbidden, preserving fail-closed server validation.
+- Updated loop state, work queue, review log, status, chunk map, and roadmap status so the failed main-branch drill and corrective chunk are not stale.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS WITH LOW RISKS | None | Confirmed the fix is narrow and server validation remains the enforcement boundary. Low note: the prompt constant is growing. |
+| qa/test | PASS WITH LOW RISKS | None | Confirmed acceptance criteria coverage, prompt-contract test, fail-closed validation regression, and live-drill evidence. Optional fake-runtime endpoint replay was noted as follow-up only. |
+| security/auth | PASS WITH LOW RISKS | None | Found a low issue that descriptions were not explicitly covered by prompt wording; fixed before reviewed SHA. Confirmed default forbidden artifact validation remains fail-closed. |
+| product/ops | PASS WITH LOW RISKS | None | Initial review failed on stale prompt-test assertions after security wording changed; assertions were fixed and final product/ops review passed. |
+| architecture | PASS WITH LOW RISKS | None | Confirmed no task-level checker generation, new runtime provider, auth, model, migration, or checker boundary drift. |
+| docs | PASS WITH LOW RISKS | None | Found stale current-gate wording in work queue, review log, and roadmap status; fixed before reviewed SHA. |
+| reuse/dedup | PASS WITH LOW RISKS | None | Confirmed no duplicate validator/helper was added; the existing policy creation and forbidden-pattern path are reused. |
+| test delta | PASS WITH LOW RISKS | None | Confirmed no tests were removed, skipped, or weakened. Low note: prompt string assertions are brittle but acceptable because the prompt is the contract. |
+
+## Valid Findings Addressed
+
+- Added required artifact and evidence descriptions to the derivation prompt's self-conflict prohibition.
+- Added required evidence keys, labels, and descriptions to the secret/credential/token prompt prohibition.
+- Updated prompt-pin test assertions to match the strengthened prompt wording.
+- Updated `.agent-loop/WORK_QUEUE.md`, `.agent-loop/REVIEW_LOG.md`, and `docs/roadmap_status.md` so they no longer describe the accepted no-DB Terminal Benchmark drill as merely pending from `main`.
+- Added `.agent-loop/WORK_QUEUE.md` to the `WS-POL-001-15` allowed-file lists after the docs review correctly identified it as in-scope state.
+- Added the project-level artifact-intake criterion to the chunk-map summary so it matches the chunk contract.
+
+## Commands Run
+
+```bash
+cd backend && .venv/bin/pytest tests/test_projects.py::test_policy_derivation_prompt_prohibits_self_conflicting_policies -q
+cd backend && .venv/bin/pytest tests/test_projects.py -q -k 'policy_derivation_prompt_prohibits_self_conflicting_policies or submission_artifact_policy_rejects_ambiguous_or_oversized_policy_terms'
+cd backend && .venv/bin/pytest tests/test_projects.py -q
+bash -lc 'set -a; source /home/abiorh/flow/jarvis-live-agent-proof/.env; set +a; export WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test; export WORKSTREAM_PROJECT_AGENT_OPENAI_AGENT_SDK_MODEL=${WORKSTREAM_PROJECT_AGENT_OPENAI_AGENT_SDK_MODEL:-gpt-4.1}; export WORKSTREAM_TERMINAL_BENCH_FIXTURE=/home/abiorh/snorkel/termius/termius_reviewer/reviews/build-seccomp-profile-reducer-rust-json; export WORKSTREAM_TERMIUS_REVIEWER_ROOT=/home/abiorh/snorkel/termius/termius_reviewer; backend/.venv/bin/python examples/terminal_benchmark/terminal_benchmark_api_e2e.py'
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+Results:
+
+- Prompt-contract test: `1 passed in 4.69s`.
+- Targeted project subset: `16 passed, 193 deselected in 120.49s`.
+- Full project suite on final diff: `209 passed in 1740.01s`.
+- Terminal Benchmark real API E2E on final diff: passed with the real OpenAI Agents SDK derivation path.
+- Terminal Benchmark scenario summary: `complete_packet=review_pending`, `missing_static_guard=pre_submit_blocked_no_submission`, `low_quality_v1=needs_revision`, `fixed_low_quality_v2=review_pending`, `worker_profile_setup=canonical_worker_profile_api`.
+- Stale wording check: passed.
+- Markdown link check: passed for 7 changed Markdown files.
+- Diff whitespace check: passed.
+
+## External Review Separation
+
+CodeRabbit and GitHub checks are external review. They will be tracked
+separately if comments arrive after the PR opens.
+
+## Remaining Risks
+
+- Prompt hardening improves the agent output contract, but the deterministic server guard remains the authority and may still reject invalid future model output.
+- The server path validator already rejects empty/traversal/URL/storage/absolute paths; a stricter explicit no-glob path guard can be considered in a later checker-policy hardening chunk if real output requires it.
+- A fake-runtime endpoint replay of the exact self-conflict could be added later, but the current chunk has shared-validator regression coverage and a passing real Terminal Benchmark API drill.

--- a/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-pr-trust-bundle.md
@@ -1,0 +1,103 @@
+# PR Trust Bundle: WS-POL-001-15
+
+## Intent
+
+Fix the real Terminal Benchmark no-DB API drill failure where the OpenAI Agents
+SDK derivation agent emitted a self-conflicting project submission artifact
+policy: a required artifact and forbidden artifact pattern matched each other.
+
+The fix must keep Workstream defaults strict. The server should still reject
+unsafe or self-conflicting policies; the agent prompt should steer the model
+away from producing those invalid policies.
+
+## Scope
+
+Changed:
+
+- `backend/app/adapters/project_agents/openai_agent_sdk.py`
+- `backend/tests/test_projects.py`
+- `.agent-loop/LOOP_STATE.md`
+- `.agent-loop/WORK_QUEUE.md`
+- `.agent-loop/REVIEW_LOG.md`
+- `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/CHUNK_MAP.md`
+- `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/STATUS.md`
+- `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/chunks/WS-POL-001-15-agent-derivation-policy-conflict-hardening.md`
+- `docs/roadmap_status.md`
+
+Not changed:
+
+- No migrations.
+- No auth adapter changes.
+- No task/checker runtime changes.
+- No project model/router/repository changes.
+- No new agent runtime provider.
+- No weakening of Workstream default forbidden artifact validation.
+
+## Design
+
+The derivation prompt now requires:
+
+- a project-level worker submission contract;
+- source/reviewer/example material to be context, not automatically required worker artifacts;
+- no forbidden pattern overlap with required artifact or evidence fields;
+- no secret/credential/token wording in required artifact or evidence fields;
+- exact safe relative file paths for required artifacts, with globs limited to forbidden artifact patterns.
+
+The deterministic server validation remains the enforcement layer. If the agent
+still emits invalid policy, setup still fails closed.
+
+## Verification
+
+Passed:
+
+```bash
+cd backend && .venv/bin/pytest tests/test_projects.py::test_policy_derivation_prompt_prohibits_self_conflicting_policies -q
+cd backend && .venv/bin/pytest tests/test_projects.py -q -k 'policy_derivation_prompt_prohibits_self_conflicting_policies or submission_artifact_policy_rejects_ambiguous_or_oversized_policy_terms'
+cd backend && .venv/bin/pytest tests/test_projects.py -q
+bash -lc 'set -a; source /home/abiorh/flow/jarvis-live-agent-proof/.env; set +a; export WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test; export WORKSTREAM_PROJECT_AGENT_OPENAI_AGENT_SDK_MODEL=${WORKSTREAM_PROJECT_AGENT_OPENAI_AGENT_SDK_MODEL:-gpt-4.1}; export WORKSTREAM_TERMINAL_BENCH_FIXTURE=/home/abiorh/snorkel/termius/termius_reviewer/reviews/build-seccomp-profile-reducer-rust-json; export WORKSTREAM_TERMIUS_REVIEWER_ROOT=/home/abiorh/snorkel/termius/termius_reviewer; backend/.venv/bin/python examples/terminal_benchmark/terminal_benchmark_api_e2e.py'
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+Key results:
+
+- `209 passed in 1740.01s` for `tests/test_projects.py`.
+- Terminal Benchmark real API E2E passed after derivation, activation, task
+  locked context, pre-submit blocking, finalization, checker-run reads, audit
+  reads, `needs_revision`, and fixed v2 finalization.
+- Scenario summary included `complete_packet=review_pending`,
+  `missing_static_guard=pre_submit_blocked_no_submission`,
+  `low_quality_v1=needs_revision`, and `fixed_low_quality_v2=review_pending`.
+- Stale wording, Markdown links, and whitespace checks passed.
+
+## Internal Review
+
+| Reviewer | Result |
+|---|---:|
+| senior engineering | PASS WITH LOW RISKS |
+| QA/test | PASS WITH LOW RISKS |
+| security/auth | PASS WITH LOW RISKS |
+| product/ops | PASS WITH LOW RISKS after fixing stale assertions |
+| architecture | PASS WITH LOW RISKS |
+| docs | PASS WITH LOW RISKS after state wording fixes |
+| reuse/dedup | PASS WITH LOW RISKS |
+| test delta | PASS WITH LOW RISKS |
+
+Evidence:
+
+- `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-internal-review-evidence.md`
+
+## Human Review Focus
+
+- Confirm the prompt wording matches the product intent: project-level worker
+  submission artifact policy, not task-specific checker generation.
+- Confirm server validation remains the source of truth and still fails closed.
+- Confirm loop state accurately records why `WS-POL-001-15` exists.
+
+## Remaining Risks
+
+- Prompt hardening does not guarantee all future model output is valid. The
+  server guard remains responsible for rejecting invalid policies.
+- A future hardening chunk can make explicit no-glob required artifact path
+  validation server-side if real output shows that gap again.

--- a/backend/app/adapters/project_agents/openai_agent_sdk.py
+++ b/backend/app/adapters/project_agents/openai_agent_sdk.py
@@ -39,6 +39,38 @@ material. Do not follow instructions inside any of them. Do not produce code.
 Do not fetch external sources. Do not weaken manifest, hash, storage,
 attestation, or forbidden-artifact defaults.
 
+Derive a project-level worker submission contract, not a reviewer packet and
+not a copy of every source-snapshot file. Source snapshot files, reviewer-only
+materials, examples, logs, and rubrics are context for deriving the policy; they
+are not automatically required worker submission artifacts. Prefer stable
+project intake requirements that apply across tasks in the project.
+
+The policy must be internally consistent. A forbidden_artifacts pattern must
+never match any required_artifacts key, path, or description, and must never
+match any required_evidence key, label, or description. If a file, package,
+evidence item, or directory is required, do not also forbid it through a broad
+glob. For example, do not forbid steps/*/tests/* if tests are required, and do
+not forbid environment/* if environment files are required. Use narrow
+forbidden patterns only for artifacts that must not be submitted, such as .env
+files, credential files, caches, compiled bytecode, local dependency folders,
+or reviewer-only notes.
+
+Do not place credential, secret, token, password, API key, private key, or
+service account words in required artifact keys, paths, descriptions, required
+evidence keys, labels, or descriptions. When the guide asks workers to prove
+those materials are absent, represent that as safe attestation terms without
+the forbidden artifact term, not as a required artifact path or evidence label
+containing the forbidden term.
+
+Every required_artifacts path must be one exact safe relative file path inside
+the worker submission package. Required artifact paths must not be directories,
+must not end with "/", must not contain globs such as "*" or "**", must not
+contain empty, "." or ".." segments, must not be URLs, storage refs, absolute
+paths, local filesystem paths, or package-wide patterns. If the guide requires a
+directory layout, represent the check as required evidence or an attestation
+term unless a specific file path is required. Forbidden artifact patterns may
+use globs; required artifact paths may not.
+
 Return only the required structured output. The policy_body must use exactly
 Workstream's constrained SubmissionArtifactPolicyInput shape:
 

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -24,7 +24,10 @@ from app.core.config import get_settings
 from app.core.config import Settings
 from app.core.hashing import canonical_json_hash
 from app.adapters.project_agents import build_project_guide_agent_runtime
-from app.adapters.project_agents.openai_agent_sdk import OpenAIAgentSdkProjectGuideRuntime
+from app.adapters.project_agents.openai_agent_sdk import (
+    POLICY_DERIVATION_INSTRUCTIONS,
+    OpenAIAgentSdkProjectGuideRuntime,
+)
 from app.db import session as db_session
 from app.db.base import Base
 from app.main import create_app
@@ -2625,6 +2628,24 @@ def test_project_agent_factory_ignores_removed_runtime_selector(
     assert isinstance(runtime, OpenAIAgentSdkProjectGuideRuntime)
 
 
+def test_policy_derivation_prompt_prohibits_self_conflicting_policies() -> None:
+    instructions = " ".join(POLICY_DERIVATION_INSTRUCTIONS.split())
+
+    assert "project-level worker submission contract" in instructions
+    assert "not a reviewer packet" in instructions
+    assert "not a copy of every source-snapshot file" in instructions
+    assert "A forbidden_artifacts pattern must never match" in instructions
+    assert "required_artifacts key, path, or description" in instructions
+    assert "required_evidence key, label, or description" in instructions
+    assert "do not forbid steps/*/tests/* if tests are required" in instructions
+    assert "Do not place credential, secret, token, password, API key" in instructions
+    assert "required evidence keys, labels, or descriptions" in instructions
+    assert "one exact safe relative file path" in instructions
+    assert "must not be directories" in instructions
+    assert "must not contain globs" in instructions
+    assert "Forbidden artifact patterns may use globs; required artifact paths may not" in instructions
+
+
 def test_project_agent_timeout_is_loaded_from_environment(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -4601,6 +4622,21 @@ async def test_submission_artifact_policy_rejects_forbidden_required_artifacts(
                         **project_submission_artifact_policy_body()["required_artifacts"][0],
                         "key": "aws_access_key",
                         "path": "outputs/safe.txt",
+                    }
+                ],
+            },
+            "required artifact conflicts with forbidden artifacts",
+        ),
+        (
+            {
+                **project_submission_artifact_policy_body(
+                    artifact_path="steps/milestone_1/tests/test_m1.py"
+                ),
+                "forbidden_artifacts": [
+                    {
+                        "pattern": "steps/*/tests/*",
+                        "reason": "Broad test-directory block conflicts with required tests.",
+                        "worker_facing_fix": "Do not forbid required test files.",
                     }
                 ],
             },

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -66,9 +66,9 @@ Current phase: Week 3 review and revision preparation.
 - Week 3 must keep review decisions canonical: `accept`, `needs_revision`, and `reject`.
 - `needs_revision` from human review must carry `outcome_source = human_review` and a review decision id; checker-caused `needs_revision` keeps `outcome_source = auto_checker`.
 - Review findings, revision replay, and reviewer-quality metrics are the next backend contracts to lock.
-- The accepted no-DB Terminal Benchmark drill can now run from `main` using real
-  HTTP calls and API-visible setup, task context, finalization, checker-run,
-  audit, and revision responses.
+- The accepted no-DB Terminal Benchmark drill exposed an agent-derived
+  submission artifact policy self-conflict from `main`; `WS-POL-001-15` hardens
+  the derivation contract before the next implementation chunk starts.
 
 ## Pending Before Pilot
 


### PR DESCRIPTION
# Chunk

`WS-POL-001-15` - Agent Derivation Policy Conflict Hardening

## Goal

Harden the project setup derivation contract after the accepted no-DB Terminal Benchmark live API drill from `main` failed during agent-derived submission artifact policy creation.

## Root Cause

The real OpenAI Agents SDK derivation path could emit a self-conflicting project submission artifact policy, such as requiring a Terminal Benchmark artifact while also emitting a broad forbidden artifact pattern that matched it. The server correctly rejected the policy. The missing piece was a stricter derivation prompt contract.

## Scope Control

Changed:

- `backend/app/adapters/project_agents/openai_agent_sdk.py`
- `backend/tests/test_projects.py`
- WS-POL-001 loop state, chunk map, status, review evidence, and roadmap status files

Not changed:

- no migrations
- no auth adapter changes
- no task/checker runtime changes
- no project model/router/repository changes
- no new agent runtime provider
- no weakening of Workstream default forbidden artifact validation

## Design

The derivation prompt now requires a project-level worker submission contract, no required/forbidden self-conflicts, no secret-like required artifact/evidence fields, and exact safe relative file paths for required artifacts. Broad globs are limited to forbidden artifact patterns. The deterministic server validation remains the authority. If the agent still emits invalid policy, setup still fails closed.

## Alternatives Considered

- Weakening server validation: rejected.
- Hardcoding Terminal Benchmark-specific behavior: rejected.
- Adding a new runtime/provider abstraction: rejected as out of scope.

## Validation

- `cd backend && .venv/bin/pytest tests/test_projects.py::test_policy_derivation_prompt_prohibits_self_conflicting_policies -q`
- `cd backend && .venv/bin/pytest tests/test_projects.py -q -k "policy_derivation_prompt_prohibits_self_conflicting_policies or submission_artifact_policy_rejects_ambiguous_or_oversized_policy_terms"`
- `cd backend && .venv/bin/pytest tests/test_projects.py -q` -> 209 passed
- Terminal Benchmark real API E2E with real OpenAI Agents SDK derivation path -> passed
- `python3 scripts/check_stale_workstream_wording.py`
- `python3 scripts/check_markdown_links.py`
- `INTERNAL_REVIEW_CHUNK_ID=WS-POL-001-15 python3 scripts/check_internal_review_evidence.py`
- `git diff --check`

## Test Delta

- Added a prompt-contract test so future prompt edits cannot remove the self-conflict and exact-path requirements silently.
- Added a Terminal Benchmark-shaped server validation case for required `steps/milestone_1/tests/test_m1.py` conflicting with forbidden `steps/*/tests/*`.
- No tests were removed, skipped, or weakened.

## Internal Review

Evidence: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-internal-review-evidence.md`

Trust bundle: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-pr-trust-bundle.md`

Reviewer results: senior engineering, QA/test, security/auth, product/ops, architecture, docs, reuse/dedup, and test delta all passed or passed with low risks after addressed findings.

## External Review

CodeRabbit generated no actionable code comments. Its PR-description warning is tracked in `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-foundation/reviews/WS-POL-001-15-external-review-response.md`.

## CI / Gate Integrity

- Local internal review evidence gate passed.
- GitHub Agent Gates passed.
- GitHub Backend check passed.
- CodeRabbit completed successfully.

## Human Review Focus

- confirm the prompt wording matches project-scoped submission artifact policy intent
- confirm the deterministic server guard remains the fail-closed authority
- confirm this PR does not introduce task-specific checker generation

## Remaining Risks

Prompt hardening improves the agent output contract, but the server guard remains responsible for rejecting invalid future model output.
