### PR TITLE
Record AUTH-05A post-merge memory

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -4,31 +4,23 @@
 
 - Active initiative: `WS-AUTH-001` - Workstream Authorization Service
 - Active planning chunk: none
-- Active implementation chunk: `WS-AUTH-001-05A` - Shared Audit Ownership And
-  Append-Only Authority Evidence
-- Branch: `codex/ws-auth-001-05-authority-evidence`
-- Worktree: `/home/abiorh/flow/workstream-auth-001-05`
-- Status: AUTH-04B post-merge memory merged through PR #114 as `97cd0f5`.
-  The user explicitly started AUTH-05. Required L1 review rejected the combined
-  contract, then passed the first repaired AUTH-05A contract at `7a9023b`.
-  Exact-SHA implementation review reopened the contract for closed privacy
-  registries, non-echoing mapping admission, typed/SQL parity, and readable SQL.
+- Active implementation chunk: none
+- Branch: `codex/ws-auth-001-05a-post-merge-memory`
+- Worktree: `/home/abiorh/flow/workstream-authorization-service`
+- Status: AUTH-05A passed required internal reviews, Backend, Agent Gates, and
+  CodeRabbit. The user explicitly approved and merged PR #115 as `8e1cde6` on
+  2026-07-14. Post-merge memory is the only active work.
 - Prior `WS-AUTH-001-01` reviewed implementation SHA: `be0b836`
 - Prior `WS-AUTH-001-01` final merged branch head: `b5217e1`
-- Latest integrated `main` merge commit: `97cd0f5`
-- Current gate: AUTH-05A runtime repair and focused evidence under the
-  human-approved semantic chunk boundary.
-- Scope checkpoint: allowed files, non-goals, acceptance criteria, behavior
-  evidence, and required review bound AUTH-05A; there is no numeric line cap.
-  AUTH-05B remains a separate inactive chunk.
-- Next chunk: AUTH-05B remains inactive until AUTH-05A merges, post-merge memory
-  is reconciled, and the user gives a separate explicit start. AUTH-06 remains
-  inactive.
-- Focused evidence: 77 isolated rate/config tests pass at 97 percent subsystem
-  coverage, 59 final config/object-graph tests pass, and the exact migration
-  proof and real API E2E pass. Final GitHub Backend passed 937 tests at 82.15
+- Latest integrated `main` merge commit: `8e1cde6`
+- Current gate: post-merge memory and stop; no implementation chunk is active.
+- Scope checkpoint: AUTH-05A is complete. AUTH-05B remains a separate inactive
+  chunk and its contract does not authorize implementation.
+- Next chunk: AUTH-05B requires this memory update to merge and a separate
+  explicit user start. AUTH-06 and later chunks remain inactive.
+- Focused evidence: the audit/delegation suite passed 11 tests at 94.55 percent
+  audit-subsystem coverage. Final GitHub Backend passed 949 tests at 82.77
   percent global coverage and 91.07 percent artifact-foundation coverage.
-  AUTH-05 and later chunks remain inactive.
 - Parallel initiative: `WS-QUAL-001-01B2` is paused at the user's direction so
   AUTH receives the laptop's test capacity. Its last official whole-app result
   remains `6466/8159` statements (`79.249908%`); no replacement evidence exists.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,16 @@
 # Review Log
 
+## 2026-07-14 - WS-AUTH-001-05A Merged
+
+PR #115 merged through explicit human approval as `8e1cde6`. Final GitHub
+checks passed: Backend ran 949 tests at 82.77 percent global coverage, Agent
+Gates passed, and CodeRabbit passed after all actionable comments were
+addressed. The audit/delegation focused suite passed 11 tests at 94.55 percent
+audit-subsystem coverage. AUTH-05A is complete; AUTH-05B remains inactive until
+post-merge memory merges and the user gives a separate explicit start.
+Senior engineering, docs, architecture, reuse, product/ops, QA/CI/test-delta,
+and security/auth/privacy review passed for this memory-only reconciliation.
+
 ## 2026-07-14 - WS-AUTH-001-05A CodeRabbit Response
 
 CodeRabbit run `30676bdc-7525-4deb-8f9e-a87d42c64f92` produced four actionable
@@ -8,7 +19,8 @@ commands executable, replaces fragile positional event mapping with explicit
 identity-link event keys, types the task audit fixture session, and replaces
 misleading reused-agent names with AUTH-05A-specific review references. Focused
 behavior, Ruff, stale authorization docs, Markdown links, and diff integrity
-pass. Exact-SHA internal re-review is required before publication of the repair.
+pass. Exact-SHA internal re-review passed at `ea16fd8` before publication of the
+repair.
 
 ## 2026-07-14 - WS-AUTH-001-05A Semantic Scope Amendment
 

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -2,14 +2,13 @@
 
 ## In Progress
 
-| Chunk | Title | Risk | Status |
-|---|---|---:|---|
-| `WS-AUTH-001-05A` | Shared Audit Ownership And Append-Only Authority Evidence | L1 | Human-approved semantic chunk boundary; runtime repair/evidence |
+None.
 
 ## Planned Next
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
+| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Inactive pending post-merge memory merge and separate explicit user start |
 | `WS-QUAL-001-01B2` | Baseline Evidence And CI Ratchet | L1 | Paused for AUTH priority; no valid replacement baseline yet |
 | `WS-QUAL-001-02` | Project Service Coverage | L1 | Inactive until 01B2 merge/memory plus explicit user start |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending relevant authorization proof and a separate explicit user start |
@@ -54,13 +53,15 @@
 | `WS-AUTH-001-03` | Legacy Actor Classification Preflight | L1 | Merged through PR #109 as `f06532e` on 2026-07-13 |
 | `WS-AUTH-001-04A` | Request And Error Context | L1 | Merged through PR #111 as `90c9a28` on 2026-07-13 |
 | `WS-AUTH-001-04B` | PostgreSQL Rate Controls | L1 | Merged through PR #113 as `05a63c8` on 2026-07-14 |
+| `WS-AUTH-001-05A` | Shared Audit Ownership And Append-Only Authority Evidence | L1 | Merged through PR #115 as `8e1cde6` on 2026-07-14 |
 
 ## Proposed Next
 
-AUTH-04B post-merge memory merged through PR #114 as `97cd0f5`. The user
-explicitly started AUTH-05. Required plan review rejected the combined contract
-before runtime edits and required children 05A/05B. Only 05A contract repair is
-active. Do not implement 05B, AUTH-06, or POL-002-04 automatically.
+AUTH-05A merged through PR #115 as `8e1cde6` after required internal reviews,
+Backend, Agent Gates, CodeRabbit, and explicit human approval passed. AUTH-05B
+remains inactive until this post-merge memory merges and the user gives a
+separate explicit start. Do not implement AUTH-05B, AUTH-06, or POL-002-04
+automatically.
 
 Coverage R10 merged through PR #108. Do not start 01B2, chunk 02, or another
 coverage implementation chunk from this worktree.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -19,8 +19,8 @@ stopped.
 | `WS-AUTH-001-04A` | Request And Error Context | L1 | Merged through PR #111 as `90c9a28` |
 | `WS-AUTH-001-04B` | PostgreSQL Rate Controls | L1 | Merged through PR #113 as `05a63c8` |
 | `WS-AUTH-001-05` | Authority Evidence And Idempotency Foundation | L1 | Split before implementation into 05A and 05B |
-| `WS-AUTH-001-05A` | Shared Audit Ownership And Append-Only Authority Evidence | L1 | Semantic chunk boundary approved; runtime repair/evidence |
-| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Inactive pending 05A merge/memory and separate explicit start |
+| `WS-AUTH-001-05A` | Shared Audit Ownership And Append-Only Authority Evidence | L1 | Merged through PR #115 as `8e1cde6` |
+| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Inactive pending post-merge memory and separate explicit start |
 | `WS-AUTH-001-06` | Canonical Actor Profile And Identity Link | L1 | Proposed |
 | `WS-AUTH-001-07` | Authorization Kernel And Permission Registry | L1 | Proposed |
 | `WS-AUTH-001-08` | Bootstrap And Administrative Role Grants | L1 | Proposed |
@@ -100,5 +100,7 @@ rejected the combined contract before runtime edits and required 05A/05B.
 The first 05A implementation review proved the original numeric ceiling
 incompatible with readable typed/database privacy parity. Repaired 05A contract
 review passed at `7cc6058`; the user subsequently replaced the line cap with
-the semantic AUTH-05A boundary. Runtime repair is active. 05B remains inactive.
-Do not start AUTH-06 or POL-002-04.
+the semantic AUTH-05A boundary. Required reviews and checks passed, and explicit
+human approval merged PR #115 as `8e1cde6` on 2026-07-14. Post-merge memory is
+active. 05B remains inactive pending a separate explicit user start. Do not
+start AUTH-06 or POL-002-04.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -52,7 +52,10 @@ typed/SQL parity require a larger readable contract. The repaired contract
 passed at `7cc6058`, but numeric hard stops repeatedly interrupted the atomic
 typed/database parity boundary. The human replaced the line cap with AUTH-05A's
 semantic scope, acceptance criteria, behavior evidence, and review gates;
-runtime repair and focused evidence are active.
+runtime repair, deterministic evidence, and required reviews then completed.
+Backend passed 949 tests at 82.77 percent global coverage, Agent Gates and
+CodeRabbit passed, and explicit human approval merged PR #115 as `8e1cde6` on
+2026-07-14.
 
 ## Active planning chunk
 
@@ -60,12 +63,13 @@ None.
 
 ## Active implementation chunk
 
-`WS-AUTH-001-05A` - Shared Audit Ownership And Append-Only Authority Evidence.
+None. Post-merge memory for `WS-AUTH-001-05A` is active; no implementation
+chunk is active.
 
 ## Current implementation branch
 
-`codex/ws-auth-001-05-authority-evidence` in
-`/home/abiorh/flow/workstream-auth-001-05`.
+`codex/ws-auth-001-05a-post-merge-memory` in
+`/home/abiorh/flow/workstream-authorization-service`.
 
 ## Chunk status
 
@@ -79,8 +83,8 @@ None.
 | `WS-AUTH-001-04A` | Merged | `codex/ws-auth-001-04-request-api-controls` | #111 | Merged as `90c9a28`; production review `cdcaf77`; final branch head `36c4aa5`. |
 | `WS-AUTH-001-04B` | Merged | `codex/ws-auth-001-04b-postgres-rate-controls` | #113 | Merged as `05a63c8`; production review `67484b5`; final branch head `94fb2fe`. |
 | `WS-AUTH-001-05` | Split | `codex/ws-auth-001-05-authority-evidence` | - | Parent split before implementation into 05A and 05B. |
-| `WS-AUTH-001-05A` | Runtime repair/evidence | `codex/ws-auth-001-05-authority-evidence` | - | Human-approved semantic chunk boundary; repair active. |
-| `WS-AUTH-001-05B` | Inactive | - | - | Idempotency and invalidation; requires 05A merge/memory and separate explicit start. |
+| `WS-AUTH-001-05A` | Merged | `codex/ws-auth-001-05-authority-evidence` | #115 | Merged as `8e1cde6`; reviewed code `ea16fd8`; final branch head `d023952`. |
+| `WS-AUTH-001-05B` | Inactive | - | - | Idempotency and invalidation; requires post-merge memory and separate explicit start. |
 | `WS-AUTH-001-06` | Proposed | - | - | Canonical actor profile and identity link. |
 | `WS-AUTH-001-07` | Proposed | - | - | Authorization kernel and permissions. |
 | `WS-AUTH-001-08` | Proposed | - | - | Bootstrap and administrative grants. |
@@ -95,15 +99,10 @@ None.
 
 ## Blockers
 
-AUTH-05A has no preimplementation blocker under its human-approved semantic
-chunk boundary. The combined AUTH-05 contract was
-rejected before code changes because migration `0017` is already owned by
-AUTH-04B and the shared-audit plus idempotency scope was not reviewable as one
-L1 change. Repaired AUTH-05A owns migration `0018`; AUTH-05B later owns
-migration `0019`. Exact-SHA review found valid arbitrary fact/reason privacy,
-non-dict Mapping retention, DB token-parity, cause-contract ambiguity, and SQL
-auditability findings; the repaired contract owns their closure without
-reactivating 05B. Non-test
+AUTH-05A has no remaining blocker and is merged. The combined AUTH-05 contract
+was rejected before runtime changes because shared audit evidence and
+idempotency/invalidation were not reviewable as one L1 change. AUTH-05A owns
+migration `0018`; inactive AUTH-05B later owns migration `0019`. Non-test
 operators must later supply explicit classification evidence rather than
 inferred kinds before the owning canonical actor migration.
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-05A-shared-audit-authority-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-05A-shared-audit-authority-evidence.md
@@ -2,10 +2,9 @@
 
 ## Status
 
-Runtime repair and focused evidence. Repaired contract review passed on
-`7cc6058`; the earlier numeric amendments passed at `611abfc`, and the human
-subsequently replaced the line ceiling with this chunk's semantic scope,
-acceptance criteria, behavior evidence, and required-review gates.
+Merged through PR #115 as `8e1cde6` on 2026-07-14 after required internal
+reviews, Backend, Agent Gates, CodeRabbit, and explicit human approval passed.
+Reviewed code SHA: `ea16fd8`; final branch head: `d023952`.
 
 ## Parent initiative
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-05A-post-merge-memory-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-05A-post-merge-memory-internal-review-evidence.md
@@ -1,0 +1,90 @@
+# Internal Review Evidence: WS-AUTH-001-05A Post-Merge Memory
+
+## Chunk
+
+`WS-AUTH-001-05A` - Post-Merge Memory Update
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: `6af02beab8a0f6cb8baca34f3deac529e500e729`
+
+Reviewed at: 2026-07-14T13:54:31Z
+
+Reviewer run IDs: senior-engineering-architecture-docs-reuse=WS-AUTH-001-05A-POST-MERGE-ENG-20260714;
+qa-test-ci-integrity=WS-AUTH-001-05A-POST-MERGE-QA-20260714;
+security-auth-privacy-product-ops=WS-AUTH-001-05A-POST-MERGE-SEC-20260714
+
+## Reviewed Change
+
+- Recorded PR #115 merged to `main` as
+  `8e1cde69db0b62b61894304912347893c798105e` on 2026-07-14.
+- Recorded final branch head
+  `d0239529a1f9617d7db4d187dff2d273e97a4e3c` and reviewed production SHA
+  `ea16fd8bd2d9bc38b37c12003e51416c08a56678`.
+- Recorded successful Backend, Agent Gates, CodeRabbit, and explicit human
+  approval.
+- Moved AUTH-05A from active implementation to merged/completed state.
+- Left no active AUTH implementation chunk.
+- Kept AUTH-05B, AUTH-06, POL-002-04, and ART-001-02 inactive behind their
+  prerequisites and separate explicit user start signals.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Confirmed merge ancestry, exact six-file scope, and stopped lifecycle state. |
+| qa/test | PASS after fixes | None | Confirmed merge/check/coverage facts and required this machine-readable evidence binding. |
+| security/auth | PASS | None | Confirmed no actor, grant, permission, route, or authority behavior became active. |
+| product/ops | PASS | None | Confirmed no product lifecycle changed and successor gates remain closed. |
+| architecture | PASS | None | Confirmed no runtime, migration, dependency, workflow, or later-chunk change. |
+| ci integrity | PASS after fixes | None | Preserved the evidence gate and supplied its required exact-SHA record. |
+| docs | PASS | None | Confirmed loop, queue, initiative, chunk, and review memory agree. |
+| reuse/dedup | PASS | None | Reused the established AUTH post-merge evidence pattern. |
+| test delta | PASS | None | No test, assertion, exclusion, threshold, or workflow changed. |
+
+## Valid Finding Addressed
+
+The reviewed lifecycle commit did not include a changed post-merge internal
+review evidence file, so both Backend and Agent Gates failed closed before test
+execution. This evidence-only record and trust bundle bind the completed
+reviewer fanout to exact SHA `6af02be` without changing lifecycle or runtime
+state.
+
+## Commands Run
+
+```bash
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_internal_review_evidence.py
+git diff --check
+git diff --name-only origin/main...HEAD
+gh pr view 115 --json state,mergedAt,mergeCommit,headRefOid,statusCheckRollup
+```
+
+Results: repository documentation and evidence checks pass after evidence
+binding. The reviewed candidate changes exactly six `.agent-loop` Markdown
+files and no executable, test, workflow, dependency, coverage-policy, schema,
+API, or product file.
+
+## External Facts
+
+- PR #115 state: merged.
+- PR #115 final head: `d023952`.
+- PR #115 merge commit: `8e1cde6`.
+- Backend: 949 tests passed at 82.77 percent repository coverage.
+- Artifact-foundation coverage: 91.07 percent.
+- AUTH-05A audit-subsystem coverage: 94.55 percent.
+- Agent Gates and CodeRabbit: passed.
+- Human merge approval: recorded by GitHub.
+
+## Stop Condition
+
+Publish and merge this memory-only update, then stop. Do not start AUTH-05B,
+AUTH-06, POL-002-04, or ART-001-02 without their separate explicit user start
+signals and recorded prerequisites.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-05A-post-merge-memory-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-05A-post-merge-memory-pr-trust-bundle.md
@@ -1,0 +1,192 @@
+# PR Trust Bundle: WS-AUTH-001-05A Post-Merge Memory
+
+## Chunk
+
+`WS-AUTH-001-05A` - Post-Merge Memory Update
+
+## Goal
+
+Reconcile durable repository memory after the user explicitly approved and
+merged AUTH-05A through PR #115.
+
+## Human-approved intent
+
+The merged AUTH-05A chunk contract is recorded at
+`../chunks/WS-AUTH-001-05A-shared-audit-authority-evidence.md`. The repository
+loop requires merge memory and a stop before any successor chunk may start.
+
+## What changed
+
+- Marked AUTH-05A merged and completed.
+- Recorded the merge commit, final reviewed revisions, checks, and coverage.
+- Left AUTH-05B and all later implementation inactive.
+- Added exact-SHA internal review evidence for this process-only update.
+
+## Why it changed
+
+Durable repository state must replace the pre-merge active-chunk state after a
+human-approved merge. The initial memory publication recorded reviewer results
+only in `REVIEW_LOG.md`; Backend and Agent Gates correctly failed closed because
+the PR lacked the required machine-readable internal evidence file.
+
+## Design chosen
+
+Use the established AUTH post-merge pattern: six lifecycle documents record the
+merged and stopped state, while a separate evidence record binds required
+reviewer results to the exact lifecycle SHA. This evidence-only repair satisfies
+the existing CI gate without changing or bypassing it.
+
+## Alternatives rejected
+
+- Re-running failed workflows without adding evidence was rejected because the
+  deterministic gate would fail for the same valid reason.
+- Weakening, skipping, or special-casing the evidence gate for memory PRs was
+  rejected because process changes require the same auditable review proof.
+- Activating AUTH-05B while reconciling memory was rejected because it requires
+  this memory merge and a separate explicit user start.
+
+## Scope control
+
+### Allowed files changed
+
+- `.agent-loop/LOOP_STATE.md`
+- `.agent-loop/REVIEW_LOG.md`
+- `.agent-loop/WORK_QUEUE.md`
+- `.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md`
+- `.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md`
+- `.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-05A-shared-audit-authority-evidence.md`
+- This post-merge internal review evidence record
+- This post-merge PR trust bundle
+
+### Files outside scope
+
+- None.
+
+## Product Behavior
+
+- [x] No Workstream product behavior changed.
+- [ ] Product behavior changed and is explained here:
+
+## Acceptance criteria proof
+
+- [x] AUTH-05A is consistently marked merged through PR #115 as `8e1cde6`.
+- [x] No AUTH implementation chunk is active; AUTH-05B requires a separate
+  explicit user start after this memory merge.
+- [x] Exact lifecycle SHA `6af02be` passed required internal reviews.
+- [x] Machine-readable review evidence now passes the unchanged CI parser.
+- [x] Merge, check, test-count, and coverage facts match GitHub evidence.
+
+## Tests/checks run
+
+```bash
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+git diff --check
+git diff --name-only origin/main...HEAD
+gh pr view 115 --json state,mergedAt,mergeCommit,headRefOid,statusCheckRollup
+gh pr checks 116
+```
+
+Result summary:
+
+```text
+Internal review evidence gate passed.
+Markdown link and all stale-state scans passed.
+Diff integrity passed.
+PR #115 facts match the recorded merge and coverage evidence.
+PR #116 Backend and Agent Gates initially failed only because the internal
+evidence file was absent; rerun after this evidence-only repair is pending.
+```
+
+## Test delta
+
+### Tests added
+
+- None.
+
+### Tests modified
+
+- None.
+
+### Tests removed/skipped
+
+- None.
+
+## CI integrity
+
+- [x] Coverage threshold unchanged
+- [x] Lint unchanged
+- [x] Typecheck unchanged
+- [x] No workflow weakening
+- [x] No package script weakening
+- [x] No unpinned new GitHub Action
+- [x] Checkout credential persistence disabled where checkout is used
+
+## External review
+
+External review response file:
+
+- None required at this point; no actionable CodeRabbit comment is open on
+  PR #116.
+
+| Source | Status | Notes |
+|---|---:|---|
+| CodeRabbit | Passed at `6af02be`; follow-up pending | Must rerun after the evidence-only push. |
+| GitHub Backend | Repair pending publication | Initial run stopped at the missing-evidence gate before tests. |
+| GitHub Agent Gates | Repair pending publication | All 36 gate regressions passed; missing-evidence gate then failed closed. |
+
+PR #115's completed Backend, Agent Gates, and CodeRabbit results are historical
+merge facts recorded by this memory update, not results for PR #116.
+
+## Reviewer results
+
+Reviewed code SHA: `6af02beab8a0f6cb8baca34f3deac529e500e729`
+
+Reviewed at: 2026-07-14T13:54:31Z
+
+Reviewer run IDs: senior-engineering-architecture-docs-reuse=WS-AUTH-001-05A-POST-MERGE-ENG-20260714;
+qa-test-ci-integrity=WS-AUTH-001-05A-POST-MERGE-QA-20260714;
+security-auth-privacy-product-ops=WS-AUTH-001-05A-POST-MERGE-SEC-20260714
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS AFTER FIXES | None | Canonical trust-bundle structure restored after review. |
+| QA/test | PASS AFTER FIXES | None | Exact evidence binding fixes both failed workflows. |
+| security/auth | PASS | None | No authority or product behavior became active. |
+| product/ops | PASS | None | Successor lifecycle gates remain closed. |
+| architecture | PASS AFTER FIXES | None | Memory and evidence remain separated from runtime state. |
+| CI integrity | PASS AFTER FIXES | None | Existing gates remain unchanged and now pass locally. |
+| docs | PASS AFTER FIXES | None | Canonical evidence and trust structures are complete. |
+| reuse/dedup | PASS | None | Reuses the established AUTH post-merge pattern. |
+| test delta | PASS | None | No test or test-selection change. |
+
+## Remaining risks
+
+- PR #116's new GitHub checks must pass after publication of the evidence-only
+  repair. GitHub owns that external verification.
+- The user still owns explicit merge approval for PR #116.
+
+## Follow-up work
+
+After PR #116 merges, stop. AUTH-05B may start only after a separate explicit
+user signal; AUTH-06 and later chunks remain inactive.
+
+## Human review focus
+
+Please inspect:
+
+- exact PR #115 merge/check/coverage facts;
+- exact reviewed lifecycle SHA and reviewer provenance;
+- absence of any CI weakening or runtime change;
+- stopped AUTH state and separate AUTH-05B start gate.
+
+## Human ownership
+
+- [ ] I can explain what changed.
+- [ ] I can explain why it changed.
+- [ ] I know what could break.
+- [ ] I accept the remaining risks.
+- [ ] The user explicitly approved this specific PR for merge.


### PR DESCRIPTION
## Summary

- record PR #115 as merged at `8e1cde6`
- preserve final Backend, Agent Gates, CodeRabbit, focused coverage, and internal-review evidence
- move AUTH-05A to completed and leave AUTH-05B plus later chunks inactive

## Scope

Memory and lifecycle documentation only. No runtime, migration, test, workflow, permission, grant, or authorization behavior changes.

## Validation

- required internal senior engineering, architecture, docs, reuse, product/ops, QA/CI/test-delta, and security/auth/privacy reviews passed
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_stale_workstream_wording.py`
- `python3 scripts/check_stale_authorization_docs.py`
- `python3 scripts/check_stale_artifact_contracts.py`
- `git diff --check`

AUTH-05B remains inactive until this memory update merges and the user gives a separate explicit start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workstream status and review records to reflect completion and merge of the AUTH-05A phase.
  * Documented updated validation results, coverage metrics, and approval details.
  * Marked the next AUTH-05B phase as inactive until post-merge activities and explicit authorization are complete.
  * Revised implementation tracking, checkpoints, blockers, and chunk status to reflect the latest project state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->