### PR TITLE
Record WS-AUTH-001-01 post-merge memory

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -2,25 +2,22 @@
 
 ## Current State
 
-- Active initiative: `WS-AUTH-001` - Workstream Authorization Service
+- Active initiative: none
 - Active planning chunk: none
-- Active implementation chunk: `WS-AUTH-001-01`
-- Branch: `codex/ws-auth-001-01-adopt-authorization-baseline`
-- Worktree: `/home/abiorh/flow/workstream-auth-001-01`
-- Status: PR #93 is published. Contributor terminology, CodeRabbit feedback, and
-  latest-main integration passed all required internal reviewer tracks at
-  `2164e3b`. The stale CI assertion repair passed at `be0b836`, and its final
-  scope evidence passed at `b7dafb3`; evidence rebind remains before the next
-  push.
-- Last merged implementation SHA: `1e20b79`
-- Last merge commit: `b1270d7`
-- Current gate: bind final local review evidence, push PR #93, observe external
-  checks, and stop for human review.
-- Next chunk: `WS-AUTH-001-02` remains proposed and must not start
-  automatically.
+- Active implementation chunk: none
+- Branch: `codex/ws-auth-001-01-post-merge-memory`
+- Worktree: `/home/abiorh/flow/workstream-auth-001-01-post-merge-memory`
+- Status: `WS-AUTH-001-01` merged through PR #93 on 2026-07-11.
+- Reviewed implementation SHA: `be0b836`
+- Final merged branch head: `b5217e1`
+- Last merge commit: `772af1d`
+- Current gate: post-merge memory review; stop after this memory update.
+- Next chunk: `WS-AUTH-001-02` remains proposed but inactive until a separate
+  explicit user start signal.
 - Parallel initiative: `WS-POL-002-03` merged through PR #90 as `a7aa474`; its
   post-merge memory merged through PR #94 as `b1270d7`. `WS-POL-002-04` remains
-  inactive pending the authorization foundation and a separate explicit start.
+  inactive pending the relevant authorization proof and a separate explicit
+  start.
 
 ## Operating Rule
 

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -2,11 +2,12 @@
 
 ## WS-AUTH-001-01
 
-Status: PR #93 published; latest-main merge, CodeRabbit repairs, CI assertion
-repair, and required internal re-review complete locally; evidence rebind,
-push, external checks, and human review pending.
+Status: merged through PR #93 on 2026-07-11 as `772af1d`.
 
 Reviewed implementation SHA: `be0b836`
+
+Final merged branch head: `b5217e1` (review/evidence and latest-main memory
+files only after the reviewed implementation SHA)
 
 Result: PASS after fixes across senior engineering, QA/test, security/auth,
 product/ops, architecture, docs, reuse/dedup, CI integrity, and test delta.
@@ -19,8 +20,11 @@ Evidence: `.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/
 
 Trust bundle: `.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-01-pr-trust-bundle.md`
 
-Next chunk: `WS-AUTH-001-02` remains inactive pending merge, memory update, and
-an explicit user start.
+Merge checks: Agent Gates, Backend, and CodeRabbit passed before explicit human
+merge. CodeRabbit had zero unresolved current review threads.
+
+Next chunk: `WS-AUTH-001-02` remains proposed but inactive until a separate
+explicit user start.
 
 ## WS-POL-002-03
 

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -2,14 +2,14 @@
 
 ## In Progress
 
-| Chunk | Title | Risk | Status |
-|---|---|---:|---|
-| `WS-AUTH-001-01` | Adopt Authorization Baseline And Repository Contracts | L1 | Active in dedicated worktree after D4-D10 approval |
+None.
 
 ## Planned Next
 
-No next chunk is active. Start requires the current chunk's human checkpoint,
-memory update, and an explicit user signal.
+| Chunk | Title | Risk | Status |
+|---|---|---:|---|
+| `WS-AUTH-001-02` | Verified Issuer Token And JWKS Boundary | L1 | Proposed but inactive until a separate explicit user start |
+| `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending relevant authorization proof and a separate explicit user start |
 
 ## Completed
 
@@ -39,14 +39,13 @@ memory update, and an explicit user signal.
 | `WS-POL-002-02` | Post-Submit Derivation Agent And Resumable Setup Integration | L1 | Merged through PR #88 as `32af6a7` on 2026-07-11 |
 | `WS-POL-002-03` | Server-Owned Policy Approval And Visibility APIs | L1 | Merged through PR #90 as `a7aa474` on 2026-07-11 |
 | `WS-AUTH-001-PLAN` | Authorization Service Planning | L0 | Merged through PR #91 as `ad6d644` on 2026-07-11 |
+| `WS-AUTH-001-01` | Adopt Authorization Baseline And Repository Contracts | L1 | Merged through PR #93 as `772af1d` on 2026-07-11 |
 
 ## Proposed Next
 
-Execute only `WS-AUTH-001-01` in its dedicated worktree. Rebind evidence after
-the latest-main merge, push PR #93, observe external checks, and stop for human
-review; do not start `WS-AUTH-001-02` or `WS-POL-002-04`. PR #90 and its PR #94
-memory update are merged; this worktree only reconciles them with the active
-authorization baseline.
+No implementation chunk is active. Do not start `WS-AUTH-001-02` or
+`WS-POL-002-04` automatically; each requires its recorded prerequisites and a
+separate explicit user start signal.
 
 ## Blocked
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -12,7 +12,7 @@ stopped.
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
 | `WS-AUTH-001-PLAN` | Authorization Service Planning | L0 | Merged through PR #91 as `ad6d644` |
-| `WS-AUTH-001-01` | Adopt Authorization Baseline And Repository Contracts | L1 | Active |
+| `WS-AUTH-001-01` | Adopt Authorization Baseline And Repository Contracts | L1 | Merged through PR #93 as `772af1d` |
 | `WS-AUTH-001-02` | Verified Issuer Token And JWKS Boundary | L1 | Proposed |
 | `WS-AUTH-001-03` | Legacy Actor Classification Preflight | L1 | Proposed |
 | `WS-AUTH-001-04` | Request, Error, And API Control Foundation | L1 | Proposed |
@@ -72,6 +72,6 @@ WS-AUTH-001-PLAN
 
 ## Stop condition
 
-After WS-AUTH-001-01 review and PR preparation, stop. Do not start
-`WS-AUTH-001-02` or `WS-POL-002-04`; this worktree only reconciles the already
-merged PR #90 behavior with the authorization baseline.
+`WS-AUTH-001-01` merged through PR #93. Stop after this post-merge memory
+update. Do not start `WS-AUTH-001-02` or `WS-POL-002-04`; each requires a
+separate explicit user start signal and its recorded prerequisites.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -7,15 +7,9 @@ Planning merged through PR #91 as
 Agent Gates, and Backend passed. CodeRabbit produced a walkthrough with no
 actionable findings, then its final check was cancelled when the PR closed.
 D4-D10 were explicitly approved and WS-AUTH-001-01 was started by the user on
-2026-07-11 in a fresh worktree from merged `main`. PR #93 is published. The
-branch now includes Contributor terminology repairs, CodeRabbit responses, and
-latest `main` through merged PR #90 plus its PR #94 memory update. Deterministic
-checks and all required internal reviewer tracks passed at `2164e3b`; final
-evidence binding is the remaining local gate before push. The GitHub Backend run
-then exposed one stale agent-runtime terminology assertion; the repair passed at
-`be0b836`, and its scope-count evidence passed at `b7dafb3`. Latest-main memory
-integration at `f7c9774` requires current review and evidence rebinding before
-the next push.
+2026-07-11. The final branch head `b5217e1` passed required internal reviews,
+Agent Gates, Backend, and CodeRabbit, then merged through PR #93 as `772af1d` on
+2026-07-11. This post-merge memory update does not activate another chunk.
 
 ## Active planning chunk
 
@@ -23,18 +17,19 @@ None.
 
 ## Active implementation chunk
 
-`WS-AUTH-001-01`
+None.
 
 ## Current implementation branch
 
-`codex/ws-auth-001-01-adopt-authorization-baseline`
+None for implementation. Post-merge memory is isolated on
+`codex/ws-auth-001-01-post-merge-memory`.
 
 ## Chunk status
 
 | Chunk | Status | Branch | PR | Notes |
 |---|---|---|---:|---|
 | `WS-AUTH-001-PLAN` | Merged | `authorization-service` | #91 | Merged as `ad6d644`; D4-D10 later approved. |
-| `WS-AUTH-001-01` | Internally reviewed | `codex/ws-auth-001-01-adopt-authorization-baseline` | #93 | Latest-main/external-review repairs passed at `2164e3b`; CI assertion repair passed at `be0b836`; final evidence rebind pending. |
+| `WS-AUTH-001-01` | Merged | `codex/ws-auth-001-01-adopt-authorization-baseline` | #93 | Authorization baseline, Contributor terminology boundary, scanner, and repository contracts; merged as `772af1d`. |
 | `WS-AUTH-001-02` | Proposed | - | - | Verified issuer token and JWKS boundary. |
 | `WS-AUTH-001-03` | Proposed | - | - | Legacy actor classification preflight. |
 | `WS-AUTH-001-04` | Proposed | - | - | Request, error, and API control foundation. |
@@ -53,11 +48,12 @@ None.
 
 ## Blockers
 
-None for the approved documentation/specification scope.
+No blocker for the completed chunk. `WS-AUTH-001-02` remains inactive until a
+separate explicit user start.
 
-Internal review evidence is recorded at
-`reviews/WS-AUTH-001-PLAN-internal-review-evidence.md` and binds reviewed SHA
-`5739e1d6fc8df0fa620bd007c45e370530ac8d12`.
+Chunk review evidence is recorded at
+`reviews/WS-AUTH-001-01-internal-review-evidence.md`; external review response
+and PR trust evidence are recorded alongside it.
 
 Production issuer configuration and legacy non-test actor classification are
 future implementation/live-proof inputs and are tracked explicitly in

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-01-post-merge-memory-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-01-post-merge-memory-internal-review-evidence.md
@@ -1,0 +1,71 @@
+# Internal Review Evidence: WS-AUTH-001-01 Post-Merge Memory
+
+## Chunk
+
+`WS-AUTH-001-01` - Post-Merge Memory Update
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: 5b99e9349e6ae83a6bf8d0fa5c84da1eb72e3200
+
+Reviewed at: 2026-07-11T21:37:15Z
+
+Reviewer run IDs: senior-engineering=/root/auth01_plan_engineering; QA/test=/root/auth01_plan_quality_ci; security/auth=/root/auth01_plan_security_product; product/ops=/root/auth01_plan_security_product; architecture=/root/auth01_plan_engineering; docs=/root/auth01_plan_quality_ci; CI-integrity=/root/auth01_plan_quality_ci; reuse/dedup=/root/auth01_plan_engineering; test-delta=/root/auth01_plan_quality_ci
+
+## Reviewed Change
+
+- Recorded PR #93 merged into `main` as `772af1d` on 2026-07-11.
+- Bound the implementation record to `be0b836` and the final merged branch head
+  to `b5217e1`.
+- Moved `WS-AUTH-001-01` from active review to completed/merged state.
+- Left no active initiative, planning chunk, or implementation chunk.
+- Kept `WS-AUTH-001-02` proposed but inactive until a separate explicit user
+  start.
+- Kept `WS-POL-002-04` inactive pending relevant authorization proof and its
+  own separate explicit user start.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Confirmed merge ancestry, exact five-file scope, stopped state, and next-chunk gates. |
+| QA/test | PASS | None | Confirmed all five durable records agree and GitHub merge/check facts are accurate. |
+| security/auth | PASS | None | Confirmed the baseline merge does not overclaim later runtime authorization proof. |
+| product/ops | PASS | None | Confirmed no later auth or policy chunk became active. |
+| architecture | PASS | None | Confirmed no runtime, schema, CI, dependency, or implementation change. |
+| docs | PASS | None | Confirmed loop state, queue, review log, status, and chunk map are consistent. |
+| CI integrity | PASS | None | Confirmed memory-only scope and successful PR #93 Agent Gates and Backend checks. |
+| reuse/dedup | PASS | None | Confirmed the existing five durable memory records are reused without a parallel state store. |
+| test delta | PASS | None | Confirmed no tests or runtime files changed. |
+
+## Commands Run
+
+```bash
+python3 scripts/check_loop_memory_state.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/test_agent_gates.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+Results: all passed. Markdown links passed for five changed Markdown files and
+31 agent-gate tests passed.
+
+## External Facts
+
+- PR #93 state: merged.
+- PR #93 final head: `b5217e1`.
+- PR #93 merge commit: `772af1d`.
+- Agent Gates, Backend, and CodeRabbit: passed.
+- Unresolved current review threads: zero.
+
+## Stop Condition
+
+No implementation chunk is active. Stop after this memory update merges. Do not
+start `WS-AUTH-001-02` or `WS-POL-002-04` without their separate explicit user
+start signals and recorded prerequisites.


### PR DESCRIPTION
## Summary
- record PR #93 merged as `772af1d` with final branch head `b5217e1`
- mark WS-AUTH-001-01 complete and leave no active chunk
- keep WS-AUTH-001-02 and WS-POL-002-04 inactive behind separate explicit starts
- add required internal post-merge review evidence

## Verification
- `python3 scripts/check_loop_memory_state.py`
- `python3 scripts/check_stale_workstream_wording.py`
- `python3 scripts/check_stale_authorization_docs.py`
- `python3 scripts/test_agent_gates.py`
- `python3 scripts/check_markdown_links.py`
- `INTERNAL_REVIEW_CHUNK_ID=WS-AUTH-001-01 python3 scripts/check_internal_review_evidence.py`
- `git diff --check`

No implementation chunk is activated by this memory-only PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authorization workstream records to show completion and merge status.
  * Added post-merge review evidence and validation details.
  * Clarified that upcoming authorization and policy work remains inactive until explicitly started.
  * Refreshed work queue, status, and planning records to reflect the current state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->