### PR TITLE
Record WS-POL-002 planning merge

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -3,19 +3,18 @@
 ## Current State
 
 - Active initiative: `WS-POL-002` - Post-Submit Checker Foundation
-- Active planning chunk: `WS-POL-002-PLAN` - Post-submit checker foundation planning
+- Active planning chunk: none
 - Active implementation chunk: none
-- Branch: `codex/ws-pol-002-post-submit-checker-planning`
-- Status: `WS-POL-001-16` merged through PR #84. Planning has started for
-  `WS-POL-002`, which will make post-submit checker setup follow the same
-  project-guide-derived, compiler-validated, deterministic shape as the
-  pre-submit checker pipeline.
+- Branch: `main`
+- Status: `WS-POL-002-PLAN` merged through PR #85. Planning is complete for
+  post-submit checker setup to follow the same project-guide-derived,
+  compiler-validated, deterministic shape as the pre-submit checker pipeline.
 - Last merged implementation SHA: `be2d5ec`
-- Last merge commit: `a3d2a3f`
-- Current gate: planning/specification for `WS-POL-002`; no implementation
-  chunk is active.
+- Last merge commit: `3fc1a68`
+- Current gate: post-merge memory update for `WS-POL-002-PLAN`; no
+  implementation chunk is active.
 - Next chunk: `WS-POL-002-01` is proposed only and inactive until the
-  planning PR is reviewed and the user gives an explicit start signal.
+  user gives an explicit start signal.
 
 ## Operating Rule
 
@@ -129,3 +128,5 @@ blockchain, frontend, or agent-runtime behavior.
 - PR #84 merged into `main` as `a3d2a3f`; it implemented `WS-POL-001-16`
   Terminal Benchmark live API drill evidence, privacy scrub, and a professional
   PDF report proving the current lifecycle through HTTP-visible APIs.
+- PR #85 merged into `main` as `3fc1a68`; it completed `WS-POL-002-PLAN`
+  planning for project-guide-derived post-submit checker setup.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -492,6 +492,10 @@ Required reviewer tracks:
 - architecture
 - docs
 - CI integrity
+- reuse/dedup - N/A with approved reason; no skills, agents, backend app code,
+  or scripts changed in the final repair.
+- test delta - N/A with approved reason; no tests or test-like files changed in
+  the final repair.
 
 Result: PASS after CodeRabbit and internal review fixes. GitHub Agent Gates,
 Backend, and CodeRabbit passed before merge.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -476,3 +476,37 @@ Trust bundle: `.agent-loop/initiatives/WS-POL-001-submission-artifact-policy-fou
 
 Next gate: `WS-POL-002` planning for post-submit checker foundation. No
 implementation chunk is active until the user explicitly starts it.
+
+## 2026-07-09 - WS-POL-002-PLAN Merged
+
+PR #85 merged into `main` as `3fc1a688743f13476d6092078d40792592823d27`.
+
+Reviewed planning SHA: `f07160145fd5b92515cfbbd1c78c81a583a86508`.
+
+Required reviewer tracks:
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- docs
+- CI integrity
+
+Result: PASS after CodeRabbit and internal review fixes. GitHub Agent Gates,
+Backend, and CodeRabbit passed before merge.
+
+Scope: created WS-POL-002 intent, discovery, plan, decisions, risks, status,
+chunk map, and chunk contracts for project-guide-derived post-submit checker
+setup. The plan keeps `PostSubmitCheckerPolicy` project-scoped, keeps derivation
+setup-time only, keeps runtime deterministic, and forbids per-task checker
+generation.
+
+Evidence: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-PLAN-internal-review-evidence.md`
+
+External review response: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-PLAN-external-review-response.md`
+
+Trust bundle: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-PLAN-pr-trust-bundle.md`
+
+Next gate: `WS-POL-002-01` Post-Submit Provenance And Compiler Contract. No
+implementation chunk is active until the user explicitly starts it.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-POL-002-PLAN` | Post-Submit Checker Foundation Planning | L1 | Active on `codex/ws-pol-002-post-submit-checker-planning` |
+| `WS-POL-002-01` | Post-Submit Provenance And Compiler Contract | L1 | Proposed; inactive until explicit user start |
 
 ## Completed
 
@@ -29,12 +29,12 @@
 | `WS-POL-001-14` | Submission Finalize And No-DB Terminal Benchmark Proof | L1 | Merged through PR #79 as `53a57c3` on 2026-07-08 |
 | `WS-POL-001-15` | Agent Derivation Policy Conflict Hardening | L1 | Merged through PR #81 as `b1a9851` on 2026-07-08 |
 | `WS-POL-001-16` | Terminal Benchmark Live API Drill | L1 | Merged through PR #84 as `a3d2a3f` on 2026-07-09 |
+| `WS-POL-002-PLAN` | Post-Submit Checker Foundation Planning | L1 | Merged through PR #85 as `3fc1a68` on 2026-07-09 |
 
 ## Proposed Next
 
-Stop after `WS-POL-002-PLAN` is reviewed. Do not start `WS-POL-002-01` until
-the planning PR is merged and the user explicitly starts the implementation
-chunk.
+Do not start `WS-POL-002-01` until the user explicitly starts the
+implementation chunk.
 
 ## Blocked
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
@@ -20,8 +20,7 @@ None.
 
 `WS-POL-002-01` - Post-Submit Provenance And Compiler Contract.
 
-This chunk is inactive until the planning PR is reviewed and the user gives an
-explicit start signal.
+This chunk is inactive until the user gives an explicit start signal.
 
 ## Chunk Status
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
@@ -2,14 +2,15 @@
 
 ## Current Status
 
-Planning started after `WS-POL-001-16` merged through PR #84.
+Planning completed and merged through PR #85 as
+`3fc1a688743f13476d6092078d40792592823d27`.
 
-No implementation chunk is active. This initiative is in planning/specification
-state on branch `codex/ws-pol-002-post-submit-checker-planning`.
+No implementation chunk is active. `WS-POL-002-01` is ready to start only after
+the user gives an explicit start signal.
 
 ## Active Planning Chunk
 
-`WS-POL-002-PLAN` - Post-submit checker foundation planning.
+None.
 
 ## Active Implementation Chunk
 
@@ -26,7 +27,7 @@ explicit start signal.
 
 | Chunk | Status | Branch | PR | Notes |
 |---|---|---|---:|---|
-| `WS-POL-002-PLAN` | Active planning | `codex/ws-pol-002-post-submit-checker-planning` | - | Defines intent, discovery, design, risks, decisions, and implementation chunks. |
+| `WS-POL-002-PLAN` | Merged | `codex/ws-pol-002-post-submit-checker-planning` | #85 | Defines intent, discovery, design, risks, decisions, and implementation chunks. |
 | `WS-POL-002-01` | Proposed | - | - | Post-Submit Provenance And Compiler Contract. |
 | `WS-POL-002-02` | Proposed | - | - | Post-submit derivation agent and resumable setup integration after pre-submit approval/compile. |
 | `WS-POL-002-03` | Proposed | - | - | Server-owned approval and setup visibility APIs; remove manual guide payload. |

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-post-merge-memory-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-post-merge-memory-internal-review-evidence.md
@@ -1,0 +1,71 @@
+# Internal Review Evidence: WS-POL-002 Post-Merge Memory
+
+## Chunk
+
+`WS-POL-002-post-merge-memory` - Record WS-POL-002 planning merge
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: fc2fd93912af29c9e530fc53bec7c168cb5e4a71
+
+Reviewed at: 2026-07-09T11:39:31Z
+
+Reviewer run IDs: senior-engineering=019f46a7-7ce3-70c3-b848-4949991cbaf4; QA/test=019f46a7-9c29-7f81-b825-774aae8a5228; security/auth=019f46a7-c11d-7df0-8388-04129a6f889b; product/ops=019f46a7-e5b2-7c63-82a7-3a9f3d85c704; architecture=019f46a8-044b-74c1-bece-92c1a9181a13; docs=019f46a8-2be8-75f0-baa4-aca39b3967c9
+
+## Reviewed Change
+
+Scope:
+
+- Recorded PR #85 as merged into `main` with merge commit
+  `3fc1a688743f13476d6092078d40792592823d27`.
+- Marked `WS-POL-002-PLAN` complete.
+- Marked `WS-POL-002-01` as the proposed next implementation chunk, inactive
+  until explicit user start.
+- Updated loop state, work queue, initiative status, review log, and roadmap
+  status without touching backend runtime, schemas, CI, tests, or product code.
+- Removed stale wording that still depended on planning PR review after PR #85
+  had already merged.
+- Added `reuse/dedup` and `test delta` N/A reviewer-track memory for PR #85 to
+  match the planning evidence.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS AFTER FIXES | None | Memory content passed; missing evidence finding is addressed by this artifact. |
+| QA/test | PASS AFTER FIXES | None | Consistency passed; missing evidence finding is addressed by this artifact. |
+| security/auth | PASS AFTER FIXES | None | No security boundary issue; missing evidence finding is addressed by this artifact. |
+| product/ops | PASS AFTER FIXES | None | Product state passed; missing evidence finding is addressed by this artifact. |
+| architecture | PASS | None | Confirmed project-scoped post-submit setup, deterministic runtime, no per-task checker generation, and no active implementation. |
+| docs | PASS | None | Confirmed merge info, artifact references, complete reviewer-track list, and no stale planning-open wording. |
+
+## Valid Findings Addressed
+
+- Added this changed internal review evidence artifact because the memory branch
+  changes engineering-loop/process files.
+- Removed stale `planning PR is reviewed` wording from WS-POL-002 status.
+- Added `reuse/dedup` and `test delta` N/A reviewer-track notes to the PR #85
+  review log entry.
+
+## Commands Run
+
+```bash
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+Results:
+
+- Stale wording check: passed.
+- Markdown link check: passed for 5 changed Markdown files.
+- `git diff --check`: passed.
+
+## Remaining Risks
+
+None for this memory update. `WS-POL-002-01` remains inactive until explicit
+user start.

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -51,6 +51,9 @@ Current phase: Week 3 review and revision preparation.
 - Chunk 16 Terminal Benchmark live API drill with privacy-scrubbed evidence and
   professional PDF report proving the current lifecycle through HTTP-visible
   APIs without database inspection.
+- WS-POL-002 post-submit checker foundation planning, including project-scoped
+  `PostSubmitCheckerPolicy` setup, trusted compiler boundaries, deterministic
+  runtime separation, and implementation chunk contracts.
 
 ## Review Tracks Closed
 
@@ -75,8 +78,8 @@ Current phase: Week 3 review and revision preparation.
   required/forbidden self-conflict; the drill now passes after hardening.
 - `WS-POL-001-16` completed a human-visible Terminal Benchmark live API drill
   without database inspection as lifecycle proof and merged through PR #84.
-- `WS-POL-002` planning is open to make post-submit checker setup match the
-  project-guide-derived, compiler-validated, deterministic pre-submit pipeline.
+- `WS-POL-002` planning merged through PR #85. `WS-POL-002-01` is ready to
+  start only after an explicit user start signal.
 
 ## Pending Before Pilot
 


### PR DESCRIPTION
## Summary

- records PR #85 as merged into main for WS-POL-002 planning
- marks WS-POL-002-PLAN complete and WS-POL-002-01 proposed/inactive
- updates loop state, work queue, initiative status, review log, roadmap status, and post-merge review evidence

## Scope

- loop memory and roadmap docs only
- no backend, schema, CI, test, or runtime behavior changes
- no implementation chunk is active

## Verification

- `python3 scripts/check_stale_workstream_wording.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_internal_review_evidence.py`
- `git diff --check`

## Internal Review

- senior engineering: PASS AFTER FIXES
- QA/test: PASS AFTER FIXES
- security/auth: PASS AFTER FIXES
- product/ops: PASS AFTER FIXES
- architecture: PASS
- docs: PASS

## Human Review Focus

- confirm WS-POL-002 planning is recorded as merged through PR #85
- confirm WS-POL-002-01 is proposed but inactive until explicit user start
- confirm no implementation work is included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status and roadmap notes to show the planning phase is complete and merged.
  * Clarified that the next work item is not active until explicitly started.

* **Chores**
  * Refreshed internal tracking records to match the latest merged state and next-step workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->