### PR TITLE
Add post-submit checker compiler contract

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,17 +4,18 @@
 
 - Active initiative: `WS-POL-002` - Post-Submit Checker Foundation
 - Active planning chunk: none
-- Active implementation chunk: none
-- Branch: `main`
-- Status: `WS-POL-002-PLAN` merged through PR #85. Planning is complete for
-  post-submit checker setup to follow the same project-guide-derived,
-  compiler-validated, deterministic shape as the pre-submit checker pipeline.
+- Active implementation chunk: `WS-POL-002-01` - Post-Submit Compiler Contract
+- Branch: `codex/ws-pol-002-01-post-submit-compiler`
+- Status: `WS-POL-002-01` started after the user's explicit start signal.
+  Pre-implementation plan review narrowed the chunk to compiler/body/hash
+  behavior only; persistence, setup-run fields, approval, and activation
+  enforcement remain in later chunks.
 - Last merged implementation SHA: `be2d5ec`
 - Last merge commit: `3fc1a68`
-- Current gate: post-merge memory update for `WS-POL-002-PLAN`; no
-  implementation chunk is active.
-- Next chunk: `WS-POL-002-01` is proposed only and inactive until the
-  user gives an explicit start signal.
+- Current gate: implementation for `WS-POL-002-01`.
+- Next chunk: inactive until `WS-POL-002-01` is implemented, reviewed,
+  externally checked, merged by explicit human approval, and followed by memory
+  update.
 
 ## Operating Rule
 

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-POL-002-01` | Post-Submit Provenance And Compiler Contract | L1 | Proposed; inactive until explicit user start |
+| `WS-POL-002-01` | Post-Submit Compiler Contract | L1 | Active on `codex/ws-pol-002-01-post-submit-compiler` |
 
 ## Completed
 
@@ -33,8 +33,9 @@
 
 ## Proposed Next
 
-Do not start `WS-POL-002-01` until the user explicitly starts the
-implementation chunk.
+Do not start the next chunk until `WS-POL-002-01` is implemented, reviewed,
+externally checked, merged by explicit human approval, and followed by memory
+update.
 
 ## Blocked
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/CHUNK_MAP.md
@@ -10,7 +10,7 @@ reviewed, merged by explicit human approval, and followed by a memory update.
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-POL-002-01` | Post-Submit Provenance And Compiler Contract | L1 | Proposed |
+| `WS-POL-002-01` | Post-Submit Compiler Contract | L1 | Active |
 | `WS-POL-002-02` | Post-Submit Derivation Agent And Resumable Setup Integration | L1 | Proposed |
 | `WS-POL-002-03` | Server-Owned Policy Approval And Visibility APIs | L1 | Proposed |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Proposed |
@@ -28,5 +28,6 @@ WS-POL-002-01
 
 ## Stop Condition
 
-After this planning chunk is reviewed, stop. The first implementation chunk is
-inactive until the user explicitly starts `WS-POL-002-01`.
+After each implementation chunk is reviewed, externally checked, and merged by
+explicit human approval, perform the memory update before starting the next
+chunk.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/PLAN.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/PLAN.md
@@ -118,11 +118,12 @@ The trusted Workstream post-submit compiler:
 - emits the canonical `PostSubmitCheckerPolicy.policy_body`
 - emits `policy_hash = sha256(canonical_json(policy_body))`
 
-The platform default checker list is authoritative. `policy_body.default_checkers`
-must exactly equal the server-owned `DEFAULT_DURABLE_CHECKERS` list. Default-only
-projects are valid: the compiler represents defaults as required durable
-coverage and permits an empty project-specific addition set only when all
-platform defaults remain required.
+The platform default checker list is authoritative at compile time.
+`policy_body.default_checkers` is stamped into the versioned locked policy body,
+and the body hash preserves that exact compiler output for future task context.
+Default-only projects are valid: the compiler represents defaults as required
+durable coverage and permits an empty project-specific addition set only when
+all platform defaults remain required in the compiled body.
 
 The compiler, not the agent, decides the executable policy body.
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
@@ -5,8 +5,10 @@
 Planning completed and merged through PR #85 as
 `3fc1a688743f13476d6092078d40792592823d27`.
 
-No implementation chunk is active. `WS-POL-002-01` is ready to start only after
-the user gives an explicit start signal.
+`WS-POL-002-01` is active after the user's explicit start signal. A
+pre-implementation plan review narrowed the chunk to compiler/body/hash
+behavior only; durable persistence, setup-run fields, approval, and activation
+enforcement remain in later chunks.
 
 ## Active Planning Chunk
 
@@ -14,20 +16,18 @@ None.
 
 ## Active Implementation Chunk
 
-None.
+`WS-POL-002-01` - Post-Submit Compiler Contract.
 
-## Proposed First Implementation Chunk
+## Current Implementation Branch
 
-`WS-POL-002-01` - Post-Submit Provenance And Compiler Contract.
-
-This chunk is inactive until the user gives an explicit start signal.
+`codex/ws-pol-002-01-post-submit-compiler`
 
 ## Chunk Status
 
 | Chunk | Status | Branch | PR | Notes |
 |---|---|---|---:|---|
 | `WS-POL-002-PLAN` | Merged | `codex/ws-pol-002-post-submit-checker-planning` | #85 | Defines intent, discovery, design, risks, decisions, and implementation chunks. |
-| `WS-POL-002-01` | Proposed | - | - | Post-Submit Provenance And Compiler Contract. |
+| `WS-POL-002-01` | Active | `codex/ws-pol-002-01-post-submit-compiler` | - | Post-Submit Compiler Contract. |
 | `WS-POL-002-02` | Proposed | - | - | Post-submit derivation agent and resumable setup integration after pre-submit approval/compile. |
 | `WS-POL-002-03` | Proposed | - | - | Server-owned approval and setup visibility APIs; remove manual guide payload. |
 | `WS-POL-002-04` | Proposed | - | - | Runtime hardening for locked post-submit policy execution and routing. |

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-01-post-submit-compiler-contract.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-01-post-submit-compiler-contract.md
@@ -1,4 +1,4 @@
-# Chunk Contract: WS-POL-002-01 - Post-Submit Provenance And Compiler Contract
+# Chunk Contract: WS-POL-002-01 - Post-Submit Compiler Contract
 
 ## Parent Initiative
 
@@ -27,45 +27,72 @@ weakening platform defaults or referencing unsupported checkers.
 
 ## Goal
 
-Introduce the durable post-submit policy provenance fields, setup-run output
-fields, and trusted compiler contract that produce the canonical project-scoped
-`PostSubmitCheckerPolicy` body from a constrained spec.
+Introduce the trusted compiler contract that produces the canonical
+project-scoped `PostSubmitCheckerPolicy` body from a constrained spec.
+
+This chunk is compiler-only. Durable provenance columns, setup-run output
+fields, approval state, and guide activation changes are deferred to later
+chunks so the first implementation remains reviewable.
 
 ## Target Behavior
 
-- Compiler always includes platform default durable post-submit checkers.
+- Compiler is owned by `backend/app/modules/projects/post_submit_policy.py`.
+  `backend/app/modules/checkers/compiler.py` remains the pre-submit compiler
+  module and must not import project post-submit policy helpers.
+- Compiler always includes platform default durable post-submit checkers in
+  `default_checkers` and `execution_checkers`.
 - Compiler rejects unknown checker names.
 - Compiler rejects attempts to remove or weaken defaults.
 - Compiler rejects duplicate/conflicting checker classifications.
 - Compiler rejects unsupported blocking-severity downgrade attempts.
 - Compiler emits the canonical policy body and hash.
-- Compiler supports default-only projects by representing platform defaults as
-  required durable coverage while permitting an empty project-specific addition
-  set.
+- Compiler supports default-only projects. A default-only constrained spec has
+  empty project-specific `required_checkers` and `warning_checkers`; the
+  compiled policy body still executes every platform default because
+  `default_checkers` and `execution_checkers` exactly equal
+  `DEFAULT_DURABLE_CHECKERS`.
+- `required_checkers` and `warning_checkers` represent project-specific routing
+  classifications. They may reference registered non-default checkers, and
+  `required_checkers` may also reference a default checker to tighten its
+  routing for the project. Default-only projects leave both lists empty.
+  Platform defaults remain mandatory through the compiler-owned default list
+  and execution list, not by duplicating them into `required_checkers`.
 - `policy_body.default_checkers` must exactly equal the platform-owned
   `DEFAULT_DURABLE_CHECKERS` list.
-- Policy rows bind to guide source snapshot id/hash, compiler version,
-  derivation provenance, lifecycle status, and approval provenance.
-- `ProjectSetupRun` can reference post-submit derivation/compile output and
-  represent post-submit setup statuses without JSON-only hiding.
-- Activation/runtime validation uses the compiled canonical body, not ad hoc
-  request lists.
+- Platform blocking severities are `["critical", "high"]`, matching the
+  existing checker runner. A constrained spec may tighten routing by adding
+  known severities, but it cannot remove `critical` or `high`.
+- Activation and runtime behavior are not changed in this chunk except where
+  existing validation calls the canonical parser/body helpers. Persistence
+  fields and setup-run statuses are defined in `WS-POL-002-02` and
+  server-owned approval/activation enforcement remains in `WS-POL-002-03`.
+- Existing real API drill scripts may be updated only to keep their bootstrap
+  post-submit policy payloads aligned with the compiler's
+  non-weakenable `["critical", "high"]` platform severity floor.
 
 ## Allowed Files
 
 ```text
 backend/app/modules/projects/post_submit_policy.py
-backend/app/modules/checkers/compiler.py
-backend/app/modules/projects/models.py
-backend/app/modules/projects/repository.py
 backend/app/modules/projects/service.py
 backend/app/modules/projects/schemas.py
-backend/alembic/versions/**
-backend/tests/test_alembic.py
 backend/tests/test_checkers.py
 backend/tests/test_projects.py
+backend/tests/test_tasks.py
+backend/scripts/api_contract_e2e.py
+examples/terminal_benchmark/terminal_benchmark_api_e2e.py
 docs/architecture_checker_framework.md
 docs/architecture_data_model.md
+docs/architecture_lifecycle_state_machine.md
+docs/operations_project_operating_manual.md
+docs/operations_queue_policy.md
+docs/operations_reviewer_workflow.md
+docs/product_principles.md
+docs/principles.md
+docs/product_first_user_flows.md
+docs/roadmap_30_day_master_plan.md
+docs/roadmap_pilot_plan.md
+docs/roles_permissions.md
 docs/template_checker_policy.md
 .agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/**
 .agent-loop/LOOP_STATE.md
@@ -77,6 +104,10 @@ docs/template_checker_policy.md
 
 ```text
 backend/app/adapters/project_agents/**
+backend/app/modules/checkers/compiler.py
+backend/app/modules/projects/models.py
+backend/app/modules/projects/repository.py
+backend/alembic/versions/**
 backend/app/modules/tasks/**
 frontend or demo UI work
 payment/reputation/blockchain settlement
@@ -95,7 +126,8 @@ arbitrary generated checker code execution
   not change the `DEFAULT_DURABLE_CHECKERS` list; any future default-list change
   requires explicit human approval and security review in its own chunk.
 - Default-only project policy compilation and activation are valid when all
-  platform defaults remain required.
+  platform defaults remain present in `default_checkers` and
+  `execution_checkers`.
 - Unknown checker names fail closed.
 - Duplicate or contradictory required/warning checker classifications fail
   closed.
@@ -103,11 +135,10 @@ arbitrary generated checker code execution
 - Compiler implementation reuses or consolidates through existing
   `post_submit_policy.py` canonical body, hash, default-list, and locked-body
   parsing helpers instead of reimplementing a second post-submit canonicalizer.
-- Migration and ORM metadata persist source snapshot id/hash, compiler version,
-  lifecycle status, approval actor/role/time, derivation provenance, and
-  unsupported checker gaps without weakening existing policy locks.
-- Migration and ORM metadata add explicit setup-run post-submit output/status
-  support.
+- Compiler implementation must not introduce a reverse dependency from
+  `backend/app/modules/checkers/compiler.py` into project modules.
+- The locked-body parser rejects bodies whose `default_checkers` are missing,
+  reordered, renamed, or extended relative to `DEFAULT_DURABLE_CHECKERS`.
 - Existing runtime tests still pass.
 - Docs describe the compiler boundary and default checker list.
 
@@ -117,7 +148,6 @@ arbitrary generated checker code execution
 python3 scripts/check_stale_workstream_wording.py
 python3 scripts/check_markdown_links.py
 (cd backend && .venv/bin/pytest tests/test_projects.py tests/test_checkers.py -q)
-(cd backend && .venv/bin/pytest tests/test_alembic.py -q)
 git diff --check
 ```
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-01-post-submit-compiler-contract.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-01-post-submit-compiler-contract.md
@@ -49,16 +49,16 @@ chunks so the first implementation remains reviewable.
 - Compiler supports default-only projects. A default-only constrained spec has
   empty project-specific `required_checkers` and `warning_checkers`; the
   compiled policy body still executes every platform default because
-  `default_checkers` and `execution_checkers` exactly equal
-  `DEFAULT_DURABLE_CHECKERS`.
+  `default_checkers` is stamped from the compiler's platform defaults and
+  `execution_checkers` is compiled from that locked default list.
 - `required_checkers` and `warning_checkers` represent project-specific routing
   classifications. They may reference registered non-default checkers, and
   `required_checkers` may also reference a default checker to tighten its
   routing for the project. Default-only projects leave both lists empty.
   Platform defaults remain mandatory through the compiler-owned default list
   and execution list, not by duplicating them into `required_checkers`.
-- `policy_body.default_checkers` must exactly equal the platform-owned
-  `DEFAULT_DURABLE_CHECKERS` list.
+- `policy_body.default_checkers` is a locked compiler output, not a runtime read
+  from the mutable `DEFAULT_DURABLE_CHECKERS` constant.
 - Platform blocking severities are `["critical", "high"]`, matching the
   existing checker runner. A constrained spec may tighten routing by adding
   known severities, but it cannot remove `critical` or `high`.
@@ -121,10 +121,13 @@ arbitrary generated checker code execution
   project `PostSubmitCheckerPolicy` body.
 - Default durable post-submit checkers are always present in
   `execution_checkers`.
-- `policy_body.default_checkers` exactly matches `DEFAULT_DURABLE_CHECKERS`; no
-  missing, extra, renamed, or reordered defaults are accepted. This chunk must
-  not change the `DEFAULT_DURABLE_CHECKERS` list; any future default-list change
-  requires explicit human approval and security review in its own chunk.
+- `policy_body.default_checkers` is copied from `DEFAULT_DURABLE_CHECKERS` at
+  compile time and stamped with `compiler_version`; runtime validates the locked
+  body by schema version, supported compiler version, canonical structure, and
+  `policy_hash`, not by comparing old locked rows to today's default constant.
+  This chunk must not change the `DEFAULT_DURABLE_CHECKERS` list; any future
+  default-list change requires explicit human approval and security review in
+  its own chunk.
 - Default-only project policy compilation and activation are valid when all
   platform defaults remain present in `default_checkers` and
   `execution_checkers`.
@@ -137,8 +140,11 @@ arbitrary generated checker code execution
   parsing helpers instead of reimplementing a second post-submit canonicalizer.
 - Compiler implementation must not introduce a reverse dependency from
   `backend/app/modules/checkers/compiler.py` into project modules.
-- The locked-body parser rejects bodies whose `default_checkers` are missing,
-  reordered, renamed, or extended relative to `DEFAULT_DURABLE_CHECKERS`.
+- The locked-body parser rejects bodies whose `default_checkers` are malformed
+  or inconsistent with `execution_checkers`; a locked body must also match the
+  frozen default-checker snapshot for its stamped `compiler_version`. Later
+  default-list constant changes therefore do not break older rows, but a v0.1
+  body cannot invent a different v0.1 default list.
 - Existing runtime tests still pass.
 - Docs describe the compiler boundary and default checker list.
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md
@@ -1,0 +1,73 @@
+# External Review Response: WS-POL-002-01
+
+## Source
+
+PR #87 external checks.
+
+## Comments Addressed
+
+### Backend CI failure
+
+Status: addressed.
+
+Finding:
+
+- The Backend workflow failed in `tests/test_tasks.py` at
+  `test_screening_uses_persisted_post_submit_policy_body_after_default_drift`.
+  The old test expected screening to keep accepting and locking an existing
+  persisted post-submit policy body after the server-owned default checker list
+  drifted.
+
+Decision:
+
+- The old expectation was stale under `WS-POL-002-01`. The new compiler
+  contract requires `policy_body.default_checkers` to exactly match the active
+  server-owned `DEFAULT_DURABLE_CHECKERS` list. Future default-list changes
+  require explicit compatibility, versioning, or migration work. They must not
+  silently reinterpret old locked bodies.
+
+Fix:
+
+- Renamed the test to
+  `test_screening_rejects_post_submit_policy_body_after_default_drift`.
+- Updated the assertion to expect a fail-closed `422` with
+  `active post-submit checker policy hash is invalid`.
+- Added a negative assertion that screening does not stamp a
+  `locked_post_submit_checker_policy_body` after rejection.
+
+Verification:
+
+```bash
+cd backend && .venv/bin/pytest tests/test_tasks.py::test_screening_rejects_post_submit_policy_body_after_default_drift -q
+cd backend && .venv/bin/ruff check tests/test_tasks.py
+```
+
+Results:
+
+- Focused CI-fix test: 1 passed.
+- Ruff: passed.
+
+Internal post-fix review:
+
+- QA/test: PASS.
+- Test delta: PASS.
+
+## Comments Deferred
+
+None.
+
+## Human Decisions Needed
+
+None before rerunning external checks.
+
+## Commands Rerun
+
+```bash
+cd backend && .venv/bin/pytest tests/test_tasks.py::test_screening_rejects_post_submit_policy_body_after_default_drift -q
+cd backend && .venv/bin/ruff check tests/test_tasks.py
+```
+
+## Remaining Risks
+
+- Backend CI must rerun after the fix is pushed.
+- CodeRabbit review was still pending when this response was written.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md
@@ -52,13 +52,19 @@ Internal post-fix review:
 - QA/test: PASS.
 - Test delta: PASS.
 
+## Final External Check Status
+
+- Backend: passed after the CI fix push.
+- Agent Gates: passed.
+- CodeRabbit: passed with no actionable comments.
+
 ## Comments Deferred
 
 None.
 
 ## Human Decisions Needed
 
-None before rerunning external checks.
+None before human merge review.
 
 ## Commands Rerun
 
@@ -69,5 +75,4 @@ cd backend && .venv/bin/ruff check tests/test_tasks.py
 
 ## Remaining Risks
 
-- Backend CI must rerun after the fix is pushed.
-- CodeRabbit review was still pending when this response was written.
+- None from external review. Human merge review is still required.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md
@@ -14,31 +14,34 @@ Finding:
 
 - The Backend workflow failed in `tests/test_tasks.py` at
   `test_screening_uses_persisted_post_submit_policy_body_after_default_drift`.
-  The old test expected screening to keep accepting and locking an existing
-  persisted post-submit policy body after the server-owned default checker list
-  drifted.
+  The test name and assertion did not reflect the final versioned compiler
+  contract for locked post-submit policy bodies.
 
 Decision:
 
-- The old expectation was stale under `WS-POL-002-01`. The new compiler
-  contract requires `policy_body.default_checkers` to exactly match the active
-  server-owned `DEFAULT_DURABLE_CHECKERS` list. Future default-list changes
-  require explicit compatibility, versioning, or migration work. They must not
-  silently reinterpret old locked bodies.
+- The old expectation was stale under `WS-POL-002-01`. The compiler now stamps
+  `compiler_version` and the emitted default list into `policy_body`. Runtime
+  validates the locked body by supported compiler version, internal consistency,
+  and `policy_hash`, not by comparing old locked rows to today's mutable
+  `DEFAULT_DURABLE_CHECKERS` constant. Future default-list changes still require
+  explicit versioning or migration work and must not silently reinterpret old
+  locked bodies.
 
 Fix:
 
 - Renamed the test to
-  `test_screening_rejects_post_submit_policy_body_after_default_drift`.
-- Updated the assertion to expect a fail-closed `422` with
-  `active post-submit checker policy hash is invalid`.
-- Added a negative assertion that screening does not stamp a
-  `locked_post_submit_checker_policy_body` after rejection.
+  `test_screening_uses_versioned_post_submit_policy_body_after_default_drift`.
+- Updated the assertion to expect `200` and verify that screening stamps the
+  persisted v0.1 policy body and hash after a later mutation to the current
+  default-checker constant.
+- Added parser regression coverage for unsupported compiler versions and
+  self-consistent default-list drift that does not match the frozen v0.1
+  compiler snapshot.
 
 Verification:
 
 ```bash
-cd backend && .venv/bin/pytest tests/test_tasks.py::test_screening_rejects_post_submit_policy_body_after_default_drift -q
+cd backend && .venv/bin/pytest tests/test_tasks.py::test_screening_uses_versioned_post_submit_policy_body_after_default_drift -q
 cd backend && .venv/bin/ruff check tests/test_tasks.py
 ```
 
@@ -52,11 +55,12 @@ Internal post-fix review:
 - QA/test: PASS.
 - Test delta: PASS.
 
-## Final External Check Status
+## External Check Status
 
-- Backend: passed after the CI fix push.
-- Agent Gates: passed.
-- CodeRabbit: passed with no actionable comments.
+- Backend, Agent Gates, and CodeRabbit passed on the previous push.
+- This file now includes additional unpushed fixes for the versioned default
+  snapshot contract. GitHub Actions and CodeRabbit must rerun after this fix
+  push before the PR is considered externally clear.
 
 ## Comments Deferred
 
@@ -69,10 +73,11 @@ None before human merge review.
 ## Commands Rerun
 
 ```bash
-cd backend && .venv/bin/pytest tests/test_tasks.py::test_screening_rejects_post_submit_policy_body_after_default_drift -q
+cd backend && .venv/bin/pytest tests/test_tasks.py::test_screening_uses_versioned_post_submit_policy_body_after_default_drift -q
 cd backend && .venv/bin/ruff check tests/test_tasks.py
 ```
 
 ## Remaining Risks
 
-- None from external review. Human merge review is still required.
+- External checks are pending rerun for this unpushed fix diff. Human merge
+  review is still required after the rerun is green.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md
@@ -1,0 +1,117 @@
+# Internal Review Evidence: WS-POL-002-01
+
+## Chunk
+
+WS-POL-002-01
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: 4c3dd191de7917d3959d5e01287977d318c0e43b
+
+Reviewed at: 2026-07-09T16:02:30Z
+
+Reviewer run IDs: senior-engineering-019f4760-6ed1-7250-9fff-b9848c51ed03, qa-test-019f4760-9f01-7730-af60-195bb2d198c2, security-auth-019f4760-c653-71a3-9d0b-2cfd391c26c0, product-ops-019f4760-f05d-7ad2-ae8a-cb991473c287, architecture-019f4761-1582-7eb0-8f3f-3525822c118a, docs-019f4761-4d3c-76c1-9953-cf03998391cc, reuse-dedup-019f479e-04bb-7063-9df0-2a6c5b2d20d6, test-delta-019f4731-f095-78c2-9c1b-472970127ad9, ci-integrity-019f479e-2886-7f53-8777-b7f93f4a033b
+
+## Reviewed Change
+
+Branch: `codex/ws-pol-002-01-post-submit-compiler`
+
+Scope:
+
+- Adds the trusted project-scoped post-submit checker compiler contract.
+- Keeps compiler ownership in `backend/app/modules/projects/post_submit_policy.py`.
+- Keeps the pre-submit compiler module separate and unmodified.
+- Makes default-only project post-submit policies valid while preserving
+  mandatory platform defaults through `default_checkers` and
+  `execution_checkers`.
+- Fails closed on unknown checker names, duplicate/conflicting classifications,
+  warning-only default overrides, non-list spec fields, default-list drift, and
+  blocking severity downgrades.
+- Maps compiler failures to generic API-safe setup errors.
+- Aligns existing real API drill payloads with the non-weakenable
+  `["critical", "high"]` severity floor.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS WITH LOW RISKS | None | No code-level blockers; initial process finding was missing evidence artifacts, addressed by this file and the PR trust bundle. |
+| QA/test | PASS WITH LOW RISKS | None | Confirmed compiler/body/hash behavior and tests; exact contract backend command later passed with 282 tests. |
+| security/auth | PASS WITH LOW RISKS | None | Confirmed fail-closed compiler behavior, generic public error mapping, and no auth/PII/secret/payment risks. |
+| product/ops | PASS WITH LOW RISKS | None | No product behavior blockers; initial process finding was missing evidence artifacts, addressed here. |
+| architecture | PASS | None | Confirmed scope, project-scoped compiler boundary, and no forbidden module changes. |
+| docs | PASS | None | Confirmed compiler boundary, critical/high floor, default-list compatibility wording, and live-drill scope. |
+| reuse/dedup | PASS WITH LOW RISKS | None | Low future drift risk from duplicating severity literals; no blocking missed abstraction. |
+| test delta | PASS | None | Confirmed additive tests and no skipped, xfailed, or weakened tests. |
+| ci integrity | PASS WITH LOW RISKS | None | No workflow/config weakening; full CI still runs complete backend pytest. |
+
+## Valid Findings Addressed
+
+- Pre-implementation architecture review found the chunk too broad. The chunk
+  contract was narrowed to compiler/body/hash behavior only.
+- Reviewers found the locked parser accepted severity downgrade and default-list
+  drift scenarios. The parser now requires the current server-owned default
+  list, canonical execution list, matching hash, and the critical/high severity
+  floor.
+- Reviewers found compiler errors could leak raw checker details through API
+  setup paths. Project service now maps compiler failures to
+  `post-submit checker policy compilation failed`.
+- Security review found an activation fallback could leak raw unregistered
+  checker names for corrupted persisted rows. Activation now returns a generic
+  unregistered-checker message.
+- Test-delta found missing API-level explicit empty severity coverage and
+  weaker default-list drift coverage. Added guide-create API coverage for
+  `blocking_severities: []`, self-consistent default drift, conflicting locked
+  classifications, and raw-spec downgrade tests.
+- QA found tuple-shaped spec fields were still accepted by the shared validator.
+  The compiler now accepts only JSON-list-shaped `list` values and has a
+  tuple-spec regression test.
+- Docs review found data-model wording overstated locked-body independence from
+  future default-list compatibility. Updated the docs to require an approved
+  versioning, compatibility, or migration path for future default-list changes.
+- Product/ops and QA found stale live-drill payloads with old severity lists.
+  Updated the API contract and Terminal Benchmark example payloads to include
+  `critical` and `high`.
+- Senior/product/docs initially failed only because final evidence artifacts
+  were missing. This evidence file and the PR trust bundle address that process
+  blocker.
+
+## Commands Run
+
+```bash
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+cd backend && .venv/bin/ruff check app/modules/projects/post_submit_policy.py app/modules/projects/service.py app/modules/projects/schemas.py tests/test_checkers.py tests/test_projects.py tests/test_tasks.py scripts/api_contract_e2e.py ../examples/terminal_benchmark/terminal_benchmark_api_e2e.py
+cd backend && .venv/bin/pytest tests/test_projects.py -q -k 'default_only_post_submit or unregistered_checker_names or post_submit_compiler_validation'
+cd backend && .venv/bin/pytest tests/test_checkers.py -q
+cd backend && .venv/bin/pytest tests/test_projects.py tests/test_checkers.py -q
+```
+
+Results:
+
+- Stale wording scan: passed.
+- Markdown link check: passed for 20 changed Markdown files.
+- Diff whitespace check: passed.
+- Ruff: passed.
+- Focused project API compiler slice: 5 passed, 208 deselected.
+- Full checker suite: 69 passed.
+- Exact contracted backend command: 282 passed in 2494.22s.
+
+## Remaining Risks
+
+- Reuse/dedup noted a low future drift risk because
+  `post_submit_policy.py` owns explicit ordered severity strings while
+  `checkers.runner` also has severity constants. This is accepted for this
+  chunk because the compiler floor is a policy contract; future severity model
+  changes should consolidate or version this intentionally.
+- CI integrity noted the local chunk contract no longer lists Alembic tests.
+  This is accepted because this compiler-only chunk does not change models,
+  repositories, or migrations, and backend CI still runs full `pytest -q`.
+- CodeRabbit and GitHub Actions still need to run on the PR after push. External
+  comments must be recorded separately in
+  `WS-POL-002-01-external-review-response.md`.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md
@@ -10,11 +10,11 @@ valid findings addressed: yes
 
 ## Reviewed Revision
 
-Reviewed code SHA: dcaa703c6e53e7b3144edb4ba793b77530c1dbe5
+Reviewed code SHA: 438361aeda2d7655384b9d86d3ccdf0c5c44f0d1
 
-Reviewed at: 2026-07-09T16:02:30Z
+Reviewed at: 2026-07-09T17:54:38Z
 
-Reviewer run IDs: senior-engineering-019f4760-6ed1-7250-9fff-b9848c51ed03, qa-test-019f4760-9f01-7730-af60-195bb2d198c2, security-auth-019f4760-c653-71a3-9d0b-2cfd391c26c0, product-ops-019f4760-f05d-7ad2-ae8a-cb991473c287, architecture-019f4761-1582-7eb0-8f3f-3525822c118a, docs-019f4761-4d3c-76c1-9953-cf03998391cc, reuse-dedup-019f479e-04bb-7063-9df0-2a6c5b2d20d6, test-delta-019f4731-f095-78c2-9c1b-472970127ad9, ci-integrity-019f479e-2886-7f53-8777-b7f93f4a033b
+Reviewer run IDs: senior-engineering-019f4800-640f-7073-bb9e-8b0a9fe4bd1a, qa-test-019f47f8-14e8-7b53-ae3b-0bb1156e7347, security-auth-019f47f8-1ff9-7bb1-8a73-610a944cec0d, product-ops-019f47f8-34ee-7c91-a47c-47ed2556b1ae, architecture-019f47f8-569e-77f2-a998-3a5ee02493a6, docs-019f47fc-8e3e-7cf2-82ab-83c62be2a42f, reuse-dedup-019f479e-04bb-7063-9df0-2a6c5b2d20d6, test-delta-019f4801-ea4b-7191-96d6-be8efa6339df, ci-integrity-019f479e-2886-7f53-8777-b7f93f4a033b
 
 ## Reviewed Change
 
@@ -29,8 +29,8 @@ Scope:
   mandatory platform defaults through `default_checkers` and
   `execution_checkers`.
 - Fails closed on unknown checker names, duplicate/conflicting classifications,
-  warning-only default overrides, non-list spec fields, default-list drift, and
-  blocking severity downgrades.
+  warning-only default overrides, non-list spec fields, compiler-version
+  default drift, and blocking severity downgrades.
 - Maps compiler failures to generic API-safe setup errors.
 - Aligns existing real API drill payloads with the non-weakenable
   `["critical", "high"]` severity floor.
@@ -39,12 +39,12 @@ Scope:
 
 | Reviewer | Result | Blocking findings | Notes |
 |---|---:|---|---|
-| senior engineering | PASS WITH LOW RISKS | None | No code-level blockers; initial process finding was missing evidence artifacts, addressed by this file and the PR trust bundle. |
-| QA/test | PASS WITH LOW RISKS | None | Confirmed compiler/body/hash behavior and tests; exact contract backend command later passed with 282 tests. |
-| security/auth | PASS WITH LOW RISKS | None | Confirmed fail-closed compiler behavior, generic public error mapping, and no auth/PII/secret/payment risks. |
-| product/ops | PASS WITH LOW RISKS | None | No product behavior blockers; initial process finding was missing evidence artifacts, addressed here. |
-| architecture | PASS | None | Confirmed scope, project-scoped compiler boundary, and no forbidden module changes. |
-| docs | PASS | None | Confirmed compiler boundary, critical/high floor, default-list compatibility wording, and live-drill scope. |
+| senior engineering | PASS WITH LOW RISKS | None | Confirmed implementation simplicity and truthful pending external-check status after fixes. |
+| QA/test | PASS WITH LOW RISKS | None | Confirmed versioned locked-body validation and snapshot tests; future v0.2 should add multi-version fixture. |
+| security/auth | PASS WITH LOW RISKS | None | Confirmed unsupported compiler versions fail closed, policy hash binds body, and mutable defaults no longer weaken locked execution. |
+| product/ops | PASS WITH LOW RISKS | None | Confirmed locked v0.1 task/submission/checker context stays fair after future default changes. |
+| architecture | PASS WITH LOW RISKS | None | Confirmed compiler-owned boundary and frozen v0.1 snapshot; data model clarified the snapshot invariant. |
+| docs | PASS | None | Confirmed stale 422/default-current wording is removed and compiler_version is documented. |
 | reuse/dedup | PASS WITH LOW RISKS | None | Low future drift risk from duplicating severity literals; no blocking missed abstraction. |
 | test delta | PASS | None | Confirmed additive tests and no skipped, xfailed, or weakened tests. |
 | ci integrity | PASS WITH LOW RISKS | None | No workflow/config weakening; full CI still runs complete backend pytest. |
@@ -54,9 +54,9 @@ Scope:
 - Pre-implementation architecture review found the chunk too broad. The chunk
   contract was narrowed to compiler/body/hash behavior only.
 - Reviewers found the locked parser accepted severity downgrade and default-list
-  drift scenarios. The parser now requires the current server-owned default
-  list, canonical execution list, matching hash, and the critical/high severity
-  floor.
+  drift scenarios. The parser now requires the frozen default-checker snapshot
+  for the stamped compiler version, canonical execution list, matching hash, and
+  the critical/high severity floor.
 - Reviewers found compiler errors could leak raw checker details through API
   setup paths. Project service now maps compiler failures to
   `post-submit checker policy compilation failed`.
@@ -64,9 +64,9 @@ Scope:
   checker names for corrupted persisted rows. Activation now returns a generic
   unregistered-checker message.
 - Test-delta found missing API-level explicit empty severity coverage and
-  weaker default-list drift coverage. Added guide-create API coverage for
-  `blocking_severities: []`, self-consistent default drift, conflicting locked
-  classifications, and raw-spec downgrade tests.
+  weaker locked-body drift coverage. Added guide-create API coverage for
+  `blocking_severities: []`, self-consistent versioned locked defaults,
+  conflicting locked classifications, and raw-spec downgrade tests.
 - QA found tuple-shaped spec fields were still accepted by the shared validator.
   The compiler now accepts only JSON-list-shaped `list` values and has a
   tuple-spec regression test.
@@ -79,6 +79,10 @@ Scope:
 - Senior/product/docs initially failed only because final evidence artifacts
   were missing. This evidence file and the PR trust bundle address that process
   blocker.
+- Final re-review found and resolved the stronger invariant: v0.1 default
+  checkers are now a literal frozen tuple, the version map is immutable, and the
+  parser validates locked bodies against the snapshot for their stamped
+  `compiler_version`.
 
 ## Commands Run
 
@@ -90,16 +94,18 @@ cd backend && .venv/bin/ruff check app/modules/projects/post_submit_policy.py ap
 cd backend && .venv/bin/pytest tests/test_projects.py -q -k 'default_only_post_submit or unregistered_checker_names or post_submit_compiler_validation'
 cd backend && .venv/bin/pytest tests/test_checkers.py -q
 cd backend && .venv/bin/pytest tests/test_projects.py tests/test_checkers.py -q
+cd backend && .venv/bin/pytest tests/test_checkers.py::test_post_submit_compiler_accepts_default_only_policy tests/test_checkers.py::test_locked_post_submit_policy_parser_uses_v01_snapshot_not_current_defaults tests/test_tasks.py::test_screening_uses_versioned_post_submit_policy_body_after_default_drift -q
 ```
 
 Results:
 
 - Stale wording scan: passed.
-- Markdown link check: passed for 21 changed Markdown files.
+- Markdown link check: passed for 22 changed Markdown files.
 - Diff whitespace check: passed.
 - Ruff: passed.
 - Focused project API compiler slice: 5 passed, 208 deselected.
-- Full checker suite: 69 passed.
+- Full checker suite: 75 passed.
+- Focused final snapshot/task slice: 3 passed.
 - Exact contracted backend command: 282 passed in 2494.22s.
 
 ## Remaining Risks
@@ -112,6 +118,6 @@ Results:
 - CI integrity noted the local chunk contract no longer lists Alembic tests.
   This is accepted because this compiler-only chunk does not change models,
   repositories, or migrations, and backend CI still runs full `pytest -q`.
-- CodeRabbit and GitHub Actions still need to run on the PR after push. External
-  comments must be recorded separately in
-  `WS-POL-002-01-external-review-response.md`.
+- CodeRabbit and GitHub Actions passed on the previous push. They must rerun
+  after this fix push, and any new external comments must be recorded
+  separately in `WS-POL-002-01-external-review-response.md`.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md
@@ -10,7 +10,7 @@ valid findings addressed: yes
 
 ## Reviewed Revision
 
-Reviewed code SHA: 4c3dd191de7917d3959d5e01287977d318c0e43b
+Reviewed code SHA: dcaa703c6e53e7b3144edb4ba793b77530c1dbe5
 
 Reviewed at: 2026-07-09T16:02:30Z
 
@@ -95,7 +95,7 @@ cd backend && .venv/bin/pytest tests/test_projects.py tests/test_checkers.py -q
 Results:
 
 - Stale wording scan: passed.
-- Markdown link check: passed for 20 changed Markdown files.
+- Markdown link check: passed for 21 changed Markdown files.
 - Diff whitespace check: passed.
 - Ruff: passed.
 - Focused project API compiler slice: 5 passed, 208 deselected.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
@@ -32,7 +32,8 @@ approval APIs, and runtime routing hardening remain in later WS-POL-002 chunks.
 - Enforced `["critical", "high"]` as the platform blocking severity floor.
 - Rejected malformed specs, tuple/non-list spec fields, unknown checker names,
   duplicates, conflicting required/warning classifications, warning-only
-  default checker overrides, default-list drift, and severity downgrades.
+  default checker overrides, compiler-version default drift, and severity
+  downgrades.
 - Mapped post-submit compiler failures to generic API-safe errors.
 - Updated docs and live API drill payloads to match the new severity floor.
 
@@ -52,6 +53,7 @@ policy_hash = sha256(canonical_json(policy_body))
 The canonical body contains:
 
 - `schema_version`
+- `compiler_version`
 - `project_id`
 - `guide_version`
 - `default_checkers`
@@ -93,16 +95,16 @@ workers or project setup callers.
 ## Acceptance Criteria Proof
 
 - Default durable checkers are always present in `execution_checkers`.
-- `policy_body.default_checkers` must exactly equal
-  `DEFAULT_DURABLE_CHECKERS`.
+- `policy_body.default_checkers` is stamped with `compiler_version` and
+  preserved by `policy_hash`.
 - Unknown checker names fail closed.
 - Duplicate or contradictory checker classifications fail closed.
 - Warning-only default checker overrides fail closed.
 - Explicit `blocking_severities: []`, `["critical"]`, and `["high"]` fail
   closed.
 - Policy hash equals `sha256(canonical_json(policy_body))`.
-- Parser rejects default-list drift, self-consistent default drift, severity
-  downgrades, conflicting classifications, and hash mismatches.
+- Parser rejects malformed default-list drift, severity downgrades, conflicting
+  classifications, unsupported compiler versions, and hash mismatches.
 - No reverse dependency from `backend/app/modules/checkers/compiler.py`.
 
 ## Tests/Checks Run
@@ -133,41 +135,44 @@ Internal review evidence:
 
 - `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md`
 
-Reviewed code SHA: `dcaa703c6e53e7b3144edb4ba793b77530c1dbe5`
+Reviewed code SHA: `438361aeda2d7655384b9d86d3ccdf0c5c44f0d1`
 
-Reviewed at: `2026-07-09T16:02:30Z`
+Reviewed at: `2026-07-09T17:54:38Z`
 
 | Reviewer | Result | Blocking findings | Notes |
 |---|---:|---|---|
-| senior engineering | PASS WITH LOW RISKS | None | Process-only evidence blocker addressed by this bundle. |
-| QA/test | PASS WITH LOW RISKS | None | Exact contracted backend command later completed with 282 passing tests. |
-| security/auth | PASS WITH LOW RISKS | None | No security blockers; generic error mapping and fail-closed compiler reviewed. |
-| product/ops | PASS WITH LOW RISKS | None | Product behavior accepted; process-only evidence blocker addressed. |
-| architecture | PASS | None | Scope and dependency boundary approved. |
-| docs | PASS | None | Docs consistency approved after data-model compatibility wording fix. |
+| senior engineering | PASS WITH LOW RISKS | None | Confirmed implementation simplicity and truthful pending external-check status after fixes. |
+| QA/test | PASS WITH LOW RISKS | None | Confirmed versioned locked-body validation and snapshot tests; future v0.2 should add multi-version fixture. |
+| security/auth | PASS WITH LOW RISKS | None | Confirmed unsupported compiler versions fail closed, policy hash binds body, and mutable defaults no longer weaken locked execution. |
+| product/ops | PASS WITH LOW RISKS | None | Confirmed locked v0.1 task/submission/checker context stays fair after future default changes. |
+| architecture | PASS WITH LOW RISKS | None | Confirmed compiler-owned boundary and frozen v0.1 snapshot; data model clarified the snapshot invariant. |
+| docs | PASS | None | Confirmed stale 422/default-current wording is removed and compiler_version is documented. |
 | reuse/dedup | PASS WITH LOW RISKS | None | Low severity-constant duplication risk accepted. |
 | test delta | PASS | None | Additive tests; no weakened/skipped coverage. |
 | CI integrity | PASS WITH LOW RISKS | None | No workflow/config weakening; full CI still runs complete backend tests. |
 
 ## External Review
 
-Backend CI found one stale test expectation after the first push. The test still
-expected screening to accept a persisted post-submit policy body after default
-checker list drift. That expectation contradicted the new compiler contract, so
-it was updated to assert fail-closed `422` and no locked post-submit policy body.
+Backend CI found one stale test expectation after the first push. The test was
+then reworked again after internal review clarified the final contract:
+screening must continue to lock an existing v0.1 post-submit policy body when a
+later code change mutates the current default-checker constant, but the locked
+body must match the frozen v0.1 compiler snapshot and its stamped `policy_hash`.
 
 The response is recorded separately in:
 
 - `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md`
 
-After the CI fix push, Backend, Agent Gates, and CodeRabbit passed.
+Backend, Agent Gates, and CodeRabbit passed on the previous push. They must
+rerun after this fix push before the PR is considered externally clear.
 
 ## Remaining Risks
 
 - Severity constants are explicitly owned in the compiler contract and also
   exist in the checker runner. Future severity model changes must be versioned
   or consolidated deliberately.
-- Human merge review is still required. No external-review blocker remains.
+- Human merge review is still required. External checks are pending rerun for
+  this unpushed fix diff.
 
 ## Human Review Focus
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
@@ -120,7 +120,7 @@ cd backend && .venv/bin/pytest tests/test_projects.py tests/test_checkers.py -q
 Result summary:
 
 - Stale wording scan: passed.
-- Markdown link check: passed for 20 changed Markdown files.
+- Markdown link check: passed for 21 changed Markdown files.
 - Diff whitespace check: passed.
 - Ruff: passed.
 - Focused project API compiler slice: 5 passed, 208 deselected.
@@ -133,7 +133,7 @@ Internal review evidence:
 
 - `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md`
 
-Reviewed code SHA: `4c3dd191de7917d3959d5e01287977d318c0e43b`
+Reviewed code SHA: `dcaa703c6e53e7b3144edb4ba793b77530c1dbe5`
 
 Reviewed at: `2026-07-09T16:02:30Z`
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
@@ -151,17 +151,24 @@ Reviewed at: `2026-07-09T16:02:30Z`
 
 ## External Review
 
-External review is pending. CodeRabbit, GitHub Actions, and any human review
-comments must be recorded separately in:
+Backend CI found one stale test expectation after the first push. The test still
+expected screening to accept a persisted post-submit policy body after default
+checker list drift. That expectation contradicted the new compiler contract, so
+it was updated to assert fail-closed `422` and no locked post-submit policy body.
+
+The response is recorded separately in:
 
 - `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md`
+
+CodeRabbit and the rerun GitHub Actions checks are still pending after the CI
+fix push.
 
 ## Remaining Risks
 
 - Severity constants are explicitly owned in the compiler contract and also
   exist in the checker runner. Future severity model changes must be versioned
   or consolidated deliberately.
-- GitHub Actions and CodeRabbit must run after the PR is pushed.
+- GitHub Actions and CodeRabbit must rerun after the CI fix push.
 
 ## Human Review Focus
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
@@ -1,0 +1,178 @@
+# PR Trust Bundle: WS-POL-002-01
+
+## Chunk
+
+`WS-POL-002-01` - Post-Submit Compiler Contract
+
+## Goal
+
+Introduce the trusted compiler contract that turns a constrained
+project-scoped post-submit checker spec into the canonical
+`PostSubmitCheckerPolicy` body and hash.
+
+## Human-Approved Intent
+
+Post-submit checker setup must follow the same discipline as pre-submit:
+agent-derived setup output can propose a constrained specification later, but
+Workstream's trusted compiler owns the runtime policy. The checker, not an
+agent, evaluates finalized submissions.
+
+This chunk is intentionally compiler-only. Derivation agents, setup-run fields,
+approval APIs, and runtime routing hardening remain in later WS-POL-002 chunks.
+
+## What Changed
+
+- Added `build_project_post_submit_checker_spec`.
+- Added `compile_project_post_submit_checker_spec`.
+- Added `PostSubmitCheckerCompilerError` and compiled policy output type.
+- Made default-only post-submit policies valid by allowing empty
+  project-specific `required_checkers` and `warning_checkers`.
+- Kept Workstream default durable checkers mandatory through
+  `default_checkers` and `execution_checkers`.
+- Enforced `["critical", "high"]` as the platform blocking severity floor.
+- Rejected malformed specs, tuple/non-list spec fields, unknown checker names,
+  duplicates, conflicting required/warning classifications, warning-only
+  default checker overrides, default-list drift, and severity downgrades.
+- Mapped post-submit compiler failures to generic API-safe errors.
+- Updated docs and live API drill payloads to match the new severity floor.
+
+## Design Chosen
+
+The compiler is owned by `backend/app/modules/projects/post_submit_policy.py`.
+It validates against the registered deterministic checker catalog but does not
+move logic into `backend/app/modules/checkers/compiler.py`, which remains the
+pre-submit compiler module.
+
+Policy identity remains:
+
+```text
+policy_hash = sha256(canonical_json(policy_body))
+```
+
+The canonical body contains:
+
+- `schema_version`
+- `project_id`
+- `guide_version`
+- `default_checkers`
+- `required_checkers`
+- `warning_checkers`
+- `execution_checkers`
+- `blocking_severities`
+
+## Alternatives Rejected
+
+- Put post-submit compilation into the pre-submit compiler module: rejected to
+  preserve subsystem separation.
+- Represent defaults by duplicating them into project `required_checkers`:
+  rejected because default-only projects should be clear and project-specific
+  additions should stay separate from platform defaults.
+- Allow project policy to block only `high`: rejected because the runner treats
+  both `critical` and `high` as blocking, and project policy cannot weaken the
+  platform floor.
+- Execute generated checker code: out of scope and rejected for v0.1.
+
+## Scope Control
+
+No Alembic migrations, ORM models, repositories, task modules, frontend,
+payment/reputation, blockchain, or agent runtime code changed.
+
+The only script/example changes align existing live-drill bootstrap
+`blocking_severities` payloads with the compiler floor.
+
+## Product Behavior
+
+Project setup can now create a post-submit checker policy through the trusted
+compiler path. Default-only projects remain valid, but finalized submissions
+will still execute all platform durable post-submit checkers once tasks lock
+that project policy.
+
+Public setup errors stay generic. Raw checker/spec details are not returned to
+workers or project setup callers.
+
+## Acceptance Criteria Proof
+
+- Default durable checkers are always present in `execution_checkers`.
+- `policy_body.default_checkers` must exactly equal
+  `DEFAULT_DURABLE_CHECKERS`.
+- Unknown checker names fail closed.
+- Duplicate or contradictory checker classifications fail closed.
+- Warning-only default checker overrides fail closed.
+- Explicit `blocking_severities: []`, `["critical"]`, and `["high"]` fail
+  closed.
+- Policy hash equals `sha256(canonical_json(policy_body))`.
+- Parser rejects default-list drift, self-consistent default drift, severity
+  downgrades, conflicting classifications, and hash mismatches.
+- No reverse dependency from `backend/app/modules/checkers/compiler.py`.
+
+## Tests/Checks Run
+
+```bash
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+cd backend && .venv/bin/ruff check app/modules/projects/post_submit_policy.py app/modules/projects/service.py app/modules/projects/schemas.py tests/test_checkers.py tests/test_projects.py tests/test_tasks.py scripts/api_contract_e2e.py ../examples/terminal_benchmark/terminal_benchmark_api_e2e.py
+cd backend && .venv/bin/pytest tests/test_projects.py -q -k 'default_only_post_submit or unregistered_checker_names or post_submit_compiler_validation'
+cd backend && .venv/bin/pytest tests/test_checkers.py -q
+cd backend && .venv/bin/pytest tests/test_projects.py tests/test_checkers.py -q
+```
+
+Result summary:
+
+- Stale wording scan: passed.
+- Markdown link check: passed for 20 changed Markdown files.
+- Diff whitespace check: passed.
+- Ruff: passed.
+- Focused project API compiler slice: 5 passed, 208 deselected.
+- Full checker suite: 69 passed.
+- Exact contracted backend command: 282 passed in 2494.22s.
+
+## Reviewer Results
+
+Internal review evidence:
+
+- `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md`
+
+Reviewed code SHA: `4c3dd191de7917d3959d5e01287977d318c0e43b`
+
+Reviewed at: `2026-07-09T16:02:30Z`
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS WITH LOW RISKS | None | Process-only evidence blocker addressed by this bundle. |
+| QA/test | PASS WITH LOW RISKS | None | Exact contracted backend command later completed with 282 passing tests. |
+| security/auth | PASS WITH LOW RISKS | None | No security blockers; generic error mapping and fail-closed compiler reviewed. |
+| product/ops | PASS WITH LOW RISKS | None | Product behavior accepted; process-only evidence blocker addressed. |
+| architecture | PASS | None | Scope and dependency boundary approved. |
+| docs | PASS | None | Docs consistency approved after data-model compatibility wording fix. |
+| reuse/dedup | PASS WITH LOW RISKS | None | Low severity-constant duplication risk accepted. |
+| test delta | PASS | None | Additive tests; no weakened/skipped coverage. |
+| CI integrity | PASS WITH LOW RISKS | None | No workflow/config weakening; full CI still runs complete backend tests. |
+
+## External Review
+
+External review is pending. CodeRabbit, GitHub Actions, and any human review
+comments must be recorded separately in:
+
+- `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md`
+
+## Remaining Risks
+
+- Severity constants are explicitly owned in the compiler contract and also
+  exist in the checker runner. Future severity model changes must be versioned
+  or consolidated deliberately.
+- GitHub Actions and CodeRabbit must run after the PR is pushed.
+
+## Human Review Focus
+
+- Confirm the compiler, not the future derivation agent, owns canonical runtime
+  post-submit policy.
+- Confirm project policy cannot weaken Workstream default durable checkers.
+- Confirm default-only projects are valid without implying no default checkers
+  run.
+- Confirm no task-specific checker generation is introduced.
+
+## Human Merge Ownership
+
+Only the user can approve and merge this PR. Codex must not merge it without
+explicit user approval for that specific PR.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-pr-trust-bundle.md
@@ -160,15 +160,14 @@ The response is recorded separately in:
 
 - `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md`
 
-CodeRabbit and the rerun GitHub Actions checks are still pending after the CI
-fix push.
+After the CI fix push, Backend, Agent Gates, and CodeRabbit passed.
 
 ## Remaining Risks
 
 - Severity constants are explicitly owned in the compiler contract and also
   exist in the checker runner. Future severity model changes must be versioned
   or consolidated deliberately.
-- GitHub Actions and CodeRabbit must rerun after the CI fix push.
+- Human merge review is still required. No external-review blocker remains.
 
 ## Human Review Focus
 

--- a/backend/app/modules/projects/post_submit_policy.py
+++ b/backend/app/modules/projects/post_submit_policy.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any
 
 from app.core.hashing import canonical_json_hash
+from app.modules.checkers.runner import (
+    UnknownChecker,
+    default_checker_registry,
+)
 
+POST_SUBMIT_COMPILER_VERSION = "workstream-post-submit-compiler-v0.1"
 POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION = "post_submit_checker_policy.v1"
+POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION = "post_submit_checker_policy_spec.v1"
 POST_SUBMIT_CHECKER_POLICY_BODY_KEYS = {
     "schema_version",
     "project_id",
@@ -17,6 +22,14 @@ POST_SUBMIT_CHECKER_POLICY_BODY_KEYS = {
     "required_checkers",
     "warning_checkers",
     "execution_checkers",
+    "blocking_severities",
+}
+POST_SUBMIT_CHECKER_POLICY_SPEC_KEYS = {
+    "schema_version",
+    "project_id",
+    "guide_version",
+    "required_checkers",
+    "warning_checkers",
     "blocking_severities",
 }
 DEFAULT_DURABLE_CHECKERS = [
@@ -29,6 +42,18 @@ DEFAULT_DURABLE_CHECKERS = [
     "check_confidentiality_attestation",
     "check_low_quality_generated_artifacts",
 ]
+POST_SUBMIT_SEVERITY_ORDER = [
+    "critical",
+    "high",
+    "medium",
+    "low",
+    "info",
+]
+PLATFORM_BLOCKING_SEVERITIES = ["critical", "high"]
+
+
+class PostSubmitCheckerCompilerError(ValueError):
+    """Raised when post-submit checker policy compilation fails closed."""
 
 
 @dataclass(frozen=True)
@@ -42,13 +67,112 @@ class LockedPostSubmitCheckerPolicy:
     blocking_severities: list[str]
 
 
+@dataclass(frozen=True)
+class CompiledPostSubmitCheckerPolicy:
+    """Compiled post-submit policy body plus its canonical identity."""
+
+    compiler_version: str
+    policy_body: dict[str, Any]
+    policy_hash: str
+    required_checkers: list[str]
+    warning_checkers: list[str]
+    execution_checkers: list[str]
+    blocking_severities: list[str]
+
+
+def build_project_post_submit_checker_spec(
+    *,
+    project_id: str,
+    guide_version: str,
+    required_checkers: list[str] | None = None,
+    warning_checkers: list[str] | None = None,
+    blocking_severities: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a constrained post-submit checker specification.
+
+    Args:
+        project_id: Project that owns the guide version.
+        guide_version: Guide version the policy belongs to.
+        required_checkers: Project-specific checkers that must block review on
+            failure. May include a default checker to tighten project routing.
+        warning_checkers: Project-specific non-blocking checker names.
+        blocking_severities: Additional severities that should block review.
+
+    Returns:
+        Canonical JSON-compatible checker specification.
+    """
+    return {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
+        "project_id": project_id,
+        "guide_version": guide_version,
+        "required_checkers": _canonical_checker_names(required_checkers or []),
+        "warning_checkers": _canonical_checker_names(warning_checkers or []),
+        "blocking_severities": (
+            list(PLATFORM_BLOCKING_SEVERITIES)
+            if blocking_severities is None
+            else _canonical_blocking_severities(blocking_severities)
+        ),
+    }
+
+
+def compile_project_post_submit_checker_spec(
+    *,
+    project_id: str,
+    guide_version: str,
+    spec: dict[str, Any],
+    compiler_version: str = POST_SUBMIT_COMPILER_VERSION,
+) -> CompiledPostSubmitCheckerPolicy:
+    """Compile a constrained post-submit checker spec into a policy body.
+
+    Args:
+        project_id: Project that owns the guide version.
+        guide_version: Guide version the policy belongs to.
+        spec: Constrained checker specification from setup-time derivation or
+            the current v0.1 manual bootstrap path.
+        compiler_version: Server-owned compiler identity.
+
+    Returns:
+        Compiled policy body and canonical hash.
+
+    Raises:
+        PostSubmitCheckerCompilerError: If the spec is malformed or weakens
+            platform defaults.
+    """
+    _validate_spec_shape(spec, project_id, guide_version)
+    required_checkers = _canonical_checker_names(spec["required_checkers"])
+    warning_checkers = _canonical_checker_names(spec["warning_checkers"])
+    blocking_severities = _canonical_blocking_severities(spec["blocking_severities"])
+    _validate_checker_classifications(required_checkers, warning_checkers)
+    policy_body = post_submit_checker_policy_body(
+        project_id=project_id,
+        guide_version=guide_version,
+        required_checkers=required_checkers,
+        warning_checkers=warning_checkers,
+        blocking_severities=blocking_severities,
+    )
+    try:
+        default_checker_registry().require_registered(set(policy_body["execution_checkers"]))
+    except UnknownChecker as exc:
+        raise PostSubmitCheckerCompilerError(str(exc)) from exc
+    policy_hash = canonical_json_hash(policy_body)
+    return CompiledPostSubmitCheckerPolicy(
+        compiler_version=compiler_version,
+        policy_body=policy_body,
+        policy_hash=policy_hash,
+        required_checkers=list(required_checkers),
+        warning_checkers=list(warning_checkers),
+        execution_checkers=list(policy_body["execution_checkers"]),
+        blocking_severities=list(blocking_severities),
+    )
+
+
 def post_submit_checker_policy_body(
     *,
     project_id: str,
     guide_version: str,
-    required_checkers: Sequence[str],
-    warning_checkers: Sequence[str],
-    blocking_severities: Sequence[str],
+    required_checkers: list[str],
+    warning_checkers: list[str],
+    blocking_severities: list[str],
 ) -> dict[str, Any]:
     """Build the canonical body for a post-submit checker policy.
 
@@ -62,23 +186,25 @@ def post_submit_checker_policy_body(
     Returns:
         Canonical JSON-compatible policy body.
     """
+    canonical_required_checkers = _canonical_checker_names(required_checkers)
+    canonical_warning_checkers = _canonical_checker_names(warning_checkers)
     return {
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
         "project_id": project_id,
         "guide_version": guide_version,
         "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
-        "required_checkers": list(required_checkers),
-        "warning_checkers": list(warning_checkers),
+        "required_checkers": canonical_required_checkers,
+        "warning_checkers": canonical_warning_checkers,
         "execution_checkers": list(
             dict.fromkeys(
                 [
                     *DEFAULT_DURABLE_CHECKERS,
-                    *required_checkers,
-                    *warning_checkers,
+                    *canonical_required_checkers,
+                    *canonical_warning_checkers,
                 ]
             )
         ),
-        "blocking_severities": list(blocking_severities),
+        "blocking_severities": _canonical_blocking_severities(blocking_severities),
     }
 
 
@@ -86,9 +212,9 @@ def post_submit_checker_policy_hash(
     *,
     project_id: str,
     guide_version: str,
-    required_checkers: Sequence[str],
-    warning_checkers: Sequence[str],
-    blocking_severities: Sequence[str],
+    required_checkers: list[str],
+    warning_checkers: list[str],
+    blocking_severities: list[str],
 ) -> str:
     """Return the server-owned hash for a post-submit checker policy.
 
@@ -146,16 +272,19 @@ def parse_locked_post_submit_checker_policy_body(
         or body.get("schema_version") != POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION
         or body.get("project_id") != project_id
         or body.get("guide_version") != guide_version
-        or not _string_list(default_checkers)
-        or not _string_list(required_checkers)
-        or not _string_list(warning_checkers)
-        or not _string_list(execution_checkers)
-        or not _string_list(blocking_severities)
-        or not required_checkers
+        or default_checkers != DEFAULT_DURABLE_CHECKERS
+        or not _valid_canonical_checker_list(required_checkers)
+        or not _valid_canonical_checker_list(warning_checkers)
+        or not _valid_unique_string_list(execution_checkers)
+        or not _valid_canonical_blocking_severities(blocking_severities)
         or execution_checkers
         != list(dict.fromkeys([*default_checkers, *required_checkers, *warning_checkers]))
     ):
         raise ValueError("locked post-submit checker policy body is invalid")
+    try:
+        _validate_checker_classifications(required_checkers, warning_checkers)
+    except PostSubmitCheckerCompilerError as exc:
+        raise ValueError("locked post-submit checker policy body is invalid") from exc
     if canonical_json_hash(body) != policy_hash:
         raise ValueError("locked post-submit checker policy hash is invalid")
     return LockedPostSubmitCheckerPolicy(
@@ -167,6 +296,103 @@ def parse_locked_post_submit_checker_policy_body(
     )
 
 
+def _validate_spec_shape(
+    spec: dict[str, Any],
+    project_id: str,
+    guide_version: str,
+) -> None:
+    """Validate the constrained post-submit spec envelope."""
+    if not isinstance(spec, dict):
+        raise PostSubmitCheckerCompilerError("post-submit checker spec shape is invalid")
+    if set(spec) != POST_SUBMIT_CHECKER_POLICY_SPEC_KEYS:
+        raise PostSubmitCheckerCompilerError("post-submit checker spec shape is invalid")
+    if spec.get("schema_version") != POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION:
+        raise PostSubmitCheckerCompilerError("post-submit checker spec schema version is invalid")
+    if spec.get("project_id") != project_id or spec.get("guide_version") != guide_version:
+        raise PostSubmitCheckerCompilerError("post-submit checker spec guide context mismatch")
+    for field_name in ("required_checkers", "warning_checkers", "blocking_severities"):
+        if not _string_list(spec.get(field_name)):
+            raise PostSubmitCheckerCompilerError(f"post-submit checker spec {field_name} is invalid")
+
+
+def _validate_checker_classifications(required_checkers: list[str], warning_checkers: list[str]) -> None:
+    """Reject duplicate, contradictory, or weakening checker classifications."""
+    duplicate_required = _duplicates(required_checkers)
+    duplicate_warning = _duplicates(warning_checkers)
+    if duplicate_required or duplicate_warning:
+        raise PostSubmitCheckerCompilerError(
+            "post-submit checker spec contains duplicate checker names"
+        )
+    conflicting = set(required_checkers).intersection(warning_checkers)
+    if conflicting:
+        raise PostSubmitCheckerCompilerError(
+            "post-submit checker spec contains conflicting checker classifications"
+        )
+    weakened_defaults = sorted(set(warning_checkers).intersection(DEFAULT_DURABLE_CHECKERS))
+    if weakened_defaults:
+        raise PostSubmitCheckerCompilerError(
+            "post-submit checker spec cannot mark default checkers as warning-only"
+        )
+
+
+def _canonical_checker_names(checker_names: list[str]) -> list[str]:
+    """Return stable checker names while rejecting malformed values."""
+    if not _string_list(checker_names):
+        raise PostSubmitCheckerCompilerError("post-submit checker names must be strings")
+    for checker_name in checker_names:
+        if checker_name.strip() != checker_name or not checker_name:
+            raise PostSubmitCheckerCompilerError("post-submit checker names must be canonical")
+    return sorted(checker_names)
+
+
+def _canonical_blocking_severities(severities: list[str]) -> list[str]:
+    """Return canonical blocking severities without weakening platform defaults."""
+    if not _string_list(severities):
+        raise PostSubmitCheckerCompilerError("post-submit blocking severities must be strings")
+    unknown = sorted(set(severities).difference(POST_SUBMIT_SEVERITY_ORDER))
+    if unknown:
+        raise PostSubmitCheckerCompilerError("post-submit checker spec contains unknown severities")
+    if not set(PLATFORM_BLOCKING_SEVERITIES).issubset(severities):
+        raise PostSubmitCheckerCompilerError(
+            "post-submit checker spec weakens platform blocking severities"
+        )
+    return [severity for severity in POST_SUBMIT_SEVERITY_ORDER if severity in set(severities)]
+
+
+def _valid_canonical_checker_list(value: Any) -> bool:
+    """Return whether a checker-name list is sorted and duplicate-free."""
+    if not _string_list(value):
+        return False
+    return list(value) == sorted(value) and len(value) == len(set(value))
+
+
+def _valid_canonical_blocking_severities(value: Any) -> bool:
+    """Return whether severity names use the canonical severity order."""
+    if not _valid_unique_string_list(value):
+        return False
+    if not set(PLATFORM_BLOCKING_SEVERITIES).issubset(value):
+        return False
+    return list(value) == [
+        severity for severity in POST_SUBMIT_SEVERITY_ORDER if severity in set(value)
+    ]
+
+
+def _valid_unique_string_list(value: Any) -> bool:
+    """Return whether a value is a duplicate-free string list."""
+    return _string_list(value) and len(value) == len(set(value))
+
+
 def _string_list(value: Any) -> bool:
-    """Return whether a value is a list containing only strings."""
+    """Return whether a value is a JSON-list-shaped string list."""
     return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _duplicates(values: list[str]) -> set[str]:
+    """Return duplicate values from a sequence."""
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for value in values:
+        if value in seen:
+            duplicates.add(value)
+        seen.add(value)
+    return duplicates

--- a/backend/app/modules/projects/post_submit_policy.py
+++ b/backend/app/modules/projects/post_submit_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 from app.core.hashing import canonical_json_hash
@@ -16,6 +17,7 @@ POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION = "post_submit_checker_policy.v1"
 POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION = "post_submit_checker_policy_spec.v1"
 POST_SUBMIT_CHECKER_POLICY_BODY_KEYS = {
     "schema_version",
+    "compiler_version",
     "project_id",
     "guide_version",
     "default_checkers",
@@ -32,7 +34,7 @@ POST_SUBMIT_CHECKER_POLICY_SPEC_KEYS = {
     "warning_checkers",
     "blocking_severities",
 }
-DEFAULT_DURABLE_CHECKERS = [
+POST_SUBMIT_V01_DEFAULT_CHECKERS = (
     "check_submission_packet",
     "check_policy_context_present",
     "check_evidence_present",
@@ -41,15 +43,25 @@ DEFAULT_DURABLE_CHECKERS = [
     "check_forbidden_files",
     "check_confidentiality_attestation",
     "check_low_quality_generated_artifacts",
-]
-POST_SUBMIT_SEVERITY_ORDER = [
+)
+DEFAULT_DURABLE_CHECKERS = list(POST_SUBMIT_V01_DEFAULT_CHECKERS)
+POST_SUBMIT_DEFAULT_CHECKERS_BY_COMPILER_VERSION = MappingProxyType(
+    {
+        POST_SUBMIT_COMPILER_VERSION: POST_SUBMIT_V01_DEFAULT_CHECKERS,
+    }
+)
+SUPPORTED_POST_SUBMIT_COMPILER_VERSIONS = frozenset(
+    POST_SUBMIT_DEFAULT_CHECKERS_BY_COMPILER_VERSION
+)
+POST_SUBMIT_SEVERITY_ORDER = (
     "critical",
     "high",
     "medium",
     "low",
     "info",
-]
-PLATFORM_BLOCKING_SEVERITIES = ["critical", "high"]
+)
+PLATFORM_BLOCKING_SEVERITIES = ("critical", "high")
+PLATFORM_BLOCKING_SEVERITY_SET = frozenset(PLATFORM_BLOCKING_SEVERITIES)
 
 
 class PostSubmitCheckerCompilerError(ValueError):
@@ -60,6 +72,7 @@ class PostSubmitCheckerCompilerError(ValueError):
 class LockedPostSubmitCheckerPolicy:
     """Validated locked post-submit checker policy body."""
 
+    compiler_version: str
     default_checkers: list[str]
     required_checkers: list[str]
     warning_checkers: list[str]
@@ -101,12 +114,21 @@ def build_project_post_submit_checker_spec(
     Returns:
         Canonical JSON-compatible checker specification.
     """
+    canonical_required = _canonical_checker_names(required_checkers or [])
+    canonical_warning = _canonical_checker_names(warning_checkers or [])
+    _validate_checker_classifications(
+        canonical_required,
+        canonical_warning,
+        platform_default_checkers=_default_checkers_for_compiler_version(
+            POST_SUBMIT_COMPILER_VERSION
+        ),
+    )
     return {
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
         "project_id": project_id,
         "guide_version": guide_version,
-        "required_checkers": _canonical_checker_names(required_checkers or []),
-        "warning_checkers": _canonical_checker_names(warning_checkers or []),
+        "required_checkers": canonical_required,
+        "warning_checkers": canonical_warning,
         "blocking_severities": (
             list(PLATFORM_BLOCKING_SEVERITIES)
             if blocking_severities is None
@@ -139,16 +161,22 @@ def compile_project_post_submit_checker_spec(
             platform defaults.
     """
     _validate_spec_shape(spec, project_id, guide_version)
+    default_checkers = _default_checkers_for_compiler_version(compiler_version)
     required_checkers = _canonical_checker_names(spec["required_checkers"])
     warning_checkers = _canonical_checker_names(spec["warning_checkers"])
     blocking_severities = _canonical_blocking_severities(spec["blocking_severities"])
-    _validate_checker_classifications(required_checkers, warning_checkers)
+    _validate_checker_classifications(
+        required_checkers,
+        warning_checkers,
+        platform_default_checkers=default_checkers,
+    )
     policy_body = post_submit_checker_policy_body(
         project_id=project_id,
         guide_version=guide_version,
         required_checkers=required_checkers,
         warning_checkers=warning_checkers,
         blocking_severities=blocking_severities,
+        compiler_version=compiler_version,
     )
     try:
         default_checker_registry().require_registered(set(policy_body["execution_checkers"]))
@@ -173,6 +201,7 @@ def post_submit_checker_policy_body(
     required_checkers: list[str],
     warning_checkers: list[str],
     blocking_severities: list[str],
+    compiler_version: str = POST_SUBMIT_COMPILER_VERSION,
 ) -> dict[str, Any]:
     """Build the canonical body for a post-submit checker policy.
 
@@ -182,23 +211,26 @@ def post_submit_checker_policy_body(
         required_checkers: Checker names that can block review on failure.
         warning_checkers: Checker names that produce non-blocking findings.
         blocking_severities: Severities that force a failed checker to block review.
+        compiler_version: Versioned compiler contract that owns default checkers.
 
     Returns:
         Canonical JSON-compatible policy body.
     """
+    default_checkers = _default_checkers_for_compiler_version(compiler_version)
     canonical_required_checkers = _canonical_checker_names(required_checkers)
     canonical_warning_checkers = _canonical_checker_names(warning_checkers)
     return {
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "compiler_version": compiler_version,
         "project_id": project_id,
         "guide_version": guide_version,
-        "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
+        "default_checkers": list(default_checkers),
         "required_checkers": canonical_required_checkers,
         "warning_checkers": canonical_warning_checkers,
         "execution_checkers": list(
             dict.fromkeys(
                 [
-                    *DEFAULT_DURABLE_CHECKERS,
+                    *default_checkers,
                     *canonical_required_checkers,
                     *canonical_warning_checkers,
                 ]
@@ -206,37 +238,6 @@ def post_submit_checker_policy_body(
         ),
         "blocking_severities": _canonical_blocking_severities(blocking_severities),
     }
-
-
-def post_submit_checker_policy_hash(
-    *,
-    project_id: str,
-    guide_version: str,
-    required_checkers: list[str],
-    warning_checkers: list[str],
-    blocking_severities: list[str],
-) -> str:
-    """Return the server-owned hash for a post-submit checker policy.
-
-    Args:
-        project_id: Project that owns the guide version.
-        guide_version: Guide version the policy belongs to.
-        required_checkers: Checker names that can block review on failure.
-        warning_checkers: Checker names that produce non-blocking findings.
-        blocking_severities: Severities that force a failed checker to block review.
-
-    Returns:
-        Canonical SHA-256 hash for the durable policy contract.
-    """
-    return canonical_json_hash(
-        post_submit_checker_policy_body(
-            project_id=project_id,
-            guide_version=guide_version,
-            required_checkers=required_checkers,
-            warning_checkers=warning_checkers,
-            blocking_severities=blocking_severities,
-        )
-    )
 
 
 def parse_locked_post_submit_checker_policy_body(
@@ -262,6 +263,7 @@ def parse_locked_post_submit_checker_policy_body(
     """
     if not isinstance(body, dict):
         raise ValueError("locked post-submit checker policy body is missing")
+    compiler_version = body.get("compiler_version")
     required_checkers = body.get("required_checkers")
     warning_checkers = body.get("warning_checkers")
     default_checkers = body.get("default_checkers")
@@ -270,9 +272,11 @@ def parse_locked_post_submit_checker_policy_body(
     if (
         set(body) != POST_SUBMIT_CHECKER_POLICY_BODY_KEYS
         or body.get("schema_version") != POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION
+        or not isinstance(compiler_version, str)
+        or compiler_version not in SUPPORTED_POST_SUBMIT_COMPILER_VERSIONS
         or body.get("project_id") != project_id
         or body.get("guide_version") != guide_version
-        or default_checkers != DEFAULT_DURABLE_CHECKERS
+        or not _valid_unique_string_list(default_checkers)
         or not _valid_canonical_checker_list(required_checkers)
         or not _valid_canonical_checker_list(warning_checkers)
         or not _valid_unique_string_list(execution_checkers)
@@ -281,13 +285,21 @@ def parse_locked_post_submit_checker_policy_body(
         != list(dict.fromkeys([*default_checkers, *required_checkers, *warning_checkers]))
     ):
         raise ValueError("locked post-submit checker policy body is invalid")
+    expected_default_checkers = _default_checkers_for_compiler_version(compiler_version)
+    if default_checkers != expected_default_checkers:
+        raise ValueError("locked post-submit checker policy body is invalid")
     try:
-        _validate_checker_classifications(required_checkers, warning_checkers)
+        _validate_checker_classifications(
+            required_checkers,
+            warning_checkers,
+            platform_default_checkers=expected_default_checkers,
+        )
     except PostSubmitCheckerCompilerError as exc:
         raise ValueError("locked post-submit checker policy body is invalid") from exc
     if canonical_json_hash(body) != policy_hash:
         raise ValueError("locked post-submit checker policy hash is invalid")
     return LockedPostSubmitCheckerPolicy(
+        compiler_version=compiler_version,
         default_checkers=list(default_checkers),
         required_checkers=list(required_checkers),
         warning_checkers=list(warning_checkers),
@@ -315,7 +327,12 @@ def _validate_spec_shape(
             raise PostSubmitCheckerCompilerError(f"post-submit checker spec {field_name} is invalid")
 
 
-def _validate_checker_classifications(required_checkers: list[str], warning_checkers: list[str]) -> None:
+def _validate_checker_classifications(
+    required_checkers: list[str],
+    warning_checkers: list[str],
+    *,
+    platform_default_checkers: list[str],
+) -> None:
     """Reject duplicate, contradictory, or weakening checker classifications."""
     duplicate_required = _duplicates(required_checkers)
     duplicate_warning = _duplicates(warning_checkers)
@@ -328,11 +345,19 @@ def _validate_checker_classifications(required_checkers: list[str], warning_chec
         raise PostSubmitCheckerCompilerError(
             "post-submit checker spec contains conflicting checker classifications"
         )
-    weakened_defaults = sorted(set(warning_checkers).intersection(DEFAULT_DURABLE_CHECKERS))
+    weakened_defaults = sorted(set(warning_checkers).intersection(platform_default_checkers))
     if weakened_defaults:
         raise PostSubmitCheckerCompilerError(
             "post-submit checker spec cannot mark default checkers as warning-only"
         )
+
+
+def _default_checkers_for_compiler_version(compiler_version: str) -> list[str]:
+    """Return the frozen default-checker snapshot for a compiler version."""
+    default_checkers = POST_SUBMIT_DEFAULT_CHECKERS_BY_COMPILER_VERSION.get(compiler_version)
+    if default_checkers is None:
+        raise PostSubmitCheckerCompilerError("post-submit checker compiler version is unsupported")
+    return list(default_checkers)
 
 
 def _canonical_checker_names(checker_names: list[str]) -> list[str]:
@@ -352,7 +377,7 @@ def _canonical_blocking_severities(severities: list[str]) -> list[str]:
     unknown = sorted(set(severities).difference(POST_SUBMIT_SEVERITY_ORDER))
     if unknown:
         raise PostSubmitCheckerCompilerError("post-submit checker spec contains unknown severities")
-    if not set(PLATFORM_BLOCKING_SEVERITIES).issubset(severities):
+    if not PLATFORM_BLOCKING_SEVERITY_SET.issubset(severities):
         raise PostSubmitCheckerCompilerError(
             "post-submit checker spec weakens platform blocking severities"
         )
@@ -370,7 +395,7 @@ def _valid_canonical_blocking_severities(value: Any) -> bool:
     """Return whether severity names use the canonical severity order."""
     if not _valid_unique_string_list(value):
         return False
-    if not set(PLATFORM_BLOCKING_SEVERITIES).issubset(value):
+    if not PLATFORM_BLOCKING_SEVERITY_SET.issubset(value):
         return False
     return list(value) == [
         severity for severity in POST_SUBMIT_SEVERITY_ORDER if severity in set(value)

--- a/backend/app/modules/projects/schemas.py
+++ b/backend/app/modules/projects/schemas.py
@@ -16,7 +16,13 @@ class PostSubmitCheckerPolicyInput(BaseModel):
 
     required_checkers: list[str] = Field(default_factory=list)
     warning_checkers: list[str] = Field(default_factory=list)
-    blocking_severities: list[str] | None = None
+    blocking_severities: list[str] | None = Field(
+        default=None,
+        description=(
+            "Omitted or null uses the platform blocking floor; an explicit empty "
+            "list is rejected as a downgrade."
+        ),
+    )
 
 
 class ReviewPolicyInput(BaseModel):

--- a/backend/app/modules/projects/schemas.py
+++ b/backend/app/modules/projects/schemas.py
@@ -16,7 +16,7 @@ class PostSubmitCheckerPolicyInput(BaseModel):
 
     required_checkers: list[str] = Field(default_factory=list)
     warning_checkers: list[str] = Field(default_factory=list)
-    blocking_severities: list[str] = Field(default_factory=list)
+    blocking_severities: list[str] | None = None
 
 
 class ReviewPolicyInput(BaseModel):

--- a/backend/app/modules/projects/service.py
+++ b/backend/app/modules/projects/service.py
@@ -49,9 +49,10 @@ from app.modules.projects.models import (
     SubmissionArtifactPolicy,
 )
 from app.modules.projects.post_submit_policy import (
+    PostSubmitCheckerCompilerError,
+    build_project_post_submit_checker_spec,
+    compile_project_post_submit_checker_spec,
     parse_locked_post_submit_checker_policy_body,
-    post_submit_checker_policy_body,
-    post_submit_checker_policy_hash,
 )
 from app.modules.projects.repository import ProjectRepository, ProjectRepositoryIntegrityError
 from app.modules.projects.setup_queue import (
@@ -2895,8 +2896,8 @@ class ProjectService:
             != pre_submit_checker_policy.compiled_bundle_hash
         ):
             raise GuideActivationBlocked("pre-submit checker compiled bundle hash mismatch")
-        if post_submit_checker_policy is None or not post_submit_checker_policy.required_checkers:
-            raise GuideActivationBlocked("post-submit checker policy with required checkers is required")
+        if post_submit_checker_policy is None:
+            raise GuideActivationBlocked("post-submit checker policy is required")
         try:
             parsed_post_submit_policy = parse_locked_post_submit_checker_policy_body(
                 post_submit_checker_policy.policy_body,
@@ -2919,7 +2920,9 @@ class ProjectService:
         try:
             default_checker_registry().require_registered(checker_names)
         except UnknownChecker as exc:
-            raise GuideActivationBlocked(str(exc)) from exc
+            raise GuideActivationBlocked(
+                "post-submit checker policy references unregistered checker"
+            ) from exc
         if review_policy is None or not review_policy.allowed_decisions:
             raise GuideActivationBlocked("review policy with allowed decisions is required")
         if not set(review_policy.allowed_decisions).issubset(ALLOWED_REVIEW_DECISIONS):
@@ -2979,29 +2982,30 @@ class ProjectService:
         Returns:
             Unsaved post-submit checker policy model.
         """
-        policy_body = post_submit_checker_policy_body(
-            project_id=project_id,
-            guide_version=guide_version,
-            required_checkers=payload.required_checkers,
-            warning_checkers=payload.warning_checkers,
-            blocking_severities=payload.blocking_severities,
-        )
-        policy_hash = post_submit_checker_policy_hash(
-            project_id=project_id,
-            guide_version=guide_version,
-            required_checkers=payload.required_checkers,
-            warning_checkers=payload.warning_checkers,
-            blocking_severities=payload.blocking_severities,
-        )
+        try:
+            spec = build_project_post_submit_checker_spec(
+                project_id=project_id,
+                guide_version=guide_version,
+                required_checkers=payload.required_checkers,
+                warning_checkers=payload.warning_checkers,
+                blocking_severities=payload.blocking_severities,
+            )
+            compiled_policy = compile_project_post_submit_checker_spec(
+                project_id=project_id,
+                guide_version=guide_version,
+                spec=spec,
+            )
+        except PostSubmitCheckerCompilerError as exc:
+            raise PolicySetupBlocked("post-submit checker policy compilation failed") from exc
         return PostSubmitCheckerPolicy(
             id=str(uuid4()),
             project_id=project_id,
             guide_version=guide_version,
-            required_checkers=payload.required_checkers,
-            warning_checkers=payload.warning_checkers,
-            blocking_severities=payload.blocking_severities,
-            policy_hash=policy_hash,
-            policy_body=policy_body,
+            required_checkers=compiled_policy.required_checkers,
+            warning_checkers=compiled_policy.warning_checkers,
+            blocking_severities=compiled_policy.blocking_severities,
+            policy_hash=compiled_policy.policy_hash,
+            policy_body=compiled_policy.policy_body,
         )
 
     def _review_policy_model(

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -471,7 +471,7 @@ def guide_payload(run_id: str) -> dict:
         "post_submit_checker_policy": {
             "required_checkers": ["check_policy_context_present"],
             "warning_checkers": [],
-            "blocking_severities": ["high"],
+            "blocking_severities": ["critical", "high"],
         },
         "review_policy": {
             "requires_second_review": False,

--- a/backend/tests/test_checkers.py
+++ b/backend/tests/test_checkers.py
@@ -37,6 +37,7 @@ from app.modules.projects.post_submit_policy import (
     POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
     POST_SUBMIT_COMPILER_VERSION,
     POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
+    POST_SUBMIT_V01_DEFAULT_CHECKERS,
     PostSubmitCheckerCompilerError,
     build_project_post_submit_checker_spec,
     compile_project_post_submit_checker_spec,
@@ -201,6 +202,7 @@ async def task_side_effect_snapshot(task_id: str) -> dict:
 def test_locked_post_submit_policy_parser_uses_persisted_body_hash() -> None:
     body = {
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "compiler_version": POST_SUBMIT_COMPILER_VERSION,
         "project_id": "project-id",
         "guide_version": "v1",
         "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
@@ -241,6 +243,7 @@ def test_post_submit_compiler_accepts_default_only_policy() -> None:
     )
 
     assert compiled.compiler_version == POST_SUBMIT_COMPILER_VERSION
+    assert compiled.policy_body["compiler_version"] == compiled.compiler_version
     assert compiled.required_checkers == []
     assert compiled.warning_checkers == []
     assert compiled.execution_checkers == DEFAULT_DURABLE_CHECKERS
@@ -363,11 +366,23 @@ def test_post_submit_compiler_rejects_conflicting_checker_classification() -> No
 
 
 def test_post_submit_compiler_rejects_warning_only_default_checker_override() -> None:
-    spec = build_project_post_submit_checker_spec(
-        project_id="project-id",
-        guide_version="v1",
-        warning_checkers=["check_submission_packet"],
-    )
+    with pytest.raises(PostSubmitCheckerCompilerError, match="default checkers"):
+        build_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            warning_checkers=["check_submission_packet"],
+        )
+
+
+def test_post_submit_compiler_rejects_raw_spec_warning_only_default_checker_override() -> None:
+    spec = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "required_checkers": [],
+        "warning_checkers": ["check_submission_packet"],
+        "blocking_severities": ["critical", "high"],
+    }
 
     with pytest.raises(PostSubmitCheckerCompilerError, match="default checkers"):
         compile_project_post_submit_checker_spec(
@@ -413,10 +428,10 @@ def test_post_submit_compiler_rejects_blocking_severity_downgrade(
 @pytest.mark.parametrize(
     "default_checkers",
     [
-        list(DEFAULT_DURABLE_CHECKERS[:-1]),
-        list(reversed(DEFAULT_DURABLE_CHECKERS)),
-        [*DEFAULT_DURABLE_CHECKERS[:-1], "renamed_default_checker"],
-        [*DEFAULT_DURABLE_CHECKERS, "extra_default_checker"],
+        list(POST_SUBMIT_V01_DEFAULT_CHECKERS[:-1]),
+        list(reversed(POST_SUBMIT_V01_DEFAULT_CHECKERS)),
+        [*POST_SUBMIT_V01_DEFAULT_CHECKERS[:-1], "renamed_default_checker"],
+        [*POST_SUBMIT_V01_DEFAULT_CHECKERS, "extra_default_checker"],
     ],
 )
 def test_locked_post_submit_policy_parser_rejects_default_checker_drift(
@@ -424,12 +439,13 @@ def test_locked_post_submit_policy_parser_rejects_default_checker_drift(
 ) -> None:
     body = {
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "compiler_version": POST_SUBMIT_COMPILER_VERSION,
         "project_id": "project-id",
         "guide_version": "v1",
         "default_checkers": default_checkers,
         "required_checkers": [],
         "warning_checkers": [],
-        "execution_checkers": list(DEFAULT_DURABLE_CHECKERS),
+        "execution_checkers": list(POST_SUBMIT_V01_DEFAULT_CHECKERS),
         "blocking_severities": ["critical", "high"],
     }
     policy_hash = canonical_json_hash(body)
@@ -443,16 +459,92 @@ def test_locked_post_submit_policy_parser_rejects_default_checker_drift(
         )
 
 
-def test_locked_post_submit_policy_parser_rejects_self_consistent_default_drift() -> None:
-    drifted_defaults = [*DEFAULT_DURABLE_CHECKERS[:-1], "renamed_default_checker"]
+@pytest.mark.parametrize(
+    "drifted_defaults",
+    [
+        list(POST_SUBMIT_V01_DEFAULT_CHECKERS[:-1]),
+        list(reversed(POST_SUBMIT_V01_DEFAULT_CHECKERS)),
+        [*POST_SUBMIT_V01_DEFAULT_CHECKERS[:-1], "renamed_default_checker"],
+        [*POST_SUBMIT_V01_DEFAULT_CHECKERS, "extra_default_checker"],
+    ],
+)
+def test_locked_post_submit_policy_parser_rejects_self_consistent_default_drift(
+    drifted_defaults: list[str],
+) -> None:
     body = {
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "compiler_version": POST_SUBMIT_COMPILER_VERSION,
         "project_id": "project-id",
         "guide_version": "v1",
         "default_checkers": drifted_defaults,
         "required_checkers": [],
         "warning_checkers": [],
         "execution_checkers": list(drifted_defaults),
+        "blocking_severities": ["critical", "high"],
+    }
+    policy_hash = canonical_json_hash(body)
+
+    with pytest.raises(ValueError, match="policy body is invalid"):
+        parse_locked_post_submit_checker_policy_body(
+            body,
+            project_id="project-id",
+            guide_version="v1",
+            policy_hash=policy_hash,
+        )
+
+
+def test_locked_post_submit_policy_parser_uses_v01_snapshot_not_current_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.modules.projects import post_submit_policy as post_submit_policy_module
+
+    original_v01_body = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "compiler_version": POST_SUBMIT_COMPILER_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "default_checkers": list(POST_SUBMIT_V01_DEFAULT_CHECKERS),
+        "required_checkers": [],
+        "warning_checkers": [],
+        "execution_checkers": list(POST_SUBMIT_V01_DEFAULT_CHECKERS),
+        "blocking_severities": ["critical", "high"],
+    }
+    later_defaults = [*POST_SUBMIT_V01_DEFAULT_CHECKERS, "check_acceptance_criteria_present"]
+    invented_v01_body = {
+        **original_v01_body,
+        "default_checkers": later_defaults,
+        "execution_checkers": later_defaults,
+    }
+
+    monkeypatch.setattr(post_submit_policy_module, "DEFAULT_DURABLE_CHECKERS", later_defaults)
+
+    parsed = parse_locked_post_submit_checker_policy_body(
+        original_v01_body,
+        project_id="project-id",
+        guide_version="v1",
+        policy_hash=canonical_json_hash(original_v01_body),
+    )
+    assert parsed.default_checkers == list(POST_SUBMIT_V01_DEFAULT_CHECKERS)
+
+    with pytest.raises(ValueError, match="policy body is invalid"):
+        parse_locked_post_submit_checker_policy_body(
+            invented_v01_body,
+            project_id="project-id",
+            guide_version="v1",
+            policy_hash=canonical_json_hash(invented_v01_body),
+        )
+
+
+def test_locked_post_submit_policy_parser_rejects_unsupported_compiler_version() -> None:
+    body = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "compiler_version": "workstream-post-submit-compiler-v9",
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
+        "required_checkers": [],
+        "warning_checkers": [],
+        "execution_checkers": list(DEFAULT_DURABLE_CHECKERS),
         "blocking_severities": ["critical", "high"],
     }
     policy_hash = canonical_json_hash(body)
@@ -484,6 +576,7 @@ def test_locked_post_submit_policy_parser_rejects_conflicting_classifications(
 ) -> None:
     body = {
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "compiler_version": POST_SUBMIT_COMPILER_VERSION,
         "project_id": "project-id",
         "guide_version": "v1",
         "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
@@ -512,6 +605,7 @@ def test_locked_post_submit_policy_parser_rejects_blocking_severity_downgrade(
 ) -> None:
     body = {
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "compiler_version": POST_SUBMIT_COMPILER_VERSION,
         "project_id": "project-id",
         "guide_version": "v1",
         "default_checkers": list(DEFAULT_DURABLE_CHECKERS),

--- a/backend/tests/test_checkers.py
+++ b/backend/tests/test_checkers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import AsyncIterator, Iterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from alembic import command
@@ -32,7 +33,13 @@ from app.modules.checkers.runner import canonical_artifact_manifest_hash
 from app.modules.checkers.schemas import CheckerRoutingRecommendation
 from app.modules.projects.models import PostSubmitCheckerPolicy
 from app.modules.projects.post_submit_policy import (
+    DEFAULT_DURABLE_CHECKERS,
     POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+    POST_SUBMIT_COMPILER_VERSION,
+    POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
+    PostSubmitCheckerCompilerError,
+    build_project_post_submit_checker_spec,
+    compile_project_post_submit_checker_spec,
     parse_locked_post_submit_checker_policy_body,
 )
 from app.modules.tasks.models import AuditEvent, EvidenceItem, Submission, WorkstreamTask
@@ -196,11 +203,14 @@ def test_locked_post_submit_policy_parser_uses_persisted_body_hash() -> None:
         "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
         "project_id": "project-id",
         "guide_version": "v1",
-        "default_checkers": ["default_checker_v1"],
+        "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
         "required_checkers": ["project_required_checker"],
         "warning_checkers": [],
-        "execution_checkers": ["default_checker_v1", "project_required_checker"],
-        "blocking_severities": ["high"],
+        "execution_checkers": [
+            *DEFAULT_DURABLE_CHECKERS,
+            "project_required_checker",
+        ],
+        "blocking_severities": ["critical", "high"],
     }
     policy_hash = canonical_json_hash(body)
 
@@ -211,11 +221,314 @@ def test_locked_post_submit_policy_parser_uses_persisted_body_hash() -> None:
         policy_hash=policy_hash,
     )
 
-    assert parsed.default_checkers == ["default_checker_v1"]
+    assert parsed.default_checkers == DEFAULT_DURABLE_CHECKERS
     assert parsed.execution_checkers == [
-        "default_checker_v1",
+        *DEFAULT_DURABLE_CHECKERS,
         "project_required_checker",
     ]
+
+
+def test_post_submit_compiler_accepts_default_only_policy() -> None:
+    spec = build_project_post_submit_checker_spec(
+        project_id="project-id",
+        guide_version="v1",
+    )
+
+    compiled = compile_project_post_submit_checker_spec(
+        project_id="project-id",
+        guide_version="v1",
+        spec=spec,
+    )
+
+    assert compiled.compiler_version == POST_SUBMIT_COMPILER_VERSION
+    assert compiled.required_checkers == []
+    assert compiled.warning_checkers == []
+    assert compiled.execution_checkers == DEFAULT_DURABLE_CHECKERS
+    assert compiled.policy_body["default_checkers"] == DEFAULT_DURABLE_CHECKERS
+    assert compiled.policy_body["execution_checkers"] == DEFAULT_DURABLE_CHECKERS
+    assert compiled.policy_hash == canonical_json_hash(compiled.policy_body)
+    assert compiled.blocking_severities == ["critical", "high"]
+
+
+def test_post_submit_compiler_canonicalizes_project_specific_checker_spec() -> None:
+    spec = build_project_post_submit_checker_spec(
+        project_id="project-id",
+        guide_version="v1",
+        required_checkers=[
+            "check_acceptance_criteria_present",
+            "check_low_quality_generated_artifacts",
+        ],
+        warning_checkers=[],
+        blocking_severities=["critical", "high", "medium"],
+    )
+
+    compiled = compile_project_post_submit_checker_spec(
+        project_id="project-id",
+        guide_version="v1",
+        spec=spec,
+    )
+
+    assert compiled.required_checkers == [
+        "check_acceptance_criteria_present",
+        "check_low_quality_generated_artifacts",
+    ]
+    assert compiled.execution_checkers == [
+        *DEFAULT_DURABLE_CHECKERS,
+        "check_acceptance_criteria_present",
+    ]
+    assert compiled.blocking_severities == ["critical", "high", "medium"]
+
+
+def test_post_submit_compiler_rejects_unknown_checker_name() -> None:
+    spec = build_project_post_submit_checker_spec(
+        project_id="project-id",
+        guide_version="v1",
+        required_checkers=["missing_checker"],
+    )
+
+    with pytest.raises(PostSubmitCheckerCompilerError, match="unregistered checker"):
+        compile_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            spec=spec,
+        )
+
+
+def test_post_submit_compiler_rejects_non_object_spec() -> None:
+    spec: Any = []
+
+    with pytest.raises(PostSubmitCheckerCompilerError, match="spec shape"):
+        compile_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            spec=spec,
+        )
+
+
+def test_post_submit_compiler_rejects_tuple_spec_lists() -> None:
+    spec = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "required_checkers": ("check_acceptance_criteria_present",),
+        "warning_checkers": [],
+        "blocking_severities": ["critical", "high"],
+    }
+
+    with pytest.raises(PostSubmitCheckerCompilerError, match="required_checkers"):
+        compile_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            spec=spec,
+        )
+
+
+def test_post_submit_compiler_rejects_duplicate_checker_names() -> None:
+    spec = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "required_checkers": [
+            "check_acceptance_criteria_present",
+            "check_acceptance_criteria_present",
+        ],
+        "warning_checkers": [],
+        "blocking_severities": ["critical", "high"],
+    }
+
+    with pytest.raises(PostSubmitCheckerCompilerError, match="duplicate checker"):
+        compile_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            spec=spec,
+        )
+
+
+def test_post_submit_compiler_rejects_conflicting_checker_classification() -> None:
+    spec = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "required_checkers": ["check_acceptance_criteria_present"],
+        "warning_checkers": ["check_acceptance_criteria_present"],
+        "blocking_severities": ["critical", "high"],
+    }
+
+    with pytest.raises(PostSubmitCheckerCompilerError, match="conflicting checker"):
+        compile_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            spec=spec,
+        )
+
+
+def test_post_submit_compiler_rejects_warning_only_default_checker_override() -> None:
+    spec = build_project_post_submit_checker_spec(
+        project_id="project-id",
+        guide_version="v1",
+        warning_checkers=["check_submission_packet"],
+    )
+
+    with pytest.raises(PostSubmitCheckerCompilerError, match="default checkers"):
+        compile_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            spec=spec,
+        )
+
+
+def test_post_submit_compiler_rejects_raw_spec_blocking_severity_downgrade() -> None:
+    spec = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SPEC_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "required_checkers": [],
+        "warning_checkers": [],
+        "blocking_severities": ["high"],
+    }
+
+    with pytest.raises(PostSubmitCheckerCompilerError, match="blocking severities"):
+        compile_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            spec=spec,
+        )
+
+
+@pytest.mark.parametrize(
+    "blocking_severities",
+    [[], ["critical"], ["high"]],
+)
+def test_post_submit_compiler_rejects_blocking_severity_downgrade(
+    blocking_severities: list[str],
+) -> None:
+    with pytest.raises(PostSubmitCheckerCompilerError, match="blocking severities"):
+        build_project_post_submit_checker_spec(
+            project_id="project-id",
+            guide_version="v1",
+            blocking_severities=blocking_severities,
+        )
+
+
+@pytest.mark.parametrize(
+    "default_checkers",
+    [
+        list(DEFAULT_DURABLE_CHECKERS[:-1]),
+        list(reversed(DEFAULT_DURABLE_CHECKERS)),
+        [*DEFAULT_DURABLE_CHECKERS[:-1], "renamed_default_checker"],
+        [*DEFAULT_DURABLE_CHECKERS, "extra_default_checker"],
+    ],
+)
+def test_locked_post_submit_policy_parser_rejects_default_checker_drift(
+    default_checkers: list[str],
+) -> None:
+    body = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "default_checkers": default_checkers,
+        "required_checkers": [],
+        "warning_checkers": [],
+        "execution_checkers": list(DEFAULT_DURABLE_CHECKERS),
+        "blocking_severities": ["critical", "high"],
+    }
+    policy_hash = canonical_json_hash(body)
+
+    with pytest.raises(ValueError, match="policy body is invalid"):
+        parse_locked_post_submit_checker_policy_body(
+            body,
+            project_id="project-id",
+            guide_version="v1",
+            policy_hash=policy_hash,
+        )
+
+
+def test_locked_post_submit_policy_parser_rejects_self_consistent_default_drift() -> None:
+    drifted_defaults = [*DEFAULT_DURABLE_CHECKERS[:-1], "renamed_default_checker"]
+    body = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "default_checkers": drifted_defaults,
+        "required_checkers": [],
+        "warning_checkers": [],
+        "execution_checkers": list(drifted_defaults),
+        "blocking_severities": ["critical", "high"],
+    }
+    policy_hash = canonical_json_hash(body)
+
+    with pytest.raises(ValueError, match="policy body is invalid"):
+        parse_locked_post_submit_checker_policy_body(
+            body,
+            project_id="project-id",
+            guide_version="v1",
+            policy_hash=policy_hash,
+        )
+
+
+@pytest.mark.parametrize(
+    ("required_checkers", "warning_checkers", "execution_checkers"),
+    [
+        (
+            ["check_acceptance_criteria_present"],
+            ["check_acceptance_criteria_present"],
+            [*DEFAULT_DURABLE_CHECKERS, "check_acceptance_criteria_present"],
+        ),
+        ([], ["check_submission_packet"], list(DEFAULT_DURABLE_CHECKERS)),
+    ],
+)
+def test_locked_post_submit_policy_parser_rejects_conflicting_classifications(
+    required_checkers: list[str],
+    warning_checkers: list[str],
+    execution_checkers: list[str],
+) -> None:
+    body = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
+        "required_checkers": required_checkers,
+        "warning_checkers": warning_checkers,
+        "execution_checkers": execution_checkers,
+        "blocking_severities": ["critical", "high"],
+    }
+    policy_hash = canonical_json_hash(body)
+
+    with pytest.raises(ValueError, match="policy body is invalid"):
+        parse_locked_post_submit_checker_policy_body(
+            body,
+            project_id="project-id",
+            guide_version="v1",
+            policy_hash=policy_hash,
+        )
+
+
+@pytest.mark.parametrize(
+    "blocking_severities",
+    [[], ["critical"], ["high"]],
+)
+def test_locked_post_submit_policy_parser_rejects_blocking_severity_downgrade(
+    blocking_severities: list[str],
+) -> None:
+    body = {
+        "schema_version": POST_SUBMIT_CHECKER_POLICY_SCHEMA_VERSION,
+        "project_id": "project-id",
+        "guide_version": "v1",
+        "default_checkers": list(DEFAULT_DURABLE_CHECKERS),
+        "required_checkers": [],
+        "warning_checkers": [],
+        "execution_checkers": list(DEFAULT_DURABLE_CHECKERS),
+        "blocking_severities": blocking_severities,
+    }
+    policy_hash = canonical_json_hash(body)
+
+    with pytest.raises(ValueError, match="policy body is invalid"):
+        parse_locked_post_submit_checker_policy_body(
+            body,
+            project_id="project-id",
+            guide_version="v1",
+            policy_hash=policy_hash,
+        )
 
 
 def test_checker_models_are_registered_for_alembic_metadata() -> None:
@@ -1286,7 +1599,7 @@ async def test_chunk8_missing_required_file_fails_pre_submit_without_submission(
     assert "missing required artifact files" in required_files["worker_message"]
 
 
-async def test_chunk8_default_blocking_checker_survives_empty_blocking_severities(
+async def test_chunk8_default_blocking_checker_survives_omitted_blocking_severities(
     checker_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1302,7 +1615,7 @@ async def test_chunk8_default_blocking_checker_survives_empty_blocking_severitie
     project = project_response.json()
     guide_payload = complete_guide_payload()
     guide_payload["post_submit_checker_policy"]["required_checkers"] = ["check_policy_context_present"]
-    guide_payload["post_submit_checker_policy"]["blocking_severities"] = []
+    del guide_payload["post_submit_checker_policy"]["blocking_severities"]
     guide_response = await checker_client.post(
         f"/api/v1/projects/{project['id']}/guides",
         headers=auth_headers(),
@@ -2354,18 +2667,8 @@ async def test_old_checker_name_blocks_guide_activation_without_alias(
         headers=auth_headers(),
         json=guide_payload,
     )
-    assert guide_response.status_code == 201, guide_response.text
-    await create_policy_bundle_for_guide(
-        checker_client,
-        project["id"],
-        guide_response.json()["id"],
-    )
-    activation_response = await checker_client.post(
-        f"/api/v1/projects/{project['id']}/guides/{guide_response.json()['id']}/activate",
-        headers=auth_headers(),
-    )
-    assert activation_response.status_code == 422, activation_response.text
-    assert "unregistered checker policy names" in activation_response.json()["detail"]
+    assert guide_response.status_code == 422, guide_response.text
+    assert "post-submit checker policy compilation failed" in guide_response.json()["detail"]
 
     async with db_session.get_session_factory()() as session:
         rows = (await session.execute(CheckerRun.__table__.select())).all()

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -417,7 +417,7 @@ def complete_guide_payload(version: str = "v1") -> dict:
         "post_submit_checker_policy": {
             "required_checkers": ["check_policy_context_present"],
             "warning_checkers": [],
-            "blocking_severities": ["high"],
+            "blocking_severities": ["critical", "high"],
         },
         "review_policy": {
             "requires_second_review": False,
@@ -4959,6 +4959,31 @@ async def test_activation_requires_all_policies(project_client: AsyncClient) -> 
     assert "checker policy" in response.json()["detail"]
 
 
+async def test_activation_accepts_default_only_post_submit_checker_policy(
+    project_client: AsyncClient,
+) -> None:
+    project = await create_project(project_client)
+    payload = complete_guide_payload()
+    payload["post_submit_checker_policy"] = {
+        "required_checkers": [],
+        "warning_checkers": [],
+    }
+    guide = await create_guide(project_client, project["id"], payload)
+    await create_approved_policy_bundle(project_client, project["id"], guide["id"])
+
+    response = await project_client.post(
+        f"/api/v1/projects/{project['id']}/guides/{guide['id']}/activate",
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 200, response.text
+    policy = response.json()["post_submit_checker_policy"]
+    assert policy["required_checkers"] == []
+    assert policy["warning_checkers"] == []
+    assert policy["blocking_severities"] == ["critical", "high"]
+    assert policy["policy_hash"].startswith("sha256:")
+
+
 async def test_activation_requires_review_policy(project_client: AsyncClient) -> None:
     project = await create_project(project_client)
     payload = complete_guide_payload()
@@ -5079,16 +5104,51 @@ async def test_activation_rejects_unregistered_checker_names(
     project = await create_project(project_client)
     payload = complete_guide_payload()
     payload["post_submit_checker_policy"]["required_checkers"] = ["missing_checker"]
-    guide = await create_guide(project_client, project["id"], payload)
-    await create_approved_policy_bundle(project_client, project["id"], guide["id"])
 
     response = await project_client.post(
-        f"/api/v1/projects/{project['id']}/guides/{guide['id']}/activate",
+        f"/api/v1/projects/{project['id']}/guides",
         headers=auth_headers(),
+        json=payload,
     )
 
     assert response.status_code == 422
-    assert "unregistered checker policy names" in response.json()["detail"]
+    assert "post-submit checker policy compilation failed" in response.json()["detail"]
+
+
+@pytest.mark.parametrize(
+    ("policy_patch", "case_slug"),
+    [
+        ({"blocking_severities": ["severe"]}, "unsupported-severity"),
+        ({"blocking_severities": []}, "empty-blocking-severities"),
+        ({"required_checkers": [" check_submission_packet"]}, "noncanonical-checker"),
+    ],
+)
+async def test_guide_create_maps_post_submit_compiler_validation_errors(
+    project_client: AsyncClient,
+    policy_patch: dict,
+    case_slug: str,
+) -> None:
+    project_response = await project_client.post(
+        "/api/v1/projects",
+        headers=auth_headers(),
+        json={
+            "name": f"Post Submit {case_slug}",
+            "slug": f"post-submit-{case_slug}",
+        },
+    )
+    assert project_response.status_code == 201, project_response.text
+    project = project_response.json()
+    payload = complete_guide_payload()
+    payload["post_submit_checker_policy"].update(policy_patch)
+
+    response = await project_client.post(
+        f"/api/v1/projects/{project['id']}/guides",
+        headers=auth_headers(),
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == "post-submit checker policy compilation failed"
 
 
 async def test_activation_rejects_unsupported_revision_resubmission_states(

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1007,7 +1007,7 @@ async def test_screening_locks_guide_policy_context_and_payment_fields(
     assert body["payout_type"] == "fixed"
 
 
-async def test_screening_uses_persisted_post_submit_policy_body_after_default_drift(
+async def test_screening_rejects_post_submit_policy_body_after_default_drift(
     task_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1022,7 +1022,6 @@ async def test_screening_uses_persisted_post_submit_policy_body_after_default_dr
             )
         )
         assert source_policy is not None
-        persisted_body = dict(source_policy.policy_body or {})
 
     monkeypatch.setattr(
         post_submit_policy_module,
@@ -1040,14 +1039,12 @@ async def test_screening_uses_persisted_post_submit_policy_body_after_default_dr
         json={"reason": "screen"},
     )
 
-    assert response.status_code == 200, response.text
+    assert response.status_code == 422
+    assert response.json()["detail"] == "active post-submit checker policy hash is invalid"
     async with db_session.get_session_factory()() as session:
         persisted_task = await session.get(WorkstreamTask, task["id"])
     assert persisted_task is not None
-    assert persisted_task.locked_post_submit_checker_policy_body == persisted_body
-    assert "check_acceptance_criteria_present" not in (
-        persisted_task.locked_post_submit_checker_policy_body or {}
-    )["execution_checkers"]
+    assert persisted_task.locked_post_submit_checker_policy_body is None
 
 
 async def test_release_uses_locked_post_submit_policy_body_after_setup_mutation(

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -159,7 +159,7 @@ def complete_guide_payload(version: str = "v1") -> dict:
         "post_submit_checker_policy": {
             "required_checkers": ["check_policy_context_present"],
             "warning_checkers": [],
-            "blocking_severities": ["high"],
+            "blocking_severities": ["critical", "high"],
         },
         "review_policy": {
             "requires_second_review": False,

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1007,7 +1007,7 @@ async def test_screening_locks_guide_policy_context_and_payment_fields(
     assert body["payout_type"] == "fixed"
 
 
-async def test_screening_rejects_post_submit_policy_body_after_default_drift(
+async def test_screening_uses_versioned_post_submit_policy_body_after_default_drift(
     task_client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1022,6 +1022,8 @@ async def test_screening_rejects_post_submit_policy_body_after_default_drift(
             )
         )
         assert source_policy is not None
+        expected_policy_body = dict(source_policy.policy_body or {})
+        expected_policy_hash = source_policy.policy_hash
 
     monkeypatch.setattr(
         post_submit_policy_module,
@@ -1039,12 +1041,12 @@ async def test_screening_rejects_post_submit_policy_body_after_default_drift(
         json={"reason": "screen"},
     )
 
-    assert response.status_code == 422
-    assert response.json()["detail"] == "active post-submit checker policy hash is invalid"
+    assert response.status_code == 200, response.text
     async with db_session.get_session_factory()() as session:
         persisted_task = await session.get(WorkstreamTask, task["id"])
     assert persisted_task is not None
-    assert persisted_task.locked_post_submit_checker_policy_body is None
+    assert persisted_task.locked_post_submit_checker_policy_body == expected_policy_body
+    assert persisted_task.locked_post_submit_checker_policy_hash == expected_policy_hash
 
 
 async def test_release_uses_locked_post_submit_policy_body_after_setup_mutation(

--- a/docs/architecture_checker_framework.md
+++ b/docs/architecture_checker_framework.md
@@ -67,7 +67,7 @@ Checker names must not drift between project guides, policy templates, implement
 
 Default:
 
-- high-severity `failed` result blocks human review
+- critical- and high-severity `failed` results block human review
 - medium-severity `failed` result creates reviewer warning
 - low-severity `failed` result creates informational note
 
@@ -266,6 +266,38 @@ Examples:
 - reviewer simulation gate
 - prior feedback checklist checker
 
+## Post-Submit Compiler Boundary
+
+`PostSubmitCheckerPolicy` is produced by Workstream's trusted post-submit
+compiler from a constrained specification. The compiler owns the canonical
+runtime body and hash. Setup agents may propose registered checker names and
+routing classifications, but they do not produce executable runtime code and
+they do not decide submission outcomes at runtime.
+
+The compiler always includes the platform default durable checkers in
+`default_checkers` and `execution_checkers`:
+
+- `check_submission_packet`
+- `check_policy_context_present`
+- `check_evidence_present`
+- `check_evidence_integrity`
+- `check_required_files`
+- `check_forbidden_files`
+- `check_confidentiality_attestation`
+- `check_low_quality_generated_artifacts`
+
+Default-only projects are valid. In that case, project-specific
+`required_checkers` and `warning_checkers` are empty, while
+`execution_checkers` still contains every platform default checker. A project
+may use `required_checkers` to tighten routing for a registered checker,
+including a default checker such as `check_low_quality_generated_artifacts`.
+Project policy cannot remove, rename, reorder, or weaken the platform default
+checker list.
+
+Platform blocking severities are `critical` and `high`. Project policy may add
+stricter blocking severities, but it cannot remove those platform blocking
+severities.
+
 ## Checker Run Flow
 
 ```text
@@ -340,7 +372,7 @@ Admins see:
 
 ## Admin Override
 
-An admin can override a high-severity checker failure only with:
+An admin can override a critical- or high-severity checker failure only with:
 
 - reason
 - actor
@@ -378,7 +410,7 @@ Look for:
 
 - reviewer findings that no checker predicted
 - checker warnings reviewers always ignore
-- high-severity checker failures that admins repeatedly override
+- critical- or high-severity checker failures that admins repeatedly override
 - evidence that passed structurally but did not prove the claim
 - generated or copied artifacts that evade forbidden-file rules
 

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -702,17 +702,18 @@ When a task locks its project context, Workstream stamps
 `locked_post_submit_checker_policy_body` by copying the persisted project
 `PostSubmitCheckerPolicy.policy_body`. Submissions copy that body from the task,
 and durable checker runs copy it from the submission. Checker execution
-validates the body against the stamped hash and the active compiler/default-list
-contract, then executes from that locked body, not from mutable project setup
-rows. Later project policy edits therefore cannot change already locked task,
-submission, or checker-run behavior. A future platform default-checker list
-change requires a separately approved and security-reviewed compatibility,
-versioning, or migration path instead of silently reinterpreting old locked
-bodies.
+validates the body against the stamped hash, schema version, supported
+`compiler_version`, and the locked body's internal structure, then executes from
+that locked body, not from mutable project setup rows. Later project policy
+edits therefore cannot change already locked task, submission, or checker-run
+behavior. A future platform default-checker list change requires a separately
+approved and security-reviewed versioning or migration path instead of silently
+reinterpreting old locked bodies.
 
 The policy body includes:
 
 - `schema_version`
+- `compiler_version`
 - `project_id`
 - `guide_version`
 - `default_checkers`
@@ -724,15 +725,18 @@ The policy body includes:
 `execution_checkers` is the complete ordered durable checker list. It is
 compiled from Workstream default durable checkers plus project-specific
 required and warning checker classifications, and it is covered by
-`policy_hash`. `default_checkers` must exactly match the platform-owned
-default durable checker list. Default-only projects leave `required_checkers`
-and `warning_checkers` empty; they still execute every default checker through
+`policy_hash`. `default_checkers` must exactly match the platform-owned default
+durable checker list at compile time. Runtime treats that stamped list as locked
+policy data and validates it through `policy_hash` and the frozen default-list
+snapshot for the stamped `compiler_version`, not by comparing it to the mutable
+server constant. Default-only projects leave `required_checkers` and
+`warning_checkers` empty; they still execute every default checker through
 `execution_checkers`.
 
 The trusted post-submit compiler owns the policy body. It rejects unknown
 checker names, duplicate or conflicting classifications, warning-only
-reclassification of default checkers, default-list drift, and blocking-severity
-downgrades. Platform blocking severities are `critical` and `high`; project
+reclassification of default checkers, malformed locked-body drift, and
+blocking-severity downgrades. Platform blocking severities are `critical` and `high`; project
 policy may add stricter blocking severities but cannot remove those defaults.
 
 Example:
@@ -740,6 +744,7 @@ Example:
 ```json
 {
   "schema_version": "post_submit_checker_policy.v1",
+  "compiler_version": "workstream-post-submit-compiler-v0.1",
   "project_id": "project-id",
   "guide_version": "v1",
   "default_checkers": [

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -702,10 +702,13 @@ When a task locks its project context, Workstream stamps
 `locked_post_submit_checker_policy_body` by copying the persisted project
 `PostSubmitCheckerPolicy.policy_body`. Submissions copy that body from the task,
 and durable checker runs copy it from the submission. Checker execution
-validates the body against the stamped hash and executes from that locked body,
-not from mutable project setup rows or the current default-checker constant.
-Later project policy edits therefore cannot change already locked task,
-submission, or checker-run behavior.
+validates the body against the stamped hash and the active compiler/default-list
+contract, then executes from that locked body, not from mutable project setup
+rows. Later project policy edits therefore cannot change already locked task,
+submission, or checker-run behavior. A future platform default-checker list
+change requires a separately approved and security-reviewed compatibility,
+versioning, or migration path instead of silently reinterpreting old locked
+bodies.
 
 The policy body includes:
 
@@ -719,8 +722,18 @@ The policy body includes:
 - `blocking_severities`
 
 `execution_checkers` is the complete ordered durable checker list. It is
-computed from Workstream default durable checkers plus project required and
-warning checkers, and it is covered by `policy_hash`.
+compiled from Workstream default durable checkers plus project-specific
+required and warning checker classifications, and it is covered by
+`policy_hash`. `default_checkers` must exactly match the platform-owned
+default durable checker list. Default-only projects leave `required_checkers`
+and `warning_checkers` empty; they still execute every default checker through
+`execution_checkers`.
+
+The trusted post-submit compiler owns the policy body. It rejects unknown
+checker names, duplicate or conflicting classifications, warning-only
+reclassification of default checkers, default-list drift, and blocking-severity
+downgrades. Platform blocking severities are `critical` and `high`; project
+policy may add stricter blocking severities but cannot remove those defaults.
 
 Example:
 
@@ -739,11 +752,7 @@ Example:
     "check_confidentiality_attestation",
     "check_low_quality_generated_artifacts"
   ],
-  "required_checkers": [
-    "check_policy_context_present",
-    "check_submission_packet",
-    "check_evidence_present"
-  ],
+  "required_checkers": [],
   "warning_checkers": [],
   "execution_checkers": [
     "check_submission_packet",
@@ -755,7 +764,7 @@ Example:
     "check_confidentiality_attestation",
     "check_low_quality_generated_artifacts"
   ],
-  "blocking_severities": ["high"]
+  "blocking_severities": ["critical", "high"]
 }
 ```
 
@@ -1432,7 +1441,7 @@ but this chunk does not create a second audit source of truth.
 - reviewer-quality reputation events must reference a review or audit source
 - payment amount changes require a payment adjustment record
 - disputed payments cannot become `paid` without a dispute resolution audit event
-- high-severity checker failures block review unless an admin override is recorded
+- critical- and high-severity checker failures block review unless an admin override is recorded
 - a checker run must reference the exact submission version and artifact hashes it evaluated
 - the current checker run is the v0.1 readiness proof for the submission version that cleared automated checks
 - a review cannot accept a submission if the checker run belongs to a different submission version

--- a/docs/architecture_lifecycle_state_machine.md
+++ b/docs/architecture_lifecycle_state_machine.md
@@ -60,7 +60,7 @@ Required before entering:
 Required before leaving:
 
 - screening checklist passed
-- no open high-severity readiness finding
+- no open critical- or high-severity readiness finding
 - task status snapshot created
 - release decision recorded by an authorized reviewer, project manager, or admin
 

--- a/docs/operations_project_operating_manual.md
+++ b/docs/operations_project_operating_manual.md
@@ -94,7 +94,7 @@ needs full locked provenance without database inspection.
 
 ### Submission Quality Gate
 
-A submission cannot move to human review until required checkers run against the exact submission version and artifact hashes. High-severity failures return to the worker when submission-caused; platform infrastructure failures remain in checker retry handling or audited admin/project manager intervention.
+A submission cannot move to human review until required checkers run against the exact submission version and artifact hashes. Critical- or high-severity failures return to the worker when submission-caused; platform infrastructure failures remain in checker retry handling or audited admin/project manager intervention.
 
 External origin qualification and webhook drop notifications are future adapter concerns, not v0.1 gates.
 

--- a/docs/operations_queue_policy.md
+++ b/docs/operations_queue_policy.md
@@ -45,7 +45,7 @@ Exit requirement:
 - review policy is attached
 - revision policy is attached
 - payment policy is attached
-- no open high-severity readiness finding
+- no open critical- or high-severity readiness finding
 
 Policy:
 
@@ -135,7 +135,7 @@ Owner:
 Policy:
 
 - reviewers only see this lane for normal work
-- any high-severity checker failure in this lane is a system bug or admin override
+- any critical- or high-severity checker failure in this lane is a system bug or admin override
 
 ### Needs Revision
 

--- a/docs/operations_reviewer_workflow.md
+++ b/docs/operations_reviewer_workflow.md
@@ -72,7 +72,7 @@ Use accept only when:
 - task requirements are satisfied
 - acceptance criteria are met
 - evidence is sufficient
-- no unresolved high-severity checker failure exists
+- no unresolved critical- or high-severity checker failure exists
 - prior revision findings are closed if applicable
 
 Accept must create:

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -53,7 +53,7 @@ Human reviewers do not spend time discovering basic package failures. Workstream
 - impossible status transitions
 - known low-quality signatures
 
-High-severity failures block review.
+Critical- and high-severity failures block review.
 
 Blocking pre-submit failures block submission creation before a submission version exists.
 

--- a/docs/product_first_user_flows.md
+++ b/docs/product_first_user_flows.md
@@ -73,7 +73,7 @@ Acceptance:
 
 Acceptance:
 
-- High-severity failure blocks human review.
+- Critical- or high-severity failure blocks human review.
 - Warnings remain visible to reviewer.
 - Every checker result is timestamped.
 
@@ -89,7 +89,7 @@ Acceptance:
 
 - Review cannot be submitted without a decision.
 - needs_revision and reject require at least one finding.
-- accept requires no unresolved high-severity checker failure.
+- accept requires no unresolved critical- or high-severity checker failure.
 
 ## Flow 6: Revision Replay
 

--- a/docs/product_principles.md
+++ b/docs/product_principles.md
@@ -39,7 +39,7 @@ Guide -> Task -> Submission -> Checker -> Review -> Revision/Acceptance -> Payme
 
 Human reviewers do not spend time on submissions that fail basic gates.
 
-High-severity checker failures block review. Medium and low severity issues are visible to reviewers and can influence decisions.
+Critical- and high-severity checker failures block review. Medium and low severity issues are visible to reviewers and can influence decisions.
 
 Blocking pre-submit checker failures block submission creation before a submission version exists.
 

--- a/docs/roadmap_30_day_master_plan.md
+++ b/docs/roadmap_30_day_master_plan.md
@@ -188,7 +188,7 @@ Day 7:
 Day 8:
 
 - implement evidence and rubric/acceptance checks
-- block `REVIEW_PENDING` when high-severity checks fail
+- block `REVIEW_PENDING` when critical- or high-severity checks fail
 
 Day 9:
 

--- a/docs/roadmap_pilot_plan.md
+++ b/docs/roadmap_pilot_plan.md
@@ -50,7 +50,7 @@ Seed negative or edge-case packets during the pilot:
 
 - fake or irrelevant evidence
 - missing revision replay row
-- high-severity checker failure with admin override request
+- critical- or high-severity checker failure with admin override request
 - reviewer disagreement on review decision
 - imported task rejected during screening
 - payment amount mismatch

--- a/docs/roles_permissions.md
+++ b/docs/roles_permissions.md
@@ -55,7 +55,7 @@ Cannot:
 - edit submitted artifacts
 - change payment status
 - review a submission from a worker they directly manage unless project policy allows disclosed review
-- accept a task with unresolved high-severity checker failures unless an admin override exists
+- accept a task with unresolved critical- or high-severity checker failures unless an admin override exists
 
 ### Finance
 

--- a/docs/template_checker_policy.md
+++ b/docs/template_checker_policy.md
@@ -20,7 +20,7 @@ Revision closure, readiness, and lifecycle movement are lifecycle guards in v0.1
 
 ## Blocking Rule
 
-High-severity failed checks block human review.
+Critical- and high-severity failed checks block human review.
 
 Medium and low severities are visible to reviewers unless this policy overrides them.
 
@@ -44,6 +44,19 @@ Task setup checks:
 | Checker | Severity | Blocks Review | Owner |
 | --- | --- | --- | --- |
 | `check_acceptance_criteria_present` | high | yes | Project manager repair, not worker revision. |
+
+## Compiler Contract
+
+Workstream compiles this project policy into the canonical
+`PostSubmitCheckerPolicy` body. The compiler always includes Workstream default
+durable checkers in `default_checkers` and `execution_checkers`. Default-only
+projects leave project-specific `required_checkers` and `warning_checkers`
+empty, but they still execute every default checker.
+
+Project-specific `required_checkers` may add a registered checker or tighten a
+default checker's routing. `warning_checkers` must not weaken a default
+checker. Unknown checker names, duplicate classifications, conflicting
+required/warning classifications, and default-checker list drift fail closed.
 
 ## Pre-Submit Boundary
 

--- a/examples/terminal_benchmark/terminal_benchmark_api_e2e.py
+++ b/examples/terminal_benchmark/terminal_benchmark_api_e2e.py
@@ -473,7 +473,7 @@ def guide_payload(fixture: TerminalBenchmarkFixture, run_id: str) -> dict:
                 "check_low_quality_generated_artifacts",
             ],
             "warning_checkers": [],
-            "blocking_severities": ["high", "medium"],
+            "blocking_severities": ["critical", "high", "medium"],
         },
         "review_policy": {
             "requires_second_review": False,


### PR DESCRIPTION
# PR Trust Bundle: WS-POL-002-01

## Chunk

`WS-POL-002-01` - Post-Submit Compiler Contract

## Goal

Introduce the trusted compiler contract that turns a constrained
project-scoped post-submit checker spec into the canonical
`PostSubmitCheckerPolicy` body and hash.

## Human-Approved Intent

Post-submit checker setup must follow the same discipline as pre-submit:
agent-derived setup output can propose a constrained specification later, but
Workstream's trusted compiler owns the runtime policy. The checker, not an
agent, evaluates finalized submissions.

This chunk is intentionally compiler-only. Derivation agents, setup-run fields,
approval APIs, and runtime routing hardening remain in later WS-POL-002 chunks.

## What Changed

- Added `build_project_post_submit_checker_spec`.
- Added `compile_project_post_submit_checker_spec`.
- Added `PostSubmitCheckerCompilerError` and compiled policy output type.
- Made default-only post-submit policies valid by allowing empty
  project-specific `required_checkers` and `warning_checkers`.
- Kept Workstream default durable checkers mandatory through
  `default_checkers` and `execution_checkers`.
- Enforced `["critical", "high"]` as the platform blocking severity floor.
- Rejected malformed specs, tuple/non-list spec fields, unknown checker names,
  duplicates, conflicting required/warning classifications, warning-only
  default checker overrides, default-list drift, and severity downgrades.
- Mapped post-submit compiler failures to generic API-safe errors.
- Updated docs and live API drill payloads to match the new severity floor.

## Design Chosen

The compiler is owned by `backend/app/modules/projects/post_submit_policy.py`.
It validates against the registered deterministic checker catalog but does not
move logic into `backend/app/modules/checkers/compiler.py`, which remains the
pre-submit compiler module.

Policy identity remains:

```text
policy_hash = sha256(canonical_json(policy_body))
```

The canonical body contains:

- `schema_version`
- `project_id`
- `guide_version`
- `default_checkers`
- `required_checkers`
- `warning_checkers`
- `execution_checkers`
- `blocking_severities`

## Alternatives Rejected

- Put post-submit compilation into the pre-submit compiler module: rejected to
  preserve subsystem separation.
- Represent defaults by duplicating them into project `required_checkers`:
  rejected because default-only projects should be clear and project-specific
  additions should stay separate from platform defaults.
- Allow project policy to block only `high`: rejected because the runner treats
  both `critical` and `high` as blocking, and project policy cannot weaken the
  platform floor.
- Execute generated checker code: out of scope and rejected for v0.1.

## Scope Control

No Alembic migrations, ORM models, repositories, task modules, frontend,
payment/reputation, blockchain, or agent runtime code changed.

The only script/example changes align existing live-drill bootstrap
`blocking_severities` payloads with the compiler floor.

## Product Behavior

Project setup can now create a post-submit checker policy through the trusted
compiler path. Default-only projects remain valid, but finalized submissions
will still execute all platform durable post-submit checkers once tasks lock
that project policy.

Public setup errors stay generic. Raw checker/spec details are not returned to
workers or project setup callers.

## Acceptance Criteria Proof

- Default durable checkers are always present in `execution_checkers`.
- `policy_body.default_checkers` must exactly equal
  `DEFAULT_DURABLE_CHECKERS`.
- Unknown checker names fail closed.
- Duplicate or contradictory checker classifications fail closed.
- Warning-only default checker overrides fail closed.
- Explicit `blocking_severities: []`, `["critical"]`, and `["high"]` fail
  closed.
- Policy hash equals `sha256(canonical_json(policy_body))`.
- Parser rejects default-list drift, self-consistent default drift, severity
  downgrades, conflicting classifications, and hash mismatches.
- No reverse dependency from `backend/app/modules/checkers/compiler.py`.

## Tests/Checks Run

```bash
python3 scripts/check_stale_workstream_wording.py
python3 scripts/check_markdown_links.py
git diff --check
cd backend && .venv/bin/ruff check app/modules/projects/post_submit_policy.py app/modules/projects/service.py app/modules/projects/schemas.py tests/test_checkers.py tests/test_projects.py tests/test_tasks.py scripts/api_contract_e2e.py ../examples/terminal_benchmark/terminal_benchmark_api_e2e.py
cd backend && .venv/bin/pytest tests/test_projects.py -q -k 'default_only_post_submit or unregistered_checker_names or post_submit_compiler_validation'
cd backend && .venv/bin/pytest tests/test_checkers.py -q
cd backend && .venv/bin/pytest tests/test_projects.py tests/test_checkers.py -q
```

Result summary:

- Stale wording scan: passed.
- Markdown link check: passed for 20 changed Markdown files.
- Diff whitespace check: passed.
- Ruff: passed.
- Focused project API compiler slice: 5 passed, 208 deselected.
- Full checker suite: 69 passed.
- Exact contracted backend command: 282 passed in 2494.22s.

## Reviewer Results

Internal review evidence:

- `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-internal-review-evidence.md`

Reviewed code SHA: `4c3dd191de7917d3959d5e01287977d318c0e43b`

Reviewed at: `2026-07-09T16:02:30Z`

| Reviewer | Result | Blocking findings | Notes |
|---|---:|---|---|
| senior engineering | PASS WITH LOW RISKS | None | Process-only evidence blocker addressed by this bundle. |
| QA/test | PASS WITH LOW RISKS | None | Exact contracted backend command later completed with 282 passing tests. |
| security/auth | PASS WITH LOW RISKS | None | No security blockers; generic error mapping and fail-closed compiler reviewed. |
| product/ops | PASS WITH LOW RISKS | None | Product behavior accepted; process-only evidence blocker addressed. |
| architecture | PASS | None | Scope and dependency boundary approved. |
| docs | PASS | None | Docs consistency approved after data-model compatibility wording fix. |
| reuse/dedup | PASS WITH LOW RISKS | None | Low severity-constant duplication risk accepted. |
| test delta | PASS | None | Additive tests; no weakened/skipped coverage. |
| CI integrity | PASS WITH LOW RISKS | None | No workflow/config weakening; full CI still runs complete backend tests. |

## External Review

External review is pending. CodeRabbit, GitHub Actions, and any human review
comments must be recorded separately in:

- `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-01-external-review-response.md`

## Remaining Risks

- Severity constants are explicitly owned in the compiler contract and also
  exist in the checker runner. Future severity model changes must be versioned
  or consolidated deliberately.
- GitHub Actions and CodeRabbit must run after the PR is pushed.

## Human Review Focus

- Confirm the compiler, not the future derivation agent, owns canonical runtime
  post-submit policy.
- Confirm project policy cannot weaken Workstream default durable checkers.
- Confirm default-only projects are valid without implying no default checkers
  run.
- Confirm no task-specific checker generation is introduced.

## Human Merge Ownership

Only the user can approve and merge this PR. Codex must not merge it without
explicit user approval for that specific PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a stronger post-submit checker policy compiler flow with canonical policy generation and stable hashing.
  * Activation now supports default-only post-submit policies (empty required/warning checkers).
* **Bug Fixes**
  * Invalid or inconsistent checker configurations now fail earlier and with clearer “policy compilation failed” behavior.
  * Blocking rules now treat **critical** and **high** checker failures as review-blocking.
* **Documentation**
  * Updated product, operations, and architecture docs (plus templates/examples) to reflect critical/high blocking and the updated post-submit policy contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->