### PR TITLE
Update WS-POL-002-02 post-merge memory

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,19 +4,15 @@
 
 - Active initiative: `WS-POL-002` - Post-Submit Checker Foundation
 - Active planning chunk: none
-- Active implementation chunk: `WS-POL-002-02` - Post-Submit Derivation Agent
-  And Resumable Setup Integration
-- Branch: `codex/ws-pol-002-02-post-submit-derivation`
-- Status: `WS-POL-002-01` merged through PR #87 as `ed52c21` on 2026-07-09.
-  `WS-POL-002-02` started after the user's explicit start signal.
-- Last merged implementation SHA: `438361a`
-- Last merge commit: `ed52c21`
-- Current gate: PR #88 for `WS-POL-002-02` is open. Internal review,
-  evidence, and external-review response are recorded; human merge review
-  requires green current-head GitHub checks and explicit user approval.
-- Next chunk: inactive until `WS-POL-002-02` is implemented, reviewed,
-  externally checked, merged by explicit human approval, and followed by memory
-  update.
+- Active implementation chunk: none
+- Branch: `main`
+- Status: `WS-POL-002-02` merged through PR #88 as `32af6a7` on 2026-07-11
+  after internal review, current-head GitHub checks, CodeRabbit, and explicit
+  human merge approval.
+- Last merged implementation SHA: `67fb3ca`
+- Last merge commit: `32af6a7`
+- Current gate: none; awaiting explicit user start for the next chunk.
+- Next chunk: `WS-POL-002-03` is inactive until the user explicitly starts it.
 
 ## Operating Rule
 

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,41 @@
 # Review Log
 
+## WS-POL-002-02
+
+Status: merged through PR #88 on 2026-07-11.
+
+Merge commit: `32af6a7`
+
+Reviewed implementation SHA: `67fb3ca`
+
+Required reviewer tracks:
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- CI integrity
+- docs
+- reuse/dedup
+- test delta
+
+Result: PASS after fixes; PR #88 external review addressed; GitHub checks passed.
+
+Scope: setup-time post-submit checker derivation, resumable setup continuation,
+generated project `PostSubmitCheckerPolicy` persistence, automatic contributor
+submission handoff to the pre-review gate, and repair-only `/finalize`
+semantics.
+
+Evidence: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-02-internal-review-evidence.md`
+
+External review response: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-02-external-review-response.md`
+
+Trust bundle: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-02-pr-trust-bundle.md`
+
+Next chunk: `WS-POL-002-03` server-owned policy approval and setup visibility
+APIs, inactive until explicit user start.
+
 ## WS-POL-002-01
 
 Status: merged through PR #87 on 2026-07-09.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-POL-002-02` | Post-Submit Derivation Agent And Resumable Setup Integration | L1 | Active on `codex/ws-pol-002-02-post-submit-derivation` |
+| `WS-POL-002-03` | Server-Owned Policy Approval And Visibility APIs | L1 | Inactive until explicit user start |
 
 ## Completed
 
@@ -31,12 +31,11 @@
 | `WS-POL-001-16` | Terminal Benchmark Live API Drill | L1 | Merged through PR #84 as `a3d2a3f` on 2026-07-09 |
 | `WS-POL-002-PLAN` | Post-Submit Checker Foundation Planning | L1 | Merged through PR #85 as `3fc1a68` on 2026-07-09 |
 | `WS-POL-002-01` | Post-Submit Compiler Contract | L1 | Merged through PR #87 as `ed52c21` on 2026-07-09 |
+| `WS-POL-002-02` | Post-Submit Derivation Agent And Resumable Setup Integration | L1 | Merged through PR #88 as `32af6a7` on 2026-07-11 |
 
 ## Proposed Next
 
-Do not start the next chunk until `WS-POL-002-02` is implemented, reviewed,
-externally checked, merged by explicit human approval, and followed by memory
-update.
+Do not start `WS-POL-002-03` until the user gives an explicit start signal.
 
 ## Blocked
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/CHUNK_MAP.md
@@ -11,7 +11,7 @@ reviewed, merged by explicit human approval, and followed by a memory update.
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
 | `WS-POL-002-01` | Post-Submit Compiler Contract | L1 | Merged |
-| `WS-POL-002-02` | Post-Submit Derivation Agent And Resumable Setup Integration | L1 | Active |
+| `WS-POL-002-02` | Post-Submit Derivation Agent And Resumable Setup Integration | L1 | Merged |
 | `WS-POL-002-03` | Server-Owned Policy Approval And Visibility APIs | L1 | Proposed |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Proposed |
 | `WS-POL-002-05` | Terminal Benchmark Post-Submit Live API Proof | L1 | Proposed |

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
@@ -10,10 +10,11 @@ implemented the version-stamped trusted post-submit compiler contract,
 default-checker snapshot validation, canonical policy hashing, and tests around
 default-drift safety.
 
-`WS-POL-002-02` is active after the user's explicit start signal. Its
-implementation, deterministic proof, internal reviewer fanout, internal review
-evidence, PR trust bundle, and external-review response are recorded. PR #88 is
-open; the current gate is current-head GitHub checks and human checkpoint.
+`WS-POL-002-02` merged through PR #88 as `32af6a7` on 2026-07-11. It
+implemented setup-time post-submit checker derivation, resumable setup
+continuation, generated project `PostSubmitCheckerPolicy` persistence, automatic
+contributor submission handoff to the pre-review gate, and repair-only
+`/finalize` semantics.
 
 ## Active Planning Chunk
 
@@ -21,11 +22,11 @@ None.
 
 ## Active Implementation Chunk
 
-`WS-POL-002-02` - Post-Submit Derivation Agent And Resumable Setup Integration.
+None.
 
 ## Current Implementation Branch
 
-`codex/ws-pol-002-02-post-submit-derivation`
+`main`
 
 ## Chunk Status
 
@@ -33,7 +34,7 @@ None.
 |---|---|---|---:|---|
 | `WS-POL-002-PLAN` | Merged | `codex/ws-pol-002-post-submit-checker-planning` | #85 | Defines intent, discovery, design, risks, decisions, and implementation chunks. |
 | `WS-POL-002-01` | Merged | `codex/ws-pol-002-01-post-submit-compiler` | #87 | Post-Submit Compiler Contract; merged as `ed52c21`. |
-| `WS-POL-002-02` | Active | `codex/ws-pol-002-02-post-submit-derivation` | #88 | Post-submit derivation agent and resumable setup integration after pre-submit approval/compile; current-head checks and human merge review remain the active gate. |
+| `WS-POL-002-02` | Merged | `codex/ws-pol-002-02-post-submit-derivation` | #88 | Post-submit derivation agent and resumable setup integration; merged as `32af6a7`. |
 | `WS-POL-002-03` | Proposed | - | - | Server-owned approval and setup visibility APIs for compiled post-submit policies. |
 | `WS-POL-002-04` | Proposed | - | - | Runtime hardening for locked post-submit policy execution and routing. |
 | `WS-POL-002-05` | Proposed | - | - | Terminal Benchmark-style live API proof and report. |

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-02-post-merge-memory-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/WS-POL-002-02-post-merge-memory-internal-review-evidence.md
@@ -1,0 +1,76 @@
+# Internal Review Evidence: WS-POL-002-02 Post-Merge Memory
+
+## Chunk
+
+WS-POL-002-02 post-merge memory update
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: e679fa1277f36793bc90d5363b11de2b08eb3632
+
+Reviewed at: 2026-07-11T10:28:21Z
+
+Reviewer run ids: senior-engineering-019f50b4-2c9e-7482-945f-a2bd1b9f6977, qa-test-019f50b4-4e7a-7bd1-9a1f-4bb7659dd4a7, security-auth-019f50b4-6945-74b3-b741-ad514fa0acc3, product-ops-019f50b4-8a7e-7ee2-b584-cb3b4757768f, architecture-019f50b4-bcb3-7733-99a5-99771d00f042, docs-019f50b4-f3ca-7292-970c-eee22bc643d7
+
+## Reviewed Change
+
+Branch: `codex/ws-pol-002-02-post-merge-memory`
+
+Scope:
+
+- Marks `WS-POL-002-02` merged through PR #88 as `32af6a7`.
+- Records reviewed implementation SHA `67fb3ca`.
+- Clears active planning and implementation chunks.
+- Moves `WS-POL-002-03` to the inactive planned-next slot.
+- Adds the PR #88 entry to `.agent-loop/REVIEW_LOG.md`.
+
+## Reviewer Results
+
+These are Codex engineering-loop reviewer verdicts, not Workstream product
+review decisions.
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS AFTER FIXES | None | Memory content was simple and accurate; missing internal-review evidence is fixed by this artifact. |
+| QA/test | PASS AFTER FIXES | None | Verified PR #88 merge commit, reviewed implementation SHA, inactive chunk state, and explicit-start next gate; missing evidence is fixed by this artifact. |
+| security/auth | PASS AFTER FIXES | None | Found no incorrect security/auth state; missing evidence for process authority is fixed by this artifact. |
+| product/ops | PASS WITH LOW RISKS | None | Confirmed `WS-POL-002-03` remains inactive until explicit user start; optional historical-state cleanup is non-blocking. |
+| architecture | PASS | None | Confirmed memory-only change does not start the next chunk or mix engineering state with product runtime behavior. |
+| docs | PASS | None | Confirmed memory update records PR #88 merge state and next chunk clearly; no additional docs required. |
+
+## Valid Findings Addressed
+
+- Senior engineering, QA/test, and security/auth found the PR lacked an
+  internal-review evidence artifact for `.agent-loop` process changes. This
+  file is the required evidence artifact and binds review to the memory-only
+  commit `e679fa1277f36793bc90d5363b11de2b08eb3632`.
+- Product/ops suggested adding PR #88 to the long historical `Last Review State`
+  section. That is optional because the current state, work queue, initiative
+  status, and review log already record PR #88; it is left out to keep this
+  memory update narrow.
+
+## Commands Run
+
+```bash
+python3 scripts/check_loop_memory_state.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+gh pr view 88 --json number,state,mergedAt,mergeCommit,url,title
+```
+
+Results:
+
+- Loop memory state check: passed.
+- Stale wording scan: passed.
+- Markdown link check: passed for 5 changed Markdown files.
+- Diff whitespace check: passed.
+- PR #88 verified merged as `32af6a7` on 2026-07-11.
+
+## Remaining Risks
+
+- `WS-POL-002-03` remains inactive until explicit user start.


### PR DESCRIPTION
## Summary

Updates durable loop memory after PR #88 merged `WS-POL-002-02` into `main`.

## Changes

- Marks `WS-POL-002-02` as merged through PR #88 / merge commit `32af6a7`.
- Moves `WS-POL-002-03` into the inactive planned-next slot.
- Adds the PR #88 review-log entry with evidence, trust bundle, and external-review links.
- Clears the active implementation chunk so the next chunk requires an explicit user start.

## Validation

- `python3 scripts/check_loop_memory_state.py`
- `python3 scripts/check_stale_workstream_wording.py`
- `python3 scripts/check_markdown_links.py`
- `git diff --check`
