### PR TITLE
Reconcile authorization action and resource catalogue

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -3,21 +3,25 @@
 ## Current State
 
 - Active initiative: `WS-AUTH-001` - Workstream Authorization Service
-- Active planning chunk: none
+- Active planning chunk: `WS-AUTH-001-CAT` - Action And Resource Catalogue
+  Reconciliation
 - Active implementation chunk: none
-- Branch: `codex/ws-auth-001-05a-post-merge-memory`
+- Branch: `codex/ws-auth-001-action-catalogue-reconciliation`
 - Worktree: `/home/abiorh/flow/workstream-authorization-service`
-- Status: AUTH-05A passed required internal reviews, Backend, Agent Gates, and
-  CodeRabbit. The user explicitly approved and merged PR #115 as `8e1cde6` on
-  2026-07-14. Post-merge memory is the only active work.
+- Status: AUTH-05A and its post-merge memory are merged. The user requested
+  repository mapping of a proposed action/resource catalogue and directed that
+  only validated rules be copied into canonical docs and owning future chunks.
 - Prior `WS-AUTH-001-01` reviewed implementation SHA: `be0b836`
 - Prior `WS-AUTH-001-01` final merged branch head: `b5217e1`
-- Latest integrated `main` merge commit: `8e1cde6`
-- Current gate: post-merge memory and stop; no implementation chunk is active.
-- Scope checkpoint: AUTH-05A is complete. AUTH-05B remains a separate inactive
-  chunk and its contract does not authorize implementation.
-- Next chunk: AUTH-05B requires this memory update to merge and a separate
-  explicit user start. AUTH-06 and later chunks remain inactive.
+- Latest integrated `main` merge commit: `ab49b73`
+- Current gate: internal review passed; ready PR, GitHub checks, CodeRabbit, and
+  explicit human merge remain. No runtime implementation chunk is active.
+- Scope checkpoint: the 52 approved identifiers and `/api/v1` namespace remain
+  unchanged. AUTH-05A's 49-identifier audit base remains runtime truth until the
+  three planned recovery identifiers receive typed/SQL parity in AUTH-13/14.
+- Next chunk: the user explicitly directed AUTH-05B to continue after this
+  reconciliation. It remains inactive until this docs-only chunk merges and its
+  post-merge memory/stop checkpoint is recorded.
 - Focused evidence: the audit/delegation suite passed 11 tests at 94.55 percent
   audit-subsystem coverage. Final GitHub Backend passed 949 tests at 82.77
   percent global coverage and 91.07 percent artifact-foundation coverage.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,14 @@
 # Review Log
 
+## 2026-07-14 - WS-AUTH-001-CAT CodeRabbit Response
+
+CodeRabbit raised two valid consistency findings on PR #117. The repair makes
+`STATUS.md` explicitly preserve all 52 approved identifiers beside AUTH-05A's
+49-identifier persisted audit base and removes the stale second AUTH-05B start
+requirement from `WORK_QUEUE.md`. The received start signal remains gated only
+by CAT merge and its post-merge memory/stop checkpoint. Internal repair review
+and repository gates are rerun before publication.
+
 ## 2026-07-14 - WS-AUTH-001-CAT Internal Review Passed
 
 The proposed action/resource catalogue failed initial repository mapping because

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,17 @@
 # Review Log
 
+## 2026-07-14 - WS-AUTH-001-CAT Internal Review Passed
+
+The proposed action/resource catalogue failed initial repository mapping because
+it claimed unapproved precedence, used `/v1`, conflicted with the merged audit
+registry, and invented cross-domain resources. The rejected root file was
+removed. Only validated rules were adopted through D15 and owning future chunk
+contracts. Repaired review now passes senior engineering, architecture, docs,
+QA/test, security/auth/privacy, and product/ops. Documentation and diff gates
+pass. The ready PR is pending external and explicit human review; AUTH-05B stays
+inactive until this docs-only amendment merges and its post-merge memory/stop
+checkpoint is recorded.
+
 ## 2026-07-14 - WS-AUTH-001-05A Merged
 
 PR #115 merged through explicit human approval as `8e1cde6`. Final GitHub

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -60,10 +60,11 @@
 ## Proposed Next
 
 AUTH-05A merged through PR #115 as `8e1cde6` after required internal reviews,
-Backend, Agent Gates, CodeRabbit, and explicit human approval passed. AUTH-05B
-remains inactive until this post-merge memory merges and the user gives a
-separate explicit start. Do not implement AUTH-05B, AUTH-06, or POL-002-04
-automatically.
+Backend, Agent Gates, CodeRabbit, and explicit human approval passed. The user
+has given the AUTH-05B start signal. AUTH-05B remains inactive only until
+`WS-AUTH-001-CAT` merges and its post-merge memory/stop checkpoint is recorded;
+no second start signal is required. Do not start AUTH-05B before those gates, or
+start AUTH-06 or POL-002-04 automatically.
 
 Coverage R10 merged through PR #108. Do not start 01B2, chunk 02, or another
 coverage implementation chunk from this worktree.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -2,13 +2,15 @@
 
 ## In Progress
 
-None.
+| Chunk | Title | Risk | Status |
+|---|---|---:|---|
+| `WS-AUTH-001-CAT` | Action And Resource Catalogue Reconciliation | L1 | Internal review passed; ready PR pending |
 
 ## Planned Next
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Inactive pending post-merge memory merge and separate explicit user start |
+| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Start signal received; inactive until CAT merge and post-merge memory |
 | `WS-QUAL-001-01B2` | Baseline Evidence And CI Ratchet | L1 | Paused for AUTH priority; no valid replacement baseline yet |
 | `WS-QUAL-001-02` | Project Service Coverage | L1 | Inactive until 01B2 merge/memory plus explicit user start |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending relevant authorization proof and a separate explicit user start |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -20,7 +20,8 @@ stopped.
 | `WS-AUTH-001-04B` | PostgreSQL Rate Controls | L1 | Merged through PR #113 as `05a63c8` |
 | `WS-AUTH-001-05` | Authority Evidence And Idempotency Foundation | L1 | Split before implementation into 05A and 05B |
 | `WS-AUTH-001-05A` | Shared Audit Ownership And Append-Only Authority Evidence | L1 | Merged through PR #115 as `8e1cde6` |
-| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Inactive pending post-merge memory and separate explicit start |
+| `WS-AUTH-001-CAT` | Action And Resource Catalogue Reconciliation | L1 | Internal review passed; ready PR pending |
+| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Start signal received; inactive until CAT merge and post-merge memory |
 | `WS-AUTH-001-06` | Canonical Actor Profile And Identity Link | L1 | Proposed |
 | `WS-AUTH-001-07` | Authorization Kernel And Permission Registry | L1 | Proposed |
 | `WS-AUTH-001-08` | Bootstrap And Administrative Role Grants | L1 | Proposed |
@@ -43,6 +44,7 @@ WS-AUTH-001-PLAN
 -> WS-AUTH-001-04A
 -> WS-AUTH-001-04B
 -> WS-AUTH-001-05A
+-> WS-AUTH-001-CAT
 -> WS-AUTH-001-05B
 -> WS-AUTH-001-06
 -> WS-AUTH-001-07
@@ -67,6 +69,9 @@ WS-AUTH-001-PLAN
 - Parent chunk 05 was split before implementation. Chunk 05A owns shared audit
   schema/writer custody and append-only authority evidence; chunk 05B owns
   idempotency and typed invalidation orchestration.
+- The docs-only catalogue reconciliation between 05A and 05B adopts a staged
+  typed action/resource registry for future chunks without changing the merged
+  permission/audit catalogue or starting runtime implementation.
 - Chunk 06 establishes canonical actor resolution while preserving only the
   enumerated non-authoritative legacy workflow-eligibility consumers required
   for intermediate-release operability.
@@ -101,6 +106,7 @@ The first 05A implementation review proved the original numeric ceiling
 incompatible with readable typed/database privacy parity. Repaired 05A contract
 review passed at `7cc6058`; the user subsequently replaced the line cap with
 the semantic AUTH-05A boundary. Required reviews and checks passed, and explicit
-human approval merged PR #115 as `8e1cde6` on 2026-07-14. Post-merge memory is
-active. 05B remains inactive pending a separate explicit user start. Do not
-start AUTH-06 or POL-002-04.
+human approval merged PR #115 as `8e1cde6` on 2026-07-14, followed by merged
+post-merge memory. The user has now given the AUTH-05B start signal; 05B remains
+inactive only until `WS-AUTH-001-CAT` merges and its post-merge memory is
+recorded. Do not start AUTH-06 or POL-002-04.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/DECISIONS.md
@@ -212,3 +212,63 @@ correlation evidence, resource identity, operation, and service principal.
 Receipts prove that storage work occurred; they do not create authority. Exact
 permission tokens and route ownership are locked in the owning AUTH cutover
 chunk contracts. AUTH-04B adds no artifact permission or route attachment.
+
+## D15: Adopt a staged typed action and resource catalogue
+
+Status: accepted by the user on 2026-07-14 after repository mapping and internal
+design review.
+
+AUTH-07 introduces a closed typed action registry. Each active `ActionId` binds
+one already approved `PermissionId` to one canonical authorization target,
+candidate authority sources, mandatory guards, principal class, and
+transaction-revalidation rule. Multiple closed actions may map to one retained
+broad permission while using distinct targets and guards; routes cannot supply
+arbitrary permission/target pairs. Creates authorize against an existing parent
+or `system` target. Feature
+repositories remain persistence owners; feature application services or
+feature-owned loaders compose closed, typed per-resource `ResourceContext`
+variants and register at the composition root without making AUTH a second
+domain-query layer. Guard definitions declare their required resource facts;
+unknown, missing, extra, or mistyped facts fail closed.
+
+Each protected route or asynchronous command declares one primary registered
+action as its authorization entry point. Domain invariants remain owned by the
+feature service. Human bearer tokens are never executable worker authority,
+and collection filtering occurs before counts or cursors. Catalogue adoption is
+staged: AUTH-07 owns types and its own current definitions, every route-owning
+AUTH-07 through AUTH-15 chunk owns declarations during its feature cutover, and
+AUTH-16 owns the aggregate generated route/command completeness manifest and
+final no-bypass proof.
+
+Reserved planned metadata contains only stable `ActionId`, approved
+`PermissionId`, owning specification/chunk, and availability. It cannot
+authorize and does not predefine a foreign-domain target, facts, guards, or
+composer. An owning cutover chunk activates an action only with its adopted
+domain contract, canonical resource composer, route or command declaration,
+allow/deny behavior proof, and generated manifest-delta proof.
+
+`ActionId` is security-significant evidence. AUTH-07 adds it to
+`AuthorizationDecision`, bounded logs/metrics, and allowed/denied authority
+events with exact typed/PostgreSQL registry parity. Historical events may remain
+null; every AUTH-07-or-later action-based decision event requires a registered
+identifier. Planned IDs can be registered before activation because they encode
+only identifier, approved permission, owner, and availability, not foreign
+resource design.
+
+The reviewed proposal did not receive independent normative precedence. Its
+`/v1` prefix, broad-permission replacement, compatibility deletion, and invented
+artifact, review, contribution, and compensation resources were rejected. The
+adopted `/api/v1` namespace and 52 approved permission identifiers remain
+unchanged. AUTH-05A currently enforces a 49-identifier typed/PostgreSQL audit
+base; the three already approved Operator recovery identifiers remain planned
+and non-executable until AUTH-13/14 add them to typed/SQL audit parity and
+activate their owning actions. Other permission additions or renames still
+require an approved specification/ADR change, typed and PostgreSQL registry
+migration, audit-history treatment, cutover ownership, and rollback proof.
+WS-REV, WS-CON, and the artifact-storage specification continue to own their
+resources and state transitions.
+
+Migration custody is reconciled with merged main: AUTH-05A owns `0018`, AUTH-05B
+solely owns `0019`, AUTH-06 uses `0020`, AUTH-07 action evidence uses `0021`,
+AUTH-08 uses `0022`, AUTH-10 uses `0023`, AUTH-12 uses `0024`, AUTH-13 uses
+`0025`, and AUTH-14 uses `0026`.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -110,11 +110,15 @@ operators must later supply explicit classification evidence rather than
 inferred kinds before the owning canonical actor migration.
 
 The proposed external catalogue cannot be adopted as a normative handoff: it
-conflicts with `/api/v1`, the merged 49-permission audit constraint, current
-project and artifact models, and staged domain ownership. `WS-AUTH-001-CAT`
-retains only safe registry/conformance rules. This is a scope decision, not an
-AUTH-05B runtime blocker; AUTH-05B begins after the docs-only amendment merges
-and its post-merge memory/stop checkpoint is recorded.
+conflicts with `/api/v1`, AUTH-05A's merged 49-identifier persisted audit base,
+current project and artifact models, and staged domain ownership. All 52
+permission identifiers remain approved, including
+`operations.task.start_override`, `operations.submission_gate.repair`, and
+`operations.checker.retry`; the three recovery identifiers receive persisted
+parity only in their owning later chunks. `WS-AUTH-001-CAT` retains only safe
+registry/conformance rules. This is a scope decision, not an AUTH-05B runtime
+blocker; AUTH-05B begins after the docs-only amendment merges and its post-merge
+memory/stop checkpoint is recorded.
 
 AUTH-04B review evidence and its PR trust bundle are recorded at
 `reviews/WS-AUTH-001-04B-internal-review-evidence.md` and

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -59,16 +59,18 @@ CodeRabbit passed, and explicit human approval merged PR #115 as `8e1cde6` on
 
 ## Active planning chunk
 
-None.
+`WS-AUTH-001-CAT` - Action And Resource Catalogue Reconciliation. This is a
+docs/specification-only mapping of a proposed catalogue against the adopted
+repository; it changes no runtime, migration, or permission identifier.
 
 ## Active implementation chunk
 
-None. Post-merge memory for `WS-AUTH-001-05A` is active; no implementation
-chunk is active.
+None. AUTH-05B remains inactive until the catalogue reconciliation merges and
+its post-merge memory/stop checkpoint is recorded.
 
 ## Current implementation branch
 
-`codex/ws-auth-001-05a-post-merge-memory` in
+`codex/ws-auth-001-action-catalogue-reconciliation` in
 `/home/abiorh/flow/workstream-authorization-service`.
 
 ## Chunk status
@@ -84,7 +86,8 @@ chunk is active.
 | `WS-AUTH-001-04B` | Merged | `codex/ws-auth-001-04b-postgres-rate-controls` | #113 | Merged as `05a63c8`; production review `67484b5`; final branch head `94fb2fe`. |
 | `WS-AUTH-001-05` | Split | `codex/ws-auth-001-05-authority-evidence` | - | Parent split before implementation into 05A and 05B. |
 | `WS-AUTH-001-05A` | Merged | `codex/ws-auth-001-05-authority-evidence` | #115 | Merged as `8e1cde6`; reviewed code `ea16fd8`; final branch head `d023952`. |
-| `WS-AUTH-001-05B` | Inactive | - | - | Idempotency and invalidation; requires post-merge memory and separate explicit start. |
+| `WS-AUTH-001-CAT` | Ready for PR | `codex/ws-auth-001-action-catalogue-reconciliation` | - | Required internal reviews and docs gates pass; runtime permission registry is unchanged. |
+| `WS-AUTH-001-05B` | Inactive | - | - | Start signal received; activate after CAT merge and post-merge memory. |
 | `WS-AUTH-001-06` | Proposed | - | - | Canonical actor profile and identity link. |
 | `WS-AUTH-001-07` | Proposed | - | - | Authorization kernel and permissions. |
 | `WS-AUTH-001-08` | Proposed | - | - | Bootstrap and administrative grants. |
@@ -105,6 +108,13 @@ idempotency/invalidation were not reviewable as one L1 change. AUTH-05A owns
 migration `0018`; inactive AUTH-05B later owns migration `0019`. Non-test
 operators must later supply explicit classification evidence rather than
 inferred kinds before the owning canonical actor migration.
+
+The proposed external catalogue cannot be adopted as a normative handoff: it
+conflicts with `/api/v1`, the merged 49-permission audit constraint, current
+project and artifact models, and staged domain ownership. `WS-AUTH-001-CAT`
+retains only safe registry/conformance rules. This is a scope decision, not an
+AUTH-05B runtime blocker; AUTH-05B begins after the docs-only amendment merges
+and its post-merge memory/stop checkpoint is recorded.
 
 AUTH-04B review evidence and its PR trust bundle are recorded at
 `reviews/WS-AUTH-001-04B-internal-review-evidence.md` and

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-06-canonical-actor-profile.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-06-canonical-actor-profile.md
@@ -41,7 +41,7 @@ backend/app/api/routes/auth.py
 backend/app/schemas/auth.py
 backend/app/db/models.py
 backend/app/modules/audit/**
-backend/alembic/versions/0018_*.py
+backend/alembic/versions/0020_*.py
 backend/tests/test_actors.py
 backend/tests/test_auth.py
 backend/tests/test_alembic.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-07-authorization-kernel.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-07-authorization-kernel.md
@@ -34,13 +34,17 @@ P1
 
 ```text
 backend/app/modules/authorization/**
+backend/app/modules/audit/**
 backend/app/modules/actors/repository.py
 backend/app/modules/actors/service.py
 backend/app/api/deps/auth.py
 backend/app/api/router.py
 backend/app/main.py
 backend/app/schemas/auth.py
+backend/alembic/versions/0021_authorization_action_evidence.py
 backend/tests/test_auth.py
+backend/tests/test_audit.py
+backend/tests/test_alembic.py
 backend/tests/test_actors.py
 backend/tests/test_app.py
 backend/scripts/api_contract_e2e.py
@@ -65,6 +69,21 @@ review/compensation permissions beyond registered future definitions
 ## Acceptance criteria
 
 - Permission identifiers are a closed registered enum/value set.
+- A closed typed action registry gives each active `ActionId` one approved
+  `PermissionId`, canonical target resource type, target-resolution rule,
+  allowed principal class, authority-candidate sources, mandatory registered
+  guards, and transaction-revalidation requirement. Multiple closed actions may
+  map to one retained broad permission with distinct targets/guards. Unknown
+  action, permission, resource, or guard identifiers deny during
+  registration/startup validation.
+- Create and collection actions authorize against an existing parent or
+  `system` target; request-supplied project, owner, parent, and state values are
+  never canonical resource facts.
+- Resource loading remains feature-owned. AUTH defines the bounded
+  `ResourceContext` protocol as closed typed per-resource variants and defines
+  the composition-root registration contract without importing feature
+  repositories or duplicating feature queries. Guards declare required facts;
+  missing, extra, or mistyped facts fail closed.
 - Request context contains verified identity plus current local actor/grant state
   and correlation/request IDs.
 - Authorization resolves actor/link state, grant candidates, canonical project,
@@ -78,6 +97,36 @@ review/compensation permissions beyond registered future definitions
 - The bootstrap system operation and default-human self permissions are the
   only usable candidates before grant tables ship.
 - Direct role/grant authorization outside this service is explicitly banned.
+- Reusable FastAPI and application-command dependencies accept one primary
+  registered action declaration. Domain invariants remain separate, and service
+  commands use fixed Workstream principals rather than serialized human tokens.
+- Catalogue completeness is staged: this chunk validates current usable
+  definitions but does not require loaders or route declarations owned by
+  inactive feature-cutover or later domain initiatives.
+- Reserved planned action metadata contains only stable `ActionId`, approved
+  `PermissionId`, owner, and availability; it never authorizes or predefines
+  another domain's target, facts, guards, or composer. Active definitions
+  require the owning domain contract, canonical composer, surface declaration,
+  and behavior tests.
+- `AuthorizationDecision`, bounded logs/metrics, and every action-based allowed
+  or denied authority event carry the stable `ActionId`. Migration `0021`
+  preserves historical nulls, establishes exact typed/PostgreSQL action-registry
+  parity, and requires a registered identifier for AUTH-07-or-later
+  action-based decision evidence. Upgrade/downgrade/re-upgrade, direct-SQL,
+  unknown-ID, and preserved-history tests pass.
+- The three authorization APIs introduced here have exact declarations:
+  permission and admin-role definition reads use `admin_role.read` against
+  `system` and expose only the authorized administrative metadata projection;
+  self authorization-context read uses `actor.profile.read_self` against the
+  current actor and returns active, currently authorized capabilities only.
+  Planned metadata never appears as an actor capability.
+- Generated OpenAPI/command manifest-delta tests prove every protected surface
+  introduced by this chunk has exactly one active `ActionId` declaration.
+- External denial precedence and concealment are an exact tested matrix. A
+  sensitive action declares its transaction linearization contract, including
+  ordered actor/link/grant/resource reload/locks or an explicitly approved
+  serializable retry strategy; each later mutation chunk proves its own
+  revoke-versus-command race.
 - `GET /api/v1/authorization/permissions` and
   `GET /api/v1/authorization/admin-role-definitions` return registered,
   non-dynamic definitions with authorization/privacy tests.
@@ -89,6 +138,13 @@ review/compensation permissions beyond registered future definitions
 
 ```bash
 (cd backend && .venv/bin/python -m ruff check app tests)
+(cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)
+(cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic downgrade -1)
+(cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_audit.py tests/test_alembic.py \
+  --cov=app.modules.authorization \
+  --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 python3 scripts/check_stale_workstream_wording.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-08-bootstrap-admin-grants.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-08-bootstrap-admin-grants.md
@@ -38,7 +38,7 @@ backend/app/api/router.py
 backend/app/db/models.py
 backend/scripts/bootstrap_access_administrator.py
 backend/app/modules/audit/**
-backend/alembic/versions/0019_*.py
+backend/alembic/versions/0022_*.py
 backend/tests/test_actors.py
 backend/tests/test_auth.py
 backend/tests/test_alembic.py
@@ -92,6 +92,11 @@ deleting revoked grants
   `GET /api/v1/actors/{actor_profile_id}/admin-role-grants`, and
   `POST /api/v1/admin-role-grants/{grant_id}/revoke` have
   allow/deny/scope/privacy/rate-limit/replay tests.
+- Each protected route and bootstrap command declares one active `ActionId`.
+  Reads map to `admin_role.read`; issue/bootstrap maps to `admin_role.grant`;
+  revoke maps to `admin_role.revoke`. Canonical scope resources and target-actor
+  guards are loaded independently, and generated manifest-delta tests prove
+  every surface introduced here has exactly one declaration.
 - Migration tests cover immutable revoked history, prior-head upgrade,
   downgrade, and preserved attribution.
 - Runbook assigns bootstrap custody, environment access, dry-run/evidence,
@@ -104,6 +109,9 @@ deleting revoked grants
 (cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic downgrade -1)
 (cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)
 (cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_actors.py \
+  --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 python3 scripts/check_stale_workstream_wording.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-09-actor-state-service-actors.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-09-actor-state-service-actors.md
@@ -77,6 +77,10 @@ product adapter bindings or callback endpoints
   actor identity-link read, identity-link revoke/reactivate, and service actor
   create/list/detail routes from the adopted contract have
   allow/deny/privacy/rate-limit/replay tests.
+- Every protected actor/link/service route declares one active `ActionId` mapped
+  to the existing actor profile, identity-link, or service-provision permission
+  and its canonically loaded target. Generated manifest-delta tests prove every
+  surface introduced here has exactly one declaration.
 - Suspension/link-revocation events explicitly require consuming lifecycle
   reconciliation; task assignment consumption belongs to chunk 13 and review
   lease consumption remains deferred to WS-REV-001.
@@ -85,6 +89,9 @@ product adapter bindings or callback endpoints
 
 ```bash
 (cd backend && .venv/bin/python -m ruff check app tests)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_actors.py \
+  --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 python3 scripts/check_stale_workstream_wording.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10-project-role-grants.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10-project-role-grants.md
@@ -39,7 +39,7 @@ backend/app/modules/projects/repository.py
 backend/app/api/router.py
 backend/app/db/models.py
 backend/app/modules/audit/**
-backend/alembic/versions/0020_*.py
+backend/alembic/versions/0023_*.py
 backend/tests/test_actors.py
 backend/tests/test_projects.py
 backend/tests/test_auth.py
@@ -98,6 +98,10 @@ project/task/checker authorization cutover
 - `POST/GET /api/v1/projects/{project_id}/role-grants`, grant detail, and grant
   revoke routes have multi-role, self-revoke, scope, privacy, rate-limit,
   replay, and negative tests.
+- Every protected grant/candidate route declares one active `ActionId` mapped to
+  `project.role_grant.read` or `project.role_grant.manage` against the
+  canonically loaded project/grant target. Generated manifest-delta tests prove
+  every surface introduced here has exactly one declaration.
 - Contributor-candidate lookup has covered-manager allow, uncovered/cross-
   project deny, pagination/count concealment, minimal-field, rate-limit, and
   inactive/non-human exclusion tests; no UUID must be recovered from logs or
@@ -113,6 +117,10 @@ project/task/checker authorization cutover
 (cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic downgrade -1)
 (cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)
 (cd backend && .venv/bin/python -m ruff check app tests)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_actors.py \
+  tests/test_projects.py --cov=app.modules.authorization \
+  --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 python3 scripts/check_stale_workstream_wording.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-11-project-read-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-11-project-read-cutover.md
@@ -69,6 +69,11 @@ token role fallback or authorization pagination after unfiltered counts
   Each role has exact-project allow, cross-project deny, minimal-field,
   concealed-not-found, and pre-filtered count/cursor tests.
 - Canonical project scope is resolved before filtering, counts, and cursors.
+- Every migrated project read/list route declares one primary registered action
+  and its canonical project or collection-parent target; permission strings and
+  secondary role policy do not live in the router.
+- Generated OpenAPI/command manifest-delta tests prove every protected project
+  read/list surface migrated here has exactly one active `ActionId` declaration.
 - ProjectRepository remains the canonical project/guide/source persistence
   query owner and returns domain records. The project application service or a
   feature-owned resource loader composes ResourceContext; persistence does not
@@ -82,6 +87,9 @@ token role fallback or authorization pagination after unfiltered counts
 
 ```bash
 (cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_projects.py \
+  --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 python3 scripts/check_stale_workstream_wording.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12-project-mutation-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12-project-mutation-cutover.md
@@ -37,7 +37,7 @@ backend/app/modules/projects/**
 backend/app/modules/authorization/**
 backend/app/api/deps/auth.py
 backend/app/workers/project_setup.py
-backend/alembic/versions/0021_*.py
+backend/alembic/versions/0024_*.py
 backend/tests/test_projects.py
 backend/tests/test_auth.py
 backend/tests/test_alembic.py
@@ -64,9 +64,18 @@ unscoped project-manager access or token role fallback
   only covered projects.
 - Project policy actions use registered permissions and transaction-local grant
   revalidation.
+- Every migrated project mutation and setup command declares one primary
+  registered action and authorizes against `system`, an existing project, or the
+  exact existing parent policy resource defined by the owning project model.
+  It does not collapse guide, source-snapshot, submission-policy, checker-policy,
+  review-policy, revision-policy, or payment-policy records into an invented
+  generic policy resource.
+- Generated OpenAPI/command manifest-delta tests prove every protected project
+  mutation/setup surface migrated here has exactly one active `ActionId`
+  declaration.
 - Approval provenance records matched local grant/actor/scope while preserving
   historical bootstrap provenance.
-- Migration `0021` adds matched local grant/scope provenance and ownership
+- Migration `0024` adds matched local grant/scope provenance and ownership
   constraints to project policy approval records without rewriting historical
   bootstrap values; prior-head upgrade, downgrade, and re-upgrade preserve
   readable history.
@@ -82,6 +91,9 @@ unscoped project-manager access or token role fallback
 (cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic downgrade -1)
 (cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)
 (cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_projects.py \
+  --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 python3 scripts/check_stale_workstream_wording.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-13-task-assignment-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-13-task-assignment-cutover.md
@@ -39,8 +39,9 @@ backend/app/modules/tasks/repository.py
 backend/app/modules/tasks/schemas.py
 backend/app/modules/tasks/models.py
 backend/app/modules/tasks/lifecycle.py
-backend/alembic/versions/0022_*.py
+backend/alembic/versions/0025_*.py
 backend/app/modules/authorization/**
+backend/app/modules/audit/**
 backend/app/api/deps/auth.py
 backend/app/workers/authority_reconciliation.py
 backend/app/workers/celery_app.py
@@ -74,11 +75,21 @@ token role or legacy active-worker-profile fallback
   authorization DTOs, and authorization does not duplicate task queries.
 - Submitter/both grant for the exact project is required for queue/claim/start,
   plus existing task availability, assignment, ownership, and state guards.
+- Every migrated task/assignment route or reconciliation command declares one
+  primary registered action against the canonically loaded project, task, or
+  assignment target. Feature-owned TaskRepository facts remain authoritative.
+- Generated OpenAPI/command manifest-delta tests prove every protected
+  task/assignment surface migrated here has exactly one active `ActionId`
+  declaration.
 - Administrative roles alone cannot claim contributor work.
 - Existing Project Manager task management remains project-scoped. The
   reasoned start override is separately authorized as
   `operations.task.start_override` for Operator recovery; matched permission,
   scope, reason, and audit event distinguish the two paths.
+- Before `operations.task.start_override` becomes active, migration `0025` and
+  the typed audit schema add that already approved identifier to the 49-item
+  AUTH-05A audit base. Upgrade/downgrade/re-upgrade and direct-SQL parity tests
+  preserve all prior audit rows and reject unknown identifiers.
 - Operator `operations.status.read` exposes a read-only cross-project task-queue
   operational projection with bounded fields; it does not grant task mutation.
   Audit Authority `audit.read` exposes only covered task evidence. Both paths
@@ -112,7 +123,7 @@ token role or legacy active-worker-profile fallback
   remains bounded only because chunk 14 still owns the final submission
   compatibility consumer; task queue/claim/start no longer depend on it.
 - The assignment persistence column, model/schema/service fields, response
-  contract, and new audit payload keys use `contributor_id`. Migration `0022`
+  contract, and new audit payload keys use `contributor_id`. Migration `0025`
   preserves every existing assignment owner, supports downgrade, and removes
   the legacy storage name without exposing a public compatibility alias.
 - Full backend suite and API contract drill pass.
@@ -126,6 +137,9 @@ token role or legacy active-worker-profile fallback
 
 ```bash
 (cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_tasks.py \
+  --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 (cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-14-submission-checker-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-14-submission-checker-cutover.md
@@ -41,8 +41,9 @@ backend/app/modules/checkers/**
 backend/app/modules/projects/schemas.py
 backend/app/modules/projects/service.py
 backend/app/adapters/project_agents/openai_agent_sdk.py
-backend/alembic/versions/0023_*.py
+backend/alembic/versions/0026_*.py
 backend/app/modules/authorization/**
+backend/app/modules/audit/**
 backend/app/api/deps/auth.py
 backend/tests/test_tasks.py
 backend/tests/test_checkers.py
@@ -70,11 +71,23 @@ legacy active-worker-profile or workflow-eligibility compatibility fallback
 
 - Exact-project submitter/both grant plus active assignment is required to
   create submissions; admin roles alone cannot submit.
+- Submission creation authorizes against its existing active assignment; every
+  migrated submission/checker/audit route declares one primary registered
+  action against a feature-owned canonical target and keeps artifact bytes and
+  unnecessary actor data outside `ResourceContext` and authority evidence.
+- Generated OpenAPI/command manifest-delta tests prove every protected
+  submission/checker/audit surface migrated here has exactly one active
+  `ActionId` declaration.
 - Manager repair/checker triggers require covered project permissions.
 - Project Manager repair uses covered `project.task.manage`; Operator recovery
   uses distinct `operations.submission_gate.repair` and
   `operations.checker.retry` permissions. Each path requires a reason and
   records matched grant/permission without granting general project authority.
+- Before `operations.submission_gate.repair` or `operations.checker.retry`
+  becomes active, migration `0026` and the typed audit schema add both already
+  approved identifiers to the 50-item post-AUTH-13 audit base. Upgrade,
+  downgrade, re-upgrade, and direct-SQL parity tests preserve earlier audit rows
+  and establish exact 52-identifier typed/PostgreSQL parity.
 - Contributor reads preserve ownership, hidden-result redaction, and concealed
   not-found behavior.
 - Audit reads expose only permission-appropriate bounded fields before counts.
@@ -93,7 +106,7 @@ legacy active-worker-profile or workflow-eligibility compatibility fallback
   `contributor_suggested_fix`, `contributor_evidence_refs`, and
   `contributor_visible` across persistence, models, schemas, services, runner
   contracts, audit payloads, and tests. Submission-policy JSON and derivation
-  contracts use `contributor_facing_fix`. Migration `0023` preserves all values,
+  contracts use `contributor_facing_fix`. Migration `0026` preserves all values,
   supports downgrade, and removes legacy storage/property names without public
   API aliases.
 - With the final consumer removed, the legacy `/api/v1/workers/me/profile`
@@ -115,6 +128,10 @@ legacy active-worker-profile or workflow-eligibility compatibility fallback
 
 ```bash
 (cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_tasks.py \
+  tests/test_checkers.py --cov=app.modules.authorization \
+  --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 (cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-15-worker-authority-removal.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-15-worker-authority-removal.md
@@ -72,6 +72,11 @@ review/contribution/compensation implementation
 ## Acceptance criteria
 
 - Internal jobs use fixed system principals and registered system permissions.
+- Every remaining asynchronous command declares one primary registered action,
+  canonical feature-owned target, and fixed service principal. Serialized human
+  identity is provenance only and never executable command authority.
+- Generated command-manifest delta tests prove every protected asynchronous
+  surface migrated here has exactly one active `ActionId` declaration.
 - Project setup is verification/removal-only here; its behavioral cutover
   remains owned by chunk 12.
 - Serialized requester context is evidence only; actor-attributed commits reload
@@ -97,6 +102,10 @@ review/contribution/compensation implementation
 python3 scripts/check_stale_authorization.py
 python3 scripts/test_agent_gates.py
 (cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_tasks.py \
+  tests/test_checkers.py --cov=app.modules.authorization \
+  --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 python3 scripts/check_stale_workstream_wording.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-16-evidence-live-proof.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-16-evidence-live-proof.md
@@ -74,6 +74,12 @@ starting WS-POL-002-03 automatically
 - Tokens, raw claims, JWKS bodies, secrets, and unnecessary PII are absent from
   logs, errors, audit, and committed evidence.
 - Table-driven tests cover every permission role/scope allow and deny case.
+- A generated conformance manifest covers every protected `/api/v1` route and
+  asynchronous command with exactly one primary registered action, canonical
+  resource type, and owning feature loader/composer. Unknown or missing
+  permissions, resources, guards, or declarations fail closed; the manifest is
+  evidence generated from the registry and surface declarations, not a second
+  policy source.
 - PostgreSQL tests cover provisioning, grant, final-admin, revocation/command,
   and idempotency races.
 - Live drill proves bootstrap, scoped admin grants, submitter/reviewer grants,
@@ -110,6 +116,10 @@ python3 scripts/check_stale_workstream_wording.py
 python3 scripts/check_markdown_links.py
 python3 scripts/check_internal_review_evidence.py
 (cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
+  tests/test_authorization.py tests/test_auth.py tests/test_actors.py \
+  tests/test_projects.py tests/test_tasks.py tests/test_checkers.py \
+  --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/auth_api_e2e.py)

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CAT-action-resource-catalogue-reconciliation.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CAT-action-resource-catalogue-reconciliation.md
@@ -1,0 +1,118 @@
+# Chunk Contract: WS-AUTH-001-CAT - Action And Resource Catalogue Reconciliation
+
+## Parent initiative
+
+`WS-AUTH-001` - Workstream Authorization Service
+
+## Goal
+
+Map the proposed action/resource catalogue against the adopted repository and
+carry forward only the safe, domain-aligned design rules into the canonical
+authorization specification and owning future chunk contracts.
+
+## Risk class
+
+L1 specification and authorization planning.
+
+## Allowed files
+
+```text
+docs/spec_authorization_service.md
+.agent-loop/LOOP_STATE.md
+.agent-loop/WORK_QUEUE.md
+.agent-loop/REVIEW_LOG.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/DECISIONS.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CAT-action-resource-catalogue-reconciliation.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-06-canonical-actor-profile.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-07-authorization-kernel.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-08-bootstrap-admin-grants.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-09-actor-state-service-actors.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10-project-role-grants.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-11-project-read-cutover.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12-project-mutation-cutover.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-13-task-assignment-cutover.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-14-submission-checker-cutover.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-15-worker-authority-removal.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-16-evidence-live-proof.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-internal-review-evidence.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-pr-trust-bundle.md
+```
+
+The local `canonical_auth.md` input is review material only and is not an
+allowed committed file.
+
+## Not allowed
+
+```text
+backend runtime, schema, migration, workflow, or CI changes
+permission additions, removals, aliases, or renames
+the archival `/v1` prefix or a new API alias
+new artifact, review, contribution, or compensation aggregates
+claiming the reviewed input has independent normative precedence
+starting AUTH-05B runtime implementation in this chunk
+```
+
+## Acceptance criteria
+
+- The 52 approved permission identifiers remain unchanged. This docs chunk does
+  not change AUTH-05A's current 49-identifier typed/PostgreSQL audit base; it
+  assigns additive parity for the three approved recovery identifiers to their
+  AUTH-13/14 activation chunks.
+- `/api/v1` remains the only canonical public API namespace.
+- The canonical spec adopts a closed typed action/resource registry, existing
+  parent targets for create operations, feature-owned resource composition,
+  fixed service authority, pre-count collection filtering, and route/command
+  conformance without redefining feature lifecycle behavior.
+- Resource contexts use closed typed variants; guard inputs are declared and
+  unknown, missing, extra, or mistyped facts fail closed.
+- Reserved planned action metadata contains stable `ActionId`, approved
+  `PermissionId`, owner, and availability; it cannot authorize or predefine a
+  foreign-domain target. Active definitions own one exact target and guard set;
+  multiple actions may map to one approved broad permission.
+- AUTH-07 assigns `ActionId` to decisions and bounded logs/metrics and plans
+  exact typed/PostgreSQL authority-evidence parity. Historical rows remain
+  readable; new action-based allowed/denied events require a registered ID.
+- AUTH-07 owns registry types and its own definitions, AUTH-07 through AUTH-15
+  own incremental surface activation and manifest-delta proof, and AUTH-16 owns
+  aggregate generated manifest proof.
+- WS-REV, WS-CON, and artifact-storage specifications retain their resource and
+  transition ownership.
+- AUTH-07 through AUTH-16 retain at least 90 percent authorization-subsystem
+  coverage; the repository-wide 78 percent baseline remains unchanged.
+- AUTH-05A retains migration `0018`, AUTH-05B solely owns `0019`, and the later
+  AUTH schema chunks use the non-conflicting `0020` through `0026` sequence.
+- The rejected root proposal is absent from the working tree and patch.
+
+## Verification commands
+
+```bash
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_internal_review_evidence.py
+git diff --check
+```
+
+## Required reviewers
+
+- senior engineering
+- QA/test
+- security/auth and privacy
+- product/ops
+- architecture
+- docs
+
+## Human review focus
+
+Review which proposed rules were adopted or rejected, preservation of the
+current permission/audit contract, staged ownership, and the absence of runtime
+or cross-domain invention.
+
+## Stop conditions
+
+Stop if adopting a rule requires a permission/migration change, invents a
+domain resource, or changes AUTH-05B runtime scope. Such work requires its own
+approved specification and chunk.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-external-review-response.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-external-review-response.md
@@ -1,0 +1,42 @@
+# External Review Response: WS-AUTH-001-CAT
+
+## Pull request
+
+PR #117 - Reconcile authorization action and resource catalogue
+
+## Comments addressed
+
+1. CodeRabbit correctly identified that `STATUS.md` described the persisted
+   audit constraint as 49 permissions without restating the 52 approved
+   identifiers. The text now distinguishes AUTH-05A's 49-identifier persisted
+   audit base from the 52 approved catalogue and names the three planned recovery
+   identifiers.
+2. CodeRabbit correctly identified a stale second-start requirement in the
+   lower `WORK_QUEUE.md` instructions. The queue now records that the AUTH-05B
+   start signal was received and that only CAT merge plus its post-merge
+   memory/stop checkpoint remain.
+
+## Comments deferred
+
+None.
+
+## Human decisions needed
+
+None. The repair preserves the already approved catalogue and lifecycle gates.
+
+## Commands rerun
+
+```text
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_loop_memory_state.py
+git diff --check
+```
+
+## Remaining risks
+
+None from these comments. AUTH-05B remains inactive until CAT merge and its
+post-merge memory/stop checkpoint.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-internal-review-evidence.md
@@ -13,13 +13,13 @@ valid findings addressed: yes
 
 ## Reviewed Revision
 
-Reviewed code SHA: `415202826759fd015fffff00448b086a1d16f919`
+Reviewed code SHA: `fdd1f3db353993bf489fda45b4c7c3ae8eef858c`
 
-Reviewed at: 2026-07-14T14:54:46Z
+Reviewed at: 2026-07-14T15:16:43Z
 
-Reviewer run IDs: senior-engineering-architecture-docs=WS-AUTH-001-CAT-ENG-20260714;
-qa-test=WS-AUTH-001-CAT-QA-20260714;
-security-auth-privacy-product-ops=WS-AUTH-001-CAT-SEC-20260714
+Reviewer run IDs: senior-engineering-architecture-docs=WS-AUTH-001-CAT-EXT-ENG-20260714;
+qa-test=WS-AUTH-001-CAT-EXT-QA-20260714;
+security-auth-privacy-product-ops=WS-AUTH-001-CAT-EXT-SEC-20260714
 
 ## Scope
 
@@ -83,6 +83,13 @@ Validated design material was retained only after repair:
 
 All reviewer sessions completed. No unresolved findings remain.
 
+## External repair confirmation
+
+The three required internal reviewer groups re-reviewed exact repair SHA
+`fdd1f3db353993bf489fda45b4c7c3ae8eef858c` and passed. External findings and
+their dispositions remain separately recorded in
+`WS-AUTH-001-CAT-external-review-response.md`.
+
 ## Deterministic evidence
 
 Passed:
@@ -92,6 +99,8 @@ python3 scripts/check_stale_workstream_wording.py
 python3 scripts/check_stale_authorization_docs.py
 python3 scripts/check_stale_artifact_contracts.py
 python3 scripts/check_markdown_links.py
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_loop_memory_state.py
 git diff --check
 ```
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-internal-review-evidence.md
@@ -1,0 +1,100 @@
+# Internal Review Evidence: WS-AUTH-001-CAT
+
+## Chunk
+
+`WS-AUTH-001-CAT` - Action And Resource Catalogue Reconciliation
+
+Primary affected implementation owner: `WS-AUTH-001-07`; later surface owners
+are `WS-AUTH-001-08` through `WS-AUTH-001-16` as recorded in the chunk map.
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: `415202826759fd015fffff00448b086a1d16f919`
+
+Reviewed at: 2026-07-14T14:54:46Z
+
+Reviewer run IDs: senior-engineering-architecture-docs=WS-AUTH-001-CAT-ENG-20260714;
+qa-test=WS-AUTH-001-CAT-QA-20260714;
+security-auth-privacy-product-ops=WS-AUTH-001-CAT-SEC-20260714
+
+## Scope
+
+Docs/specification-only reconciliation of the proposed action/resource catalogue
+against merged Workstream models, routes, audit constraints, domain ownership,
+and the approved AUTH chunk sequence. No runtime, migration, CI, dependency, or
+test file changed.
+
+## Initial review disposition
+
+The proposed root document failed review and was removed. It incorrectly claimed
+normative precedence, used `/v1`, replaced adopted permission identifiers,
+invented artifact/review/compensation resources, conflicted with the merged audit
+registry, and required all loaders before their domains exist.
+
+Validated design material was retained only after repair:
+
+- exact `ActionId` declarations map to approved `PermissionId` values;
+- multiple actions may use one retained broad permission with distinct targets;
+- feature-owned services compose closed typed resource contexts;
+- creates authorize against an existing parent or `system` target;
+- planned action metadata is non-executable and domain-neutral;
+- every route-owning chunk proves its manifest delta and 90 percent AUTH coverage;
+- AUTH-16 aggregates, rather than first discovers, surface coverage;
+- fixed service principals and pre-count filtering remain mandatory; and
+- action identity is carried in decisions, bounded telemetry, and audit evidence.
+
+## Findings repaired
+
+1. Distinguished 52 approved permission identifiers from AUTH-05A's current
+   49-identifier typed/PostgreSQL audit base. AUTH-13/14 own additive parity for
+   the three already-approved recovery identifiers before activation.
+2. Separated exact `ActionId` from `PermissionId`, allowing precise targets and
+   guards without an unapproved permission rename.
+3. Limited planned metadata to stable action/permission IDs, owner, and
+   availability; foreign-domain resource facts remain with their specifications.
+4. Added per-chunk manifest-delta proof and 90 percent authorization-subsystem
+   coverage requirements from AUTH-07 through AUTH-16.
+5. Required closed typed resource variants, exact concealment precedence, and an
+   explicit mutation/revocation linearization contract.
+6. Added `ActionId` to decision/evidence requirements under AUTH-07 migration
+   `0021`, including historical compatibility and exact typed/SQL registry proof.
+7. Reconciled migration custody: `0018` AUTH-05A, `0019` AUTH-05B, then
+   `0020` through `0026` for AUTH-06/07/08/10/12/13/14.
+8. Removed the rejected untracked root proposal to prevent accidental staging or
+   discovery as a second authority.
+9. Exact-SHA security review found a low-risk stale AUTH-05B start gate in the
+   durable state files. They now record the received signal and exact remaining
+   CAT merge/post-merge-memory prerequisites consistently.
+
+## Reviewer results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Dalton confirmed ActionId evidence and migration custody. |
+| qa/test | PASS | None | Locke confirmed manifest, coverage, audit parity, and migration proof allocation. |
+| security/auth | PASS after fixes | None | Sagan confirmed source removal, privacy, planned/active boundaries, and reconciled the AUTH-05B gate. |
+| product/ops | PASS | None | Sagan confirmed human/service and domain-lifecycle ownership. |
+| architecture | PASS | None | Dalton confirmed staged ownership and collision-free migrations. |
+| docs | PASS | None | Dalton confirmed canonical precedence and domain boundaries. |
+
+All reviewer sessions completed. No unresolved findings remain.
+
+## Deterministic evidence
+
+Passed:
+
+```text
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+No backend test suite was run because the patch contains only Markdown planning
+and specification changes. It adds future test/coverage requirements and does
+not modify tests, CI, dependencies, thresholds, skips, or exclusions.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-pr-trust-bundle.md
@@ -65,7 +65,11 @@ product/ops passed after all valid findings were repaired. Full details are in
 
 ## External Review
 
-Pending GitHub checks, CodeRabbit, and human review.
+Backend and Agent Gates passed. CodeRabbit raised two valid documentation
+consistency comments: preserve the 52-approved/49-persisted distinction and
+remove a stale second AUTH-05B start requirement. Both are repaired and recorded
+in `WS-AUTH-001-CAT-external-review-response.md`; CodeRabbit re-review and human
+review remain.
 
 ## Remaining Risks And Follow-Up
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CAT-pr-trust-bundle.md
@@ -1,0 +1,87 @@
+# PR Trust Bundle: WS-AUTH-001-CAT
+
+## Chunk
+
+`WS-AUTH-001-CAT` - Action And Resource Catalogue Reconciliation
+
+## Goal And Human-Approved Intent
+
+Review the proposed catalogue against the live repository, copy only validated
+rules into canonical docs and owning future chunks, reject incompatible content,
+then resume AUTH-05B after this docs-only amendment merges.
+
+## What Changed And Why
+
+- Added a staged typed `ActionId`/`PermissionId` model to the canonical AUTH spec.
+- Updated AUTH-07 through AUTH-16 contracts with exact ownership, conformance,
+  evidence, coverage, and audit-parity requirements.
+- Preserved 52 approved permission identifiers while recording the current
+  49-identifier persisted audit base and planned recovery transition.
+- Reconciled future AUTH migration custody through `0026`.
+- Recorded D15 and current loop state.
+- Removed the rejected root proposal instead of committing a competing authority.
+
+The change is needed because the input contained sound authorization mechanics
+but contradicted merged API, audit, model, and cross-domain contracts.
+
+## Design Chosen
+
+Routes and commands declare exact stable `ActionId` values. Each active action
+maps to one approved `PermissionId`, canonical target, typed resource facts, and
+guard set. Multiple actions may map to one retained broad permission. Planned
+metadata is non-executable and cannot predesign resources owned by WS-REV,
+WS-CON, or artifact storage. Feature services remain canonical resource owners.
+
+## Alternatives Rejected
+
+- Treating the input as a normative addendum.
+- Replacing broad permission identifiers without audit/schema migration.
+- Adding `/v1` or a compatibility route tree.
+- Centralizing feature queries inside AUTH.
+- Inventing artifact outbox/recovery or future review/compensation aggregates.
+- Deferring missing route declarations or coverage regressions until AUTH-16.
+- Recording only broad permission when exact action identity affects guards.
+
+## Scope And Product Behavior
+
+The patch changes Markdown only. It does not activate authorization, change an
+API, alter a permission, migrate data, modify product lifecycle behavior, or
+start AUTH-05B. Current runtime behavior remains unchanged.
+
+## Acceptance Proof And Checks
+
+All chunk acceptance criteria are reflected in the canonical spec, D15, and
+owning future chunk contracts. Stale wording, authorization-doc, artifact
+contract, Markdown-link, and diff-integrity checks pass.
+
+No tests were added, changed, removed, skipped, or weakened. No CI, dependency,
+coverage threshold, or configuration changed.
+
+## Reviewer Results
+
+Senior engineering, architecture, docs, QA/test, security/auth/privacy, and
+product/ops passed after all valid findings were repaired. Full details are in
+`WS-AUTH-001-CAT-internal-review-evidence.md`.
+
+## External Review
+
+Pending GitHub checks, CodeRabbit, and human review.
+
+## Remaining Risks And Follow-Up
+
+The catalogue is a future implementation contract, not runtime proof. AUTH-05B
+remains the next runtime chunk and is unaffected by this action catalogue.
+AUTH-07 must implement the registry/evidence design; route-owning chunks must
+prove activation incrementally; later domain initiatives require their own
+approved resources and permission migrations.
+
+## Human Review Focus
+
+Confirm the 52-approved/49-persisted distinction, `ActionId` evidence, domain
+ownership, planned/active boundary, per-chunk 90 percent coverage, and migration
+sequence. Confirm that no rejected catalogue content entered canonical docs.
+
+## Human Merge Ownership
+
+Only the user may explicitly approve and merge this PR. AUTH-05B begins only
+after this amendment merges and loop memory is current.

--- a/docs/spec_authorization_service.md
+++ b/docs/spec_authorization_service.md
@@ -174,8 +174,72 @@ audit.read
 audit.export
 ```
 
+These are 52 approved authorization identifiers. AUTH-05A's current typed and
+PostgreSQL audit registry accepts 49; the three approved Operator recovery
+identifiers `operations.task.start_override`,
+`operations.submission_gate.repair`, and `operations.checker.retry` are reserved
+planned metadata and cannot become active actions until AUTH-13/14 add matching
+typed/SQL audit parity with upgrade, downgrade, and preserved-history proof.
+
 Adding a permission requires a specification/ADR update and human approval.
 Routers cannot invent identifiers or evaluate grant unions.
+
+### Action And Resource Registration
+
+The permission catalog is consumed through a closed, typed action registry.
+Each active action definition has its own stable `ActionId` and binds one
+approved `PermissionId` to:
+
+- one canonical authorization target resource type;
+- the rule for resolving that target, including the existing parent or `system`
+  target used when the requested operation creates a new resource;
+- the allowed human or service principal class and authority-candidate sources;
+- registered global, resource, ownership, assignment, separation-of-duties, and
+  lifecycle guards; and
+- the closed, typed resource facts required by each guard; and
+- whether authority must be revalidated inside the committing transaction.
+
+Multiple closed actions may map to one approved broad permission while having
+different canonical targets and guards. For example, create and update actions
+may share an approved management permission but target an existing parent and
+an existing child respectively. Routes declare `ActionId`, never an arbitrary
+permission/target pair. Splitting a broad permission into new permission tokens
+still requires the separate approval and migration rule above.
+
+The registry does not own domain persistence or state transitions. Feature
+repositories return their domain records, and feature application services or
+feature-owned loaders compose the bounded `ResourceContext`. Loader
+implementations may be registered at the application composition root, but the
+authorization module must not duplicate feature queries or import a parallel
+resource repository. Resource contexts use closed per-resource variants rather
+than a free-form attribute bag. Registration rejects undeclared facts, and
+authorization fails closed when a required fact is absent or has the wrong
+type. Request bodies, query values, and path combinations remain untrusted
+hints; canonical parent, project, owner, assignment, and state facts come from
+PostgreSQL.
+
+Each protected FastAPI route and asynchronous command declares one primary
+registered action. That declaration selects the authorization target and
+mandatory guards; it does not replace domain invariants or permit a route-local
+secondary policy. Internal jobs declare fixed Workstream service authority and
+never serialize a human bearer token as executable authority. Collection
+actions authorize and filter against their canonical parent scope before
+counts, cursors, facets, or distinct values are computed.
+
+Registration and completeness are staged with the approved chunk map. Chunk 07
+introduces the types and registry. Reserved action metadata contains only the
+stable `ActionId`, approved `PermissionId`, owning specification/chunk, and
+`planned` availability; it is not executable and does not predefine a
+foreign-domain target, facts, or guards. Every route-owning chunk from 07
+through 15 may promote an action to active only when its owning domain contract,
+feature-owned resource composition, surface declaration, and behavior tests
+exist. Each such chunk generates a manifest-delta proof for every surface it
+migrates. Chunk 16 aggregates and verifies the complete route/command manifest
+rather than first discovering missing declarations there.
+Resources and transitions owned by WS-REV, WS-CON, or the artifact-storage
+specification are not invented by AUTH; their owning specification must first
+approve the resource facts and operation before a corresponding permission is
+added under the approval rule above.
 
 ## Authorization Algorithm
 
@@ -196,6 +260,15 @@ For every protected operation:
 
 Authorization decisions are request-scoped and are not cached across requests.
 List filtering occurs before counts and pagination cursors.
+
+`AuthorizationDecision` carries the stable `ActionId` in addition to permission,
+resource, scope, matched authority, and denial information. The action identifier
+is included in bounded logs/metrics and every action-based allowed or denied
+authority event emitted by AUTH-07 or a later chunk. AUTH-07 adds nullable
+historical storage and exact typed/SQL registry parity; legacy rows remain null,
+while new action-based decision events must contain a registered identifier. A
+new action identifier requires the same approved typed/PostgreSQL registry and
+migration treatment as a permission.
 
 ## Separation And Recovery Rules
 
@@ -261,6 +334,7 @@ Authority events are append-only and include, when applicable:
 - schema/event version;
 - request and correlation identifiers;
 - acting and target actor references;
+- registered action identifier for action-based decisions;
 - matched grant and permission;
 - exact project/resource reference;
 - required reason;
@@ -345,6 +419,17 @@ Each owning chunk must prove:
   contract drill;
 - no test skip, xfail, assertion weakening, dependency override, fabricated
   authorization context, or direct grant insertion as product proof.
+- every protected route and asynchronous command migrated by that chunk has one
+  primary registered action declaration, a canonical target derived through its
+  owning feature boundary, and allow/deny tests for its mandatory guards.
+
+Final chunk 16 proof includes a generated `/api/v1` route and asynchronous
+command manifest. It fails closed on an unknown permission or resource type, a
+duplicate or missing primary declaration, or an unregistered guard. The manifest
+is conformance evidence, not a second policy source.
+
+Each activating chunk must also prove its authorization-subsystem changes at or
+above 90 percent coverage and preserve the repository-wide 78 percent baseline.
 
 The final live drill must operate through supported APIs/commands without
 direct database authority edits.


### PR DESCRIPTION
# PR Trust Bundle: WS-AUTH-001-CAT

## Chunk

`WS-AUTH-001-CAT` - Action And Resource Catalogue Reconciliation

## Goal And Human-Approved Intent

Review the proposed catalogue against the live repository, copy only validated
rules into canonical docs and owning future chunks, reject incompatible content,
then resume AUTH-05B after this docs-only amendment merges.

## What Changed And Why

- Added a staged typed `ActionId`/`PermissionId` model to the canonical AUTH spec.
- Updated AUTH-07 through AUTH-16 contracts with exact ownership, conformance,
  evidence, coverage, and audit-parity requirements.
- Preserved 52 approved permission identifiers while recording the current
  49-identifier persisted audit base and planned recovery transition.
- Reconciled future AUTH migration custody through `0026`.
- Recorded D15 and current loop state.
- Removed the rejected root proposal instead of committing a competing authority.

The change is needed because the input contained sound authorization mechanics
but contradicted merged API, audit, model, and cross-domain contracts.

## Design Chosen

Routes and commands declare exact stable `ActionId` values. Each active action
maps to one approved `PermissionId`, canonical target, typed resource facts, and
guard set. Multiple actions may map to one retained broad permission. Planned
metadata is non-executable and cannot predesign resources owned by WS-REV,
WS-CON, or artifact storage. Feature services remain canonical resource owners.

## Alternatives Rejected

- Treating the input as a normative addendum.
- Replacing broad permission identifiers without audit/schema migration.
- Adding `/v1` or a compatibility route tree.
- Centralizing feature queries inside AUTH.
- Inventing artifact outbox/recovery or future review/compensation aggregates.
- Deferring missing route declarations or coverage regressions until AUTH-16.
- Recording only broad permission when exact action identity affects guards.

## Scope And Product Behavior

The patch changes Markdown only. It does not activate authorization, change an
API, alter a permission, migrate data, modify product lifecycle behavior, or
start AUTH-05B. Current runtime behavior remains unchanged.

## Acceptance Proof And Checks

All chunk acceptance criteria are reflected in the canonical spec, D15, and
owning future chunk contracts. Stale wording, authorization-doc, artifact
contract, Markdown-link, and diff-integrity checks pass.

No tests were added, changed, removed, skipped, or weakened. No CI, dependency,
coverage threshold, or configuration changed.

## Reviewer Results

Senior engineering, architecture, docs, QA/test, security/auth/privacy, and
product/ops passed after all valid findings were repaired. Full details are in
`WS-AUTH-001-CAT-internal-review-evidence.md`.

## External Review

Pending GitHub checks, CodeRabbit, and human review.

## Remaining Risks And Follow-Up

The catalogue is a future implementation contract, not runtime proof. AUTH-05B
remains the next runtime chunk and is unaffected by this action catalogue.
AUTH-07 must implement the registry/evidence design; route-owning chunks must
prove activation incrementally; later domain initiatives require their own
approved resources and permission migrations.

## Human Review Focus

Confirm the 52-approved/49-persisted distinction, `ActionId` evidence, domain
ownership, planned/active boundary, per-chunk 90 percent coverage, and migration
sequence. Confirm that no rejected catalogue content entered canonical docs.

## Human Merge Ownership

Only the user may explicitly approve and merge this PR. AUTH-05B begins only
after this amendment merges and loop memory is current.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the authorization model with typed action and resource registration, canonical targets, and fail-closed validation.
  * Documented stable action identifiers in authorization decisions, audit evidence, logs, and metrics.
  * Expanded conformance requirements for protected API routes and asynchronous commands.
  * Preserved the existing `/api/v1` namespace and approved permission identifiers.
  * Added reconciliation, review, sequencing, and verification guidance for upcoming authorization work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->