### PR TITLE
Record AUTH-04A post-merge memory

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,20 +4,20 @@
 
 - Active initiative: `WS-AUTH-001` - Workstream Authorization Service
 - Active planning chunk: none
-- Active implementation chunk: `WS-AUTH-001-04A` - Request And Error Context
-- Branch: `codex/ws-auth-001-04-request-api-controls`
-- Worktree: `/home/abiorh/flow/workstream-auth-001-04`
-- Status: AUTH-04A implementation and required internal repair review pass on
-  production SHA `cdcaf77`; final reviewed candidate `4fd6db9` includes only
-  additive scalar-context and logging-state behavior-test repairs plus evidence.
+- Active implementation chunk: none
+- Branch: `codex/ws-auth-001-04a-post-merge-memory`
+- Worktree: `/home/abiorh/flow/workstream-authorization-service`
+- Status: AUTH-04A merged through PR #111 as `90c9a28` after Backend, Agent
+  Gates, CodeRabbit, required internal review, and explicit human approval
+  passed.
 - Prior `WS-AUTH-001-01` reviewed implementation SHA: `be0b836`
 - Prior `WS-AUTH-001-01` final merged branch head: `b5217e1`
-- Latest integrated `main` merge commit: `1864867`
-- Current gate: publish the ready PR, then require GitHub Backend, Agent Gates,
-  CodeRabbit, and explicit human review before merge.
+- Latest integrated `main` merge commit: `90c9a28`
+- Current gate: publish and merge the AUTH-04A post-merge memory update, then
+  stop.
 - Next chunk: none; do not start `WS-AUTH-001-05` automatically.
-- `WS-AUTH-001-04B` is inactive until AUTH-04A merges, memory is updated, and
-  the user gives its separate explicit start signal.
+- `WS-AUTH-001-04B` is inactive until this memory update merges and the user
+  gives its separate explicit start signal.
 - Parallel initiative: `WS-QUAL-001-01B2` is paused at the user's direction so
   AUTH receives the laptop's test capacity. Its last official whole-app result
   remains `6466/8159` statements (`79.249908%`); no replacement evidence exists.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,17 @@
 # Review Log
 
+## 2026-07-13 - WS-AUTH-001-04A Merged
+
+PR #111 merged `WS-AUTH-001-04A` to `main` as `90c9a28` after final branch head
+`36c4aa5` passed Backend, Agent Gates, CodeRabbit, all required internal
+reviewers, and explicit human approval. Reviewed production head `cdcaf77`
+contains the request/error implementation; reviewed candidate `4fd6db9`
+contains only its additive behavior-test repairs and lifecycle evidence.
+
+The current work is post-merge memory only. `WS-AUTH-001-04B` remains inactive
+pending this memory update merge and a separate explicit user start. No AUTH
+product implementation is active.
+
 ## 2026-07-13 - WS-AUTH-001-04A Internal Review Passed
 
 All required implementation tracks pass on production SHA `cdcaf77`.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-AUTH-001-04A` | Request And Error Context | L1 | Internal review passed; ready PR publication active, complete GitHub checks required before merge |
+| - | No active implementation chunk | - | AUTH-04A post-merge memory in progress; no product implementation active |
 
 ## Planned Next
 
@@ -53,14 +53,14 @@
 | `WS-QUAL-001-01B1A-R2` | Canonical Coverage Grammar | L1 | Merged through PR #105 as `8a4182e` on 2026-07-12; post-merge memory merged through PR #106 as `6dccb8e` |
 | `WS-AUTH-001-02` | Verified Issuer Token And JWKS Boundary | L1 | Merged through PR #107 as `060b780` on 2026-07-13 |
 | `WS-AUTH-001-03` | Legacy Actor Classification Preflight | L1 | Merged through PR #109 as `f06532e` on 2026-07-13 |
+| `WS-AUTH-001-04A` | Request And Error Context | L1 | Merged through PR #111 as `90c9a28` on 2026-07-13 |
 
 ## Proposed Next
 
-`WS-AUTH-001-03` post-merge memory merged through PR #110 as `1864867`. The user
-explicitly started parent `WS-AUTH-001-04`. Required plan review split it before
-runtime implementation. Only child `WS-AUTH-001-04A` contract repair and
-re-review are active in its isolated worktree. Do not start 04B, AUTH-05, or
-POL-002-04 automatically.
+`WS-AUTH-001-04A` merged through PR #111 as `90c9a28` after all required checks
+and reviews passed. Its post-merge memory update is active; no AUTH product
+implementation is active. Do not start 04B, AUTH-05, or POL-002-04
+automatically.
 
 Coverage R10 merged through PR #108. Do not start 01B2, chunk 02, or another
 coverage implementation chunk from this worktree.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -16,8 +16,8 @@ stopped.
 | `WS-AUTH-001-02` | Verified Issuer Token And JWKS Boundary | L1 | Merged through PR #107 as `060b780` |
 | `WS-AUTH-001-03` | Legacy Actor Classification Preflight | L1 | Merged through PR #109 as `f06532e` |
 | `WS-AUTH-001-04` | Request, Error, And API Control Foundation | L1 | Split before implementation into 04A and 04B |
-| `WS-AUTH-001-04A` | Request And Error Context | L1 | Internally reviewed; ready PR publication active and complete GitHub checks required |
-| `WS-AUTH-001-04B` | PostgreSQL Rate Controls | L1 | Inactive pending 04A merge/memory and separate explicit start |
+| `WS-AUTH-001-04A` | Request And Error Context | L1 | Merged through PR #111 as `90c9a28` |
+| `WS-AUTH-001-04B` | PostgreSQL Rate Controls | L1 | Inactive pending 04A memory merge and separate explicit start |
 | `WS-AUTH-001-05` | Authority Evidence And Idempotency Foundation | L1 | Proposed |
 | `WS-AUTH-001-06` | Canonical Actor Profile And Identity Link | L1 | Proposed |
 | `WS-AUTH-001-07` | Authorization Kernel And Permission Registry | L1 | Proposed |
@@ -79,9 +79,8 @@ WS-AUTH-001-PLAN
 
 AUTH-03 post-merge memory merged through PR #110 as `1864867`. The user
 explicitly started parent AUTH-04. Required plan review split it before runtime
-implementation. AUTH-04A's repaired-contract review passed at `f98bbfc`;
-production review passed at `cdcaf77`, and the final test-only revision is
-bound in internal review evidence after exact-head confirmation. Ready PR
-publication and complete GitHub checks are the current gate.
+implementation. AUTH-04A merged through PR #111 as `90c9a28` after required
+internal review, Backend, Agent Gates, CodeRabbit, and explicit human approval
+passed. Its post-merge memory update is the current gate.
 Do not start AUTH-04B, AUTH-05, or POL-002-04; each retains its separate start
 signal and prerequisites.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -32,7 +32,9 @@ logging, behavior-proof, and lifecycle-evidence findings were repaired; all
 required tracks pass on production SHA `cdcaf77`, and final test-only head
 `4fd6db9` passed exact-head confirmation for the additive scalar-context and
 logging-state behavior-test repairs plus lifecycle evidence.
-AUTH-04B remains inactive.
+Backend, Agent Gates, and CodeRabbit passed on final branch head `36c4aa5`, then
+explicit human approval merged PR #111 to `main` as `90c9a28` on 2026-07-13.
+AUTH-04A post-merge memory is active; AUTH-04B remains inactive.
 
 ## Active planning chunk
 
@@ -40,13 +42,12 @@ None.
 
 ## Active implementation chunk
 
-`WS-AUTH-001-04A` - Request And Error Context. Internal review passed and ready
-PR publication is active. Complete GitHub checks remain required before merge.
-No later chunk is active.
+None.
 
 ## Current implementation branch
 
-`codex/ws-auth-001-04-request-api-controls`.
+None. Post-merge memory uses `codex/ws-auth-001-04a-post-merge-memory` and makes
+no product implementation change.
 
 ## Chunk status
 
@@ -57,7 +58,7 @@ No later chunk is active.
 | `WS-AUTH-001-02` | Merged | `codex/ws-auth-001-02-verified-issuer-token` | #107 | Merged as `060b780`; reviewed code SHA `47dd5a7`. |
 | `WS-AUTH-001-03` | Merged | `codex/ws-auth-001-03-legacy-actor-classification` | #109 | Merged as `f06532e`; reviewed code `8c5334c`; final branch head `43ffbfe`. |
 | `WS-AUTH-001-04` | Split | `codex/ws-auth-001-04-request-api-controls` | - | Parent split before runtime implementation. |
-| `WS-AUTH-001-04A` | Internally reviewed | `codex/ws-auth-001-04-request-api-controls` | - | Production review passed at `cdcaf77`; final reviewed candidate `4fd6db9` confirmed. |
+| `WS-AUTH-001-04A` | Merged | `codex/ws-auth-001-04-request-api-controls` | #111 | Merged as `90c9a28`; production review `cdcaf77`; final branch head `36c4aa5`. |
 | `WS-AUTH-001-04B` | Inactive | - | - | PostgreSQL rate controls; requires 04A merge/memory and separate explicit start. |
 | `WS-AUTH-001-05` | Proposed | - | - | Authority evidence and idempotency foundation. |
 | `WS-AUTH-001-06` | Proposed | - | - | Canonical actor profile and identity link. |
@@ -74,15 +75,16 @@ No later chunk is active.
 
 ## Blockers
 
-No external blocker. The combined AUTH-04 plan failed its internal gate and was
-split before runtime edits. AUTH-04A's repaired contract passed at `f98bbfc`;
-valid implementation-review findings passed repair review. A local complete
-run exposed and reproduced an Alembic logging-state test interaction; its exact
-order now passes, and GitHub Backend owns complete-suite proof before merge.
-AUTH-04B later owns the migration corrected from the now-owned `0016` prefix to
-`0017` on current main, but remains inactive. Non-test
+No active implementation blocker because no AUTH product chunk is active.
+AUTH-04B may start only after this memory update merges and the user gives a
+separate explicit start signal. It later owns migration `0017`, following the
+now-owned `0016` prefix on current main. Non-test
 operators must later supply explicit classification evidence rather than
 inferred kinds before the owning canonical actor migration.
+
+AUTH-04A review evidence and its PR trust bundle are recorded at
+`reviews/WS-AUTH-001-04A-internal-review-evidence.md` and
+`reviews/WS-AUTH-001-04A-pr-trust-bundle.md`.
 
 AUTH-03 review evidence and its PR trust bundle are recorded at
 `reviews/WS-AUTH-001-03-internal-review-evidence.md` and

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-04A-request-error-context.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-04A-request-error-context.md
@@ -216,8 +216,9 @@ legacy compatibility, OpenAPI truth, and unchanged product authority.
 ## Activation
 
 The user explicitly started parent AUTH-04 on 2026-07-13. Required plan review
-split it before implementation. Only this repaired 04A contract is active;
-runtime edits remain gated on its required preimplementation re-review.
+split it before implementation. Only this repaired 04A contract was activated,
+and runtime edits began only after its required preimplementation re-review
+passed.
 
 ## Merge result
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-04A-request-error-context.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-04A-request-error-context.md
@@ -218,3 +218,10 @@ legacy compatibility, OpenAPI truth, and unchanged product authority.
 The user explicitly started parent AUTH-04 on 2026-07-13. Required plan review
 split it before implementation. Only this repaired 04A contract is active;
 runtime edits remain gated on its required preimplementation re-review.
+
+## Merge result
+
+PR #111 merged the reviewed AUTH-04A implementation to `main` as `90c9a28` on
+2026-07-13 after Backend, Agent Gates, CodeRabbit, all required internal
+reviewers, and explicit human approval passed. Final branch head was `36c4aa5`;
+reviewed production head was `cdcaf77`. AUTH-04B and AUTH-05 remain inactive.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-04A-post-merge-memory-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-04A-post-merge-memory-internal-review-evidence.md
@@ -1,0 +1,86 @@
+# Internal Review Evidence: WS-AUTH-001-04A Post-Merge Memory
+
+## Chunk
+
+`WS-AUTH-001-04A` - Post-Merge Memory Update
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: `ab984f77eaf2c24d2f6c5a0bc6f58edcd4802593`
+
+Reviewed at: 2026-07-13T21:24:37Z
+
+Reviewer run IDs: senior-engineering=WS-AUTH-001-04A-POST-MERGE-ENG-ARCH-20260713;
+architecture=WS-AUTH-001-04A-POST-MERGE-ENG-ARCH-20260713;
+docs=WS-AUTH-001-04A-POST-MERGE-ENG-ARCH-20260713;
+qa-test=WS-AUTH-001-04A-POST-MERGE-QA-SEC-PROD-20260713;
+security-auth=WS-AUTH-001-04A-POST-MERGE-QA-SEC-PROD-20260713;
+product-ops=WS-AUTH-001-04A-POST-MERGE-QA-SEC-PROD-20260713
+
+## Reviewed Change
+
+- Recorded PR #111 merged to `main` as
+  `90c9a2857d60c4cdc4d5946c61d26e3f5ba4860f` on 2026-07-13.
+- Recorded final branch head
+  `36c4aa5b940152114ac57384c867077f3ff9094e`, reviewed candidate
+  `4fd6db9ebe9911d30ec85657903b71707fc3bbfb`, and reviewed production
+  head `cdcaf77f4a73d091afd54232f378f9a2831376c5`.
+- Recorded successful Backend, Agent Gates, CodeRabbit, and explicit human
+  approval.
+- Moved AUTH-04A from active review to merged/completed state.
+- Left no active AUTH product implementation chunk.
+- Kept AUTH-04B, AUTH-05, and POL-002-04 inactive behind their prerequisites
+  and separate explicit user start signals.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Confirmed merge ancestry, exact six-file scope, and stopped product state after the historical-wording repair. |
+| QA/test | PASS | None | Confirmed merge/check facts and all lifecycle records agree. |
+| security/auth | PASS | None | Confirmed no rate control, grant, role, identity, authority, or later AUTH work became active. |
+| product/ops | PASS | None | Confirmed no product lifecycle behavior changed and successor gates remain closed. |
+| architecture | PASS | None | Confirmed no runtime, schema, dependency, workflow, or later-chunk change. |
+| docs | PASS | None | Confirmed global, initiative, and chunk memory consistently record AUTH-04A merged. |
+
+## Valid Finding Addressed
+
+The completed 04A contract still described itself as active and gated on
+preimplementation review. The repair converted that paragraph to historical
+tense without changing the recorded merge result or successor gates.
+
+## Commands Run
+
+```bash
+python3 scripts/check_loop_memory_state.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_internal_review_evidence.py
+git diff --check
+git diff --name-only origin/main...HEAD
+gh pr view 111 --json state,mergedAt,mergeCommit,headRefOid,statusCheckRollup
+```
+
+Results: all repository documentation checks passed. The reviewed candidate
+changes exactly six `.agent-loop` Markdown files and no executable, test,
+workflow, dependency, coverage-policy, schema, API, or product file.
+
+## External Facts
+
+- PR #111 state: merged.
+- PR #111 final head: `36c4aa5`.
+- PR #111 merge commit: `90c9a28`.
+- Agent Gates, Backend, and CodeRabbit: passed.
+- Human merge approval: recorded by GitHub.
+
+## Stop Condition
+
+Publish and merge this memory-only update, then stop. Do not start AUTH-04B,
+AUTH-05, or POL-002-04 without their separate explicit user start signals and
+recorded prerequisites.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-04A-post-merge-memory-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-04A-post-merge-memory-pr-trust-bundle.md
@@ -1,0 +1,107 @@
+# PR Trust Bundle: WS-AUTH-001-04A Post-Merge Memory
+
+## Chunk
+
+`WS-AUTH-001-04A` - Post-Merge Memory Update
+
+## Goal
+
+Record the completed AUTH-04A merge and preserve the stopped authorization
+state before rate controls or later authorization work starts.
+
+## Human-Approved Intent
+
+The user explicitly confirmed PR #111 merged. This PR performs only the
+required post-merge memory checkpoint.
+
+## What Changed
+
+- Recorded PR #111 merged as `90c9a28` on 2026-07-13.
+- Recorded final branch head `36c4aa5`, reviewed candidate `4fd6db9`, and
+  reviewed production head `cdcaf77`.
+- Moved AUTH-04A to completed across global, initiative, and chunk memory.
+- Cleared the active AUTH product implementation slot.
+- Kept AUTH-04B and later chunks inactive behind separate explicit start gates.
+
+## Why It Changed
+
+Durable repository state must reflect the human merge checkpoint before the
+authorization loop can consider any successor chunk.
+
+## Design Chosen
+
+The update changes the six existing lifecycle records used by prior AUTH merge
+checkpoints and adds only this reviewed evidence bundle.
+
+## Alternatives Rejected
+
+- Starting AUTH-04B directly from chat state.
+- Leaving 04A marked active after merge.
+- Combining rate-control implementation with the memory checkpoint.
+
+## Scope Control
+
+The reviewed candidate changes exactly six `.agent-loop` Markdown files. The
+evidence-only commit adds this trust bundle and its internal review record. No
+runtime, test, workflow, dependency, threshold, schema, migration, API,
+authorization behavior, or product lifecycle changed.
+
+## Product Behavior
+
+None. This is durable engineering memory only.
+
+## Acceptance Criteria Proof
+
+GitHub records bind PR #111 final head `36c4aa5` to merge commit `90c9a28` and
+show successful Backend, Agent Gates, and CodeRabbit checks. All lifecycle
+records agree that no implementation is active and AUTH-04B remains gated.
+
+## Tests And Checks
+
+Loop memory, stale Workstream wording, stale authorization docs, stale artifact
+contracts, Markdown links, internal-review evidence, and diff hygiene pass.
+Executable tests were not rerun because there is no executable delta.
+
+## Test Delta
+
+No application or test file changed.
+
+## CI Integrity
+
+No workflow, dependency, coverage threshold, exclusion, package, or script
+changed. The memory PR retains normal GitHub checks.
+
+## Reviewer Results
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, and docs
+review pass at exact candidate `ab984f77eaf2c24d2f6c5a0bc6f58edcd4802593`
+with no remaining findings.
+
+## External Review
+
+GitHub checks, CodeRabbit, and explicit human review begin after this ready
+memory PR is published.
+
+## Remaining Risks
+
+- AUTH-04B still requires this memory PR to merge and a separate explicit user
+  start.
+- The separate whole-app coverage initiative remains paused at its official
+  79.249908 percent baseline.
+- Provider-neutral `IdentityIssuerVerifier` adoption still depends on the
+  shared external-service adapter foundation and its own reviewed AUTH chunk.
+
+## Follow-Up Work
+
+After this memory PR merges, stop. AUTH-04B, AUTH-05, and policy work retain
+their separate checkpoints and prerequisites.
+
+## Human Review Focus
+
+Confirm PR #111 merge facts, memory-only scope, no active implementation, and
+the closed AUTH-04B start gate.
+
+## Human Merge Ownership
+
+Only the user may approve and merge this memory PR. Publication does not start
+AUTH-04B or authorize any later chunk.


### PR DESCRIPTION
# PR Trust Bundle: WS-AUTH-001-04A Post-Merge Memory

## Chunk

`WS-AUTH-001-04A` - Post-Merge Memory Update

## Goal

Record the completed AUTH-04A merge and preserve the stopped authorization
state before rate controls or later authorization work starts.

## Human-Approved Intent

The user explicitly confirmed PR #111 merged. This PR performs only the
required post-merge memory checkpoint.

## What Changed

- Recorded PR #111 merged as `90c9a28` on 2026-07-13.
- Recorded final branch head `36c4aa5`, reviewed candidate `4fd6db9`, and
  reviewed production head `cdcaf77`.
- Moved AUTH-04A to completed across global, initiative, and chunk memory.
- Cleared the active AUTH product implementation slot.
- Kept AUTH-04B and later chunks inactive behind separate explicit start gates.

## Why It Changed

Durable repository state must reflect the human merge checkpoint before the
authorization loop can consider any successor chunk.

## Design Chosen

The update changes the six existing lifecycle records used by prior AUTH merge
checkpoints and adds only this reviewed evidence bundle.

## Alternatives Rejected

- Starting AUTH-04B directly from chat state.
- Leaving 04A marked active after merge.
- Combining rate-control implementation with the memory checkpoint.

## Scope Control

The reviewed candidate changes exactly six `.agent-loop` Markdown files. The
evidence-only commit adds this trust bundle and its internal review record. No
runtime, test, workflow, dependency, threshold, schema, migration, API,
authorization behavior, or product lifecycle changed.

## Product Behavior

None. This is durable engineering memory only.

## Acceptance Criteria Proof

GitHub records bind PR #111 final head `36c4aa5` to merge commit `90c9a28` and
show successful Backend, Agent Gates, and CodeRabbit checks. All lifecycle
records agree that no implementation is active and AUTH-04B remains gated.

## Tests And Checks

Loop memory, stale Workstream wording, stale authorization docs, stale artifact
contracts, Markdown links, internal-review evidence, and diff hygiene pass.
Executable tests were not rerun because there is no executable delta.

## Test Delta

No application or test file changed.

## CI Integrity

No workflow, dependency, coverage threshold, exclusion, package, or script
changed. The memory PR retains normal GitHub checks.

## Reviewer Results

Senior engineering, QA/test, security/auth, product/ops, architecture, and docs
review pass at exact candidate `ab984f77eaf2c24d2f6c5a0bc6f58edcd4802593`
with no remaining findings.

## External Review

GitHub checks, CodeRabbit, and explicit human review begin after this ready
memory PR is published.

## Remaining Risks

- AUTH-04B still requires this memory PR to merge and a separate explicit user
  start.
- The separate whole-app coverage initiative remains paused at its official
  79.249908 percent baseline.
- Provider-neutral `IdentityIssuerVerifier` adoption still depends on the
  shared external-service adapter foundation and its own reviewed AUTH chunk.

## Follow-Up Work

After this memory PR merges, stop. AUTH-04B, AUTH-05, and policy work retain
their separate checkpoints and prerequisites.

## Human Review Focus

Confirm PR #111 merge facts, memory-only scope, no active implementation, and
the closed AUTH-04B start gate.

## Human Merge Ownership

Only the user may approve and merge this memory PR. Publication does not start
AUTH-04B or authorize any later chunk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status and review records to reflect completion and merge of the AUTH-04A workstream.
  * Added post-merge review evidence and a trust bundle documenting approvals, checks, merge details, and remaining risks.
  * Clarified that follow-on work remains inactive until the post-merge records are published and separately started.
  * Updated workstream maps and task tracking to show no active implementation work and defined next-step gates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->