### PR TITLE
Add isolated backend test database runner

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -2,19 +2,19 @@
 
 ## Current State
 
-- Active initiative: none
+- Active initiative: `WS-QUAL-001` - Backend Coverage Floor
 - Active planning chunk: none
-- Active implementation chunk: none
-- Branch: `codex/ws-art-001-01-post-merge-memory`
-- Worktree: `/home/abiorh/flow/workstream`
-- Status: `WS-ART-001-01` merged through PR #101 as `050eb15`. No artifact
-  implementation chunk is active.
+- Active implementation chunk: `WS-QUAL-001-01A` - Isolated Database Runner
+- Branch: `codex/ws-qual-001-01-coverage-harness`
+- Worktree: `/home/abiorh/flow/workstream-qual-001`
+- Status: `WS-QUAL-001-01A` is active after the reviewed circuit-breaker split;
+  `WS-ART-001-01` and its post-merge memory are merged through PRs #101/#102.
 - Prior WS-ART reviewed planning SHA: `f7fbc33`
 - Prior WS-ART final evidence-bound planning branch head: `c069064`
 - WS-ART planning merge commit: `8644a43`
 - Prior WS-AUTH-001-01 reviewed implementation SHA: `be0b836`
 - Prior WS-AUTH-001-01 final merged branch head: `b5217e1`
-- Latest merge commit: `050eb15eab8c57e6bc265477a5e92484d27a893c`
+- Latest merge commit: `c3ba098d242aa2413318bb47edb25d605200fcad`
 - WS-QUAL final reviewed planning SHA: `0d9dd987d546c864fa8de7bae462e5e73a1b5ea9`
 - WS-QUAL final evidence-bound branch head: `3da1769882e9f6db4c48ef3dba33da8380e6a613`
 - WS-QUAL planning merge commit: `9046d52f31c7c39f06e06c45c43783bb08a5181c`
@@ -22,9 +22,10 @@
 - WS-ART-001-01 reviewed implementation SHA: `5574bf59cf1cb86da76749e0cbc529036346fa8a`
 - WS-ART-001-01 final evidence-bound branch head: `2b8c2a0`
 - WS-ART-001-01 merge commit: `050eb15eab8c57e6bc265477a5e92484d27a893c`
-- Current gate: publish and merge this WS-ART post-merge memory update, then stop.
-- Next chunk: `WS-QUAL-001-01` remains proposed and inactive until this memory
-  update is complete and the user gives a separate explicit start.
+- Implementation base SHA: `58d44596f614895964b82bb344e0ed98596eaae8`
+- Current gate: final rebased evidence and PR publication for `WS-QUAL-001-01A`.
+- Next chunk: `WS-QUAL-001-01B` remains inactive until 01A merges and the user
+  gives a separate explicit start; do not start `WS-QUAL-001-02` automatically.
 - Paused implementation: `WS-AUTH-001-02` remains implemented on
   `codex/ws-auth-001-02-verified-issuer-token` and is paused before publication
   pending a separate explicit user resume signal after this memory update.

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -7,8 +7,9 @@
 - Active implementation chunk: `WS-QUAL-001-01A` - Isolated Database Runner
 - Branch: `codex/ws-qual-001-01-coverage-harness`
 - Worktree: `/home/abiorh/flow/workstream-qual-001`
-- Status: `WS-QUAL-001-01A` is active after the reviewed circuit-breaker split;
-  `WS-ART-001-01` and its post-merge memory are merged through PRs #101/#102.
+- Status: combined `WS-QUAL-001-01` exceeded its reviewed cap. All L1 reviewer
+  groups rejected A2 and required the accepted `01A` / `01B` split. `01A` is
+  active; `WS-ART-001-01` and its memory merged through PRs #101/#102.
 - Prior WS-ART reviewed planning SHA: `f7fbc33`
 - Prior WS-ART final evidence-bound planning branch head: `c069064`
 - WS-ART planning merge commit: `8644a43`
@@ -23,7 +24,7 @@
 - WS-ART-001-01 final evidence-bound branch head: `2b8c2a0`
 - WS-ART-001-01 merge commit: `050eb15eab8c57e6bc265477a5e92484d27a893c`
 - Implementation base SHA: `58d44596f614895964b82bb344e0ed98596eaae8`
-- Current gate: final rebased evidence and PR publication for `WS-QUAL-001-01A`.
+- Current gate: publish `WS-QUAL-001-01A`, then external and human review.
 - Next chunk: `WS-QUAL-001-01B` remains inactive until 01A merges and the user
   gives a separate explicit start; do not start `WS-QUAL-001-02` automatically.
 - Paused implementation: `WS-AUTH-001-02` remains implemented on

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -24,7 +24,8 @@
 - WS-ART-001-01 final evidence-bound branch head: `2b8c2a0`
 - WS-ART-001-01 merge commit: `050eb15eab8c57e6bc265477a5e92484d27a893c`
 - Implementation base SHA: `58d44596f614895964b82bb344e0ed98596eaae8`
-- Current gate: publish `WS-QUAL-001-01A`, then external and human review.
+- Current gate: final GitHub checks and human review of PR #103 after
+  CodeRabbit repairs reviewed at `d1582ec64b9176c5ead62f695c7a23b48e4c72b9`.
 - Next chunk: `WS-QUAL-001-01B` remains inactive until 01A merges and the user
   gives a separate explicit start; do not start `WS-QUAL-001-02` automatically.
 - Paused implementation: `WS-AUTH-001-02` remains implemented on

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,19 @@
 # Review Log
 
+## WS-QUAL-001-01
+
+Status: explicitly started on 2026-07-12; repaired L1 preimplementation review
+passed across senior engineering, QA/test, security/auth, product/ops,
+architecture, CI integrity, docs, reuse/dedup, and test delta.
+
+Scope: isolated database runner, coverage policy/inventory/ratchet, focused
+behavior tests, initial clean-main baseline, canonical CI command, and runbook.
+
+User quality direction: behavior and safety proof outrank percentage gains;
+execution-only line-chasing tests are prohibited.
+
+Next: bounded implementation and evidence for chunk 01 only.
+
 ## WS-QUAL-001-PLAN
 
 Status: merged through PR #99 on 2026-07-12 as `9046d52`.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,18 +1,25 @@
 # Review Log
 
-## WS-QUAL-001-01
+## WS-QUAL-001-01A
 
-Status: explicitly started on 2026-07-12; repaired L1 preimplementation review
-passed across senior engineering, QA/test, security/auth, product/ops,
-architecture, CI integrity, docs, reuse/dedup, and test delta.
+Status: implementation and all required internal reviews passed; PR publication
+pending. The bound SHA is recorded in the internal review evidence.
 
-Scope: isolated database runner, coverage policy/inventory/ratchet, focused
-behavior tests, initial clean-main baseline, canonical CI command, and runbook.
+Scope: isolated least-privilege database runner, API guards, focused behavior
+tests, two-phase complete-suite CI, and database-testing runbook.
 
 User quality direction: behavior and safety proof outrank percentage gains;
 execution-only line-chasing tests are prohibited.
 
-Next: bounded implementation and evidence for chunk 01 only.
+Review findings: child credentials must not retain admin authority; destructive
+helpers must revalidate identifiers; collision proof must preserve an existing
+session; runner lifecycle tests and provisioned suite require explicit phases.
+
+Evidence: `.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-internal-review-evidence.md`
+
+Trust bundle: `.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-pr-trust-bundle.md`
+
+Next: external and human review of 01A only. Do not start 01B.
 
 ## WS-QUAL-001-PLAN
 

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,12 +4,13 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-QUAL-001-01` | Coverage Harness And Baseline | L1 | Active; preimplementation review passed |
+| `WS-QUAL-001-01A` | Isolated Database Runner | L1 | Internally reviewed; PR publication pending |
 
 ## Planned Next
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
+| `WS-QUAL-001-01B` | Coverage Policy And Baseline | L1 | Inactive until 01A merge and explicit user start |
 | `WS-AUTH-001-02` | Verified Issuer Token And JWKS Boundary | L1 | Paused before publication pending separate explicit user resume |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending relevant authorization proof and a separate explicit user start |
 | `WS-ART-001-02` | Flow Node Adapter And Reconciliation | L1 | Proposed; inactive pending separate explicit user start |
@@ -49,7 +50,7 @@
 
 ## Proposed Next
 
-`WS-QUAL-001-01` is the only active chunk. Do not resume `WS-AUTH-001-02` or
+`WS-QUAL-001-01A` is the only active chunk. Do not resume `WS-AUTH-001-02` or
 start another implementation chunk automatically.
 
 `WS-ART-001-01` is merged. Do not start `WS-ART-001-02` or edit Flow Node until

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -2,13 +2,14 @@
 
 ## In Progress
 
-None.
+| Chunk | Title | Risk | Status |
+|---|---|---:|---|
+| `WS-QUAL-001-01` | Coverage Harness And Baseline | L1 | Active; preimplementation review passed |
 
 ## Planned Next
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-QUAL-001-01` | Coverage Harness And Baseline | L1 | Proposed; inactive pending separate explicit user start |
 | `WS-AUTH-001-02` | Verified Issuer Token And JWKS Boundary | L1 | Paused before publication pending separate explicit user resume |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending relevant authorization proof and a separate explicit user start |
 | `WS-ART-001-02` | Flow Node Adapter And Reconciliation | L1 | Proposed; inactive pending separate explicit user start |
@@ -48,9 +49,8 @@ None.
 
 ## Proposed Next
 
-No chunk is active. Do not implement `WS-QUAL-001-01`, resume
-`WS-AUTH-001-02`, or start another implementation chunk automatically. Each
-requires a separate explicit user signal after this memory update merges.
+`WS-QUAL-001-01` is the only active chunk. Do not resume `WS-AUTH-001-02` or
+start another implementation chunk automatically.
 
 `WS-ART-001-01` is merged. Do not start `WS-ART-001-02` or edit Flow Node until
 the user gives a separate explicit start signal.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/CHUNK_MAP.md
@@ -2,15 +2,18 @@
 
 | Chunk | Scope | Risk | State |
 |---|---|---:|---|
-| `WS-QUAL-001-01` | Coverage harness, isolated database proof, clean main baseline, initial non-decreasing CI ratchet | L1 | Active; preimplementation review passed |
+| `WS-QUAL-001-01` | Combined harness/baseline contract | L1 | Split after circuit-breaker review |
+| `WS-QUAL-001-01A` | Isolated least-privilege database runner and two-phase complete-suite CI | L1 | Internally reviewed; PR publication pending |
+| `WS-QUAL-001-01B` | Coverage policy, clean main baseline, and initial non-decreasing CI ratchet | L1 | Inactive until 01A merge and explicit start |
 | `WS-QUAL-001-02` | Project setup/policy/correction service coverage; floor at least 82% | L1 | Inactive |
 | `WS-QUAL-001-03` | Project repository/router coverage; floor at least 84% | L1 | Inactive |
 | `WS-QUAL-001-04` | Task service/repository/router coverage; floor at least 86% | L1 | Inactive |
 | `WS-QUAL-001-05` | Checker service/runner/repository/router/worker coverage; floor at least 88% | L1 | Inactive |
 | `WS-QUAL-001-06` | Enumerated residual gaps and permanent 90% CI floor | L1 | Inactive |
 
-Each coverage-test chunk is limited to 500 implementation lines, defined in the
-plan. Missing its numeric floor or size budget stops the chunk for replanning;
+Each coverage-test chunk is limited to 500 implementation lines, except the
+reviewed chunk-01A genuine-proof exception capped at 700. Missing its numeric
+floor or size budget stops the chunk for replanning;
 scope does not spill into the next chunk. A later chunk may start only after the
 prior PR merges, post-merge evidence plus initiative `STATUS.md` and global
 `LOOP_STATE.md`, `WORK_QUEUE.md`, and `REVIEW_LOG.md` are updated and merged,

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/CHUNK_MAP.md
@@ -2,7 +2,7 @@
 
 | Chunk | Scope | Risk | State |
 |---|---|---:|---|
-| `WS-QUAL-001-01` | Coverage harness, isolated database proof, clean main baseline, initial non-decreasing CI ratchet | L1 | Proposed; inactive pending post-merge memory and explicit user start |
+| `WS-QUAL-001-01` | Coverage harness, isolated database proof, clean main baseline, initial non-decreasing CI ratchet | L1 | Active; preimplementation review passed |
 | `WS-QUAL-001-02` | Project setup/policy/correction service coverage; floor at least 82% | L1 | Inactive |
 | `WS-QUAL-001-03` | Project repository/router coverage; floor at least 84% | L1 | Inactive |
 | `WS-QUAL-001-04` | Task service/repository/router coverage; floor at least 86% | L1 | Inactive |

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/DECISIONS.md
@@ -47,7 +47,7 @@ or fail-closed behavior. Execution-only tests added to hit lines or percentages
 are prohibited even if they increase coverage. Test-delta and product/ops
 reviewers must reject them.
 
-## D6: Chunk 01 uses a bounded 700-line exception for genuine proof
+## D6: Chunk 01A uses a bounded 700-line exception for genuine proof
 
 Status: accepted from the user's D5 direction on 2026-07-12 after internal L1
 circuit-breaker review.
@@ -55,10 +55,11 @@ circuit-breaker review.
 The original 500-line forecast proved incompatible with the required owned-DB
 lifecycle, redaction, cleanup, ratchet, and negative behavior matrix: the two
 control scripts alone require 387 readable lines before tests, guards, workflow,
-and runbook. Chunk 01 may use at most 700 implementation lines, with the added
-budget reserved for behavior tests and safety/error handling. Allowed files and
-all production exclusions remain unchanged. Crossing 700 requires a split and a
-new human decision.
+and runbook. After the D7 split, `WS-QUAL-001-01A` may use at most 700
+implementation lines; the cap applies to 01A, not the former combined Chunk 01
+or 01B. The added budget is reserved for behavior tests and safety/error
+handling. Allowed files and all production exclusions remain unchanged.
+Crossing 700 requires another split and a new human decision.
 
 ## D7: Split database isolation from coverage policy
 

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/DECISIONS.md
@@ -46,3 +46,28 @@ as state, lifecycle, authorization, audit, queue/retry, HTTP, redaction, cleanup
 or fail-closed behavior. Execution-only tests added to hit lines or percentages
 are prohibited even if they increase coverage. Test-delta and product/ops
 reviewers must reject them.
+
+## D6: Chunk 01 uses a bounded 700-line exception for genuine proof
+
+Status: accepted from the user's D5 direction on 2026-07-12 after internal L1
+circuit-breaker review.
+
+The original 500-line forecast proved incompatible with the required owned-DB
+lifecycle, redaction, cleanup, ratchet, and negative behavior matrix: the two
+control scripts alone require 387 readable lines before tests, guards, workflow,
+and runbook. Chunk 01 may use at most 700 implementation lines, with the added
+budget reserved for behavior tests and safety/error handling. Allowed files and
+all production exclusions remain unchanged. Crossing 700 requires a split and a
+new human decision.
+
+## D7: Split database isolation from coverage policy
+
+Status: accepted on 2026-07-12 after all required L1 reviewer groups rejected A2.
+
+The executable harness reached 923 implementation lines before completing the
+required ratchet and negative behavior matrix. Real concurrency/interruption
+catalog proof, strict policy failure tests, and the operator runbook were
+underestimated by A1. The rejected A2 proposal would have raised the cap to
+1,100. Reviewers required `01A` for the least-privilege database lifecycle and
+`01B` for coverage policy/CI/evidence. The split preserves genuine proof without
+compressing safety code. Production scope and later chunks remain unchanged.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/DECISIONS.md
@@ -35,3 +35,14 @@ new 90 percent repository requirement lacks an approved enforcement path. The
 pause avoids mixing roughly 849 statements of legacy coverage debt into an auth
 PR. Resumption requires an explicit user signal after the coverage plan is
 approved; this decision does not discard or redesign the auth implementation.
+
+## D5: Behavior proof outranks percentage gains
+
+Status: accepted by the user on 2026-07-12.
+
+Coverage is a safety signal, not the purpose of a test. Every new test must
+protect a real behavior or safety invariant and assert an observable result such
+as state, lifecycle, authorization, audit, queue/retry, HTTP, redaction, cleanup,
+or fail-closed behavior. Execution-only tests added to hit lines or percentages
+are prohibited even if they increase coverage. Test-delta and product/ops
+reviewers must reject them.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/PLAN.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/PLAN.md
@@ -58,6 +58,10 @@ initialization, missing or malformed base/branch evidence is fatal.
 New tests must assert externally meaningful results: returned values, persisted
 state, emitted audit records, queued work, mapped HTTP errors, or fail-closed
 behavior. Pure branch execution without an outcome assertion is insufficient.
+Coverage percentage is a safety signal, not a reason to add a test. Every added
+test must identify the real behavior or safety invariant it protects and assert
+an observable outcome. Tests whose only value is executing previously uncovered
+lines are rejected even when they increase the measured percentage.
 Each chunk records added/modified/deleted/skipped tests and scans its diff for
 `skip`, `xfail`, deleted assertions, selection changes, and coverage pragmas.
 Tests reuse existing domain fixtures in their owning test file; copied database
@@ -82,15 +86,24 @@ and fails an implementation count above 500.
 
 ## Isolated database contract
 
-`WORKSTREAM_TEST_DATABASE_URL` is authoritative for tests. A shared test runner
-accepts an admin DSN only through `WORKSTREAM_TEST_ADMIN_DATABASE_URL`, validates
-local Postgres, derives `workstream_test_<12 lowercase hex>` from the canonical
-worktree path plus a nonce, provisions it, sets both test/runtime URLs only for
-the child process, terminates only owned-database connections, and drops it in a
-`finally` block. Identifiers are never interpolated without strict regex
-validation. CI's service database is already isolated per job. API drill guards
-accept the strict derived name but never use the nonlocal write-risk override
-for coverage proof.
+`WORKSTREAM_TEST_DATABASE_URL` is authoritative for tests. A shared runner
+accepts a parent-only admin DSN through `WORKSTREAM_TEST_ADMIN_DATABASE_URL` and
+requires exact scheme `postgresql+asyncpg` plus host `localhost`, `127.0.0.1`, or
+`::1`. It derives a name matching `^workstream_test_[a-f0-9]{12}$` from the
+canonical worktree path plus a nonce. The name must full-match before safely
+quoted identifier use; catalog values are parameterized.
+
+Ownership begins only after `CREATE DATABASE` succeeds. Collision or create
+failure never attaches to, terminates, or drops an existing database. Cleanup
+terminates sessions for the exact owned `datname` and drops only that database
+after child success, nonzero exit, timeout, or interruption.
+
+The child environment removes `WORKSTREAM_TEST_ADMIN_DATABASE_URL` and
+`WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE`, overwrites both test/runtime database
+URLs with the derived target, and exposes no admin credential. Parent output and
+errors redact both credentialed admin and target URLs. CI's service database is
+already isolated per job. API drill guards accept the strict derived name; the
+runner makes the nonlocal override unavailable to ordinary coverage proof.
 
 ## Verification
 

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/PLAN.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/PLAN.md
@@ -13,8 +13,10 @@
 7. Close the enumerated adapter/core/worker gaps and set the permanent CI floor
    to exactly 90 percent or higher.
 
-Each implementation chunk changes tests and coverage configuration only. Any
-production defect exposed by a test stops that chunk and is repaired in a
+Each coverage-raising implementation chunk changes tests and coverage
+configuration only. Chunk 01A is the explicit exception for its isolated
+database runner, API drill guards, CI wiring, and operations runbook. Any
+production defect exposed by a test stops the active chunk and is repaired in a
 separately scoped change rather than hidden inside coverage work.
 
 ## Threshold policy
@@ -100,9 +102,12 @@ canonical worktree path plus a nonce. The name must full-match before safely
 quoted identifier use; catalog values are parameterized.
 
 Ownership begins only after `CREATE DATABASE` succeeds. Collision or create
-failure never attaches to, terminates, or drops an existing database. Cleanup
-terminates sessions for the exact owned `datname` and drops only that database
-after child success, nonzero exit, timeout, or interruption.
+failure never attaches to, terminates, or drops an existing database. After
+catalog ownership validation, cleanup terminates sessions for the exact owned
+`datname` and the runner-created unique ephemeral role, including a role session
+on the admin database that would otherwise block `DROP ROLE`. It drops only the
+owned database and role after child success, nonzero exit, timeout, or
+interruption; unrelated database and role sessions survive.
 
 The child environment removes `WORKSTREAM_TEST_ADMIN_DATABASE_URL` and
 `WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE`, overwrites both test/runtime database

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/PLAN.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/PLAN.md
@@ -2,15 +2,15 @@
 
 ## Approach
 
-1. Establish reproducible measurement with `pytest-cov`, one safe test-database
-   provisioner, full `app` inventory proof, machine-readable evidence, and a
-   base-ref-enforced non-decreasing ratchet.
-2. Cover project setup/policy/correction service behavior and reach at least 82%.
-3. Cover project repository/router behavior and reach at least 84%.
-4. Cover task service/repository/router behavior and reach at least 86%.
-5. Cover checker service/runner/repository/router/worker behavior and reach at
+1. Establish the isolated least-privilege test-database provisioner.
+2. Establish reproducible `pytest-cov` measurement, full `app` inventory proof,
+   machine-readable evidence, and a base-ref-enforced non-decreasing ratchet.
+3. Cover project setup/policy/correction service behavior and reach at least 82%.
+4. Cover project repository/router behavior and reach at least 84%.
+5. Cover task service/repository/router behavior and reach at least 86%.
+6. Cover checker service/runner/repository/router/worker behavior and reach at
    least 88%.
-6. Close the enumerated adapter/core/worker gaps and set the permanent CI floor
+7. Close the enumerated adapter/core/worker gaps and set the permanent CI floor
    to exactly 90 percent or higher.
 
 Each implementation chunk changes tests and coverage configuration only. Any
@@ -67,11 +67,17 @@ Each chunk records added/modified/deleted/skipped tests and scans its diff for
 Tests reuse existing domain fixtures in their owning test file; copied database
 reset, actor/project/task factories, HTTP clients, and queue helpers are banned.
 
-The 500-line budget is additions plus deletions from the merge base across
+The default 500-line budget is additions plus deletions from the merge base across
 implementation/config/test/workflow/runbook files. `.agent-loop` planning,
 evidence, status, and trust-bundle lines are reported separately and excluded
 from that implementation-size numerator. The policy checker emits both counts
-and fails an implementation count above 500.
+and fails above the reviewed per-chunk cap supplied by the contract. Later
+chunks use the default 500 cap.
+
+The combined chunk 01 was split after all L1 reviewer groups rejected a proposed
+1,100-line cap. Chunk 01A retains the reviewed 700-line limit for the database
+lifecycle boundary. Chunk 01B consumes its CLI contract and keeps coverage/CI/
+evidence review independent. Later chunks retain the default 500-line cap.
 
 ## Alternatives rejected
 

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/STATUS.md
@@ -12,12 +12,15 @@
 - Planning merge commit: `9046d52f31c7c39f06e06c45c43783bb08a5181c`
 - Internal review: PASS after cleanup, signal, authority, CI, and split repairs
 - Active implementation chunk: `WS-QUAL-001-01A`
+- Implementation PR: `https://github.com/Flow-Research/workstream/pull/103`
 - Planning PR: `https://github.com/Flow-Research/workstream/pull/99` (merged)
 - Implementation base: `58d44596f614895964b82bb344e0ed98596eaae8`
 - Start signal: explicit user start on 2026-07-12
 - Split review: combined 01 rejected; 01A database boundary accepted for repair
 - Measured whole-app coverage: 79.25 percent; artifact scope: 91.07 percent
-- Next gate: external checks and human review of the 01A PR
+- External review: seven CodeRabbit requests repaired and internally re-reviewed
+  at `d1582ec64b9176c5ead62f695c7a23b48e4c72b9`
+- Next gate: final GitHub checks and human review of PR #103
 
 ## Stop condition
 

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/STATUS.md
@@ -2,7 +2,7 @@
 
 ## Current state
 
-- Phase: `WS-QUAL-001-01` implementation
+- Phase: `WS-QUAL-001-01A` implementation after circuit-breaker split
 - Branch: `codex/ws-qual-001-01-coverage-harness`
 - Worktree: `/home/abiorh/flow/workstream-qual-001`
 - Authoritative target: 90 percent complete backend application statement coverage
@@ -10,14 +10,15 @@
 - Final reviewed planning SHA: `0d9dd987d546c864fa8de7bae462e5e73a1b5ea9`
 - Final evidence-bound branch head: `3da1769882e9f6db4c48ef3dba33da8380e6a613`
 - Planning merge commit: `9046d52f31c7c39f06e06c45c43783bb08a5181c`
-- Internal review: all nine required tracks passed; no sessions remain open
-- Active implementation chunk: `WS-QUAL-001-01`
+- Internal review: PASS after cleanup, signal, authority, CI, and split repairs
+- Active implementation chunk: `WS-QUAL-001-01A`
 - Planning PR: `https://github.com/Flow-Research/workstream/pull/99` (merged)
 - Implementation base: `58d44596f614895964b82bb344e0ed98596eaae8`
 - Start signal: explicit user start on 2026-07-12
-- Preimplementation review: PASS across all required tracks
-- Next gate: bounded implementation and deterministic evidence
+- Split review: combined 01 rejected; 01A database boundary accepted for repair
+- Measured whole-app coverage: 79.25 percent; artifact scope: 91.07 percent
+- Next gate: external checks and human review of the 01A PR
 
 ## Stop condition
 
-Only `WS-QUAL-001-01` is authorized. Do not start chunk 02 automatically.
+Only `WS-QUAL-001-01A` is authorized. Do not start 01B or chunk 02 automatically.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/STATUS.md
@@ -2,8 +2,8 @@
 
 ## Current state
 
-- Phase: planning merged; implementation inactive
-- Branch: `codex/ws-qual-001-plan-post-merge-memory`
+- Phase: `WS-QUAL-001-01` implementation
+- Branch: `codex/ws-qual-001-01-coverage-harness`
 - Worktree: `/home/abiorh/flow/workstream-qual-001`
 - Authoritative target: 90 percent complete backend application statement coverage
 - Diagnostic AUTH-02 baseline: 78.26 percent after database isolation repair
@@ -11,13 +11,13 @@
 - Final evidence-bound branch head: `3da1769882e9f6db4c48ef3dba33da8380e6a613`
 - Planning merge commit: `9046d52f31c7c39f06e06c45c43783bb08a5181c`
 - Internal review: all nine required tracks passed; no sessions remain open
-- Active implementation chunk: none
+- Active implementation chunk: `WS-QUAL-001-01`
 - Planning PR: `https://github.com/Flow-Research/workstream/pull/99` (merged)
-- Next gate: post-merge memory, then explicit user start for one proposed chunk
-- Post-merge memory PR: `https://github.com/Flow-Research/workstream/pull/100`
-  (ready for review)
+- Implementation base: `58d44596f614895964b82bb344e0ed98596eaae8`
+- Start signal: explicit user start on 2026-07-12
+- Preimplementation review: PASS across all required tracks
+- Next gate: bounded implementation and deterministic evidence
 
 ## Stop condition
 
-Planning merge does not authorize implementation. `WS-QUAL-001-01` remains
-proposed until post-merge memory completes and the user explicitly starts it.
+Only `WS-QUAL-001-01` is authorized. Do not start chunk 02 automatically.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-01-coverage-harness-baseline.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-01-coverage-harness-baseline.md
@@ -189,9 +189,13 @@ added. Implementation remains stopped until engineering/architecture/reuse,
 QA/CI/test-delta, and security/product/docs reviewers approve this amendment;
 rejection requires splitting the chunk before further implementation.
 
-## Verification commands
+## Historical verification record
 
-```bash
+The combined contract is superseded and the following commands are
+non-executable historical context. Active verification lives in the separate
+01A and 01B chunk contracts.
+
+```text
 (cd backend && .venv/bin/python -m pip check)
 (cd backend && .venv/bin/python -m ruff check tests scripts)
 (cd backend && tmp_dir=$(mktemp -d) && trap 'rm -rf "$tmp_dir"' EXIT && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- .venv/bin/python -m pytest -q --cov=app --cov-report=term-missing --cov-report=json:"$tmp_dir/coverage.json" --cov-fail-under=0 && .venv/bin/python scripts/coverage_policy.py --coverage-json "$tmp_dir/coverage.json" --database-metadata "$tmp_dir/database.json" --compute-floor)

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-01-coverage-harness-baseline.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-01-coverage-harness-baseline.md
@@ -1,5 +1,9 @@
 # Chunk Contract: WS-QUAL-001-01 Coverage Harness And Baseline
 
+Status: superseded by the reviewed `WS-QUAL-001-01A` / `WS-QUAL-001-01B`
+split after implementation exceeded 700 lines and exposed separate database
+authority and CI-policy boundaries. Do not execute this combined contract.
+
 ## Goal
 
 Create reproducible full-backend coverage measurement, isolate the test
@@ -134,8 +138,10 @@ test deletion or weakened assertions
   `diff_text` from the existing root `workstream_agent_gate.py` for allowed
   scope, binary/symlink/untracked detection, the implementation budget, deleted
   assertions, skip/xfail, selection narrowing, and coverage pragmas. It does not
-  duplicate Git parsing or create another broad agent gate. Boundary tests cover
-  500 vs 501; manual test-delta review remains required for semantic weakening.
+  duplicate Git parsing or create another broad agent gate. Parameterized tests
+  prove the default 500 cap passes at 500 and fails at 501, this chunk passes at
+  700 and fails at 701, and supplying 700 cannot mutate the stored/default cap
+  for later chunks. Manual test-delta review remains required for semantic weakening.
 - Metadata tests reject missing/malformed/extra keys, unsafe database names,
   absent or mismatched Alembic heads, stale/non-HEAD tree SHAs, and any URL or
   credential material; successful initialization binds the validated metadata
@@ -144,13 +150,15 @@ test deletion or weakened assertions
   are preferred; mocks may isolate subprocess/DB mechanics but may not replace
   the real catalog lifecycle proof.
 
-## Implementation line budget
+## Contract amendment A1: genuine-proof line budget
 
 Implementation lines are additions plus deletions outside `.agent-loop` against
-the merge base. Forecast: `coverage_policy.py` 120, `run_isolated_tests.py` 85,
-coverage tests 105, runner integration tests 55, API guard tests/edits 35,
-pyproject/conftest/workflow 20, runbook 60; total 480. Stop and replan before
-exceeding 500. The new policy dynamically loads the existing root gate helpers
+the merge base. Discovery showed the original 500-line forecast undercounted
+readable safety/error handling: the two scripts require 387 lines before tests.
+Revised forecast: control scripts 390, genuine behavior tests 190, API/config/
+workflow edits 45, runbook 55; total 680. Hard cap: 700. The added budget is
+reserved for behavior proof and safety handling, not scope expansion. Stop and
+split before exceeding 700. The new policy dynamically loads the existing root gate helpers
 from their canonical path and remains limited to coverage config, inventory,
 evidence, ratchet, coverage workflow integrity, allowed scope, and size/test
 delta controls required by this chunk.
@@ -167,6 +175,20 @@ before the later evidence-only commit. The canonical second pass runs against
 that exact clean commit. Evidence can therefore name the measured tree without
 self-reference.
 
+## Contract amendment A2: observed proof size
+
+The first executable implementation reached 923 lines before the complete
+ratchet and failure matrix was finished. The A1 estimate omitted the cost of
+real concurrent catalog presence/interruption proof, strict evidence/config/
+workflow negative cases, and the operator runbook. Compressing back to 700
+would remove named behavior assertions or make the safety scripts materially
+harder to review, contrary to D5 and the user's explicit behavior-first
+direction. The revised forecast is 1,050 lines with a hard cap of 1,100 for
+this chunk only. No production file, scope, exclusion, or later-chunk budget is
+added. Implementation remains stopped until engineering/architecture/reuse,
+QA/CI/test-delta, and security/product/docs reviewers approve this amendment;
+rejection requires splitting the chunk before further implementation.
+
 ## Verification commands
 
 ```bash
@@ -174,7 +196,7 @@ self-reference.
 (cd backend && .venv/bin/python -m ruff check tests scripts)
 (cd backend && tmp_dir=$(mktemp -d) && trap 'rm -rf "$tmp_dir"' EXIT && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- .venv/bin/python -m pytest -q --cov=app --cov-report=term-missing --cov-report=json:"$tmp_dir/coverage.json" --cov-fail-under=0 && .venv/bin/python scripts/coverage_policy.py --coverage-json "$tmp_dir/coverage.json" --database-metadata "$tmp_dir/database.json" --compute-floor)
 # Commit all final non-evidence files and configured six-decimal floor here.
-(cd backend && tmp_dir=$(mktemp -d) && trap 'rm -rf "$tmp_dir"' EXIT && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- .venv/bin/python -m pytest -q --cov=app --cov-report=term-missing --cov-report=json:"$tmp_dir/coverage.json" && .venv/bin/python scripts/coverage_policy.py --coverage-json "$tmp_dir/coverage.json" --database-metadata "$tmp_dir/database.json" --base-ref origin/main --initialize --minimum-milestone=<six-decimal-baseline> --max-implementation-lines=500 --check-test-delta)
+(cd backend && tmp_dir=$(mktemp -d) && trap 'rm -rf "$tmp_dir"' EXIT && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- .venv/bin/python -m pytest -q --cov=app --cov-report=term-missing --cov-report=json:"$tmp_dir/coverage.json" && .venv/bin/python scripts/coverage_policy.py --coverage-json "$tmp_dir/coverage.json" --database-metadata "$tmp_dir/database.json" --base-ref origin/main --initialize --minimum-milestone=<six-decimal-baseline> --max-implementation-lines=700 --check-test-delta)
 (cd backend && .venv/bin/python -m pytest -q tests/test_coverage_contract.py tests/test_api_contract_e2e.py)
 (cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python -m pytest -q tests/test_isolated_database_runner.py)
 (cd backend && .venv/bin/python -m pip check)

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-01-coverage-harness-baseline.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-01-coverage-harness-baseline.md
@@ -18,6 +18,7 @@ backend/pyproject.toml
 backend/tests/conftest.py
 backend/tests/test_coverage_contract.py
 backend/tests/test_api_contract_e2e.py
+backend/tests/test_isolated_database_runner.py
 backend/scripts/coverage_policy.py
 backend/scripts/run_isolated_tests.py
 backend/scripts/api_contract_e2e.py
@@ -46,24 +47,61 @@ test deletion or weakened assertions
 - `pytest-cov` is a development dependency with compatible bounds.
 - Coverage source is exactly `app`; the report includes every importable
   application module and fails below the configured floor.
+- Coverage report precision is exactly six. The floor is computed with Decimal
+  or integer arithmetic as
+  `floor((covered_lines * 100 / num_statements) * 10^6) / 10^6`.
+- Bootstrap is two-pass: first run isolated measurement with threshold disabled
+  and compute the candidate floor without creating evidence; write final config
+  and commit every non-evidence file; then rerun the canonical no-CLI-override
+  coverage command on that exact implementation tree and initialize evidence
+  from the second-pass JSON with `HEAD` as `measured_tree_sha`.
 - CI runs the same complete-suite coverage command used locally.
 - `WORKSTREAM_TEST_DATABASE_URL` is the authoritative child-process URL. The
-  runner accepts the admin DSN only from `WORKSTREAM_TEST_ADMIN_DATABASE_URL`,
-  validates local Postgres, provisions only a name matching
-  `^workstream_test_[a-f0-9]{12}$`, sets child test/runtime URLs, and terminates
-  and drops only its owned database in `finally` cleanup.
+  runner accepts the parent-only admin DSN only from
+  `WORKSTREAM_TEST_ADMIN_DATABASE_URL`; requires scheme `postgresql+asyncpg`
+  and host `localhost`, `127.0.0.1`, or `::1`; provisions only a full-match name
+  `^workstream_test_[a-f0-9]{12}$`; and safely quotes validated identifiers while
+  parameterizing catalog values.
+- Ownership is recorded only after create succeeds. Collision/create failure
+  never attaches to, terminates, or drops an existing database. Cleanup targets
+  exact owned sessions/database after child success, failure, timeout, or
+  interruption.
+- After creation, the runner upgrades only its owned database to the repository
+  Alembic head, queries `alembic_version`, requires exactly one version matching
+  the repository head, records it, and only then launches the requested child.
+  Migration failure triggers owned cleanup and never launches the child.
+- Child env removes the admin DSN and nonlocal override, overwrites both test and
+  runtime URLs with the derived target, propagates the exact child exit status,
+  and redacts both credentialed admin/target URLs from errors and output.
+- Before cleanup, the runner writes canonical credential-free metadata to its
+  caller-provided temporary path. Metadata schema v1 contains exactly
+  `schema_version`, strict `database_name`, catalog-observed `alembic_head`, and
+  current 40-hex `tree_sha`. It contains no URL. Policy validation requires the
+  metadata tree SHA to equal current `HEAD`, binding evidence to the same run.
 - `test_coverage_contract.py` and `test_api_contract_e2e.py` are statically
   proven DB-free before their direct focused command; every DB-capable command
   runs through the provisioner.
+- New harness tests prove real safety behavior: unsafe/nonlocal databases fail
+  closed, owned databases are cleaned up after child success and failure,
+  credentials stay redacted, application inventory cannot shrink, coverage
+  exclusions and threshold regression are rejected, and existing CI gates
+  cannot be removed or bypassed. Execution-only line hits are not accepted.
 - API drills accept that strict local derived name; ordinary proof rejects the
   nonlocal write-risk override. Credentials and credentialed URLs never appear
   in output or evidence.
 - Coverage JSON is checked against the complete `backend/app/**/*.py` inventory.
   The policy rejects omit/include/exclusion rules, application coverage pragmas,
   narrowed `--cov`, and missing modules.
-- A clean `origin/main` evidence summary records tree SHA, exact covered/total
-  statements, six-decimal percentage/floor, tool versions, safe database name,
-  and Alembic head.
+- Baseline evidence is canonical sorted JSON with a trailing newline at
+  `.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/evidence/coverage-baseline.json`.
+  Schema v1 requires typed keys: `schema_version`, `base_merge_sha`,
+  `measured_tree_sha`, `covered_lines`, `num_statements`, `measured_percent`,
+  `configured_floor`, `minimum_milestone`, `python_version`, `coverage_version`,
+  `pytest_cov_version`, `database_name`, and `alembic_head`. Decimal values are
+  six-place strings; SHAs are 40 lowercase hex; no URL or credential is stored.
+- Base comparison reads that exact path with `git show <merge-base>:<path>`.
+  Initialization is allowed only when the merge base lacks the path. The base
+  merge SHA and measured harness-tree SHA are distinct and recorded.
 - The policy compares the configured floor and evidence with the merge base and
   fails any decrease; unchanged denominators also require non-decreasing covered
   statements.
@@ -74,14 +112,71 @@ test deletion or weakened assertions
   updates, API drill use, and troubleshooting without the write-risk override.
 - No production file changes.
 
+## Required behavior-proof matrix
+
+- Runner tests assert stable non-secret diagnostics for unsafe scheme/host/name,
+  collisions, child env stripping/overwrites, exact exit propagation, and URL
+  redaction. Real local catalog proof observes database absence/presence/absence,
+  exact-session termination, concurrent unique invocations, and cleanup after
+  success, nonzero exit, timeout, and interruption. Catalog proof also verifies
+  pre-child migration to exactly one repository head and cleanup on migration
+  failure.
+- API guard tests preserve `workstream_test` and `test_workstream`; accept the
+  strict derived name only on loopback hosts; reject case, suffix, quoting, and
+  remote-host lookalikes; and prove ordinary runner execution strips the
+  nonlocal override and errors contain no credentialed URL.
+- Policy tests assert exit code plus stable diagnostic for every failure:
+  missing app inventory, omit/include/exclude/pragma, missing/narrowed
+  `--cov=app`, measured below configured/milestone, lower base floor/covered
+  count, unexplained denominator change, invalid/reused initialization,
+  missing/malformed evidence and removed/narrowed/bypassed coverage-related CI
+  gates. The policy imports and invokes `changed_files`, `numstat`, and
+  `diff_text` from the existing root `workstream_agent_gate.py` for allowed
+  scope, binary/symlink/untracked detection, the implementation budget, deleted
+  assertions, skip/xfail, selection narrowing, and coverage pragmas. It does not
+  duplicate Git parsing or create another broad agent gate. Boundary tests cover
+  500 vs 501; manual test-delta review remains required for semantic weakening.
+- Metadata tests reject missing/malformed/extra keys, unsafe database names,
+  absent or mismatched Alembic heads, stale/non-HEAD tree SHAs, and any URL or
+  credential material; successful initialization binds the validated metadata
+  fields into baseline evidence.
+- Each test names the behavior or invariant it protects. Parameterized fixtures
+  are preferred; mocks may isolate subprocess/DB mechanics but may not replace
+  the real catalog lifecycle proof.
+
+## Implementation line budget
+
+Implementation lines are additions plus deletions outside `.agent-loop` against
+the merge base. Forecast: `coverage_policy.py` 120, `run_isolated_tests.py` 85,
+coverage tests 105, runner integration tests 55, API guard tests/edits 35,
+pyproject/conftest/workflow 20, runbook 60; total 480. Stop and replan before
+exceeding 500. The new policy dynamically loads the existing root gate helpers
+from their canonical path and remains limited to coverage config, inventory,
+evidence, ratchet, coverage workflow integrity, allowed scope, and size/test
+delta controls required by this chunk.
+
+Generated raw coverage JSON lives in a shell-owned OS temporary directory. One
+command creates it with `mktemp -d`, installs an EXIT trap, runs measurement and
+policy while the file exists, then removes the directory. The policy never
+deletes a caller path. Only summarized evidence is committed;
+`backend/coverage.json` is never created.
+
+`measured_tree_sha` is the commit containing every final non-`.agent-loop`
+implementation/config/test/workflow/runbook change and the configured floor,
+before the later evidence-only commit. The canonical second pass runs against
+that exact clean commit. Evidence can therefore name the measured tree without
+self-reference.
+
 ## Verification commands
 
 ```bash
 (cd backend && .venv/bin/python -m pip check)
 (cd backend && .venv/bin/python -m ruff check tests scripts)
-(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python scripts/run_isolated_tests.py -- .venv/bin/python -m pytest -q --cov=app --cov-report=term-missing --cov-report=json:coverage.json)
-(cd backend && .venv/bin/python scripts/coverage_policy.py --coverage-json coverage.json --base-ref origin/main --initialize --minimum-milestone=<six-decimal-baseline> --max-implementation-lines=500 --check-test-delta)
+(cd backend && tmp_dir=$(mktemp -d) && trap 'rm -rf "$tmp_dir"' EXIT && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- .venv/bin/python -m pytest -q --cov=app --cov-report=term-missing --cov-report=json:"$tmp_dir/coverage.json" --cov-fail-under=0 && .venv/bin/python scripts/coverage_policy.py --coverage-json "$tmp_dir/coverage.json" --database-metadata "$tmp_dir/database.json" --compute-floor)
+# Commit all final non-evidence files and configured six-decimal floor here.
+(cd backend && tmp_dir=$(mktemp -d) && trap 'rm -rf "$tmp_dir"' EXIT && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- .venv/bin/python -m pytest -q --cov=app --cov-report=term-missing --cov-report=json:"$tmp_dir/coverage.json" && .venv/bin/python scripts/coverage_policy.py --coverage-json "$tmp_dir/coverage.json" --database-metadata "$tmp_dir/database.json" --base-ref origin/main --initialize --minimum-milestone=<six-decimal-baseline> --max-implementation-lines=500 --check-test-delta)
 (cd backend && .venv/bin/python -m pytest -q tests/test_coverage_contract.py tests/test_api_contract_e2e.py)
+(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python -m pytest -q tests/test_isolated_database_runner.py)
 (cd backend && .venv/bin/python -m pip check)
 python3 scripts/check_stale_workstream_wording.py
 python3 scripts/check_markdown_links.py

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-01A-isolated-database-runner.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-01A-isolated-database-runner.md
@@ -1,0 +1,67 @@
+# Chunk Contract: WS-QUAL-001-01A Isolated Database Runner
+
+## Goal
+
+Provide one safe local Postgres provisioner so concurrent worktrees and CI jobs
+run the complete backend suite without shared mutable database state or exposing
+admin authority to test children.
+
+## Risk and scope
+
+- Risk: L1 database/test infrastructure
+- Implementation cap: 700 changed lines; later chunks retain 500
+- Allowed: `backend/tests/conftest.py`, `backend/tests/test_api_contract_e2e.py`,
+  `backend/tests/test_isolated_database_runner.py`,
+  `backend/scripts/run_isolated_tests.py`,
+  `backend/scripts/api_contract_e2e.py`, `backend/scripts/week2_api_e2e.py`,
+  `.github/workflows/backend.yml`, `docs/operations_backend_testing.md`, and
+  WS-QUAL/global loop memory.
+- Forbidden: `backend/app/**`, migrations, coverage dependencies/policy/floor/
+  evidence, API/schema changes, test skips, weakened assertions, or nonlocal DBs.
+
+## Acceptance criteria
+
+- Parent accepts only `WORKSTREAM_TEST_ADMIN_DATABASE_URL` with exact
+  `postgresql+asyncpg` scheme, loopback host, and existing admin database.
+- Each invocation creates a strict unique database and strict unique ephemeral
+  login. The login owns only that database and has no superuser, create-role,
+  create-database, replication, or bypass-RLS authority. Child target URLs use
+  only the ephemeral credential; admin credentials and authority remain parent-only.
+- Destructive helpers revalidate identifiers at point of use. Create collision
+  cleans only the newly owned role and never terminates, attaches to, or drops
+  the existing database or its sessions.
+- The owned database is migrated to exactly one repository Alembic head before
+  child launch. Migration failure never launches the child.
+- Child env removes admin/nonlocal variables and overwrites test/runtime URLs.
+  Complete admin and target URLs are redacted from output; metadata contains
+  only schema version, database name, observed Alembic head, and current HEAD.
+- Cleanup terminates exact ephemeral-role/database sessions, drops the database
+  and role, fails closed on cleanup error, and runs after success, nonzero exit,
+  timeout, SIGINT, or SIGTERM.
+- Real Postgres tests prove absence/presence/absence, concurrent uniqueness,
+  least privilege, migration, collision session survival, exact cleanup, exit
+  propagation, timeout/interruption cleanup, and credential redaction.
+- CI uses two explicit phases: lifecycle tests run with the parent admin DSN;
+  every other test runs inside one provisioned database. Together they collect
+  every test exactly once. The API drill retains its dedicated local test DB.
+- The runbook documents env-only credentials, the exact two-phase local/CI
+  commands, cleanup/redaction, API drill safety, and troubleshooting.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m pip check)
+(cd backend && .venv/bin/python -m ruff check tests scripts)
+(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python -m pytest -q tests/test_isolated_database_runner.py)
+(cd backend && tmp_dir=$(mktemp -d) && trap 'rm -rf "$tmp_dir"' EXIT && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<local-admin-dsn> .venv/bin/python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- .venv/bin/python -m pytest -q --ignore=tests/test_isolated_database_runner.py)
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+## Review and stop
+
+Required tracks: senior engineering, QA/test, security/auth, product/ops,
+architecture, CI integrity, docs, reuse/dedup, and test delta. Stop on production
+changes, admin credentials in a child, shared mutable DB state, skipped tests,
+or more than 700 implementation lines. Do not start `WS-QUAL-001-01B`.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-external-review-response.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-external-review-response.md
@@ -1,0 +1,57 @@
+# External Review Response: WS-QUAL-001-01A
+
+## Comments Addressed
+
+- Marked the superseded combined contract's verification block as historical
+  and non-executable.
+- Scoped the 700-line exception explicitly to 01A and documented 01A's runner,
+  guard, CI, and runbook exception to the later tests-only coverage rule.
+- Preserved role-aware cleanup after verifying it is required to terminate the
+  unique ephemeral role's detached admin-database session before `DROP ROLE`.
+  The plan now states the ownership boundary; real Postgres tests prove
+  unrelated sessions survive.
+- Corrected the runbook to distinguish admin-database provisioning/cleanup from
+  isolated application execution and to document host-failure recovery.
+- Tightened CI to a 210-minute child deadline inside a 240-minute job deadline.
+- Centralized the strict derived database regex in the runner and reused the
+  same compiled object in both API drills.
+- Replaced generic authority wording after Agent Gates identified
+  `GENERIC_ADMIN_PRODUCT_AUTHORITY`.
+
+## Comments Deferred
+
+None. The request to narrow cleanup to `datname` alone was resolved through the
+reviewer's offered alternative: explicit justification and behavior proof for
+the broader unique-role boundary. Narrowing the query would leak the role when
+its session remains on the admin database after the owned database is absent.
+
+## Informational Findings
+
+CodeRabbit reported 34.78 percent docstring coverage by scanning a different
+surface. The repository's configured gate scopes `backend/app`; it passed at
+100 percent, 928/928 required docstrings. No unrelated script docstrings were
+added.
+
+## Commands Rerun
+
+```text
+16 runner lifecycle tests passed in 200.74s
+14 API guard tests passed
+Ruff passed
+pip check passed
+configured docstring coverage passed at 100% (928/928)
+stale authorization documentation check passed
+stale Workstream wording check passed
+Markdown link check passed for 12 changed files
+git diff --check passed
+implementation delta: 700/700
+strict derived database/role catalog: clean
+```
+
+## Remaining Risks
+
+- The provisioned application suite's measured runtime is 3:08:04; the child
+  deadline has about 22 minutes of measured headroom.
+- Host-level termination can still prevent cleanup and require exact manual
+  recovery using strict catalog names.
+- Whole-backend coverage remains 79.25 percent; this chunk does not start 01B.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-internal-review-evidence.md
@@ -1,0 +1,95 @@
+# Internal Review Evidence: WS-QUAL-001-01A
+
+## Chunk
+
+`WS-QUAL-001-01A`: isolated database runner
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: `5d1951b19b383f3ad54e7b1217c9a7378b435902`
+
+Reviewed at: 2026-07-12T17:08:05Z
+
+Reviewer run IDs: engineering=`qual01a_final_engineering`; quality-ci=`qual01a_final_quality`; security-product-docs=`qual01a_final_security`; earlier repair cycles=`auth01_plan_engineering,auth01_plan_quality_ci,auth01_plan_security_product`
+
+## Reviewed Change
+
+- Added a strict local Postgres provisioner with one unique database and one
+  least-privilege ephemeral role per invocation.
+- Migrated the owned database to the repository head before child execution,
+  stripped admin/nonlocal authority, redacted URLs, and recorded credential-free
+  run metadata.
+- Added ownership-checked partial-create compensation, exact role/database
+  session termination, independent database/role reconciliation, bounded
+  process-group termination, and signal-safe cleanup.
+- Replaced shared test database fallback with explicit two-phase CI: runner
+  lifecycle tests use the step-scoped admin DSN; every remaining test runs in
+  the provisioned database.
+- Preserved main's 78 percent whole-app gate, 90 percent artifact gate, and
+  dedicated API drill database after rebasing PRs #101 and #102.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS AFTER FIXES | None | Partial-create, detached-role, absent-DB, and migration-interrupt cleanup repaired. |
+| QA/test | PASS | None | Tests assert real lifecycle outcomes; all 541 collected tests are partitioned exactly once. |
+| security/auth | PASS AFTER FIXES | None | Admin authority is parent-only; destructive cleanup is ownership checked and exact. |
+| product/ops | PASS | None | Test infrastructure only; product lifecycle and actor behavior are unchanged. |
+| architecture | PASS | None | Database lifecycle is separated from inactive coverage-policy chunk 01B. |
+| CI integrity | PASS | None | Existing coverage gates remain hard; 300-minute timeout matches measured runtime without narrowing. |
+| docs | PASS AFTER FIXES | None | Runbook covers credentials, two phases, timeout, cleanup, redaction, and troubleshooting. |
+| reuse/dedup | PASS | None | Existing gate helpers and parallel drill guards were not replaced by a second framework. |
+| test delta | PASS | None | No skips, xfails, exclusions, deleted assertions, or selection loss. |
+
+## Deterministic Evidence
+
+```text
+Final SHA lifecycle suite: 16 passed in 348.94s
+Focused final cleanup/migration cases: 4 passed in 25.24s
+Provisioned application suite: 525 passed in 11284.43s
+Whole-app coverage: 6466/8159 statements, 79.25% (floor 78%)
+Artifact coverage: 1274/1399 statements, 91.07% (floor 90%)
+Aggregate collection after final tests: 541 = 16 lifecycle + 525 provisioned
+Implementation delta: 700/700 lines outside .agent-loop
+Ruff: pass
+pip check: pass
+Catalog after successful runs: no derived database or role
+```
+
+The 525-test application run was completed before the final cleanup-only repair.
+That repair changed only runner cleanup and lifecycle tests; QA/CI/test-delta
+review explicitly accepted the application result as applicable. The final SHA
+then passed all 16 lifecycle tests, including the repaired paths.
+
+## Findings Addressed
+
+- Split the original 923-line combined harness/policy change at the database
+  lifecycle versus coverage-policy boundary instead of weakening proof.
+- Replaced admin credentials in child URLs with a non-privileged ephemeral role.
+- Scoped the admin DSN to the CI Test step.
+- Compensated partial role/database creation across interruption windows.
+- Added bounded TERM-to-KILL escalation for uncooperative child process groups.
+- Preserved existing database sessions on collision and unrelated admin sessions
+  during cleanup.
+- Reconciled an already-absent owned database without leaking the ephemeral role,
+  and terminated role sessions connected to other local databases.
+- Preserved exit 130 for interruption during migration and child execution.
+
+## Remaining Risks
+
+- The complete suite took 3:08:04 locally; CI now allows 300 minutes. Runtime
+  regression must trigger performance work, not skipped or narrowed tests.
+- The whole backend is at 79.25 percent, not the required 90 percent. Inactive
+  chunks 01B and 02-06 own the ratchet and genuine behavior gaps.
+- Host-level termination can prevent any process cleanup; the runbook and strict
+  names allow exact recovery of a residual local database/role pair.
+
+## Stop Condition
+
+Publish 01A for external and human review, then stop. Do not start 01B, chunk 02,
+or resume AUTH without the required merge/memory/start checkpoints.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-internal-review-evidence.md
@@ -10,11 +10,13 @@ valid findings addressed: yes
 
 ## Reviewed Revision
 
-Reviewed code SHA: `5d1951b19b383f3ad54e7b1217c9a7378b435902`
+Reviewed code SHA: `d1582ec64b9176c5ead62f695c7a23b48e4c72b9`
 
-Reviewed at: 2026-07-12T17:08:05Z
+Reviewed at: 2026-07-12T18:03:00Z
 
-Reviewer run IDs: engineering=`qual01a_final_engineering`; quality-ci=`qual01a_final_quality`; security-product-docs=`qual01a_final_security`; earlier repair cycles=`auth01_plan_engineering,auth01_plan_quality_ci,auth01_plan_security_product`
+Reviewer run IDs: external-repair engineering=`qual103_eng_review`;
+quality-ci=`qual103_qa_ci_review`; security-product-docs=`qual103_sec_ops_docs`;
+original implementation=`qual01a_final_engineering,qual01a_final_quality,qual01a_final_security`
 
 ## Reviewed Change
 
@@ -41,7 +43,7 @@ Reviewer run IDs: engineering=`qual01a_final_engineering`; quality-ci=`qual01a_f
 | security/auth | PASS AFTER FIXES | None | Admin authority is parent-only; destructive cleanup is ownership checked and exact. |
 | product/ops | PASS | None | Test infrastructure only; product lifecycle and actor behavior are unchanged. |
 | architecture | PASS | None | Database lifecycle is separated from inactive coverage-policy chunk 01B. |
-| CI integrity | PASS | None | Existing coverage gates remain hard; 300-minute timeout matches measured runtime without narrowing. |
+| CI integrity | PASS | None | Existing coverage gates remain hard; the 210-minute child deadline leaves a bounded 30-minute cleanup/job window. |
 | docs | PASS AFTER FIXES | None | Runbook covers credentials, two phases, timeout, cleanup, redaction, and troubleshooting. |
 | reuse/dedup | PASS | None | Existing gate helpers and parallel drill guards were not replaced by a second framework. |
 | test delta | PASS | None | No skips, xfails, exclusions, deleted assertions, or selection loss. |
@@ -49,7 +51,8 @@ Reviewer run IDs: engineering=`qual01a_final_engineering`; quality-ci=`qual01a_f
 ## Deterministic Evidence
 
 ```text
-Final SHA lifecycle suite: 16 passed in 348.94s
+Final SHA lifecycle suite: 16 passed in 200.74s
+API guard suite: 14 passed
 Focused final cleanup/migration cases: 4 passed in 25.24s
 Provisioned application suite: 525 passed in 11284.43s
 Whole-app coverage: 6466/8159 statements, 79.25% (floor 78%)
@@ -62,9 +65,10 @@ Catalog after successful runs: no derived database or role
 ```
 
 The 525-test application run was completed before the final cleanup-only repair.
-That repair changed only runner cleanup and lifecycle tests; QA/CI/test-delta
-review explicitly accepted the application result as applicable. The final SHA
-then passed all 16 lifecycle tests, including the repaired paths.
+Later external-review repairs changed only contracts, the runbook, CI timeout
+wiring, and reuse of the unchanged derived-name regex. QA/CI/test-delta review
+explicitly accepted the application result as applicable. The final SHA passed
+all 16 lifecycle tests and all 14 API guard cases.
 
 ## Findings Addressed
 
@@ -82,8 +86,9 @@ then passed all 16 lifecycle tests, including the repaired paths.
 
 ## Remaining Risks
 
-- The complete suite took 3:08:04 locally; CI now allows 300 minutes. Runtime
-  regression must trigger performance work, not skipped or narrowed tests.
+- The complete suite took 3:08:04 locally; CI gives the child 210 minutes and
+  the job 240 minutes. Runtime regression must trigger performance work, not
+  skipped or narrowed tests.
 - The whole backend is at 79.25 percent, not the required 90 percent. Inactive
   chunks 01B and 02-06 own the ratchet and genuine behavior gaps.
 - Host-level termination can prevent any process cleanup; the runbook and strict

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-pr-trust-bundle.md
@@ -21,8 +21,8 @@ and safety proof outrank coverage percentage gains.
   cleanup failure, and URL redaction.
 - Changed Backend CI to a complete two-phase partition and retained main's 78
   percent whole-app and 90 percent artifact gates.
-- Added the backend testing runbook and a 300-minute job timeout based on measured
-  complete-suite runtime.
+- Added the backend testing runbook, a 210-minute child deadline, and a
+  240-minute job timeout based on measured complete-suite runtime.
 
 ## Design And Alternatives
 
@@ -41,8 +41,8 @@ coverage-policy implementation is changed. Chunk 01B remains inactive.
 
 ## Acceptance Proof
 
-- Final SHA `5d1951b19b383f3ad54e7b1217c9a7378b435902`.
-- 16 lifecycle tests passed on final SHA.
+- Final reviewed SHA `d1582ec64b9176c5ead62f695c7a23b48e4c72b9`.
+- 16 lifecycle tests and 14 API guard tests passed on final SHA.
 - 525 provisioned application tests passed; whole-app coverage is 79.25 percent.
 - Artifact subsystem coverage is 91.07 percent.
 - All 541 tests are executed exactly once across the two CI phases.
@@ -66,7 +66,10 @@ test delta. No sub-agent session remains open.
 
 ## External Review
 
-GitHub checks, CodeRabbit, and human review are pending.
+CodeRabbit posted seven requests. All valid contract, runbook, timeout, and
+reuse findings were repaired; role-aware cleanup was retained with explicit
+ownership justification and real-catalog proof. The initial Agent Gates wording
+failure was repaired. Final GitHub checks and human review remain pending.
 
 ## Remaining Risks And Follow-Up
 

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-01A-pr-trust-bundle.md
@@ -1,0 +1,92 @@
+# PR Trust Bundle: WS-QUAL-001-01A
+
+## Chunk
+
+`WS-QUAL-001-01A`: isolated database runner
+
+## Goal And Intent
+
+Give every backend test run a unique migrated local Postgres database without
+sharing state or exposing database-admin authority to the test child. Behavior
+and safety proof outrank coverage percentage gains.
+
+## What Changed And Why
+
+- Added `run_isolated_tests.py` to create a strict database and ephemeral role,
+  migrate, execute, redact, and clean up.
+- Made `WORKSTREAM_TEST_DATABASE_URL` mandatory for DB-backed tests.
+- Allowed strict derived local names in both destructive API drill guards.
+- Added real Postgres lifecycle tests for least privilege, collisions,
+  concurrency, partial creation, migration, signals, timeout, detached sessions,
+  cleanup failure, and URL redaction.
+- Changed Backend CI to a complete two-phase partition and retained main's 78
+  percent whole-app and 90 percent artifact gates.
+- Added the backend testing runbook and a 300-minute job timeout based on measured
+  complete-suite runtime.
+
+## Design And Alternatives
+
+The parent uses an admin DSN only to provision and destroy resources. The child
+receives a random role with no superuser, create-role, create-database,
+replication, inheritance, or bypass-RLS authority. Destructive operations use
+validated identifiers and parameterized catalog values.
+
+Rejected: a shared database, admin child credentials, test skips, coverage
+exclusions, a single 1,100-line PR, or hiding the three-hour runtime.
+
+## Scope And Product Behavior
+
+No `backend/app/**`, migration, public API/schema, auth product behavior, or
+coverage-policy implementation is changed. Chunk 01B remains inactive.
+
+## Acceptance Proof
+
+- Final SHA `5d1951b19b383f3ad54e7b1217c9a7378b435902`.
+- 16 lifecycle tests passed on final SHA.
+- 525 provisioned application tests passed; whole-app coverage is 79.25 percent.
+- Artifact subsystem coverage is 91.07 percent.
+- All 541 tests are executed exactly once across the two CI phases.
+- Ruff, dependency, stale-wording, Markdown-link, diff, and catalog-clean checks
+  passed during the reviewed loop.
+- Implementation is exactly 700/700 lines; `.agent-loop` evidence is excluded.
+
+## Test Delta And CI Integrity
+
+No test was deleted, skipped, xfailed, weakened, or added solely to hit a line.
+The single `--ignore` in phase two is exactly offset by executing that full test
+file in phase one. Existing coverage commands remain mandatory. The timeout was
+raised because the complete measured run exceeded three hours; selection and
+thresholds were not changed.
+
+## Reviewer Results
+
+All required tracks pass after repairs: senior engineering, QA/test,
+security/auth, product/ops, architecture, CI integrity, docs, reuse/dedup, and
+test delta. No sub-agent session remains open.
+
+## External Review
+
+GitHub checks, CodeRabbit, and human review are pending.
+
+## Remaining Risks And Follow-Up
+
+- CI runtime is high and must be monitored.
+- Whole-backend coverage remains 79.25 percent. 01B and 02-06 remain required
+  unless later complete-suite evidence legitimately collapses milestones.
+- Host shutdown may leave a strictly named local resource requiring exact
+  operator cleanup.
+
+## Human Review Focus
+
+- Parent-only admin authority and child least privilege.
+- Ownership checks and cleanup after partial creation, signals, and child-owned
+  database removal.
+- Exact 16 + 525 test partition with both inherited coverage gates preserved.
+- The database-runner versus coverage-policy chunk split.
+
+## Human Merge Ownership
+
+- [ ] I can explain the provisioning and cleanup authority boundary.
+- [ ] I verified CI and external review results.
+- [ ] I confirm 01B and AUTH have not started.
+- [ ] The user explicitly approved this specific PR for merge.

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 300
+    timeout-minutes: 240
 
     services:
       postgres:
@@ -61,7 +61,7 @@ jobs:
           tmp_dir=$(mktemp -d)
           trap 'rm -rf "$tmp_dir"' EXIT
           python -m pytest -q tests/test_isolated_database_runner.py
-          python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- python -m pytest -q --ignore=tests/test_isolated_database_runner.py --cov=app --cov-report=term-missing --cov-fail-under=78
+          python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" --timeout-seconds 12600 -- python -m pytest -q --ignore=tests/test_isolated_database_runner.py --cov=app --cov-report=term-missing --cov-fail-under=78
 
       - name: Artifact foundation coverage
         working-directory: backend

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 300
 
     services:
       postgres:
@@ -24,9 +25,6 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
-
-    env:
-      WORKSTREAM_TEST_DATABASE_URL: postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -57,7 +55,13 @@ jobs:
 
       - name: Test
         working-directory: backend
-        run: pytest -q --cov=app --cov-report=term-missing --cov-fail-under=78
+        env:
+          WORKSTREAM_TEST_ADMIN_DATABASE_URL: postgresql+asyncpg://workstream:workstream@localhost:5433/postgres
+        run: |
+          tmp_dir=$(mktemp -d)
+          trap 'rm -rf "$tmp_dir"' EXIT
+          python -m pytest -q tests/test_isolated_database_runner.py
+          python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- python -m pytest -q --ignore=tests/test_isolated_database_runner.py --cov=app --cov-report=term-missing --cov-fail-under=78
 
       - name: Artifact foundation coverage
         working-directory: backend

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -8,6 +8,7 @@ import hashlib
 import hmac
 import json
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -42,6 +43,7 @@ DEFAULT_FLOW_ISSUER = "https://auth.flow.local/e2e"
 DEFAULT_FLOW_AUDIENCE = "workstream-api"
 LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
 LOCAL_DATABASE_NAMES = {"workstream_test", "test_workstream"}
+DERIVED_DATABASE_NAME = re.compile(r"workstream_test_[a-f0-9]{12}")
 ASYNC_POSTGRES_SCHEMES = {"postgresql+asyncpg"}
 NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
 STRONG_ATTESTATION = (
@@ -441,7 +443,10 @@ def assert_local_database_url(database_url: str) -> None:
     is_local_async_postgres = (
         parsed.scheme in ASYNC_POSTGRES_SCHEMES
         and parsed.hostname in LOCAL_DATABASE_HOSTS
-        and database_name in LOCAL_DATABASE_NAMES
+        and (
+            database_name in LOCAL_DATABASE_NAMES
+            or DERIVED_DATABASE_NAME.fullmatch(database_name) is not None
+        )
     )
     override = os.environ.get("WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE")
     if is_local_async_postgres or override == NONLOCAL_DATABASE_OVERRIDE_VALUE:
@@ -450,7 +455,7 @@ def assert_local_database_url(database_url: str) -> None:
         "Refusing to run API contract E2E against a non-local database. "
         "Use an async Postgres URL such as postgresql+asyncpg:// on "
         "localhost/127.0.0.1 with a local test database named "
-        "workstream_test or test_workstream, or set "
+        "workstream_test, test_workstream, or workstream_test_<12 lowercase hex>, or set "
         f"WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE={NONLOCAL_DATABASE_OVERRIDE_VALUE}."
     )
 

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -8,7 +8,6 @@ import hashlib
 import hmac
 import json
 import os
-import re
 import socket
 import subprocess
 import sys
@@ -28,6 +27,7 @@ from app.modules.projects.post_submit_policy import (
     build_project_post_submit_checker_spec,
     compile_project_post_submit_checker_spec,
 )
+from run_isolated_tests import NAME_RE as DERIVED_DATABASE_NAME
 
 EXPECTED_DURABLE_CHECKERS = {
     "check_submission_packet",
@@ -43,7 +43,6 @@ DEFAULT_FLOW_ISSUER = "https://auth.flow.local/e2e"
 DEFAULT_FLOW_AUDIENCE = "workstream-api"
 LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
 LOCAL_DATABASE_NAMES = {"workstream_test", "test_workstream"}
-DERIVED_DATABASE_NAME = re.compile(r"workstream_test_[a-f0-9]{12}")
 ASYNC_POSTGRES_SCHEMES = {"postgresql+asyncpg"}
 NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
 STRONG_ATTESTATION = (

--- a/backend/scripts/run_isolated_tests.py
+++ b/backend/scripts/run_isolated_tests.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Run a command against one owned, temporary local Postgres database."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import secrets
+import signal
+import subprocess
+import sys
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import asyncpg
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+ROOT = Path(__file__).resolve().parents[1]
+NAME_RE = re.compile(r"workstream_test_[a-f0-9]{12}")
+ROLE_RE = re.compile(r"workstream_role_[a-f0-9]{12}")
+LOOPBACK = {"localhost", "127.0.0.1", "::1"}
+ADMIN_ENV = "WORKSTREAM_TEST_ADMIN_DATABASE_URL"
+OVERRIDE_ENV = "WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE"
+INTERRUPTED = False
+TERMINATION_GRACE_SECONDS = 2.0
+
+
+class RunnerError(RuntimeError):
+    """A stable, non-secret isolation failure."""
+
+
+def _urls(admin_url: str) -> tuple[str, str, str, str]:
+    parsed = urlsplit(admin_url)
+    if parsed.scheme != "postgresql+asyncpg" or parsed.hostname not in LOOPBACK:
+        raise RunnerError("unsafe_admin_database")
+    if not parsed.path.strip("/") or parsed.query or parsed.fragment:
+        raise RunnerError("unsafe_admin_database")
+    suffix = hashlib.sha256(
+        f"{ROOT.resolve()}:{secrets.token_hex(16)}".encode()
+    ).hexdigest()[:12]
+    name, role, password = f"workstream_test_{suffix}", f"workstream_role_{suffix}", secrets.token_hex(24)
+    _identifiers(name, role)
+    try:
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        port = f":{parsed.port}" if parsed.port else ""
+    except ValueError as exc:
+        raise RunnerError("unsafe_admin_database") from exc
+    netloc = f"{quote(role)}:{quote(password)}@{host}{port}"
+    return name, role, password, urlunsplit((parsed.scheme, netloc, f"/{name}", "", ""))
+
+
+def _identifiers(name: str, role: str) -> None:
+    if NAME_RE.fullmatch(name) is None or ROLE_RE.fullmatch(role) is None:
+        raise RunnerError("unsafe_database_identifier")
+
+
+def _asyncpg_url(url: str) -> str:
+    return "postgresql" + url.removeprefix("postgresql+asyncpg")
+
+
+def _head() -> str:
+    config = Config(str(ROOT / "alembic.ini"))
+    config.set_main_option("script_location", str(ROOT / "alembic"))
+    heads = ScriptDirectory.from_config(config).get_heads()
+    if len(heads) != 1:
+        raise RunnerError("ambiguous_alembic_head")
+    return heads[0]
+
+
+async def _create(admin_url: str, name: str, role: str, password: str) -> None:
+    _identifiers(name, role)
+    connection = await asyncpg.connect(_asyncpg_url(admin_url))
+    role_created = False
+    try:
+        password_literal = await connection.fetchval("SELECT quote_literal($1)", password)
+        await connection.execute(
+            f'CREATE ROLE "{role}" LOGIN PASSWORD {password_literal} '
+            "NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS"
+        )
+        role_created = True
+        await connection.execute(f'CREATE DATABASE "{name}" OWNER "{role}"')
+    except (asyncpg.DuplicateDatabaseError, asyncpg.DuplicateObjectError) as exc:
+        if role_created:
+            await connection.execute(f'DROP ROLE "{role}"')
+        raise RunnerError("database_collision") from exc
+    except BaseException:
+        try:
+            owner = await connection.fetchval(
+                "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = $1", name
+            )
+            if owner == role:
+                await connection.fetch(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = $1 AND pid <> pg_backend_pid()",
+                    name,
+                )
+                await connection.execute(f'DROP DATABASE "{name}"')
+            role_exists = await connection.fetchval(
+                "SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = $1)", role
+            )
+            if role_exists:
+                await connection.execute(f'DROP ROLE "{role}"')
+        except Exception as cleanup_error:
+            raise RunnerError("provisioning_cleanup_failed") from cleanup_error
+        raise
+    finally:
+        await connection.close()
+
+
+async def _drop(admin_url: str, name: str, role: str) -> None:
+    _identifiers(name, role)
+    connection = await asyncpg.connect(_asyncpg_url(admin_url))
+    try:
+        owner = await connection.fetchval(
+            "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname = $1", name
+        )
+        if owner not in (None, role):
+            raise RunnerError("cleanup_ownership_mismatch")
+        await connection.fetch(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE (datname = $1 OR usename = $2) AND pid <> pg_backend_pid()",
+            name, role,
+        )
+        if owner:
+            await connection.execute(f'DROP DATABASE "{name}"')
+        if await connection.fetchval("SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = $1)", role):
+            await connection.execute(f'DROP ROLE "{role}"')
+    finally:
+        await connection.close()
+
+
+async def _observed_head(target_url: str) -> str:
+    connection = await asyncpg.connect(_asyncpg_url(target_url))
+    try:
+        rows = await connection.fetch("SELECT version_num FROM alembic_version")
+    finally:
+        await connection.close()
+    expected = _head()
+    if [row["version_num"] for row in rows] != [expected]:
+        raise RunnerError("alembic_head_mismatch")
+    return expected
+
+
+def _child_env(target_url: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop(ADMIN_ENV, None)
+    env.pop(OVERRIDE_ENV, None)
+    env["WORKSTREAM_TEST_DATABASE_URL"] = target_url
+    env["WORKSTREAM_DATABASE_URL"] = target_url
+    return env
+
+
+def _emit(data: bytes, stream, secrets_to_hide: tuple[str, ...]) -> None:
+    for value in secrets_to_hide:
+        data = data.replace(value.encode(), b"[REDACTED_DATABASE_URL]")
+    stream.buffer.write(data)
+    stream.flush()
+
+
+def _run(
+    command: list[str], env: dict[str, str], timeout: float | None
+) -> tuple[int, bytes, bytes]:
+    process = subprocess.Popen(
+        command,
+        cwd=ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+        return process.returncode, stdout, stderr
+    except subprocess.TimeoutExpired:
+        _signal_group(process, signal.SIGKILL)
+        stdout, stderr = process.communicate()
+        return 124, stdout, stderr
+    except KeyboardInterrupt:
+        _signal_group(process, signal.SIGTERM)
+        try:
+            stdout, stderr = process.communicate(timeout=TERMINATION_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            _signal_group(process, signal.SIGKILL)
+            stdout, stderr = process.communicate()
+        return 130, stdout, stderr
+
+
+def _signal_group(process: subprocess.Popen, value: int) -> None:
+    try:
+        os.killpg(process.pid, value)
+    except ProcessLookupError:
+        pass
+
+
+def _interrupt(_signum, _frame) -> None:
+    global INTERRUPTED
+    INTERRUPTED = True
+    raise KeyboardInterrupt
+
+
+def _defer_interrupt(_signum, _frame) -> None:
+    global INTERRUPTED
+    INTERRUPTED = True
+
+
+def main() -> int:
+    """Provision, migrate, run, redact, and clean up one database."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--metadata-json", required=True, type=Path)
+    parser.add_argument("--timeout-seconds", type=float)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    command = args.command[1:] if args.command[:1] == ["--"] else args.command
+    global INTERRUPTED
+    INTERRUPTED = False
+    admin_url = os.environ.pop(ADMIN_ENV, "")
+    owned = False
+    result = 2
+    previous_sigint = signal.signal(signal.SIGINT, _defer_interrupt)
+    previous_sigterm = signal.signal(signal.SIGTERM, _defer_interrupt)
+    try:
+        if (
+            not command
+            or args.metadata_json.exists()
+            or args.metadata_json.is_symlink()
+            or not args.metadata_json.parent.is_dir()
+        ):
+            raise RunnerError("invalid_runner_arguments")
+        name, role, password, target_url = _urls(admin_url)
+        asyncio.run(_create(admin_url, name, role, password))
+        owned = True
+        signal.signal(signal.SIGINT, _interrupt)
+        signal.signal(signal.SIGTERM, _interrupt)
+        if INTERRUPTED:
+            raise KeyboardInterrupt
+        migration = _run(
+            [sys.executable, "-m", "alembic", "upgrade", "head"], _child_env(target_url), None
+        )
+        _emit(migration[1], sys.stdout, (admin_url, target_url))
+        _emit(migration[2], sys.stderr, (admin_url, target_url))
+        if migration[0] == 130 and INTERRUPTED:
+            raise KeyboardInterrupt
+        if migration[0] != 0:
+            raise RunnerError("migration_failed")
+        head = asyncio.run(_observed_head(target_url))
+        metadata = {
+            "alembic_head": head,
+            "database_name": name,
+            "schema_version": 1,
+            "tree_sha": subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], cwd=ROOT, text=True
+            ).strip(),
+        }
+        args.metadata_json.write_text(
+            json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        code, stdout, stderr = _run(command, _child_env(target_url), args.timeout_seconds)
+        _emit(stdout, sys.stdout, (admin_url, target_url))
+        _emit(stderr, sys.stderr, (admin_url, target_url))
+        result = code
+    except (RunnerError, OSError, asyncpg.PostgresError) as exc:
+        code = exc.args[0] if isinstance(exc, RunnerError) else "database_operation_failed"
+        print(f"isolated-test runner failed: {code}", file=sys.stderr)
+    except KeyboardInterrupt:
+        print("isolated-test runner interrupted", file=sys.stderr)
+        result = 130
+    finally:
+        signal.signal(signal.SIGINT, _defer_interrupt)
+        signal.signal(signal.SIGTERM, _defer_interrupt)
+        if owned:
+            try:
+                asyncio.run(_drop(admin_url, name, role))
+            except BaseException:
+                print("isolated-test runner failed: cleanup_failed", file=sys.stderr)
+                result = 2
+        signal.signal(signal.SIGINT, previous_sigint)
+        signal.signal(signal.SIGTERM, previous_sigterm)
+    return result
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/week2_api_e2e.py
+++ b/backend/scripts/week2_api_e2e.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -54,6 +55,7 @@ DATABASE_URL_ENV = "WORKSTREAM_DATABASE_URL"
 TEST_DATABASE_URL_ENV = "WORKSTREAM_TEST_DATABASE_URL"
 LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
 LOCAL_DATABASE_NAMES = {"workstream_test", "test_workstream"}
+DERIVED_DATABASE_NAME = re.compile(r"workstream_test_[a-f0-9]{12}")
 ASYNC_POSTGRES_SCHEMES = {"postgresql+asyncpg"}
 NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
 STRONG_ATTESTATION = (
@@ -96,7 +98,10 @@ def assert_local_database_url(database_url: str) -> None:
     is_local_async_postgres = (
         parsed.scheme in ASYNC_POSTGRES_SCHEMES
         and parsed.hostname in LOCAL_DATABASE_HOSTS
-        and database_name in LOCAL_DATABASE_NAMES
+        and (
+            database_name in LOCAL_DATABASE_NAMES
+            or DERIVED_DATABASE_NAME.fullmatch(database_name) is not None
+        )
     )
     override = os.environ.get("WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE")
     if is_local_async_postgres or override == NONLOCAL_DATABASE_OVERRIDE_VALUE:
@@ -105,7 +110,7 @@ def assert_local_database_url(database_url: str) -> None:
         "Refusing to run Week 2 API E2E against a non-local database. "
         "Use an async Postgres URL such as postgresql+asyncpg:// on "
         "localhost/127.0.0.1 with a local test database named "
-        "workstream_test or test_workstream, or set "
+        "workstream_test, test_workstream, or workstream_test_<12 lowercase hex>, or set "
         f"WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE={NONLOCAL_DATABASE_OVERRIDE_VALUE}."
     )
 

--- a/backend/scripts/week2_api_e2e.py
+++ b/backend/scripts/week2_api_e2e.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -19,6 +18,7 @@ from app.db import session as db_session
 from app.modules.checkers.models import CheckerResult, CheckerRun
 from app.modules.tasks.models import AuditEvent, EvidenceItem, Submission, WorkstreamTask
 from api_contract_e2e import (
+    DERIVED_DATABASE_NAME,
     alembic_config,
     api_environment as contract_api_environment,
     create_policy_bundle_for_guide,
@@ -55,7 +55,6 @@ DATABASE_URL_ENV = "WORKSTREAM_DATABASE_URL"
 TEST_DATABASE_URL_ENV = "WORKSTREAM_TEST_DATABASE_URL"
 LOCAL_DATABASE_HOSTS = {"localhost", "127.0.0.1", "::1"}
 LOCAL_DATABASE_NAMES = {"workstream_test", "test_workstream"}
-DERIVED_DATABASE_NAME = re.compile(r"workstream_test_[a-f0-9]{12}")
 ASYNC_POSTGRES_SCHEMES = {"postgresql+asyncpg"}
 NONLOCAL_DATABASE_OVERRIDE_VALUE = "I_UNDERSTAND_THIS_WRITES_DATA"
 STRONG_ATTESTATION = (

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,7 +11,6 @@ import pytest
 
 from app.core.config import get_settings
 
-DEFAULT_TEST_DATABASE_URL = "postgresql+asyncpg://workstream:workstream@localhost:5433/workstream"
 DDL_LOCK_DIRECTORY = Path("/tmp")
 
 
@@ -44,10 +43,10 @@ def migration_lock(postgres_database_url: str):
 
 @pytest.fixture
 def postgres_database_url() -> str:
-    return os.environ.get(
-        "WORKSTREAM_TEST_DATABASE_URL",
-        os.environ.get("WORKSTREAM_DATABASE_URL", DEFAULT_TEST_DATABASE_URL),
-    )
+    value = os.environ.get("WORKSTREAM_TEST_DATABASE_URL")
+    if not value:
+        pytest.fail("WORKSTREAM_TEST_DATABASE_URL is required for database-backed tests")
+    return value
 
 
 @pytest.fixture

--- a/backend/tests/test_api_contract_e2e.py
+++ b/backend/tests/test_api_contract_e2e.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+MODULES = [importlib.import_module("api_contract_e2e"), importlib.import_module("week2_api_e2e")]
+
+
+@pytest.mark.parametrize("module", MODULES)
+@pytest.mark.parametrize(
+    "name", ["workstream_test", "test_workstream", "workstream_test_012345abcdef"]
+)
+def test_api_drill_database_guard_accepts_only_supported_local_names(module, name: str) -> None:
+    """The destructive drill accepts historical and isolated local test DB names."""
+    module.assert_local_database_url(
+        f"postgresql+asyncpg://workstream:secret@127.0.0.1:5433/{name}"
+    )
+
+
+@pytest.mark.parametrize("module", MODULES)
+@pytest.mark.parametrize(
+    ("host", "name"),
+    [
+        ("db.example.com", "workstream_test_012345abcdef"),
+        ("localhost", "workstream_test_012345abcdef_extra"),
+        ("localhost", "workstream_test_012345ABCDEf"),
+        ("localhost", '"workstream_test_012345abcdef"'),
+    ],
+)
+def test_api_drill_database_guard_rejects_lookalikes_without_leaking_url(
+    monkeypatch: pytest.MonkeyPatch, module, host: str, name: str
+) -> None:
+    """Remote and lookalike targets fail closed with a non-secret diagnostic."""
+    monkeypatch.delenv("WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE", raising=False)
+    url = f"postgresql+asyncpg://workstream:secret@{host}:5433/{name}"
+    with pytest.raises(RuntimeError) as exc_info:
+        module.assert_local_database_url(url)
+    assert url not in str(exc_info.value)
+    assert "Refusing to run" in str(exc_info.value)

--- a/backend/tests/test_isolated_database_runner.py
+++ b/backend/tests/test_isolated_database_runner.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+from types import SimpleNamespace
+
+import asyncpg
+import pytest
+
+RUNNER = Path(__file__).resolve().parents[1] / "scripts/run_isolated_tests.py"
+ADMIN_ENV = "WORKSTREAM_TEST_ADMIN_DATABASE_URL"
+SPEC = importlib.util.spec_from_file_location("isolated_runner_test", RUNNER)
+assert SPEC and SPEC.loader
+runner = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(runner)
+
+
+async def _names(admin_url: str) -> set[str]:
+    connection = await asyncpg.connect("postgresql" + admin_url.removeprefix("postgresql+asyncpg"))
+    try:
+        rows = await connection.fetch("SELECT datname FROM pg_database WHERE datname LIKE 'workstream_test_%'")
+        return {row["datname"] for row in rows}
+    finally:
+        await connection.close()
+
+
+async def _roles(admin_url: str) -> set[str]:
+    connection = await asyncpg.connect("postgresql" + admin_url.removeprefix("postgresql+asyncpg"))
+    try:
+        rows = await connection.fetch("SELECT rolname FROM pg_roles WHERE rolname LIKE 'workstream_role_%'")
+        return {row["rolname"] for row in rows}
+    finally:
+        await connection.close()
+
+
+def _run(tmp_path: Path, code: str, *, timeout: float | None = None) -> subprocess.CompletedProcess:
+    command = [sys.executable, str(RUNNER), "--metadata-json", str(tmp_path / "database.json")]
+    if timeout is not None:
+        command += ["--timeout-seconds", str(timeout)]
+    command += ["--", sys.executable, "-c", code]
+    return subprocess.run(command, text=True, capture_output=True, env=os.environ.copy())
+
+
+def _mock_successful_main(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, drop) -> None:
+    async def noop(*_): return None
+    async def observed(*_): return "0015"
+    calls = iter([(0, b"", b""), (0, b"", b"")])
+    monkeypatch.setenv(ADMIN_ENV, "postgresql+asyncpg://local@localhost/postgres")
+    monkeypatch.setattr(runner, "_urls", lambda _: ("workstream_test_012345abcdef", "workstream_role_012345abcdef", "password", "target"))
+    monkeypatch.setattr(runner, "_create", noop)
+    monkeypatch.setattr(runner, "_observed_head", observed)
+    monkeypatch.setattr(runner, "_drop", drop)
+    monkeypatch.setattr(runner, "_run", lambda *_: next(calls))
+    monkeypatch.setattr(runner.subprocess, "check_output", lambda *_args, **_kwargs: "1" * 40)
+    monkeypatch.setattr(sys, "argv", [str(RUNNER), "--metadata-json", str(tmp_path / "db.json"), "--", "child"])
+
+
+def test_runner_rejects_nonlocal_admin_without_exposing_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Provisioning credentials cannot authorize a remote destructive target."""
+    secret = "postgresql+asyncpg://admin:secret@db.example.com/postgres"
+    monkeypatch.setenv(ADMIN_ENV, secret)
+    result = _run(tmp_path, "pass")
+    assert result.returncode == 2
+    assert secret not in result.stderr
+    assert "unsafe_admin_database" in result.stderr
+
+
+@pytest.mark.parametrize(("code", "expected"), [("raise SystemExit(7)", 7), ("import time; time.sleep(2)", 124)])
+def test_runner_propagates_failure_and_always_drops_owned_database(
+    tmp_path: Path, code: str, expected: int
+) -> None:
+    """Child failure and timeout remain visible without leaving database state."""
+    admin = os.environ[ADMIN_ENV]
+    before = asyncio.run(_names(admin))
+    roles = asyncio.run(_roles(admin))
+    result = _run(tmp_path, code, timeout=0.1 if expected == 124 else None)
+    assert result.returncode == expected
+    assert asyncio.run(_names(admin)) == before
+    assert asyncio.run(_roles(admin)) == roles
+
+
+def test_runner_strips_parent_secrets_migrates_and_redacts_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The child sees only its target while metadata proves migration and cleanup."""
+    admin = os.environ[ADMIN_ENV]
+    monkeypatch.setenv("WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE", "unsafe")
+    code = "\n".join([
+        "import asyncio, asyncpg, os",
+        "assert 'WORKSTREAM_TEST_ADMIN_DATABASE_URL' not in os.environ",
+        "assert 'WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE' not in os.environ",
+        "url = os.environ['WORKSTREAM_DATABASE_URL']",
+        "async def check():",
+        " c = await asyncpg.connect('postgresql' + url.removeprefix('postgresql+asyncpg'))",
+        " row = await c.fetchrow('select current_database(), rolsuper, rolcreatedb, rolcreaterole, rolreplication, rolbypassrls from pg_roles where rolname=current_user')",
+        " await c.close()",
+        " assert row[0].startswith('workstream_test_') and not any(row[1:])",
+        "asyncio.run(check())",
+        "print(url)",
+    ])
+    before = asyncio.run(_names(admin))
+    roles = asyncio.run(_roles(admin))
+    result = _run(tmp_path, code)
+    metadata = json.loads((tmp_path / "database.json").read_text(encoding="utf-8"))
+    assert result.returncode == 0
+    assert "[REDACTED_DATABASE_URL]" in result.stdout
+    assert admin not in result.stdout + result.stderr
+    assert metadata["database_name"].startswith("workstream_test_")
+    assert metadata["alembic_head"]
+    assert asyncio.run(_names(admin)) == before
+    assert asyncio.run(_roles(admin)) == roles
+
+
+@pytest.mark.parametrize("child_drops_database", [False, True])
+def test_cleanup_terminates_only_owned_sessions_and_drops_role(child_drops_database: bool) -> None:
+    """Cleanup terminates exact owned sessions while an unrelated session survives."""
+    admin = os.environ[ADMIN_ENV]
+    async def exercise() -> None:
+        name, role, password, target = runner._urls(admin)
+        await runner._create(admin, name, role, password)
+        spectator = await asyncpg.connect(runner._asyncpg_url(admin))
+        owned = await asyncpg.connect(runner._asyncpg_url(target))
+        if child_drops_database:
+            controller = await asyncpg.connect(runner._asyncpg_url(target).rsplit("/", 1)[0] + "/postgres")
+            await controller.execute(f'DROP DATABASE "{name}" WITH (FORCE)')
+        await runner._drop(admin, name, role)
+        with pytest.raises((asyncpg.PostgresError, asyncpg.InterfaceError, ConnectionResetError)):
+            await owned.fetchval("SELECT 1")
+        if child_drops_database:
+            with pytest.raises((asyncpg.PostgresError, asyncpg.InterfaceError, ConnectionResetError)):
+                await controller.fetchval("SELECT 1")
+        assert await spectator.fetchval("SELECT 1") == 1
+        await spectator.close()
+        assert name not in await _names(admin) and role not in await _roles(admin)
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize(
+    ("name", "role"),
+    [("workstream_test_bad", "workstream_role_012345abcdef"), ("workstream_test_012345abcdef", "admin")],
+)
+def test_destructive_boundaries_revalidate_identifiers(name: str, role: str) -> None:
+    """Direct destructive helper use rejects every noncanonical identifier."""
+    for operation in (
+        lambda: runner._create(os.environ[ADMIN_ENV], name, role, "password"),
+        lambda: runner._drop(os.environ[ADMIN_ENV], name, role),
+    ):
+        with pytest.raises(runner.RunnerError, match="unsafe_database_identifier"):
+            asyncio.run(operation())
+
+
+def test_runner_concurrency_is_unique_and_interrupt_cleanup_is_exact(tmp_path: Path) -> None:
+    """Concurrent owned DBs are observable, unique, and removed on interruption."""
+    admin = os.environ[ADMIN_ENV]
+    before = asyncio.run(_names(admin))
+    roles = asyncio.run(_roles(admin))
+    processes = []
+    for index in range(2):
+        marker = tmp_path / f"child-{index}"
+        ignored = "import signal; signal.signal(signal.SIGTERM, signal.SIG_IGN); " if index == 0 else ""
+        code = ignored + f"import os,time,urllib.parse,pathlib; pathlib.Path({str(marker)!r}).write_text(urllib.parse.urlsplit(os.environ['WORKSTREAM_DATABASE_URL']).path[1:]); time.sleep(30)"
+        command = [sys.executable, str(RUNNER), "--metadata-json", str(tmp_path / f"db-{index}.json"), "--", sys.executable, "-c", code]
+        processes.append((subprocess.Popen(command, env=os.environ.copy()), marker))
+    try:
+        deadline = time.monotonic() + 120
+        while not all(marker.exists() for _, marker in processes) and time.monotonic() < deadline:
+            time.sleep(0.1)
+        names = {marker.read_text() for _, marker in processes}
+        assert len(names) == 2 and names <= asyncio.run(_names(admin))
+    finally:
+        for index, (process, _) in enumerate(processes):
+            process.send_signal(signal.SIGTERM if index == 0 else signal.SIGINT)
+            assert process.wait(timeout=15) == 130
+    assert asyncio.run(_names(admin)) == before
+    assert asyncio.run(_roles(admin)) == roles
+
+
+def test_collision_never_claims_or_drops_existing_database() -> None:
+    """A create collision leaves the pre-existing database and sessions untouched."""
+    admin = os.environ[ADMIN_ENV]
+    async def exercise() -> None:
+        suffix = os.urandom(6).hex()
+        name, role = f"workstream_test_{suffix}", f"workstream_role_{suffix}"
+        password = os.urandom(16).hex()
+        await runner._create(admin, name, role, password)
+        target = "postgresql" + admin.removeprefix("postgresql+asyncpg").rsplit("/", 1)[0] + f"/{name}"
+        session = await asyncpg.connect(target)
+        try:
+            with pytest.raises(runner.RunnerError, match="database_collision"):
+                await runner._create(admin, name, "workstream_role_abcdef012345", password)
+            assert name in await _names(admin)
+            assert await session.fetchval("SELECT 1") == 1
+            assert "workstream_role_abcdef012345" not in await _roles(admin)
+        finally:
+            await session.close()
+            await runner._drop(admin, name, role)
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("trigger", ["CREATE ROLE", "CREATE DATABASE"])
+def test_interruption_after_partial_create_compensates_real_resources(
+    monkeypatch: pytest.MonkeyPatch, trigger: str
+) -> None:
+    """Interruption after either provisioning DDL leaves no role or database."""
+    admin = os.environ[ADMIN_ENV]
+    before, roles = asyncio.run(_names(admin)), asyncio.run(_roles(admin))
+    real_connect = asyncpg.connect
+    class InterruptingConnection:
+        def __init__(self, connection):
+            self.connection, self.triggered = connection, False
+        async def execute(self, query, *args):
+            result = await self.connection.execute(query, *args)
+            if query.startswith(trigger) and not self.triggered:
+                self.triggered = True
+                raise KeyboardInterrupt
+            return result
+        def __getattr__(self, name):
+            return getattr(self.connection, name)
+    async def connect(url):
+        return InterruptingConnection(await real_connect(url))
+    fake = SimpleNamespace(
+        connect=connect,
+        DuplicateDatabaseError=asyncpg.DuplicateDatabaseError,
+        DuplicateObjectError=asyncpg.DuplicateObjectError,
+    )
+    monkeypatch.setattr(runner, "asyncpg", fake)
+    name, role, password, _ = runner._urls(admin)
+    with pytest.raises(KeyboardInterrupt):
+        asyncio.run(runner._create(admin, name, role, password))
+    assert asyncio.run(_names(admin)) == before
+    assert asyncio.run(_roles(admin)) == roles
+
+
+@pytest.mark.parametrize(("migration_code", "interrupted", "expected"), [(9, False, 2), (130, True, 130)])
+def test_migration_failure_or_interrupt_cleans_without_starting_child(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, migration_code: int,
+    interrupted: bool, expected: int,
+) -> None:
+    """Migration failure or interruption cleans before any child can run."""
+    events = []
+    async def record(event, *_):
+        events.append(event)
+    monkeypatch.setenv(ADMIN_ENV, "postgresql+asyncpg://local@localhost/postgres")
+    monkeypatch.setattr(runner, "_urls", lambda _: ("workstream_test_012345abcdef", "workstream_role_012345abcdef", "password", "target"))
+    monkeypatch.setattr(runner, "_create", lambda *_: record("create"))
+    monkeypatch.setattr(runner, "_drop", lambda *_: record("drop"))
+    def migration(*_):
+        runner.INTERRUPTED = interrupted
+        return migration_code, b"", b""
+    monkeypatch.setattr(runner, "_run", migration)
+    monkeypatch.setattr(sys, "argv", [str(RUNNER), "--metadata-json", str(tmp_path / "db.json"), "--", "child"])
+    assert runner.main() == expected
+    assert events == ["create", "drop"]
+
+
+def test_cleanup_failure_overrides_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful child cannot hide failure to destroy owned database state."""
+    async def fail_drop(*_):
+        raise RuntimeError("secret detail")
+    _mock_successful_main(tmp_path, monkeypatch, fail_drop)
+    assert runner.main() == 2
+
+
+def test_cleanup_defers_repeated_signals_and_preserves_child_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated SIGINT/SIGTERM cannot interrupt owned cleanup or rewrite success."""
+    async def signalled_drop(*_):
+        os.kill(os.getpid(), signal.SIGINT)
+        os.kill(os.getpid(), signal.SIGTERM)
+    _mock_successful_main(tmp_path, monkeypatch, signalled_drop)
+    assert runner.main() == 0

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -1,0 +1,47 @@
+# Backend Testing Operations
+Workstream's backend suite uses a new local Postgres database per invocation. The
+provisioner owns a strict `workstream_test_<12 lowercase hex>` database, migrates it,
+and creates an ephemeral login without superuser, database/role creation, replication,
+or row-security-bypass authority. It drops both after success, failure, timeout, or interruption.
+
+## Local full suite
+Keep the admin URL in the environment with `postgresql+asyncpg` and a loopback host.
+Never put real or shared credentials in arguments, logs, evidence, or configuration.
+
+```bash
+cd backend
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+export WORKSTREAM_TEST_ADMIN_DATABASE_URL='postgresql+asyncpg://USER:PASSWORD@localhost:5433/postgres'
+.venv/bin/python -m pytest -q tests/test_isolated_database_runner.py
+.venv/bin/python scripts/run_isolated_tests.py --metadata-json "$tmp_dir/database.json" -- .venv/bin/python -m pytest -q --ignore=tests/test_isolated_database_runner.py
+unset WORKSTREAM_TEST_ADMIN_DATABASE_URL
+```
+
+Run both phases. The second can exceed three hours locally; CI allows 300 minutes.
+
+The runner removes the admin URL before child launch, overwrites both child database URLs,
+removes the nonlocal override, redacts complete URLs, and writes only credential-free metadata.
+
+## Focused checks
+The API-guard tests are statically DB-free:
+
+```bash
+.venv/bin/python -m pytest -q tests/test_api_contract_e2e.py
+```
+
+Runner lifecycle tests require the same admin environment variable:
+
+```bash
+.venv/bin/python -m pytest -q tests/test_isolated_database_runner.py
+```
+
+Run the destructive API drill only against `workstream_test`, `test_workstream`, or a runner-derived local name:
+
+```bash
+WORKSTREAM_DATABASE_URL='postgresql+asyncpg://USER:PASSWORD@localhost:5433/workstream_test' .venv/bin/python scripts/api_contract_e2e.py
+```
+
+Do not use `WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE` for ordinary proof.
+
+If provisioning fails, confirm the local admin can create/drop databases and roles, terminate owned sessions, and reach the named admin database. Diagnostics omit credentials.

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -1,8 +1,7 @@
 # Backend Testing Operations
-Workstream's backend suite uses a new local Postgres database per invocation. The
-provisioner owns a strict `workstream_test_<12 lowercase hex>` database, migrates it,
-and creates an ephemeral login without superuser, database/role creation, replication,
-or row-security-bypass authority. It drops both after success, failure, timeout, or interruption.
+Workstream's application tests run against a new local Postgres database per
+invocation. Provisioning and cleanup use the admin database; the application
+phase receives only a strict `workstream_test_<12 lowercase hex>` database and an ephemeral login without elevated authority.
 
 ## Local full suite
 Keep the admin URL in the environment with `postgresql+asyncpg` and a loopback host.
@@ -18,10 +17,13 @@ export WORKSTREAM_TEST_ADMIN_DATABASE_URL='postgresql+asyncpg://USER:PASSWORD@lo
 unset WORKSTREAM_TEST_ADMIN_DATABASE_URL
 ```
 
-Run both phases. The second can exceed three hours locally; CI allows 300 minutes.
+Run both phases. The second can exceed three hours locally; CI gives the child 210 minutes and the job 240 minutes so cleanup retains a bounded window.
 
 The runner removes the admin URL before child launch, overwrites both child database URLs,
 removes the nonlocal override, redacts complete URLs, and writes only credential-free metadata.
+It attempts to drop the owned database and ephemeral login after success,
+failure, timeout, or interruption. Host termination or a database error can
+prevent cleanup; recover manually with the admin login, targeting only the exact strict database and role names reported by local catalog inspection.
 
 ## Focused checks
 The API-guard tests are statically DB-free:

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -23,7 +23,7 @@ The runner removes the admin URL before child launch, overwrites both child data
 removes the nonlocal override, redacts complete URLs, and writes only credential-free metadata.
 It attempts to drop the owned database and ephemeral login after success,
 failure, timeout, or interruption. Host termination or a database error can
-prevent cleanup; recover manually with the admin login, targeting only the exact strict database and role names reported by local catalog inspection.
+prevent cleanup; recover manually with the database provisioning credential, targeting only the exact strict database and role names reported by local catalog inspection.
 
 ## Focused checks
 The API-guard tests are statically DB-free:
@@ -46,4 +46,4 @@ WORKSTREAM_DATABASE_URL='postgresql+asyncpg://USER:PASSWORD@localhost:5433/works
 
 Do not use `WORKSTREAM_ALLOW_NONLOCAL_E2E_DATABASE` for ordinary proof.
 
-If provisioning fails, confirm the local admin can create/drop databases and roles, terminate owned sessions, and reach the named admin database. Diagnostics omit credentials.
+If provisioning fails, confirm the local PostgreSQL provisioning credential can create/drop databases and roles, terminate owned sessions, and reach the named admin database. Diagnostics omit credentials.


### PR DESCRIPTION
# PR Trust Bundle: WS-QUAL-001-01A

## Chunk

`WS-QUAL-001-01A`: isolated database runner

## Goal And Intent

Give every backend test run a unique migrated local Postgres database without
sharing state or exposing database-admin authority to the test child. Behavior
and safety proof outrank coverage percentage gains.

## What Changed And Why

- Added `run_isolated_tests.py` to create a strict database and ephemeral role,
  migrate, execute, redact, and clean up.
- Made `WORKSTREAM_TEST_DATABASE_URL` mandatory for DB-backed tests.
- Allowed strict derived local names in both destructive API drill guards.
- Added real Postgres lifecycle tests for least privilege, collisions,
  concurrency, partial creation, migration, signals, timeout, detached sessions,
  cleanup failure, and URL redaction.
- Changed Backend CI to a complete two-phase partition and retained main's 78
  percent whole-app and 90 percent artifact gates.
- Added the backend testing runbook and a 300-minute job timeout based on measured
  complete-suite runtime.

## Design And Alternatives

The parent uses an admin DSN only to provision and destroy resources. The child
receives a random role with no superuser, create-role, create-database,
replication, inheritance, or bypass-RLS authority. Destructive operations use
validated identifiers and parameterized catalog values.

Rejected: a shared database, admin child credentials, test skips, coverage
exclusions, a single 1,100-line PR, or hiding the three-hour runtime.

## Scope And Product Behavior

No `backend/app/**`, migration, public API/schema, auth product behavior, or
coverage-policy implementation is changed. Chunk 01B remains inactive.

## Acceptance Proof

- Final SHA `5d1951b19b383f3ad54e7b1217c9a7378b435902`.
- 16 lifecycle tests passed on final SHA.
- 525 provisioned application tests passed; whole-app coverage is 79.25 percent.
- Artifact subsystem coverage is 91.07 percent.
- All 541 tests are executed exactly once across the two CI phases.
- Ruff, dependency, stale-wording, Markdown-link, diff, and catalog-clean checks
  passed during the reviewed loop.
- Implementation is exactly 700/700 lines; `.agent-loop` evidence is excluded.

## Test Delta And CI Integrity

No test was deleted, skipped, xfailed, weakened, or added solely to hit a line.
The single `--ignore` in phase two is exactly offset by executing that full test
file in phase one. Existing coverage commands remain mandatory. The timeout was
raised because the complete measured run exceeded three hours; selection and
thresholds were not changed.

## Reviewer Results

All required tracks pass after repairs: senior engineering, QA/test,
security/auth, product/ops, architecture, CI integrity, docs, reuse/dedup, and
test delta. No sub-agent session remains open.

## External Review

GitHub checks, CodeRabbit, and human review are pending.

## Remaining Risks And Follow-Up

- CI runtime is high and must be monitored.
- Whole-backend coverage remains 79.25 percent. 01B and 02-06 remain required
  unless later complete-suite evidence legitimately collapses milestones.
- Host shutdown may leave a strictly named local resource requiring exact
  operator cleanup.

## Human Review Focus

- Parent-only admin authority and child least privilege.
- Ownership checks and cleanup after partial creation, signals, and child-owned
  database removal.
- Exact 16 + 525 test partition with both inherited coverage gates preserved.
- The database-runner versus coverage-policy chunk split.

## Human Merge Ownership

- [ ] I can explain the provisioning and cleanup authority boundary.
- [ ] I verified CI and external review results.
- [ ] I confirm 01B and AUTH have not started.
- [ ] The user explicitly approved this specific PR for merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend tests now run against unique, isolated local PostgreSQL databases with temporary least-privilege credentials.
  * Added safeguards for database naming, cleanup, interruption handling, and sensitive URL redaction.
  * API contract checks now support approved derived local database names while rejecting unsafe targets.

* **CI**
  * Backend verification now uses a two-phase isolated test workflow with expanded timeout support.

* **Documentation**
  * Added operational guidance for running and troubleshooting backend tests locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->