### PR TITLE
Enforce initiative-local loop memory gates

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -41,7 +41,7 @@
 Workstream engineering chunks move through:
 
 ```text
-Intent -> Discovery -> Plan -> Chunk Map -> Chunk Contract -> Implementation -> Evidence -> Internal Review -> PR -> Human Checkpoint -> Memory Update -> Stop
+Intent -> Discovery -> Plan -> Chunk Map -> Chunk Contract -> Implementation -> Evidence -> Internal Review -> PR -> Human Checkpoint -> Automated Merge Memory -> Stop
 ```
 
 The merged `WS-POL-001-03` chunk moved task readiness and submission creation

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -2,19 +2,19 @@
 
 ## Current State
 
-- Active initiative in this worktree: `WS-ART-001` - Immutable Artifact Storage
-- Active planning chunk: `WS-ART-001-OBJECT-STORAGE-AMENDMENT`
+- This authored file is reviewed planning/history context, not canonical live
+  post-merge state. Canonical state is the signed schema-v2 output on
+  `automation/loop-memory`.
+- Active initiative: none recorded here
+- Active planning chunk: none
 - Active implementation chunk: none
-- Branch: `codex/ws-art-001-object-storage-planning-amendment`
-- Worktree: `/home/abiorh/flow/workstream`
-- Latest integrated `main` merge commit: `ad71c7e` from PR #119.
-- Status: PR #120's branch integrates AUTH-05B PR #119 through merge SHA
-  `1545d9aa37329c13efa53f7ad9076ffca1fbfaf6`. The bounded three-file conflict
-  resolution passed deterministic proof and every required `gpt-5.5` high
-  reviewer track; all reviewer sessions are closed.
-- Current gate: publish the evidence-bound branch, wait for fresh GitHub checks
-  and external review, then stop for explicit human review and merge approval.
-  No storage runtime implementation is active.
+- PR #119 merged `WS-AUTH-001-05B` as `ad71c7e`.
+- PR #120 merged `WS-ART-001-OBJECT-STORAGE-AMENDMENT` as `4408256`.
+- PR #122 merged the first automated post-merge memory implementation as
+  `fc89fb6`; its schema-v1 cross-initiative next pointer is superseded by the
+  schema-v2 initiative-local clean cut.
+- Current gate: no product chunk is selected by this authored file. A human
+  must explicitly start one candidate after reading current signed state.
 - Scope checkpoint: AWS S3 is the only v0.1 production provider; MinIO is
   local/CI S3 protocol proof; LocalStorage is focused development/test; R2 and
   Flow Node are deferred. Product modules receive narrow artifact capabilities,
@@ -23,11 +23,11 @@
   including 21 artifact permissions. AUTH-07 registers them, AUTH-08 defines
   applicable Operator grants, AUTH-09 provisions fixed service principals, and
   each owning WS-ART feature chunk activates only its own canonical actions.
-- Next artifact chunk: `WS-ART-001-02A1` remains inactive until this amendment
-  merges and the user gives a separate explicit start signal.
+- Next artifact candidate: `WS-ART-001-02A1` remains inactive until the user
+  gives a separate explicit start signal.
 - Parallel authorization work: `WS-AUTH-001-05B` merged through PR #119 as
-  `ad71c7e`. `WS-AUTH-001-06` remains inactive pending post-merge memory and a
-  separate explicit user start.
+  `ad71c7e`. `WS-AUTH-001-06` remains inactive pending a separate explicit
+  user start.
 - Parallel coverage work: `WS-QUAL-001-01B2` remains paused. Its last official
   whole-app result is `6466/8159` statements (`79.249908%`); no replacement
   evidence exists.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -11,7 +11,7 @@ signed-snapshot replay, and malformed/symlinked branch-state denial. Fifty-five
 focused behavior tests pass; updater and independent-checker branch coverage are
 90.79 and 94.41 percent. Protected `main` now requires Agent Gates and Backend
 test and dismisses stale approvals; the generated branch blocks deletion and
-force-push. PR publication and external review remain pending.
+force-push. PR #122 subsequently passed external review and merged.
 
 ## 2026-07-14 - WS-ART-001 Object Storage Amendment Internal Review Passed
 
@@ -129,8 +129,8 @@ security/auth/privacy review after repair. Valid findings closed committed-row
 evidence injection, request/result target substitution, incomplete linked-event
 context, mismatch scope/resource semantics, rejected-value retention, and
 missing migration/operation behavior proof. The focused suite passed 26 tests
-at 96.88 percent authorization-subsystem coverage. PR publication and external
-checks remain pending; AUTH-06 is inactive.
+at 96.88 percent authorization-subsystem coverage. PR #119 subsequently passed
+external checks and merged; AUTH-06 remains inactive.
 
 ## 2026-07-14 - WS-AUTH-001-05B Repaired Plan Passed
 

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -2,19 +2,18 @@
 
 ## In Progress
 
-| Chunk | Title | Risk | Status |
-|---|---|---:|---|
-| `WS-ART-001-OBJECT-STORAGE-AMENDMENT` | AWS-First Object Storage Planning Amendment | L1 | Publication branch updated from `main`; merge-resolution review pending |
+None. This authored queue does not select a global next chunk; live post-merge
+state is read from signed `automation/loop-memory` output.
 
 ## Planned Next
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-AUTH-001-06` | Canonical Actor Profile And Identity Link | L1 | Inactive until AUTH-05B post-merge memory and a separate explicit user start |
+| `WS-AUTH-001-06` | Canonical Actor Profile And Identity Link | L1 | Inactive until a separate explicit user start |
 | `WS-QUAL-001-01B2` | Baseline Evidence And CI Ratchet | L1 | Paused for AUTH priority; no valid replacement baseline yet |
 | `WS-QUAL-001-02` | Project Service Coverage | L1 | Inactive until 01B2 merge/memory plus explicit user start |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending relevant authorization proof and a separate explicit user start |
-| `WS-ART-001-02A1` | External Service Adapter Foundation | L1 | Proposed only after amendment merge and explicit user start |
+| `WS-ART-001-02A1` | External Service Adapter Foundation | L1 | Inactive until a separate explicit user start |
 | `WS-ART-001-02A2` | Committed Source And Local Preparation | L1 | Inactive until 02A1 merge and explicit user start |
 | `WS-ART-001-02A3` | ArtifactStore v2 Local Clean Cut | L1 | Inactive until 02A2 merge and explicit user start |
 | `WS-ART-001-02B1` | S3-Compatible MinIO And AWS | L1 | Inactive until 02A3 merge and explicit user start |
@@ -66,6 +65,8 @@
 | `WS-AUTH-001-CAT` | Action And Resource Catalogue Reconciliation | L1 | Merged through PR #117 as `4c5d4fc` on 2026-07-14 |
 | `WS-AUTH-001-CAT-MEMORY` | Catalogue Post-Merge Memory | L1 | Merged through PR #118 as `eba7e2b` on 2026-07-14 |
 | `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Merged through PR #119 as `ad71c7e` on 2026-07-14 |
+| `WS-ART-001-OBJECT-STORAGE-AMENDMENT` | AWS-First Object Storage Planning Amendment | L1 | Merged through PR #120 as `4408256` on 2026-07-14 |
+| `WS-ENG-001-02` | Automated Post-Merge Memory | L1 | Merged through PR #122 as `fc89fb6`; schema-v1 output superseded by WS-ENG-001-03 |
 
 ## Proposed Next
 
@@ -76,9 +77,9 @@ Do not start AUTH-06 or POL-002-04 automatically.
 Coverage R10 merged through PR #108. Do not start 01B2, chunk 02, or another
 coverage implementation chunk from this worktree.
 
-`WS-ART-001-01` is merged. The parallel planning amendment makes AWS S3 the
-only v0.1 production provider. R2 and Flow Node are deferred. Do not start 02A1
-until the amendment merges and the user gives a separate explicit start signal.
+`WS-ART-001-01` and the AWS-first planning amendment are merged. R2 and Flow
+Node are deferred. Do not start 02A1 until the user gives a separate explicit
+start signal.
 
 Coverage work proceeds independently in its own worktree and is not owned by
 this AUTH queue update.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
@@ -6,8 +6,8 @@ Each chunk is one PR. No later chunk starts automatically.
 |---|---|---:|---|
 | `WS-ART-001-PLAN` | Original artifact planning. | L1 | Merged through PR #97 |
 | `WS-ART-001-01` | Artifact domain and LocalStorage v1 foundation. | L1 | Merged through PR #101 |
-| `WS-ART-001-OBJECT-STORAGE-AMENDMENT` | Make AWS S3 the v0.1 production provider with MinIO local/CI protocol proof; keep optional providers outside v0.1. | L1 | Active planning only |
-| `WS-ART-001-02A1` | Install only ADR 0014's small typed external-service adapter/factory foundation without migrating a capability. | L1 | Proposed after amendment merge and explicit start |
+| `WS-ART-001-OBJECT-STORAGE-AMENDMENT` | Make AWS S3 the v0.1 production provider with MinIO local/CI protocol proof; keep optional providers outside v0.1. | L1 | Merged through PR #120 as `4408256` |
+| `WS-ART-001-02A1` | Install only ADR 0014's small typed external-service adapter/factory foundation without migrating a capability. | L1 | Inactive until explicit user start |
 | `WS-ART-001-02A2` | Add bounded committed-source preparation and inactive scratch-cleanup mechanics without changing the active v1 port. | L1 | Proposed after 02A1 |
 | `WS-ART-001-02A3` | Replace ArtifactStore v1 with byte-only v2, activate API-startup and Celery Beat scratch cleanup, migrate schema/callers/factory, and remove `flow_node` in one atomic clean cut. | L1 | Proposed after 02A2 |
 | `WS-ART-001-02B1` | Implement the S3-compatible adapter, MinIO integration, and AWS S3 production profile. | L1 | Proposed after 02A3 |

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
@@ -2,8 +2,9 @@
 
 ## Current State
 
-Original planning merged through PR #97 and artifact/LocalStorage foundation
-merged through PR #101. No artifact implementation chunk is active.
+Original planning merged through PR #97, artifact/LocalStorage foundation
+merged through PR #101, and the AWS-first object-storage amendment merged
+through PR #120 as `4408256`. No artifact implementation chunk is active.
 
 The Flow Node-focused amendment candidate `6cc422d` passed deterministic checks
 but failed internal review on recovery/API completeness. Before repair, the user
@@ -22,39 +23,19 @@ approval or reusable evidence. Its source remains on branch
 
 ## Active Work
 
-`WS-ART-001-OBJECT-STORAGE-AMENDMENT` is planning-only. It updates intent,
-architecture, ADR/spec, chunk contracts, durable memory, and deterministic
-stale-contract protection. It does not edit runtime code, configure AWS S3,
-operate Flow Node, add a deferred provider, or activate artifact routes.
+None. `WS-ART-001-02A1` remains an inactive candidate requiring a separate
+explicit user start.
 
 ## Next Proposed Chunk
 
-`WS-ART-001-02A1` is proposed after this amendment merges and the user starts it
-explicitly. It installs only the shared typed external-service adapter/factory
-foundation. `02A2` adds committed-source preparation and narrows LocalStorage
-internals without changing the active port. `02A3` performs the atomic
+`WS-ART-001-02A1` is proposed only after the user starts it explicitly. It
+installs the shared typed external-service adapter/factory foundation. `02A2`
+adds committed-source preparation and narrows LocalStorage internals without
+changing the active port. `02A3` performs the atomic
 ArtifactStore v2/LocalStorage/schema cut and removes `flow_node`. `02B1` then
 owns MinIO and AWS S3. There is no active R2 chunk.
 
 ## Gate
 
-Merge SHA `1545d9aa37329c13efa53f7ad9076ffca1fbfaf6` received every
-required internal track after `main` advanced through AUTH-05B PR #119: senior
-engineering, architecture, QA/test, security/auth, product/ops, reuse/dedup, CI
-integrity, test delta, and docs. Valid evidence/status findings are closed in
-the permitted post-review files. Every reviewer used `gpt-5.5` with high
-reasoning and every reviewer session is closed.
-
-Deterministic proof passes: Ruff; stale artifact, authorization, and Workstream
-wording scans; loop-memory state; 75 changed Markdown links; diff hygiene; the
-runtime-scope guard; and 44 agent-gate regression tests in a PEP 668-safe,
-hash-pinned temporary environment.
-
-Evidence:
-
-- `reviews/WS-ART-001-OBJECT-STORAGE-AMENDMENT-internal-review-evidence.md`
-- `reviews/WS-ART-001-OBJECT-STORAGE-AMENDMENT-pr-trust-bundle.md`
-
-The current gate is external review and explicit human merge approval. GitHub
-checks and CodeRabbit remain separate from internal review. Do not merge without
-the user's approval, and do not start `WS-ART-001-02A1` automatically.
+PR #120 is merged. No later artifact chunk starts automatically. The next
+artifact event requires an explicit user start for `WS-ART-001-02A1`.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-OBJECT-STORAGE-AMENDMENT.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-OBJECT-STORAGE-AMENDMENT.md
@@ -1,6 +1,6 @@
-# Chunk Contract: WS-ART-001 Object Storage Planning Amendment
+# Chunk Contract: WS-ART-001-OBJECT-STORAGE-AMENDMENT - Object Storage Planning Amendment
 
-Initiative: `WS-ART-001` | Risk: L1 | Status: Active planning only
+Initiative: `WS-ART-001` | Risk: L1 | Status: Merged through PR #120
 
 ## Goal
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -21,7 +21,7 @@ stopped.
 | `WS-AUTH-001-05` | Authority Evidence And Idempotency Foundation | L1 | Split before implementation into 05A and 05B |
 | `WS-AUTH-001-05A` | Shared Audit Ownership And Append-Only Authority Evidence | L1 | Merged through PR #115 as `8e1cde6` |
 | `WS-AUTH-001-CAT` | Action And Resource Catalogue Reconciliation | L1 | Merged through PR #117 as `4c5d4fc` |
-| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Implemented and internally reviewed; PR publication pending |
+| `WS-AUTH-001-05B` | Authority Idempotency And Invalidation Foundation | L1 | Merged through PR #119 as `ad71c7e` |
 | `WS-AUTH-001-06` | Canonical Actor Profile And Identity Link | L1 | Proposed |
 | `WS-AUTH-001-07` | Authorization Kernel And Permission Registry | L1 | Proposed |
 | `WS-AUTH-001-08` | Bootstrap And Administrative Role Grants | L1 | Proposed |
@@ -115,6 +115,6 @@ the semantic AUTH-05A boundary. Required reviews and checks passed, and explicit
 human approval merged PR #115 as `8e1cde6` on 2026-07-14, followed by merged
 post-merge memory. `WS-AUTH-001-CAT` then merged through PR #117 as `4c5d4fc`
 after Backend, Agent Gates, CodeRabbit, and explicit human approval passed. The
-CAT post-merge memory merged through PR #118 as `eba7e2b`; AUTH-05B runtime SHA
-`e083890` is internally reviewed, and PR publication is pending. Do not start
-AUTH-06 or POL-002-04.
+CAT post-merge memory merged through PR #118 as `eba7e2b`; AUTH-05B then merged
+through PR #119 as `ad71c7e`. Do not start AUTH-06 or POL-002-04 without a
+separate explicit user start.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -109,7 +109,7 @@ AUTH-05A and CAT post-merge memory have no remaining blocker and are merged.
 The combined AUTH-05 contract
 was rejected before runtime changes because shared audit evidence and
 idempotency/invalidation were not reviewable as one L1 change. AUTH-05A owns
-migration `0018`; active AUTH-05B owns migration `0019`. Non-test
+migration `0018`; merged AUTH-05B owns migration `0019`. Non-test
 operators must later supply explicit classification evidence rather than
 inferred kinds before the owning canonical actor migration.
 
@@ -121,9 +121,8 @@ permission identifiers remain approved, including
 `operations.checker.retry`; the three recovery identifiers receive persisted
 parity only in their owning later chunks. `WS-AUTH-001-CAT` retains only safe
 registry/conformance rules. This is a scope decision, not an AUTH-05B runtime
-blocker. PR #118 is merged, and AUTH-05B runtime SHA `e083890` is internally
-reviewed. Its current gate is PR publication and external checks; AUTH-06 and
-POL-002-04 remain inactive.
+blocker. PR #118 and AUTH-05B PR #119 are merged. AUTH-06 and POL-002-04 remain
+inactive until an explicit human start.
 
 AUTH-04B review evidence and its PR trust bundle are recorded at
 `reviews/WS-AUTH-001-04B-internal-review-evidence.md` and

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -60,24 +60,21 @@ The user requested action/resource catalogue reconciliation before AUTH-05B.
 That docs-only work passed required internal reviews, Backend, Agent Gates, and
 CodeRabbit; explicit human approval merged PR #117 as `4c5d4fc` on 2026-07-14.
 Its post-merge memory merged through PR #118 as `eba7e2b`. AUTH-05B's repaired
-L1 plan passed before runtime edits. Implementation, repair, focused evidence,
-and all required internal review tracks now pass at reviewed runtime SHA
-`e083890`; PR publication is pending.
+L1 plan, implementation, repair, focused evidence, and required review tracks
+passed before explicit human approval merged PR #119 as `ad71c7e`.
 
 ## Active planning chunk
 
-None. AUTH-05B implementation is internally reviewed under its approved
-repaired contract.
+None. `WS-AUTH-001-06` remains an inactive candidate requiring a separate
+explicit user start.
 
 ## Active implementation chunk
 
-`WS-AUTH-001-05B` is implemented and internally reviewed. GitHub checks,
-CodeRabbit, and explicit human review remain pending.
+None.
 
 ## Current implementation branch
 
-`codex/ws-auth-001-05b-idempotency-invalidation` in
-`/home/abiorh/flow/workstream-authorization-service`.
+None recorded by this authored status file.
 
 ## Chunk status
 
@@ -93,7 +90,7 @@ CodeRabbit, and explicit human review remain pending.
 | `WS-AUTH-001-05` | Split | `codex/ws-auth-001-05-authority-evidence` | - | Parent split before implementation into 05A and 05B. |
 | `WS-AUTH-001-05A` | Merged | `codex/ws-auth-001-05-authority-evidence` | #115 | Merged as `8e1cde6`; reviewed code `ea16fd8`; final branch head `d023952`. |
 | `WS-AUTH-001-CAT` | Merged | `codex/ws-auth-001-action-catalogue-reconciliation` | #117 | Merged as `4c5d4fc`; final branch head `5b4ec96`. |
-| `WS-AUTH-001-05B` | In review | `codex/ws-auth-001-05b-idempotency-invalidation` | - | Reviewed runtime SHA `e083890`; PR publication pending. |
+| `WS-AUTH-001-05B` | Merged | `codex/ws-auth-001-05b-idempotency-invalidation` | #119 | Merged as `ad71c7e`; reviewed runtime SHA `e083890`. |
 | `WS-AUTH-001-06` | Proposed | - | - | Canonical actor profile and identity link. |
 | `WS-AUTH-001-07` | Proposed | - | - | Authorization kernel and permissions. |
 | `WS-AUTH-001-08` | Proposed | - | - | Bootstrap and administrative grants. |

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/CHUNK_MAP.md
@@ -5,7 +5,8 @@
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
 | `WS-ENG-001-01` | Codex-native zero-trust loop bootstrap | L1 | Merged through PR #23 as `b9fe19b` |
-| `WS-ENG-001-02` | Automated Post-Merge Memory | L1 | Internally reviewed; PR evidence/publication pending |
+| `WS-ENG-001-02` | Automated Post-Merge Memory | L1 | Merged through PR #122 as `fc89fb6` |
+| `WS-ENG-001-03` | Initiative-Local Loop Gates | L1 | Corrective schema-v2 clean cut; completion recorded by signed automation |
 
 ## Future Work
 

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/DECISIONS.md
@@ -21,6 +21,11 @@
 - Authenticate all generated state with an Actions-only Ed25519 key and a
   reviewed public key because organization policy disables deploy-key writer
   restriction for the automation branch.
+- Scope a non-null merge-intent successor to the completed chunk's own
+  initiative. Cross-initiative priority remains in human-owned planning and
+  cannot be asserted by immutable post-merge metadata.
+- Reject schema v1 everywhere and start the replacement signed ledger from the
+  `WS-ENG-001-03` schema-v2 merge intent.
 
 ## Deferred
 

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/RISKS.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/RISKS.md
@@ -13,7 +13,7 @@
 | Concurrent merges race and overwrite state | High | Serialize workflow runs, enforce monotonic merge timestamps, reject conflicting duplicate SHAs, and keep an append-only ledger. |
 | Missing PR metadata forces intent inference | High | Agent Gates requires one newly added strict merge-intent JSON file; updater reloads its reviewed head blob and fails closed on missing, modified, duplicate, malformed, or inconsistent metadata. |
 | A required check is missing or failed despite merge | High | Record observed conclusions and mark generated integrity as attention required; never report missing evidence as passed. |
-| Automation permissions or transient GitHub failure prevent update | Medium | Preserve idempotent trusted-default-branch `repository_dispatch` replay by exact merge SHA; do not hand-edit generated state. |
+| Automation permissions or transient GitHub failure prevent update | Medium | Preserve idempotent trusted-default-branch `repository_dispatch` replay bound to the current protected-main SHA; do not hand-edit generated state. |
 | Generated branch is edited manually | High | Declare workflow-only ownership, validate JSON/render/ledger agreement, and reject conflicting replay state. |
 | One initiative declares another initiative's next lifecycle gate | High | Schema v2 requires a non-null next chunk to share the completed initiative prefix; global priority remains human-owned. |
 | Invalid schema-v1 state contaminates the corrected ledger | Critical | Reject it completely, clear only fixed generated paths, and bootstrap schema v2 from WS-ENG-001-03. |

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/RISKS.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/RISKS.md
@@ -15,3 +15,5 @@
 | A required check is missing or failed despite merge | High | Record observed conclusions and mark generated integrity as attention required; never report missing evidence as passed. |
 | Automation permissions or transient GitHub failure prevent update | Medium | Preserve idempotent trusted-default-branch `repository_dispatch` replay by exact merge SHA; do not hand-edit generated state. |
 | Generated branch is edited manually | High | Declare workflow-only ownership, validate JSON/render/ledger agreement, and reject conflicting replay state. |
+| One initiative declares another initiative's next lifecycle gate | High | Schema v2 requires a non-null next chunk to share the completed initiative prefix; global priority remains human-owned. |
+| Invalid schema-v1 state contaminates the corrected ledger | Critical | Reject it completely, clear only fixed generated paths, and bootstrap schema v2 from WS-ENG-001-03. |

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/STATUS.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/STATUS.md
@@ -3,26 +3,21 @@
 ## Current
 
 - `WS-ENG-001-01`: merged through PR #23 on 2026-06-20; complete
-- `WS-ENG-001-02`: implementation complete and all required internal reviewer
-  tracks passed; ready PR #122 is in external and human review
-- Merge commit: `b9fe19b96109e9786e1d6d89488abfbe68a05d4a`
-- Reviewed implementation SHA: `8670005639b5d080d3adceca840b8fae4addc115`
-- Reviewed integrated SHA: `501890305167223fd50d42484adc75c6fae99bd2`
-- Current gate: complete external checks and explicit human review for PR #122
-- Next chunk: inactive
+- `WS-ENG-001-02`: merged through PR #122 as `fc89fb6`; complete
+- `WS-ENG-001-03`: corrective schema-v2 contract for initiative-local next gates
+- Current gate: canonical completion is recorded only by signed post-merge state
+- Product runtime: unchanged
 
 ## Last Update
 
-The automated memory implementation reconciles from an immutable bootstrap,
-binds lifecycle intent to reviewed-head JSON, authenticates canonical state with
-Ed25519, rejects stale signed snapshots against protected `main`, and rebuilds
-malformed or hostile branch state. Sixty-three focused behavior tests pass;
-updater and independent-checker branch coverage are 90.79 and 94.41 percent.
-Live `main` protection now requires Agent Gates and Backend test with stale
-approval dismissal. The generated branch blocks deletion and force-push.
+The first live generated state proved signing, protected-main freshness, and
+workflow isolation, but exposed that schema v1 allowed `WS-ENG-001-02` to name
+`WS-AUTH-001-06` as a global next chunk. The corrective chunk makes successor
+authority initiative-local, rejects schema v1 without compatibility, and
+rebootstraps generated state at schema v2. No artifact, authorization, or other
+Workstream product runtime is active in this engineering chunk.
 
 ## Next Required Event
 
-Merge only PR #122 after its external checks pass and the user explicitly
-approves that specific PR. Do not start another engineering or product chunk
-automatically.
+Do not select a product chunk from this authored file. Read verified signed
+post-merge state, then require a separate explicit user start.

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/chunks/WS-ENG-001-03-initiative-local-loop-gates.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/chunks/WS-ENG-001-03-initiative-local-loop-gates.md
@@ -1,0 +1,219 @@
+# Chunk Contract: WS-ENG-001-03 - Initiative-Local Loop Gates
+
+## Parent Initiative
+
+`WS-ENG-001` - Codex Zero-Trust Loop Bootstrap
+
+## Goal
+
+Correct automated post-merge memory so a merge intent may name only the next
+chunk in its own initiative. Reconcile stale authored loop state on `main` and
+cleanly rebootstrap signed schema-v2 state from this corrective chunk.
+
+## Human-Approved Intent
+
+The user explicitly approved an end-to-end correction after the first live
+generated state exposed a cross-initiative next pointer from `WS-ENG-001-02` to
+`WS-AUTH-001-06`. Parallel initiative priority remains a human-owned work-queue
+decision; one merged chunk must not declare lifecycle authority for another
+initiative.
+
+## Risk Class
+
+L1 - CI, signed engineering memory, and lifecycle authority infrastructure.
+
+## Work Type
+
+Architecture, CI, bug, test, docs, and engineering-process maintenance.
+
+## Allowed Files
+
+```text
+AGENTS.md
+.agents/skills/memory-update/SKILL.md
+.agent-loop/LOOP_STATE.md
+.agent-loop/WORK_QUEUE.md
+.agent-loop/REVIEW_LOG.md
+.agent-loop/policies/repository-engineering-policy.md
+.agent-loop/templates/PR_TRUST_BUNDLE.md
+.agent-loop/merge-intents/WS-ENG-001-03.json
+.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/CHUNK_MAP.md
+.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/DECISIONS.md
+.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/RISKS.md
+.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/STATUS.md
+.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/chunks/WS-ENG-001-03-initiative-local-loop-gates.md
+.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/reviews/WS-ENG-001-03-*.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
+.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
+.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-OBJECT-STORAGE-AMENDMENT.md
+.github/pull_request_template.md
+.github/workflows/agent-gates.yml
+.github/workflows/loop-memory.yml
+docs/operations_post_merge_memory.md
+scripts/update_post_merge_memory.py
+scripts/check_loop_memory_state.py
+scripts/test_agent_gates.py
+```
+
+## Not Allowed
+
+```text
+backend/**
+frontend/**
+database schema or migrations
+Workstream product lifecycle behavior
+authentication or authorization runtime behavior
+artifact storage runtime behavior
+dependency changes
+coverage threshold reductions
+lint, test, evidence, approval, or branch-protection weakening
+direct automated writes to main
+general schema-v1 compatibility paths
+manual edits to automation/loop-memory
+```
+
+## Design Chosen
+
+- Future merge intents use schema version 2.
+- `chunk_id` and non-null `next_chunk_id` must both belong to
+  `initiative_id`.
+- A null next chunk is valid and means that the completed initiative declares
+  no successor. Global or parallel priority remains outside the merge intent.
+- Schema v1 is rejected everywhere. There is no compatibility parser,
+  normalizer, alias, or migration path.
+- Existing signed schema-v1 generated state is intentionally invalid under the
+  new validator. The trusted workflow clears only fixed generated paths and
+  starts a new schema-v2 ledger at this corrective chunk's immutable merge
+  intent, then reconciles later protected-main commits.
+- Generator and independent checker both validate completed-chunk and gate
+  agreement, initiative ownership, schema, rendering, and ledger history.
+- Agent Gates require each non-null successor to resolve to exactly one
+  same-initiative chunk contract whose heading matches both successor ID and
+  title. Post-merge collection rechecks the same reviewed-head contract.
+- Trusted-main workflow execution resolves current protected `main` after
+  checkout. A stale explicit replay target fails closed; a queued push event
+  may reconcile forward only when its event SHA is an ancestor of current
+  protected `main`.
+- Authored `main` loop files are planning and historical context. Canonical
+  post-merge state remains the verified signed state on
+  `automation/loop-memory`; authored files must not retain merged PRs as active.
+
+## Alternatives Rejected
+
+- Keep one global `next_chunk_id`: rejected because parallel initiatives make
+  it ambiguous and allow one initiative to claim another's lifecycle gate.
+- Store a list of global next chunks in merge intent: rejected because global
+  prioritization is mutable human planning, not immutable merged-chunk fact.
+- Migrate or normalize PR #122 schema-v1 state: rejected because the generated
+  ledger contains only one invalid entry and retaining it would add permanent
+  compatibility logic without product value.
+- Hand-edit signed state: rejected because generated branch ownership and
+  signature provenance must remain intact.
+
+## Acceptance Criteria
+
+- [ ] New schema-v2 merge intents reject a cross-initiative `next_chunk_id`.
+- [ ] Same-initiative and null next gates parse, persist, render, sign, verify,
+      and replay deterministically.
+- [ ] Every schema-v1 intent, state, ledger entry, and signature domain is
+      rejected without migration or normalization.
+- [ ] Existing signed schema-v1 state is rejected, only fixed generated files
+      are cleared, and this chunk becomes the unique schema-v2 bootstrap.
+- [ ] Generator and independent checker reject cross-initiative or mismatched
+      next gates in live state and any ledger record.
+- [ ] Workflow structural tests preserve trusted-main execution, fixed branch
+      writes, freshness verification, and absence of bypass controls.
+- [ ] A stale `repository_dispatch` target fails closed even when generated
+      state is missing or invalid; a queued push target may only reconcile
+      forward to the current protected-main SHA.
+- [ ] Authored loop, initiative, and queue records no longer claim PR #119,
+      PR #120, or PR #122 are pending or active.
+- [ ] `WS-AUTH-001-06` and `WS-ART-001-02A1` remain separate inactive
+      candidates requiring explicit human start; neither is selected globally
+      by this engineering merge intent.
+- [ ] Changed loop-memory scripts retain at least 90 percent branch coverage.
+- [ ] Regression coverage starts from signed schema-v1 state containing the
+      invalid cross-initiative successor, proves only fixed generated paths are
+      cleared, starts from this schema-v2 bootstrap, verifies protected-main
+      freshness, and passes the independent state checker.
+- [ ] Regression coverage rejects cross-initiative successors in both live
+      state and every ledger record, and rejects stale PR #119/#120/#122
+      pending or active claims while preserving AUTH-06 and ART-02A1 as
+      separate inactive candidates.
+- [ ] Forward-looking documentation and templates use schema v2; schema v1 is
+      mentioned only as rejected historical state.
+- [ ] No Workstream product behavior, runtime, dependency, or gate threshold
+      changes.
+
+## Verification Commands
+
+```bash
+python3 -m py_compile scripts/update_post_merge_memory.py scripts/check_loop_memory_state.py scripts/test_agent_gates.py
+python3 scripts/test_agent_gates.py
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m coverage run --branch --source=scripts -m pytest -q scripts/test_agent_gates.py
+python3 -m coverage report -m --include='scripts/update_post_merge_memory.py' --fail-under=90
+python3 -m coverage report -m --include='scripts/check_loop_memory_state.py' --fail-under=90
+python3 scripts/update_post_merge_memory.py validate-merge-intent --base-ref origin/main
+python3 scripts/check_loop_memory_state.py
+python3 scripts/check_loop_memory_state.py --state-root <rebuilt-schema-v2-state>
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+python3 scripts/workstream_agent_gate.py --base origin/main --head HEAD --format markdown
+git diff --check
+```
+
+## Required Reviewers
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- CI integrity
+- docs
+- reuse/dedup
+- test delta
+
+## Human Review Focus
+
+- Cross-initiative next pointers fail before merge and during generated-state
+  validation.
+- Schema v1 has no executable acceptance path.
+- A same-initiative successor must exist at the reviewed head and its contract
+  heading must match the merge-intent ID and title.
+- A hostile or stale signed state rebuild cannot bypass protected-main
+  freshness or signature checks.
+- Global priority remains human-owned and is not inferred from the last merge.
+- No product runtime or existing engineering gate is weakened.
+
+## Stop Conditions
+
+- Rebuild requires editing historical authority or generated state by hand.
+- Any proposed implementation path would accept schema-v1 input.
+- The workflow would execute pull-request-head code with write credentials.
+- The change requires a product runtime, dependency, or coverage-threshold
+  modification.
+- The same blocking defect remains after two repair cycles.
+
+## Required Regression Tests
+
+- schema-v2 same-initiative successor accepted;
+- schema-v2 null successor accepted and rendered without a selected next chunk;
+- schema-v2 cross-initiative, missing-contract, duplicate-contract, and
+  title-mismatched successors rejected;
+- every schema-v1 intent and generated-state form rejected;
+- signed schema-v1 state rejected, fixed paths cleared, this chunk used as the
+  unique schema-v2 bootstrap, re-signed, freshness-verified, and accepted by
+  the independent checker;
+- cross-initiative live-state and historical-ledger records rejected;
+- stale dispatch target rejected with both valid and invalid existing state;
+- queued push event reconciles only to current protected `main`;
+- workflow step order, trusted checkout, freshness binding, fixed push target,
+  and absence of bypass controls validated structurally;
+- stale authored-main claims for PR #119, PR #120, and PR #122 rejected while
+  inactive AUTH-06 and ART-02A1 planning remains valid.

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/chunks/WS-ENG-001-03-initiative-local-loop-gates.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/chunks/WS-ENG-001-03-initiative-local-loop-gates.md
@@ -90,8 +90,9 @@ manual edits to automation/loop-memory
 - Generator and independent checker both validate completed-chunk and gate
   agreement, initiative ownership, schema, rendering, and ledger history.
 - Agent Gates require each non-null successor to resolve to exactly one
-  same-initiative chunk contract whose heading matches both successor ID and
-  title. Post-merge collection rechecks the same reviewed-head contract.
+  chunk contract under the declared initiative directory whose canonical
+  heading matches both successor ID and title. Post-merge collection rechecks
+  the same reviewed-head contract.
 - Trusted-main workflow execution resolves current protected `main` after
   checkout. A stale explicit replay target fails closed; a queued push event
   may reconcile forward only when its event SHA is an ancestor of current
@@ -115,6 +116,8 @@ manual edits to automation/loop-memory
 ## Acceptance Criteria
 
 - [ ] New schema-v2 merge intents reject a cross-initiative `next_chunk_id`.
+- [ ] A successor contract under any other initiative directory is rejected,
+      even when its filename and heading claim the expected successor ID.
 - [ ] Same-initiative and null next gates parse, persist, render, sign, verify,
       and replay deterministically.
 - [ ] Every schema-v1 intent, state, ledger entry, and signature domain is
@@ -204,8 +207,9 @@ git diff --check
 
 - schema-v2 same-initiative successor accepted;
 - schema-v2 null successor accepted and rendered without a selected next chunk;
-- schema-v2 cross-initiative, missing-contract, duplicate-contract, and
-  title-mismatched successors rejected;
+- schema-v2 cross-initiative, wrong-directory, non-canonical-heading,
+  missing-contract, duplicate-contract, and title-mismatched successors
+  rejected;
 - every schema-v1 intent and generated-state form rejected;
 - signed schema-v1 state rejected, fixed paths cleared, this chunk used as the
   unique schema-v2 bootstrap, re-signed, freshness-verified, and accepted by

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/chunks/WS-ENG-001-03-initiative-local-loop-gates.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/chunks/WS-ENG-001-03-initiative-local-loop-gates.md
@@ -90,9 +90,10 @@ manual edits to automation/loop-memory
 - Generator and independent checker both validate completed-chunk and gate
   agreement, initiative ownership, schema, rendering, and ledger history.
 - Agent Gates require each non-null successor to resolve to exactly one
-  chunk contract under the declared initiative directory whose canonical
-  heading matches both successor ID and title. Post-merge collection rechecks
-  the same reviewed-head contract.
+  chunk contract under the unique existing directory for the declared
+  initiative whose canonical heading matches both successor ID and title.
+  A second same-prefix initiative directory fails closed. Post-merge
+  collection rechecks the same reviewed-head directory and contract.
 - Trusted-main workflow execution resolves current protected `main` after
   checkout. A stale explicit replay target fails closed; a queued push event
   may reconcile forward only when its event SHA is an ancestor of current
@@ -118,6 +119,8 @@ manual edits to automation/loop-memory
 - [ ] New schema-v2 merge intents reject a cross-initiative `next_chunk_id`.
 - [ ] A successor contract under any other initiative directory is rejected,
       even when its filename and heading claim the expected successor ID.
+- [ ] Zero or multiple same-prefix directories for the declared initiative
+      fail before successor lookup.
 - [ ] Same-initiative and null next gates parse, persist, render, sign, verify,
       and replay deterministically.
 - [ ] Every schema-v1 intent, state, ledger entry, and signature domain is

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/reviews/WS-ENG-001-03-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/reviews/WS-ENG-001-03-internal-review-evidence.md
@@ -1,0 +1,70 @@
+# Internal Review Evidence: WS-ENG-001-03
+
+Open sub-agent sessions: none
+
+Valid findings addressed: yes
+
+Reviewed code SHA: `27302401f5bcb1134241808b5f9afa57fa4ab1ad`
+
+Reviewed at: 2026-07-15T05:33:58Z
+
+Reviewer run IDs: senior-engineering=`019f643a-c271-7e00-ac73-9d4763fb7d17`; QA/test=`019f643a-c717-7992-8dca-c964d3050bbc`; security/auth=`019f643a-cb81-7000-af4a-db2a54e2cb57`; product/ops=`019f643a-d18f-7541-922d-a84a9d1b68c9`; architecture=`019f643a-d7ff-7eb1-a091-481a2c8924b2`; CI-integrity=`019f643a-e18d-7f63-853a-b1ee1ef827d1`; docs=`019f643f-4a84-7d63-9919-404f3715b805`; reuse/dedup=`019f6440-44dc-7613-b512-1f5ef5b8b12b`; test-delta=`019f6440-4a9e-7140-8152-b12ce2fb3555`
+
+## Binding
+
+- Base: `fc89fb688689d9bc8b95811d43ec460b22f753ab`
+- Final reviewed implementation: `27302401f5bcb1134241808b5f9afa57fa4ab1ad`
+- Contract: `WS-ENG-001-03 Initiative-Local Loop Gates`
+- Scope: 23 files changed; no Workstream product runtime or dependency change
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Exact schema, successor, replay, signing, and workflow boundaries passed. |
+| QA/test | PASS | None | Deterministic suite and 94 percent branch coverage passed. |
+| security/auth | PASS | None | Trusted-main binding and step-scoped token/signing material passed. |
+| product/ops | PASS | None | No Workstream product lifecycle, role, payment, or reputation behavior changed. |
+| architecture | PASS | None | Engineering-loop scope and independent-checker boundary passed. |
+| CI integrity | PASS | None | No gate, threshold, checkout, or fixed-branch write weakening found. |
+| docs | PASS | None | Schema-v2, current-main, template, and authored-state wording passed. |
+| reuse/dedup | PASS | None | No compatibility path, forked convention, or missed helper reuse found. |
+| test delta | PASS | None | 71-test delta contains no skips or weakening and covers every required boundary. |
+
+## Findings Repaired
+
+- Required exact integer schema version `2`; float, string, boolean, and v1
+  values now fail independently in generator and checker paths.
+- Made local and reviewed-head successor discovery Markdown-only and rejected a
+  matching chunk contract under every foreign initiative directory.
+- Bound both PR templates to an identical schema-v2 merge-intent paragraph.
+- Removed stale present-tense publication claims for merged PR #119 and PR #122
+  and added deterministic stale-state guards.
+- Added full null-successor persistence, idempotent replay, render, sign,
+  expected-main verification, and independent-checker proof.
+- Added isolated rejection proof for schema-v1 ledger envelopes and the old
+  schema-v1 signature domain against otherwise valid schema-v2 state.
+
+## Deterministic Evidence
+
+```text
+scripts/test_agent_gates.py: 71 passed
+scripts/update_post_merge_memory.py branch coverage: 94%
+scripts/check_loop_memory_state.py branch coverage: 94%
+merge-intent validation: passed
+loop-memory state validation: passed
+stale Workstream/auth/artifact scans: passed
+Markdown links: passed for 18 changed Markdown files
+git diff --check: passed
+```
+
+The static sensor reports `REVIEW_REQUIRED` because this is an approved L1
+workflow and lifecycle-authority change. That routing result is satisfied by
+the nine completed reviewer tracks above; it is not a bypass or failed check.
+
+## Scope Integrity
+
+No backend, frontend, database, authentication runtime, authorization runtime,
+artifact runtime, payment, reputation, dependency, or coverage-threshold file
+changed. Schema v1 remains rejection-only history with no compatibility parser,
+normalizer, alias, fallback, or migration path.

--- a/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/reviews/WS-ENG-001-03-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ENG-001-codex-zero-trust-loop-bootstrap/reviews/WS-ENG-001-03-pr-trust-bundle.md
@@ -1,0 +1,83 @@
+# PR Trust Bundle: WS-ENG-001-03
+
+## Chunk
+
+`WS-ENG-001-03` - Initiative-Local Loop Gates
+
+Merge intent: `.agent-loop/merge-intents/WS-ENG-001-03.json`
+
+## Goal
+
+Prevent one merged initiative from selecting another initiative's next chunk,
+make schema-v2 generated memory fail closed, and bind replay to current
+protected `main` without changing Workstream product behavior.
+
+## Human-Approved Intent
+
+The user approved an end-to-end correction after the first live generated state
+exposed a cross-initiative next pointer. Global initiative priority remains a
+human decision; this merge intent records a null successor.
+
+## What Changed
+
+- Added strict schema-v2 intent, record, ledger, rendering, and signature-domain
+  validation with no schema-v1 compatibility path.
+- Bound non-null successors to one canonical same-initiative Markdown contract
+  and reject every foreign matching contract locally and at reviewed head.
+- Bound replay to current protected `main`, with stale dispatch rejection and
+  first-parent-only queued-push reconciliation.
+- Scoped workflow credentials and signing material, preserved a fixed generated
+  branch target, and reconciled stale authored state for merged PRs.
+- Added 71 deterministic gate tests and exact PR-template contract parity.
+
+## Scope Control
+
+Only approved engineering-loop, workflow, policy, template, script, test, and
+documentation files changed. No product runtime, database, dependency, or gate
+threshold changed.
+
+## Product Behavior
+
+- [x] No Workstream product behavior changed.
+
+## Evidence
+
+- Internal evidence: `WS-ENG-001-03-internal-review-evidence.md`
+- 71 agent-gate tests passed.
+- Both changed loop-memory modules have 94 percent branch coverage.
+- Merge-intent, stale-state, stale-wording, auth-doc, artifact-contract,
+  Markdown-link, compilation, and diff checks passed.
+
+## Internal Reviewer Results
+
+All required senior engineering, QA/test, security/auth, product/ops,
+architecture, CI integrity, docs, reuse/dedup, and test-delta tracks passed on
+reviewed SHA `27302401f5bcb1134241808b5f9afa57fa4ab1ad`. Every reviewer session
+is closed and every valid prior finding is repaired.
+
+## External Review
+
+GitHub Actions and CodeRabbit are pending PR publication. Their results belong
+in a separate external-review response; they do not replace internal evidence.
+
+## Remaining Risks
+
+The first schema-v2 post-merge workflow execution occurs only after this PR is
+merged. The workflow fails closed on stale targets, malformed state, signature
+failure, missing checks, ambiguous successor contracts, or unexpected history.
+
+## Human Review Focus
+
+- Confirm a merge intent cannot select a chunk from another initiative.
+- Confirm schema v1 has no executable acceptance or migration path.
+- Confirm only trusted `main` workflow code receives write/signing capability.
+- Confirm the workflow writes only signed state to `automation/loop-memory`.
+- Confirm AUTH-06 and ART-02A1 remain inactive until separate explicit starts.
+
+## Human Merge Ownership
+
+- [ ] I can explain what changed.
+- [ ] I can explain why it changed.
+- [ ] I know what could break.
+- [ ] I accept the remaining risks.
+- [ ] I explicitly approve this specific PR for merge.

--- a/.agent-loop/merge-intents/WS-ENG-001-03.json
+++ b/.agent-loop/merge-intents/WS-ENG-001-03.json
@@ -1,0 +1,9 @@
+{
+  "chunk_id": "WS-ENG-001-03",
+  "chunk_title": "Initiative-Local Loop Gates",
+  "initiative_id": "WS-ENG-001",
+  "next_chunk_id": null,
+  "next_chunk_title": null,
+  "next_requires_explicit_start": true,
+  "schema_version": 2
+}

--- a/.agent-loop/templates/PR_TRUST_BUNDLE.md
+++ b/.agent-loop/templates/PR_TRUST_BUNDLE.md
@@ -9,9 +9,10 @@ in sync with this template.
 
 Merge intent: `.agent-loop/merge-intents/<CHUNK_ID>.json`
 
-Add exactly one new merge-intent file in this PR. It must contain the chunk,
-title, next chunk or JSON `null`, and explicit-start requirement. Trusted
-post-merge automation reads that immutable file from the reviewed final head.
+Add exactly one new schema-v2 merge-intent file in this PR. It must contain the
+chunk, title, same-initiative next chunk or JSON `null`, and explicit-start
+requirement. Trusted post-merge automation reads that immutable file from the
+reviewed final head. A merge intent never prioritizes another initiative.
 
 ## Goal
 

--- a/.agents/skills/memory-update/SKILL.md
+++ b/.agents/skills/memory-update/SKILL.md
@@ -11,8 +11,13 @@ generated state after merge.
 ## Before Merge
 
 - Add one `.agent-loop/merge-intents/<chunk-id>.json` file to the reviewed PR.
+- Use merge-intent schema version 2.
 - Record the initiative, completed chunk, title, next chunk or `null`, and
   whether the next chunk requires a separate explicit start.
+- A non-null next chunk must belong to the same initiative and match exactly
+  one existing chunk contract ID and title. Use `null` when this initiative has
+  no declared successor; never use merge intent to prioritize another
+  initiative.
 - Keep implementation/specification memory in the owning PR where it can be
   reviewed with the change.
 
@@ -59,5 +64,6 @@ automation succeeds.
   `automation/loop-memory`, only when written by the trusted workflow, and only
   while its public-key signature verifies.
 - If automation fails, send the documented `loop-memory-replay`
-  `repository_dispatch` with the exact merge SHA after correcting permissions.
+  `repository_dispatch` with the current protected-main SHA after correcting
+  permissions. Stale replay targets fail closed.
   Merge-intent content is immutable after merge; do not edit generated state.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,9 +9,10 @@ in sync when the trust-bundle structure changes.
 
 Merge intent: `.agent-loop/merge-intents/<chunk-id>.json`
 
-Add exactly one new merge-intent file in this PR. It must contain the chunk,
-title, next chunk or JSON `null`, and explicit-start requirement. Post-merge
-automation reads that immutable file from the reviewed final head.
+Add exactly one new schema-v2 merge-intent file in this PR. It must contain the
+chunk, title, same-initiative next chunk or JSON `null`, and explicit-start
+requirement. Post-merge automation reads that immutable file from the reviewed
+final head. A merge intent never prioritizes another initiative.
 
 ## Goal
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,8 +11,8 @@ Merge intent: `.agent-loop/merge-intents/<chunk-id>.json`
 
 Add exactly one new schema-v2 merge-intent file in this PR. It must contain the
 chunk, title, same-initiative next chunk or JSON `null`, and explicit-start
-requirement. Post-merge automation reads that immutable file from the reviewed
-final head. A merge intent never prioritizes another initiative.
+requirement. Trusted post-merge automation reads that immutable file from the
+reviewed final head. A merge intent never prioritizes another initiative.
 
 ## Goal
 

--- a/.github/workflows/loop-memory.yml
+++ b/.github/workflows/loop-memory.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       EVENT_NAME: ${{ github.event_name }}
-      EVENT_SHA: ${{ github.event_name == 'push' && github.sha || github.event.client_payload.merge_sha }}
+      EVENT_SHA: ${{ github.event_name == 'push' && github.sha || github.event.client_payload.target_sha }}
       STATE_BRANCH: automation/loop-memory
 
     steps:

--- a/.github/workflows/loop-memory.yml
+++ b/.github/workflows/loop-memory.yml
@@ -64,14 +64,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          LOOP_MEMORY_SIGNING_KEY: ${{ secrets.LOOP_MEMORY_SIGNING_KEY }}
         run: |
           set -euo pipefail
           gh auth setup-git
-          private_key="${RUNNER_TEMP}/loop-memory-signing-key.pem"
-          printf '%s\n' "${LOOP_MEMORY_SIGNING_KEY}" > "${private_key}"
-          chmod 600 "${private_key}"
-          echo "LOOP_MEMORY_PRIVATE_KEY=${private_key}" >> "${GITHUB_ENV}"
           state_dir="${RUNNER_TEMP}/loop-memory-state"
           if git ls-remote --exit-code --heads origin "refs/heads/${STATE_BRANCH}" >/dev/null; then
             git clone --depth 1 --single-branch --branch "${STATE_BRANCH}" \
@@ -124,12 +119,18 @@ jobs:
 
       - name: Validate generated state
         shell: bash
+        env:
+          LOOP_MEMORY_SIGNING_KEY: ${{ secrets.LOOP_MEMORY_SIGNING_KEY }}
         run: |
           set -euo pipefail
           state_dir="${{ steps.state.outputs.state_dir }}"
+          private_key="${RUNNER_TEMP}/loop-memory-signing-key.pem"
+          trap 'rm -f "${private_key}"' EXIT
+          printf '%s\n' "${LOOP_MEMORY_SIGNING_KEY}" > "${private_key}"
+          chmod 600 "${private_key}"
           python3 scripts/update_post_merge_memory.py sign-state \
             --state-root "${state_dir}" \
-            --private-key "${LOOP_MEMORY_PRIVATE_KEY}"
+            --private-key "${private_key}"
           python3 scripts/update_post_merge_memory.py verify-state \
             --state-root "${state_dir}" \
             --public-key .agent-loop/keys/loop-memory-signing-public.pem \

--- a/.github/workflows/loop-memory.yml
+++ b/.github/workflows/loop-memory.yml
@@ -24,7 +24,8 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       GITHUB_TOKEN: ${{ github.token }}
-      MERGE_SHA: ${{ github.event_name == 'push' && github.sha || github.event.client_payload.merge_sha }}
+      EVENT_NAME: ${{ github.event_name }}
+      EVENT_SHA: ${{ github.event_name == 'push' && github.sha || github.event.client_payload.merge_sha }}
       STATE_BRANCH: automation/loop-memory
 
     steps:
@@ -32,6 +33,30 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: main
+
+      - name: Resolve trusted protected-main target
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${EVENT_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid event SHA." >&2
+            exit 1
+          fi
+          git fetch --no-tags origin \
+            "+refs/heads/main:refs/remotes/origin/main"
+          target_sha=$(git rev-parse --verify refs/remotes/origin/main)
+          if [[ ! "${target_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Cannot resolve protected main." >&2
+            exit 1
+          fi
+          target_sha=$(python3 scripts/update_post_merge_memory.py resolve-target \
+            --repository-root . \
+            --event-name "${EVENT_NAME}" \
+            --event-sha "${EVENT_SHA}" \
+            --current-main-sha "${target_sha}")
+          git checkout --detach "${target_sha}"
+          echo "TARGET_SHA=${target_sha}" >> "${GITHUB_ENV}"
 
       - name: Prepare generated state branch
         id: state
@@ -65,8 +90,8 @@ jobs:
         run: |
           set -euo pipefail
           state_dir="${{ steps.state.outputs.state_dir }}"
-          if [[ ! "${MERGE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Invalid merge SHA." >&2
+          if [[ ! "${TARGET_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid protected-main target SHA." >&2
             exit 1
           fi
           current_sha=""
@@ -79,7 +104,7 @@ jobs:
           plan_args=(
             plan-commits
             --repository-root .
-            --target-sha "${MERGE_SHA}"
+            --target-sha "${TARGET_SHA}"
           )
           if [[ -n "${current_sha}" ]]; then
             plan_args+=(--current-sha "${current_sha}")
@@ -104,7 +129,9 @@ jobs:
           python3 scripts/update_post_merge_memory.py verify-state \
             --state-root "${state_dir}" \
             --public-key .agent-loop/keys/loop-memory-signing-public.pem \
-            --expected-main-sha "${MERGE_SHA}"
+            --expected-main-sha "${TARGET_SHA}"
+          python3 scripts/check_loop_memory_state.py \
+            --state-root "${state_dir}"
 
       - name: Commit generated state branch
         shell: bash

--- a/.github/workflows/loop-memory.yml
+++ b/.github/workflows/loop-memory.yml
@@ -22,8 +22,6 @@ jobs:
   loop-memory:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
-      GITHUB_TOKEN: ${{ github.token }}
       EVENT_NAME: ${{ github.event_name }}
       EVENT_SHA: ${{ github.event_name == 'push' && github.sha || github.event.client_payload.merge_sha }}
       STATE_BRANCH: automation/loop-memory
@@ -37,12 +35,15 @@ jobs:
 
       - name: Resolve trusted protected-main target
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           if [[ ! "${EVENT_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Invalid event SHA." >&2
             exit 1
           fi
+          gh auth setup-git
           git fetch --no-tags origin \
             "+refs/heads/main:refs/remotes/origin/main"
           target_sha=$(git rev-parse --verify refs/remotes/origin/main)
@@ -62,6 +63,7 @@ jobs:
         id: state
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           LOOP_MEMORY_SIGNING_KEY: ${{ secrets.LOOP_MEMORY_SIGNING_KEY }}
         run: |
           set -euo pipefail
@@ -87,6 +89,8 @@ jobs:
 
       - name: Reconcile every unrecorded main commit
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           state_dir="${{ steps.state.outputs.state_dir }}"
@@ -135,6 +139,8 @@ jobs:
 
       - name: Commit generated state branch
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           state_dir="${{ steps.state.outputs.state_dir }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ Workstream is how Flow measures, certifies, and coordinates useful human-agent w
 - Every non-trivial task starts with the smallest applicable loop artifact: an initiative plan for large work, or a chunk contract for bounded work.
 - Do not implement a chunk until its allowed files, not-allowed changes, acceptance criteria, risk class, verification commands, and required reviewers are explicit.
 - Do not begin the next chunk automatically after finishing the current chunk.
+- Merge-intent schema v2 may name only a successor in the same initiative. Use
+  a null successor when no same-initiative chunk is declared; cross-initiative
+  priority remains a human-owned work-queue decision.
 - Every implementation or specification chunk must receive internal sub-agent review before external PR review is treated as sufficient.
 - Generated commits on `automation/loop-memory` are deterministic process output, not implementation or specification chunks. They do not require reviewer fanout, a second human approval, or a PR. This exception does not apply to `main`, workflow code, generator code, policies, or hand-edited memory.
 - Required internal reviewer tracks are senior engineering, QA/test, security/auth, and product/ops unless the chunk is explicitly unrelated to that track.

--- a/docs/operations_post_merge_memory.md
+++ b/docs/operations_post_merge_memory.md
@@ -90,7 +90,7 @@ error, replay trusted default-branch automation with:
 ```bash
 gh api --method POST repos/Flow-Research/workstream/dispatches \
   -f event_type=loop-memory-replay \
-  -F client_payload[merge_sha]="$(git rev-parse origin/main)"
+  -F client_payload[target_sha]="$(git rev-parse origin/main)"
 ```
 
 `repository_dispatch` always selects the workflow from the default branch;

--- a/docs/operations_post_merge_memory.md
+++ b/docs/operations_post_merge_memory.md
@@ -33,7 +33,7 @@ Every PR adds exactly one immutable file at
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "initiative_id": "WS-AUTH-001",
   "chunk_id": "WS-AUTH-001-06",
   "chunk_title": "Canonical Actor Profile And Identity Link",
@@ -44,9 +44,13 @@ Every PR adds exactly one immutable file at
 ```
 
 Agent Gates rejects missing, modified, duplicate, malformed, unknown-key,
-mismatched path/chunk, or incomplete next-chunk metadata before merge. The
-post-merge updater fetches this exact added file from the reviewed final head;
-PR-body edits cannot substitute lifecycle authority.
+mismatched path/chunk, or incomplete next-chunk metadata before merge. A
+non-null next chunk must belong to the same initiative and resolve to exactly
+one chunk contract whose heading has the same ID and title. A null value means
+the initiative declares no successor; it never selects another initiative.
+The post-merge updater fetches this exact added file and the referenced
+successor contract from the reviewed final head. PR-body edits cannot
+substitute lifecycle authority.
 
 The protected `main` branch requires `agent-gates` and Backend `test`, and it
 dismisses stale approvals after a new push. A changed intent therefore needs
@@ -55,10 +59,12 @@ fresh checks and human review before merge.
 ## Normal Operation
 
 1. The manager reviews and merges the normal PR.
-2. `Loop Memory` resolves every unrecorded first-parent commit through the
-   protected-main SHA. On first use, the immutable `WS-ENG-001-02` merge intent
-   anchors the activation commit; later runs start from the canonical ledger
-   tail. Canceled or out-of-order events therefore cannot lose a merge.
+2. `Loop Memory` resolves the current protected-main SHA before reading or
+   clearing generated state. The immutable `WS-ENG-001-03` schema-v2 merge
+   intent anchors the replacement ledger; later runs start from its canonical
+   tail. A queued push may reconcile forward only when its event SHA is an
+   ancestor of current protected `main`. A replay must name current protected
+   `main` exactly.
 3. The updater validates the committed merge intent and records observed
    Backend, Agent Gates, and CodeRabbit conclusions from each final PR head.
 4. The workflow commits generated files directly to `automation/loop-memory`.
@@ -84,14 +90,17 @@ error, replay trusted default-branch automation with:
 ```bash
 gh api --method POST repos/Flow-Research/workstream/dispatches \
   -f event_type=loop-memory-replay \
-  -F client_payload[merge_sha]=<40-character-merged-main-sha>
+  -F client_payload[merge_sha]="$(git rev-parse origin/main)"
 ```
 
 `repository_dispatch` always selects the workflow from the default branch;
-callers cannot choose feature-branch workflow code for the write token. Replays
-are idempotent and reconcile skipped intermediate commits. Invalid immutable
-intent requires an explicit corrective engineering PR; generated files must
-not be edited by hand.
+callers cannot choose feature-branch workflow code for the write token. Stale
+replay SHAs fail closed before generated state is inspected. Replays are
+idempotent and reconcile skipped intermediate commits. Schema-v1 generated
+state and signatures are rejected and the four fixed generated paths are
+cleared before the schema-v2 bootstrap; no schema-v1 intent is parsed or
+normalized. Invalid immutable schema-v2 intent requires an explicit corrective
+engineering PR; generated files must not be edited by hand.
 
 ## Review Policy
 

--- a/scripts/check_loop_memory_state.py
+++ b/scripts/check_loop_memory_state.py
@@ -87,6 +87,13 @@ FORBIDDEN_PATTERNS = (
         re.compile(r"PR #122[^\n]*(?:pending|active)", re.IGNORECASE),
         "PR #122 is merged; it cannot remain pending or active",
     ),
+    (
+        re.compile(
+            r"PR publication and external (?:review|checks) remain pending",
+            re.IGNORECASE,
+        ),
+        "merged authored state cannot retain a pending publication claim",
+    ),
 )
 GENERATED_FILES = (
     ".agent-loop/STATE.json",

--- a/scripts/check_loop_memory_state.py
+++ b/scripts/check_loop_memory_state.py
@@ -21,6 +21,12 @@ INITIATIVE_STATUS_FILES = tuple(
     str(path.relative_to(ROOT))
     for path in (ROOT / ".agent-loop/initiatives").glob("*/STATUS.md")
 )
+STATUS_BEARING_CONTRACT_FILES = (
+    (
+        ".agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/"
+        "WS-ART-001-OBJECT-STORAGE-AMENDMENT.md"
+    ),
+)
 FORBIDDEN_PATTERNS = (
     (re.compile(r"PR #\d+ open", re.IGNORECASE), "merged main cannot list an open PR"),
     (
@@ -72,8 +78,8 @@ FORBIDDEN_PATTERNS = (
     ),
     (
         re.compile(
-            r"`WS-ART-001-OBJECT-STORAGE-AMENDMENT`[^\n]*Active planning",
-            re.IGNORECASE,
+            r"WS-ART-001-OBJECT-STORAGE-AMENDMENT.{0,200}Active planning",
+            re.IGNORECASE | re.DOTALL,
         ),
         "PR #120 is merged; the artifact amendment cannot remain active",
     ),
@@ -99,6 +105,7 @@ def checked_paths() -> list[Path]:
     """Return loop memory paths that must not contain pre-merge state."""
     paths = [ROOT / path for path in CHECKED_FILES]
     paths.extend(ROOT / path for path in INITIATIVE_STATUS_FILES)
+    paths.extend(ROOT / path for path in STATUS_BEARING_CONTRACT_FILES)
     return paths
 
 

--- a/scripts/check_loop_memory_state.py
+++ b/scripts/check_loop_memory_state.py
@@ -56,6 +56,13 @@ FORBIDDEN_PATTERNS = (
         "PR #119 is merged; AUTH-05B publication cannot remain pending",
     ),
     (
+        re.compile(
+            r"AUTH-05B.{0,300}(?:current gate is\s+PR publication|external checks)",
+            re.IGNORECASE | re.DOTALL,
+        ),
+        "PR #119 is merged; AUTH-05B cannot remain at publication or external checks",
+    ),
+    (
         re.compile(r"`WS-AUTH-001-05B`\s*\|\s*In review", re.IGNORECASE),
         "PR #119 is merged; AUTH-05B cannot remain in review",
     ),
@@ -95,6 +102,16 @@ def checked_paths() -> list[Path]:
     return paths
 
 
+def _is_bounded_single_line(value: object, maximum: int) -> bool:
+    """Return whether one value is a bounded non-empty single-line string."""
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip()
+    return bool(normalized) and len(normalized) <= maximum and not any(
+        ord(char) < 32 for char in normalized
+    )
+
+
 def _metadata_failures(metadata: object, label: str) -> list[str]:
     """Independently validate one completed-chunk metadata object."""
     expected = {
@@ -124,9 +141,7 @@ def _metadata_failures(metadata: object, label: str) -> list[str]:
         or not chunk_id.startswith(f"{initiative_id}-")
     ):
         failures.append(f"{label}: completed chunk does not belong to initiative")
-    if not isinstance(metadata.get("chunk_title"), str) or not metadata.get(
-        "chunk_title"
-    ):
+    if not _is_bounded_single_line(metadata.get("chunk_title"), 160):
         failures.append(f"{label}: invalid completed chunk title")
     if (next_chunk_id is None) != (next_chunk_title is None):
         failures.append(f"{label}: incomplete next chunk metadata")
@@ -137,8 +152,8 @@ def _metadata_failures(metadata: object, label: str) -> list[str]:
         or not next_chunk_id.startswith(f"{initiative_id}-")
     ):
         failures.append(f"{label}: next chunk does not belong to initiative")
-    if next_chunk_title is not None and (
-        not isinstance(next_chunk_title, str) or not next_chunk_title
+    if next_chunk_title is not None and not _is_bounded_single_line(
+        next_chunk_title, 160
     ):
         failures.append(f"{label}: invalid next chunk title")
     if not isinstance(metadata.get("next_requires_explicit_start"), bool):
@@ -203,12 +218,7 @@ def _record_failures(record: object, label: str) -> list[str]:
         failures.append(f"{label}: invalid source pr_url")
     for field, maximum in (("pr_title", 240), ("head_ref", 240), ("merged_by", 160)):
         value = source.get(field)
-        if (
-            not isinstance(value, str)
-            or not value.strip()
-            or len(value.strip()) > maximum
-            or any(ord(char) < 32 for char in value.strip())
-        ):
+        if not _is_bounded_single_line(value, maximum):
             failures.append(f"{label}: invalid source {field}")
     merged_at = source.get("merged_at")
     try:

--- a/scripts/check_loop_memory_state.py
+++ b/scripts/check_loop_memory_state.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import re
 import sys
+from datetime import datetime
 from pathlib import Path
 
 
@@ -50,12 +51,41 @@ FORBIDDEN_PATTERNS = (
         ),
         "merged main cannot keep a completed chunk in active In progress state",
     ),
+    (
+        re.compile(r"AUTH-05B[^\n]*publication is pending", re.IGNORECASE),
+        "PR #119 is merged; AUTH-05B publication cannot remain pending",
+    ),
+    (
+        re.compile(r"`WS-AUTH-001-05B`\s*\|\s*In review", re.IGNORECASE),
+        "PR #119 is merged; AUTH-05B cannot remain in review",
+    ),
+    (
+        re.compile(r"PR #120's branch", re.IGNORECASE),
+        "PR #120 is merged; its branch cannot remain active state",
+    ),
+    (
+        re.compile(
+            r"`WS-ART-001-OBJECT-STORAGE-AMENDMENT`[^\n]*Active planning",
+            re.IGNORECASE,
+        ),
+        "PR #120 is merged; the artifact amendment cannot remain active",
+    ),
+    (
+        re.compile(r"PR #122[^\n]*(?:pending|active)", re.IGNORECASE),
+        "PR #122 is merged; it cannot remain pending or active",
+    ),
 )
 GENERATED_FILES = (
     ".agent-loop/STATE.json",
     ".agent-loop/LOOP_STATE.md",
     ".agent-loop/MERGE_LOG.jsonl",
 )
+SCHEMA_VERSION = 2
+STATE_BRANCH = "automation/loop-memory"
+REQUIRED_CHECKS = ("agent-gates", "test", "CodeRabbit")
+ID_PATTERN = re.compile(r"^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+$")
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 def checked_paths() -> list[Path]:
@@ -63,6 +93,254 @@ def checked_paths() -> list[Path]:
     paths = [ROOT / path for path in CHECKED_FILES]
     paths.extend(ROOT / path for path in INITIATIVE_STATUS_FILES)
     return paths
+
+
+def _metadata_failures(metadata: object, label: str) -> list[str]:
+    """Independently validate one completed-chunk metadata object."""
+    expected = {
+        "schema_version",
+        "initiative_id",
+        "chunk_id",
+        "chunk_title",
+        "next_chunk_id",
+        "next_chunk_title",
+        "next_requires_explicit_start",
+    }
+    if not isinstance(metadata, dict) or set(metadata) != expected:
+        return [f"{label}: invalid completed-chunk schema"]
+    failures: list[str] = []
+    if metadata.get("schema_version") != SCHEMA_VERSION:
+        failures.append(f"{label}: unsupported completed-chunk schema version")
+    initiative_id = metadata.get("initiative_id")
+    chunk_id = metadata.get("chunk_id")
+    next_chunk_id = metadata.get("next_chunk_id")
+    next_chunk_title = metadata.get("next_chunk_title")
+    if not isinstance(initiative_id, str) or not ID_PATTERN.fullmatch(initiative_id):
+        failures.append(f"{label}: invalid initiative id")
+    if (
+        not isinstance(chunk_id, str)
+        or not ID_PATTERN.fullmatch(chunk_id)
+        or not isinstance(initiative_id, str)
+        or not chunk_id.startswith(f"{initiative_id}-")
+    ):
+        failures.append(f"{label}: completed chunk does not belong to initiative")
+    if not isinstance(metadata.get("chunk_title"), str) or not metadata.get(
+        "chunk_title"
+    ):
+        failures.append(f"{label}: invalid completed chunk title")
+    if (next_chunk_id is None) != (next_chunk_title is None):
+        failures.append(f"{label}: incomplete next chunk metadata")
+    if next_chunk_id is not None and (
+        not isinstance(next_chunk_id, str)
+        or not ID_PATTERN.fullmatch(next_chunk_id)
+        or not isinstance(initiative_id, str)
+        or not next_chunk_id.startswith(f"{initiative_id}-")
+    ):
+        failures.append(f"{label}: next chunk does not belong to initiative")
+    if next_chunk_title is not None and (
+        not isinstance(next_chunk_title, str) or not next_chunk_title
+    ):
+        failures.append(f"{label}: invalid next chunk title")
+    if not isinstance(metadata.get("next_requires_explicit_start"), bool):
+        failures.append(f"{label}: invalid explicit-start flag")
+    return failures
+
+
+def _record_failures(record: object, label: str) -> list[str]:
+    """Independently validate one complete schema-v2 state record."""
+    expected = {
+        "schema_version",
+        "repository",
+        "state_branch",
+        "updated_at",
+        "source",
+        "completed_chunk",
+        "active",
+        "gate",
+        "checks",
+    }
+    if not isinstance(record, dict) or set(record) != expected:
+        return [f"{label}: invalid record schema"]
+    failures: list[str] = []
+    if record.get("schema_version") != SCHEMA_VERSION:
+        failures.append(f"{label}: unsupported schema version")
+    if record.get("state_branch") != STATE_BRANCH:
+        failures.append(f"{label}: unexpected state branch")
+    repository = record.get("repository")
+    if not isinstance(repository, str) or not REPOSITORY_PATTERN.fullmatch(repository):
+        failures.append(f"{label}: invalid repository")
+    source = record.get("source")
+    expected_source = {
+        "main_sha",
+        "first_parent_sha",
+        "pr_number",
+        "pr_url",
+        "pr_title",
+        "head_sha",
+        "head_ref",
+        "merged_at",
+        "merged_by",
+        "intent_path",
+        "intent_blob_sha",
+    }
+    if not isinstance(source, dict) or set(source) != expected_source:
+        failures.append(f"{label}: invalid source")
+        source = {}
+    for field in ("main_sha", "first_parent_sha", "head_sha", "intent_blob_sha"):
+        value = source.get(field)
+        if not isinstance(value, str) or not SHA_PATTERN.fullmatch(value):
+            failures.append(f"{label}: invalid source {field}")
+    pr_number = source.get("pr_number")
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
+        failures.append(f"{label}: invalid source pr_number")
+    if (
+        isinstance(repository, str)
+        and isinstance(pr_number, int)
+        and not isinstance(pr_number, bool)
+        and source.get("pr_url")
+        != f"https://github.com/{repository}/pull/{pr_number}"
+    ):
+        failures.append(f"{label}: invalid source pr_url")
+    for field, maximum in (("pr_title", 240), ("head_ref", 240), ("merged_by", 160)):
+        value = source.get(field)
+        if (
+            not isinstance(value, str)
+            or not value.strip()
+            or len(value.strip()) > maximum
+            or any(ord(char) < 32 for char in value.strip())
+        ):
+            failures.append(f"{label}: invalid source {field}")
+    merged_at = source.get("merged_at")
+    try:
+        parsed_time = datetime.fromisoformat(merged_at.replace("Z", "+00:00"))
+    except (AttributeError, ValueError):
+        failures.append(f"{label}: invalid source merged_at")
+    else:
+        if parsed_time.tzinfo is None:
+            failures.append(f"{label}: source merged_at has no timezone")
+    if record.get("updated_at") != merged_at:
+        failures.append(f"{label}: updated_at does not match merged_at")
+    metadata = record.get("completed_chunk")
+    failures.extend(_metadata_failures(metadata, label))
+    if isinstance(metadata, dict):
+        expected_path = f".agent-loop/merge-intents/{metadata.get('chunk_id')}.json"
+        if source.get("intent_path") != expected_path:
+            failures.append(f"{label}: intent path does not match completed chunk")
+        expected_gate = {
+            "status": "stopped_after_merge",
+            "next_chunk_id": metadata.get("next_chunk_id"),
+            "next_chunk_title": metadata.get("next_chunk_title"),
+            "next_requires_explicit_start": metadata.get(
+                "next_requires_explicit_start"
+            ),
+        }
+        if record.get("gate") != expected_gate:
+            failures.append(f"{label}: next gate does not match completed chunk")
+    if record.get("active") != {
+        "planning_chunk": None,
+        "implementation_chunk": None,
+    }:
+        failures.append(f"{label}: post-merge active state is not empty")
+    checks = record.get("checks")
+    if not isinstance(checks, dict) or set(checks) != {
+        "required",
+        "all_required_passed",
+    }:
+        failures.append(f"{label}: invalid check evidence")
+    else:
+        required = checks.get("required")
+        if not isinstance(required, dict) or set(required) != set(REQUIRED_CHECKS):
+            failures.append(f"{label}: incomplete required-check evidence")
+        else:
+            for name in REQUIRED_CHECKS:
+                result = required[name]
+                if not isinstance(result, dict) or set(result) != {
+                    "kind",
+                    "conclusion",
+                    "url",
+                }:
+                    failures.append(f"{label}: invalid check evidence for {name}")
+                    continue
+                if not isinstance(result.get("kind"), str):
+                    failures.append(f"{label}: invalid check kind for {name}")
+                conclusion = result.get("conclusion")
+                if conclusion is not None and not isinstance(conclusion, str):
+                    failures.append(f"{label}: invalid check conclusion for {name}")
+                url = result.get("url")
+                if url is not None and not isinstance(url, str):
+                    failures.append(f"{label}: invalid check URL for {name}")
+            calculated = all(
+                isinstance(required[name], dict)
+                and required[name].get("conclusion") == "success"
+                for name in REQUIRED_CHECKS
+            )
+            if checks.get("all_required_passed") is not calculated:
+                failures.append(f"{label}: inconsistent aggregate check evidence")
+    return failures
+
+
+def _markdown_text(value: str) -> str:
+    """Escape one bounded value for the independently rendered Markdown."""
+    return (
+        value.replace("\\", "\\\\")
+        .replace("`", "\\`")
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def _render_state(state: dict) -> str:
+    """Independently render the expected human-readable state."""
+    source = state["source"]
+    completed = state["completed_chunk"]
+    gate = state["gate"]
+    checks = state["checks"]
+    next_line = "- Next chunk: none recorded."
+    if gate["next_chunk_id"]:
+        start = (
+            "requires a separate explicit start"
+            if gate["next_requires_explicit_start"]
+            else "may use an existing start signal"
+        )
+        next_line = (
+            f"- Next chunk: `{gate['next_chunk_id']}` - "
+            f"{_markdown_text(gate['next_chunk_title'])}; {start}."
+        )
+    check_lines = [
+        f"  - `{name}`: `{checks['required'][name]['conclusion'] or 'missing'}`"
+        for name in REQUIRED_CHECKS
+    ]
+    integrity = "passed" if checks["all_required_passed"] else "attention required"
+    return "\n".join(
+        [
+            "# Generated Workstream Loop State",
+            "",
+            "> Canonical generated view. Do not edit this branch by hand.",
+            "",
+            f"- Repository: `{state['repository']}`",
+            f"- Last merged PR: [#{source['pr_number']}]({source['pr_url']}) - "
+            f"{_markdown_text(source['pr_title'])}",
+            f"- Merge commit: `{source['main_sha']}`",
+            f"- Final PR head: `{source['head_sha']}`",
+            f"- Merged at: `{source['merged_at']}` by `{source['merged_by']}`",
+            f"- Merge intent: `{source['intent_path']}` at blob "
+            f"`{source['intent_blob_sha']}`",
+            f"- Completed chunk: `{completed['chunk_id']}` - "
+            f"{_markdown_text(completed['chunk_title'])}",
+            "- Active planning chunk: none",
+            "- Active implementation chunk: none",
+            f"- Current gate: `{gate['status']}`",
+            next_line,
+            f"- Required check evidence: {integrity}",
+            *check_lines,
+            "",
+            "Machine-readable state: `.agent-loop/STATE.json`",
+            "Append-only merge ledger: `.agent-loop/MERGE_LOG.jsonl`",
+            "",
+        ]
+    )
 
 
 def generated_state_failures(root: Path) -> list[str]:
@@ -86,11 +364,7 @@ def generated_state_failures(root: Path) -> list[str]:
         return [f"generated loop memory is unreadable: {exc.__class__.__name__}"]
     if not isinstance(state, dict):
         return [".agent-loop/STATE.json: expected a JSON object"]
-    failures: list[str] = []
-    if state.get("schema_version") != 1:
-        failures.append(".agent-loop/STATE.json: unsupported schema version")
-    if state.get("state_branch") != "automation/loop-memory":
-        failures.append(".agent-loop/STATE.json: unexpected state branch")
+    failures = _record_failures(state, ".agent-loop/STATE.json")
     previous_hash = None
     previous_main_sha = None
     ledger_records = []
@@ -100,20 +374,20 @@ def generated_state_failures(root: Path) -> list[str]:
         "record",
         "entry_hash",
     }
-    for entry in ledger:
+    for index, entry in enumerate(ledger):
+        label = f".agent-loop/MERGE_LOG.jsonl:{index + 1}"
         if (
             not isinstance(entry, dict)
             or set(entry) != expected_keys
-            or entry.get("schema_version") != 1
+            or entry.get("schema_version") != SCHEMA_VERSION
         ):
-            failures.append(".agent-loop/MERGE_LOG.jsonl: invalid entry schema")
+            failures.append(f"{label}: invalid entry schema")
             break
         record = entry.get("record")
         if not isinstance(record, dict):
-            failures.append(
-                ".agent-loop/MERGE_LOG.jsonl: entry record is not an object"
-            )
+            failures.append(f"{label}: entry record is not an object")
             break
+        failures.extend(_record_failures(record, label))
         payload = (
             f"{previous_hash or ''}\n"
             f"{json.dumps(record, sort_keys=True, separators=(',', ':'), ensure_ascii=True)}"
@@ -123,16 +397,14 @@ def generated_state_failures(root: Path) -> list[str]:
             entry.get("previous_entry_hash") != previous_hash
             or entry.get("entry_hash") != expected_hash
         ):
-            failures.append(".agent-loop/MERGE_LOG.jsonl: hash chain is invalid")
+            failures.append(f"{label}: hash chain is invalid")
             break
         source = record.get("source", {})
         if (
             previous_main_sha is not None
             and source.get("first_parent_sha") != previous_main_sha
         ):
-            failures.append(
-                ".agent-loop/MERGE_LOG.jsonl: first-parent chain is invalid"
-            )
+            failures.append(f"{label}: first-parent chain is invalid")
             break
         previous_hash = expected_hash
         previous_main_sha = source.get("main_sha")
@@ -141,14 +413,10 @@ def generated_state_failures(root: Path) -> list[str]:
         failures.append(
             ".agent-loop/MERGE_LOG.jsonl: ledger tail does not match live state"
         )
-    source = state.get("source", {})
-    chunk = state.get("completed_chunk", {})
-    for value, label in (
-        (source.get("main_sha"), "merge SHA"),
-        (chunk.get("chunk_id"), "completed chunk"),
-    ):
-        if not isinstance(value, str) or f"`{value}`" not in rendered:
-            failures.append(f".agent-loop/LOOP_STATE.md: missing generated {label}")
+    if not failures and rendered != _render_state(state):
+        failures.append(
+            ".agent-loop/LOOP_STATE.md: rendered state does not match canonical JSON"
+        )
     return failures
 
 
@@ -160,7 +428,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Validate generated state or legacy main memory."""
+    """Validate generated automation state or authored main-branch memory."""
     args = build_parser().parse_args([] if argv is None else argv)
     if args.state_root:
         failures = generated_state_failures(args.state_root)

--- a/scripts/check_loop_memory_state.py
+++ b/scripts/check_loop_memory_state.py
@@ -112,6 +112,11 @@ def _is_bounded_single_line(value: object, maximum: int) -> bool:
     )
 
 
+def _is_valid_lifecycle_id(value: object) -> bool:
+    """Return whether one lifecycle ID has canonical syntax and bounds."""
+    return _is_bounded_single_line(value, 80) and bool(ID_PATTERN.fullmatch(value))
+
+
 def _metadata_failures(metadata: object, label: str) -> list[str]:
     """Independently validate one completed-chunk metadata object."""
     expected = {
@@ -132,11 +137,10 @@ def _metadata_failures(metadata: object, label: str) -> list[str]:
     chunk_id = metadata.get("chunk_id")
     next_chunk_id = metadata.get("next_chunk_id")
     next_chunk_title = metadata.get("next_chunk_title")
-    if not isinstance(initiative_id, str) or not ID_PATTERN.fullmatch(initiative_id):
+    if not _is_valid_lifecycle_id(initiative_id):
         failures.append(f"{label}: invalid initiative id")
     if (
-        not isinstance(chunk_id, str)
-        or not ID_PATTERN.fullmatch(chunk_id)
+        not _is_valid_lifecycle_id(chunk_id)
         or not isinstance(initiative_id, str)
         or not chunk_id.startswith(f"{initiative_id}-")
     ):
@@ -146,8 +150,7 @@ def _metadata_failures(metadata: object, label: str) -> list[str]:
     if (next_chunk_id is None) != (next_chunk_title is None):
         failures.append(f"{label}: incomplete next chunk metadata")
     if next_chunk_id is not None and (
-        not isinstance(next_chunk_id, str)
-        or not ID_PATTERN.fullmatch(next_chunk_id)
+        not _is_valid_lifecycle_id(next_chunk_id)
         or not isinstance(initiative_id, str)
         or not next_chunk_id.startswith(f"{initiative_id}-")
     ):

--- a/scripts/check_loop_memory_state.py
+++ b/scripts/check_loop_memory_state.py
@@ -124,6 +124,11 @@ def _is_valid_lifecycle_id(value: object) -> bool:
     return _is_bounded_single_line(value, 80) and bool(ID_PATTERN.fullmatch(value))
 
 
+def _is_current_schema_version(value: object) -> bool:
+    """Return whether value is exactly the supported integer schema version."""
+    return type(value) is int and value == SCHEMA_VERSION
+
+
 def _metadata_failures(metadata: object, label: str) -> list[str]:
     """Independently validate one completed-chunk metadata object."""
     expected = {
@@ -138,7 +143,7 @@ def _metadata_failures(metadata: object, label: str) -> list[str]:
     if not isinstance(metadata, dict) or set(metadata) != expected:
         return [f"{label}: invalid completed-chunk schema"]
     failures: list[str] = []
-    if metadata.get("schema_version") != SCHEMA_VERSION:
+    if not _is_current_schema_version(metadata.get("schema_version")):
         failures.append(f"{label}: unsupported completed-chunk schema version")
     initiative_id = metadata.get("initiative_id")
     chunk_id = metadata.get("chunk_id")
@@ -187,7 +192,7 @@ def _record_failures(record: object, label: str) -> list[str]:
     if not isinstance(record, dict) or set(record) != expected:
         return [f"{label}: invalid record schema"]
     failures: list[str] = []
-    if record.get("schema_version") != SCHEMA_VERSION:
+    if not _is_current_schema_version(record.get("schema_version")):
         failures.append(f"{label}: unsupported schema version")
     if record.get("state_branch") != STATE_BRANCH:
         failures.append(f"{label}: unexpected state branch")
@@ -399,7 +404,7 @@ def generated_state_failures(root: Path) -> list[str]:
         if (
             not isinstance(entry, dict)
             or set(entry) != expected_keys
-            or entry.get("schema_version") != SCHEMA_VERSION
+            or not _is_current_schema_version(entry.get("schema_version"))
         ):
             failures.append(f"{label}: invalid entry schema")
             break

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -2132,6 +2132,14 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
             ),
             "must" if field != "initiative_id" else "required",
         )
+    oversized_id = "WS-" + ("A" * 78)
+    oversized_metadata = dict(metadata_payload)
+    oversized_metadata["initiative_id"] = oversized_id
+    assert_loop_error(
+        updater,
+        lambda: updater.parse_loop_metadata(json.dumps(oversized_metadata)),
+        "bounded single-line",
+    )
 
     class RemoteClient:
         def __init__(self, tree, returned_sha: str = "e" * 40):
@@ -2270,12 +2278,15 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
         lambda value: value.clear(),
         lambda value: value.update(schema_version=1),
         lambda value: value.update(initiative_id="bad"),
+        lambda value: value.update(initiative_id="WS-" + ("A" * 78)),
+        lambda value: value.update(chunk_id="WS-AUTH-" + ("A" * 73)),
         lambda value: value.update(chunk_id="WS-ART-001-01"),
         lambda value: value.update(chunk_title=""),
         lambda value: value.update(chunk_title="x" * 161),
         lambda value: value.update(chunk_title="valid\ninjected"),
         lambda value: value.update(next_chunk_title=None),
         lambda value: value.update(next_chunk_id="WS-ART-001-02"),
+        lambda value: value.update(next_chunk_id="WS-AUTH-" + ("A" * 73)),
         lambda value: value.update(next_chunk_title=7),
         lambda value: value.update(next_chunk_title="x" * 161),
         lambda value: value.update(next_requires_explicit_start="yes"),
@@ -2369,6 +2380,8 @@ def test_loop_memory_workflow_isolated_write_boundary() -> None:
     assert "EVENT_SHA" in workflow
     assert "TARGET_SHA" in workflow
     assert "MERGE_SHA" not in workflow
+    assert "github.event.client_payload.target_sha" in workflow
+    assert "github.event.client_payload.merge_sha" not in workflow
     job_environment = workflow.split("    steps:", 1)[0]
     assert "GH_TOKEN:" not in job_environment
     assert "GITHUB_TOKEN:" not in job_environment

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -1204,6 +1204,45 @@ def updater_base64(value: str) -> str:
     return base64.b64encode(value.encode("utf-8")).decode("ascii")
 
 
+def sign_loop_state_with_domain(
+    updater, root: Path, private_key: Path, domain: bytes
+) -> None:
+    """Sign canonical generated state with one explicit test signature domain."""
+    payload = bytearray(domain)
+    for relative_path in (
+        updater.STATE_PATH,
+        updater.RENDERED_PATH,
+        updater.LEDGER_PATH,
+    ):
+        path_bytes = relative_path.as_posix().encode("ascii")
+        content = (root / relative_path).read_bytes()
+        payload.extend(len(path_bytes).to_bytes(4, "big"))
+        payload.extend(path_bytes)
+        payload.extend(len(content).to_bytes(8, "big"))
+        payload.extend(content)
+    with tempfile.NamedTemporaryFile() as payload_file:
+        payload_file.write(payload)
+        payload_file.flush()
+        signed = subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-sign",
+                "-rawin",
+                "-inkey",
+                str(private_key),
+                "-in",
+                payload_file.name,
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ).stdout
+    (root / updater.SIGNATURE_PATH).write_text(
+        base64.b64encode(signed).decode("ascii") + "\n", encoding="ascii"
+    )
+
+
 def loop_record(
     module,
     *,
@@ -2021,38 +2060,11 @@ def test_schema_v1_signed_state_is_discarded_before_clean_v2_bootstrap() -> None
         (root / updater.LEDGER_PATH).write_text(
             f"{updater._canonical_json(entry)}\n", encoding="utf-8"
         )
-        payload = bytearray(b"workstream-loop-memory-signature-v1\0")
-        for relative_path in (
-            updater.STATE_PATH,
-            updater.RENDERED_PATH,
-            updater.LEDGER_PATH,
-        ):
-            path_bytes = relative_path.as_posix().encode("ascii")
-            content = (root / relative_path).read_bytes()
-            payload.extend(len(path_bytes).to_bytes(4, "big"))
-            payload.extend(path_bytes)
-            payload.extend(len(content).to_bytes(8, "big"))
-            payload.extend(content)
-        with tempfile.NamedTemporaryFile() as payload_file:
-            payload_file.write(payload)
-            payload_file.flush()
-            signed = subprocess.run(
-                [
-                    "openssl",
-                    "pkeyutl",
-                    "-sign",
-                    "-rawin",
-                    "-inkey",
-                    str(private_key),
-                    "-in",
-                    payload_file.name,
-                ],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-            ).stdout
-        (root / updater.SIGNATURE_PATH).write_text(
-            base64.b64encode(signed).decode("ascii") + "\n", encoding="ascii"
+        sign_loop_state_with_domain(
+            updater,
+            root,
+            private_key,
+            b"workstream-loop-memory-signature-v1\0",
         )
         sentinel = agent_loop / "preserved.txt"
         sentinel.write_text("not generated\n", encoding="utf-8")
@@ -2074,6 +2086,66 @@ def test_schema_v1_signed_state_is_discarded_before_clean_v2_bootstrap() -> None
             root, public_key, current["source"]["main_sha"]
         )
         assert checker.generated_state_failures(root) == []
+
+
+def test_schema_v1_ledger_and_signature_domains_fail_independently() -> None:
+    """V2 state rejects an isolated v1 ledger envelope and v1 signature domain."""
+    updater = load_module(
+        "post_merge_v1_isolated_rejection", "scripts/update_post_merge_memory.py"
+    )
+    checker = load_module(
+        "post_merge_v1_isolated_checker", "scripts/check_loop_memory_state.py"
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        ledger_root = root / "ledger"
+        updater.apply_merge_record(ledger_root, loop_record(updater))
+        ledger_path = ledger_root / updater.LEDGER_PATH
+        ledger_entry = json.loads(ledger_path.read_text(encoding="utf-8"))
+        ledger_entry["schema_version"] = 1
+        ledger_path.write_text(
+            f"{updater._canonical_json(ledger_entry)}\n", encoding="utf-8"
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater.validate_generated_state(ledger_root),
+            "ledger entry has an invalid schema",
+        )
+        assert any(
+            "invalid entry schema" in failure
+            for failure in checker.generated_state_failures(ledger_root)
+        )
+
+        signature_root = root / "signature"
+        updater.apply_merge_record(signature_root, loop_record(updater))
+        updater.validate_generated_state(signature_root)
+        private_key = root / "private.pem"
+        public_key = root / "public.pem"
+        subprocess.run(
+            ["openssl", "genpkey", "-algorithm", "ED25519", "-out", private_key],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        subprocess.run(
+            ["openssl", "pkey", "-in", private_key, "-pubout", "-out", public_key],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        sign_loop_state_with_domain(
+            updater,
+            signature_root,
+            private_key,
+            b"workstream-loop-memory-signature-v1\0",
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater.verify_generated_state_signature(
+                signature_root, public_key, "a" * 40
+            ),
+            "signature verification failed",
+        )
 
 
 def test_live_and_historical_records_reject_cross_initiative_gates() -> None:
@@ -2157,15 +2229,39 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
             "a" * 40,
             no_successor,
         )
-    no_successor_record = loop_record(updater)
-    no_successor_record["completed_chunk"] = updater.asdict(no_successor)
-    no_successor_record["gate"] = {
-        "status": "stopped_after_merge",
-        "next_chunk_id": None,
-        "next_chunk_title": None,
-        "next_requires_explicit_start": True,
-    }
-    assert "Next chunk: none recorded" in updater.render_state(no_successor_record)
+        no_successor_record = loop_record(updater)
+        no_successor_record["completed_chunk"] = updater.asdict(no_successor)
+        no_successor_record["gate"] = {
+            "status": "stopped_after_merge",
+            "next_chunk_id": None,
+            "next_chunk_title": None,
+            "next_requires_explicit_start": True,
+        }
+        assert updater.apply_merge_record(root, no_successor_record) is True
+        assert updater.apply_merge_record(root, no_successor_record) is False
+        updater.validate_generated_state(root)
+        assert "Next chunk: none recorded" in (
+            root / updater.RENDERED_PATH
+        ).read_text(encoding="utf-8")
+        assert checker.generated_state_failures(root) == []
+
+        private_key = root / "private.pem"
+        public_key = root / "public.pem"
+        subprocess.run(
+            ["openssl", "genpkey", "-algorithm", "ED25519", "-out", private_key],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        subprocess.run(
+            ["openssl", "pkey", "-in", private_key, "-pubout", "-out", public_key],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        updater.sign_generated_state(root, private_key)
+        updater.verify_generated_state_signature(root, public_key, "a" * 40)
+        assert checker.generated_state_failures(root) == []
 
     assert updater._contract_title("not a contract\n", "WS-AUTH-001-07") is None
     assert (
@@ -4465,6 +4561,7 @@ def main() -> int:
         test_generated_loop_memory_validator_detects_drift,
         test_generated_loop_memory_signature_authenticates_every_canonical_file,
         test_schema_v1_signed_state_is_discarded_before_clean_v2_bootstrap,
+        test_schema_v1_ledger_and_signature_domains_fail_independently,
         test_live_and_historical_records_reject_cross_initiative_gates,
         test_loop_memory_schema_v2_rejection_matrix_is_fail_closed,
         test_generated_loop_memory_prepare_recovers_hostile_path_types,

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -1069,6 +1069,7 @@ def test_loop_memory_state_rejects_pre_merge_status() -> None:
     )
     original_root = checker.ROOT
     original_status_files = checker.INITIATIVE_STATUS_FILES
+    original_contract_files = checker.STATUS_BEARING_CONTRACT_FILES
     with tempfile.TemporaryDirectory() as tmpdir:
         root = Path(tmpdir)
         (root / ".agent-loop/initiatives/example").mkdir(parents=True)
@@ -1090,12 +1091,14 @@ def test_loop_memory_state_rejects_pre_merge_status() -> None:
         )
         checker.ROOT = root
         checker.INITIATIVE_STATUS_FILES = (".agent-loop/initiatives/example/STATUS.md",)
+        checker.STATUS_BEARING_CONTRACT_FILES = ()
         try:
             with contextlib.redirect_stderr(io.StringIO()):
                 assert checker.main() == 1
         finally:
             checker.ROOT = original_root
             checker.INITIATIVE_STATUS_FILES = original_status_files
+            checker.STATUS_BEARING_CONTRACT_FILES = original_contract_files
 
 
 def test_loop_memory_state_accepts_merged_fixture() -> None:
@@ -1105,6 +1108,7 @@ def test_loop_memory_state_accepts_merged_fixture() -> None:
     )
     original_root = checker.ROOT
     original_status_files = checker.INITIATIVE_STATUS_FILES
+    original_contract_files = checker.STATUS_BEARING_CONTRACT_FILES
     with tempfile.TemporaryDirectory() as tmpdir:
         root = Path(tmpdir)
         (root / ".agent-loop/initiatives/example").mkdir(parents=True)
@@ -1126,12 +1130,14 @@ def test_loop_memory_state_accepts_merged_fixture() -> None:
         )
         checker.ROOT = root
         checker.INITIATIVE_STATUS_FILES = (".agent-loop/initiatives/example/STATUS.md",)
+        checker.STATUS_BEARING_CONTRACT_FILES = ()
         try:
             with contextlib.redirect_stdout(io.StringIO()):
                 assert checker.main() == 0
         finally:
             checker.ROOT = original_root
             checker.INITIATIVE_STATUS_FILES = original_status_files
+            checker.STATUS_BEARING_CONTRACT_FILES = original_contract_files
 
 
 def test_loop_memory_state_rejects_known_merged_pr_staleness() -> None:
@@ -1147,7 +1153,10 @@ def test_loop_memory_state_rejects_known_merged_pr_staleness() -> None:
         ),
         "| `WS-AUTH-001-05B` | In review | branch | - | pending |",
         "PR #120's branch is ready for review.",
-        "`WS-ART-001-OBJECT-STORAGE-AMENDMENT` is Active planning.",
+        (
+            "# Chunk Contract: WS-ART-001-OBJECT-STORAGE-AMENDMENT\n"
+            "Status: Active planning only"
+        ),
         "PR #122 remains active.",
     )
     for sample in stale_samples:
@@ -2263,6 +2272,11 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
     base = loop_record(updater)
     record_mutations = (
         (lambda row: row.update(state_branch="main"), "state branch"),
+        (lambda row: row.update(repository=7), "repository must be owner/name"),
+        (
+            lambda row: row["source"].update(main_sha=None),
+            "40 lowercase hexadecimal",
+        ),
         (lambda row: row["source"].update(pr_number=True), "positive PR number"),
         (lambda row: row["source"].update(pr_url="https://invalid"), "PR URL"),
         (lambda row: row.update(updated_at="2026-07-14T20:01:00Z"), "updated_at"),

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -1134,10 +1134,36 @@ def test_loop_memory_state_accepts_merged_fixture() -> None:
             checker.INITIATIVE_STATUS_FILES = original_status_files
 
 
+def test_loop_memory_state_rejects_known_merged_pr_staleness() -> None:
+    """Known PR #119/#120/#122 facts cannot regress to pending or active."""
+    checker = load_module(
+        "loop_memory_known_merge_staleness", "scripts/check_loop_memory_state.py"
+    )
+    stale_samples = (
+        "AUTH-05B runtime is reviewed; publication is pending.",
+        "| `WS-AUTH-001-05B` | In review | branch | - | pending |",
+        "PR #120's branch is ready for review.",
+        "`WS-ART-001-OBJECT-STORAGE-AMENDMENT` is Active planning.",
+        "PR #122 remains active.",
+    )
+    for sample in stale_samples:
+        assert any(
+            pattern.search(sample) for pattern, _message in checker.FORBIDDEN_PATTERNS
+        ), sample
+    valid_candidates = (
+        "`WS-AUTH-001-06` remains inactive until explicit user start.",
+        "`WS-ART-001-02A1` remains inactive until explicit user start.",
+    )
+    for sample in valid_candidates:
+        assert not any(
+            pattern.search(sample) for pattern, _message in checker.FORBIDDEN_PATTERNS
+        ), sample
+
+
 def valid_loop_intent() -> str:
     """Return one valid committed merge-intent JSON fixture."""
     return (
-        '{"schema_version":1,"initiative_id":"WS-AUTH-001",'
+        '{"schema_version":2,"initiative_id":"WS-AUTH-001",'
         '"chunk_id":"WS-AUTH-001-06","chunk_title":"Canonical Actor Profile",'
         '"next_chunk_id":"WS-AUTH-001-07","next_chunk_title":"Authorization Kernel",'
         '"next_requires_explicit_start":true}\n'
@@ -1160,7 +1186,7 @@ def loop_record(
     """Return one complete generated-state fixture."""
     metadata = module.parse_loop_metadata(valid_loop_intent())
     return {
-        "schema_version": 1,
+        "schema_version": module.SCHEMA_VERSION,
         "repository": "Flow-Research/workstream",
         "state_branch": "automation/loop-memory",
         "updated_at": merged_at,
@@ -1206,7 +1232,7 @@ def test_post_merge_metadata_is_strict_and_bounded() -> None:
     invalid_bodies = [
         "",
         valid_loop_intent() + valid_loop_intent(),
-        valid_loop_intent().replace('"schema_version":1', '"schema_version":2'),
+        valid_loop_intent().replace('"schema_version":2', '"schema_version":1'),
         valid_loop_intent().replace(
             '"chunk_id":"WS-AUTH-001-06"', '"chunk_id":"WS-POL-002-04"'
         ),
@@ -1214,7 +1240,7 @@ def test_post_merge_metadata_is_strict_and_bounded() -> None:
             '"next_chunk_title":"Authorization Kernel"', '"next_chunk_title":null'
         ),
         valid_loop_intent().replace(
-            '"schema_version":1', '"schema_version":1,"unexpected":true'
+            '"schema_version":2', '"schema_version":2,"unexpected":true'
         ),
     ]
     for body in invalid_bodies:
@@ -1223,6 +1249,124 @@ def test_post_merge_metadata_is_strict_and_bounded() -> None:
         except updater.LoopMemoryError:
             continue
         raise AssertionError(f"invalid merge intent passed: {body}")
+
+    assert_loop_error(
+        updater,
+        lambda: updater.parse_loop_metadata(
+            valid_loop_intent().replace("WS-AUTH-001-07", "WS-ART-001-02A1")
+        ),
+        "next_chunk_id must belong",
+    )
+
+
+def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
+    """A non-null successor resolves to one same-title reviewed contract."""
+    updater = load_module(
+        "post_merge_successor_contract", "scripts/update_post_merge_memory.py"
+    )
+    metadata = updater.parse_loop_metadata(valid_loop_intent())
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        contract = (
+            root
+            / ".agent-loop/initiatives/WS-AUTH-001-example/chunks/"
+            "WS-AUTH-001-07-authorization-kernel.md"
+        )
+        contract.parent.mkdir(parents=True)
+        contract.write_text(
+            "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
+            encoding="utf-8",
+        )
+        updater._validate_local_successor_contract(root, metadata)
+
+        contract.write_text(
+            "# Chunk Contract: WS-AUTH-001-07 - Wrong Title\n", encoding="utf-8"
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater._validate_local_successor_contract(root, metadata),
+            "heading does not match",
+        )
+        contract.unlink()
+        assert_loop_error(
+            updater,
+            lambda: updater._validate_local_successor_contract(root, metadata),
+            "exactly one chunk contract",
+        )
+        contract.write_text(
+            "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
+            encoding="utf-8",
+        )
+        duplicate = (
+            root
+            / ".agent-loop/initiatives/WS-AUTH-001-duplicate/chunks/"
+            "WS-AUTH-001-07-copy.md"
+        )
+        duplicate.parent.mkdir(parents=True)
+        duplicate.write_text(contract.read_text(encoding="utf-8"), encoding="utf-8")
+        assert_loop_error(
+            updater,
+            lambda: updater._validate_local_successor_contract(root, metadata),
+            "exactly one chunk contract",
+        )
+
+    class RemoteClient:
+        def __init__(self, tree, contract_text: str, returned_sha: str = "e" * 40):
+            self.tree = tree
+            self.contract_text = contract_text
+            self.returned_sha = returned_sha
+
+        def get_json(self, path: str):
+            if "/git/trees/" in path:
+                return self.tree
+            return {
+                "encoding": "base64",
+                "sha": self.returned_sha,
+                "content": updater_base64(self.contract_text),
+            }
+
+    tree_item = {
+        "type": "blob",
+        "path": (
+            ".agent-loop/initiatives/WS-AUTH-001-example/chunks/"
+            "WS-AUTH-001-07-authorization-kernel.md"
+        ),
+        "sha": "e" * 40,
+    }
+    valid_tree = {"truncated": False, "tree": [tree_item]}
+    updater._validate_remote_successor_contract(
+        RemoteClient(
+            valid_tree,
+            "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
+        ),
+        "Flow-Research/workstream",
+        "b" * 40,
+        metadata,
+    )
+    remote_cases = (
+        ({"truncated": True, "tree": [tree_item]}, "Authorization Kernel", "incomplete"),
+        ({"truncated": False, "tree": []}, "Authorization Kernel", "exactly one"),
+        (
+            {"truncated": False, "tree": [tree_item, dict(tree_item)]},
+            "Authorization Kernel",
+            "exactly one",
+        ),
+        (valid_tree, "Wrong Title", "heading does not match"),
+    )
+    for tree, title, expected in remote_cases:
+        assert_loop_error(
+            updater,
+            lambda tree=tree, title=title: updater._validate_remote_successor_contract(
+                RemoteClient(
+                    tree,
+                    f"# Chunk Contract: WS-AUTH-001-07 - {title}\n",
+                ),
+                "Flow-Research/workstream",
+                "b" * 40,
+                metadata,
+            ),
+            expected,
+        )
 
 
 def test_post_merge_state_is_idempotent_and_monotonic() -> None:
@@ -1393,6 +1537,104 @@ def test_post_merge_reconciliation_bootstraps_and_recovers_every_commit() -> Non
         )
 
 
+def test_loop_memory_target_resolution_rejects_stale_replays() -> None:
+    """Dispatch must be current; queued push may only reconcile forward."""
+    updater = load_module(
+        "post_merge_target_resolution", "scripts/update_post_merge_memory.py"
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        subprocess.run(
+            ["git", "init", "--initial-branch", "main", str(root)],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "user.email", "test@example.test"],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(root), "config", "user.name", "Test"], check=True
+        )
+        tracked = root / "state.txt"
+        tracked.write_text("one\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(root), "add", "state.txt"], check=True)
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-m", "one"],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        first = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        tracked.write_text("two\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(root), "add", "state.txt"], check=True)
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-m", "two"],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        current = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert (
+            updater.resolve_reconciliation_target(root, "push", first, current)
+            == current
+        )
+        assert (
+            updater.resolve_reconciliation_target(
+                root, "repository_dispatch", current, current
+            )
+            == current
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater.resolve_reconciliation_target(
+                root, "repository_dispatch", first, current
+            ),
+            "replay target is stale",
+        )
+
+        subprocess.run(
+            ["git", "-C", str(root), "switch", "-c", "divergent", first],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        (root / "other.txt").write_text("other\n", encoding="utf-8")
+        subprocess.run(["git", "-C", str(root), "add", "other.txt"], check=True)
+        subprocess.run(
+            ["git", "-C", str(root), "commit", "-m", "divergent"],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        divergent = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+        assert_loop_error(
+            updater,
+            lambda: updater.resolve_reconciliation_target(
+                root, "push", divergent, current
+            ),
+            "not on current protected-main ancestry",
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater.resolve_reconciliation_target(
+                root, "manual", current, current
+            ),
+            "unsupported loop-memory event",
+        )
+
+
 def test_post_merge_collection_binds_exact_pr_and_checks() -> None:
     """The collector binds one main merge SHA and final-head check evidence."""
     updater = load_module(
@@ -1471,6 +1713,26 @@ def test_post_merge_collection_binds_exact_pr_and_checks() -> None:
                 }
             ]
         },
+        f"/repos/Flow-Research/workstream/git/trees/{head_sha}?recursive=1": {
+            "truncated": False,
+            "tree": [
+                {
+                    "type": "blob",
+                    "path": (
+                        ".agent-loop/initiatives/WS-AUTH-001-example/chunks/"
+                        "WS-AUTH-001-07-authorization-kernel.md"
+                    ),
+                    "sha": "e" * 40,
+                }
+            ],
+        },
+        f"/repos/Flow-Research/workstream/git/blobs/{'e' * 40}": {
+            "encoding": "base64",
+            "sha": "e" * 40,
+            "content": updater_base64(
+                "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n"
+            ),
+        },
     }
 
     class FakeClient:
@@ -1513,8 +1775,9 @@ def test_generated_loop_memory_validator_detects_drift() -> None:
         )
         rendered_path.write_text("stale\n", encoding="utf-8")
         failures = checker.generated_state_failures(root)
-        assert any("merge SHA" in failure for failure in failures)
-        assert any("completed chunk" in failure for failure in failures)
+        assert failures == [
+            ".agent-loop/LOOP_STATE.md: rendered state does not match canonical JSON"
+        ]
 
 
 def test_generated_loop_memory_signature_authenticates_every_canonical_file() -> None:
@@ -1606,6 +1869,379 @@ def test_generated_loop_memory_signature_authenticates_every_canonical_file() ->
         )
 
 
+def test_schema_v1_signed_state_is_discarded_before_clean_v2_bootstrap() -> None:
+    """A valid old-domain signature cannot preserve any schema-v1 state."""
+    updater = load_module(
+        "post_merge_v1_clean_cut", "scripts/update_post_merge_memory.py"
+    )
+    checker = load_module(
+        "post_merge_v1_clean_cut_checker", "scripts/check_loop_memory_state.py"
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        private_key = root / "private.pem"
+        public_key = root / "public.pem"
+        subprocess.run(
+            ["openssl", "genpkey", "-algorithm", "ED25519", "-out", private_key],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        subprocess.run(
+            ["openssl", "pkey", "-in", private_key, "-pubout", "-out", public_key],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        rejected_v1_state = loop_record(updater)
+        rejected_v1_state["schema_version"] = 1
+        rejected_v1_state["completed_chunk"]["schema_version"] = 1
+        rejected_v1_state["completed_chunk"]["next_chunk_id"] = "WS-ART-001-02A1"
+        rejected_v1_state["completed_chunk"]["next_chunk_title"] = "External Adapter"
+        rejected_v1_state["gate"]["next_chunk_id"] = "WS-ART-001-02A1"
+        rejected_v1_state["gate"]["next_chunk_title"] = "External Adapter"
+        entry = {
+            "schema_version": 1,
+            "previous_entry_hash": None,
+            "record": rejected_v1_state,
+            "entry_hash": updater._ledger_hash(None, rejected_v1_state),
+        }
+        agent_loop = root / ".agent-loop"
+        agent_loop.mkdir()
+        (root / updater.STATE_PATH).write_text(
+            updater._canonical_json(rejected_v1_state, pretty=True), encoding="utf-8"
+        )
+        (root / updater.RENDERED_PATH).write_text(
+            updater.render_state(rejected_v1_state), encoding="utf-8"
+        )
+        (root / updater.LEDGER_PATH).write_text(
+            f"{updater._canonical_json(entry)}\n", encoding="utf-8"
+        )
+        payload = bytearray(b"workstream-loop-memory-signature-v1\0")
+        for relative_path in (
+            updater.STATE_PATH,
+            updater.RENDERED_PATH,
+            updater.LEDGER_PATH,
+        ):
+            path_bytes = relative_path.as_posix().encode("ascii")
+            content = (root / relative_path).read_bytes()
+            payload.extend(len(path_bytes).to_bytes(4, "big"))
+            payload.extend(path_bytes)
+            payload.extend(len(content).to_bytes(8, "big"))
+            payload.extend(content)
+        with tempfile.NamedTemporaryFile() as payload_file:
+            payload_file.write(payload)
+            payload_file.flush()
+            signed = subprocess.run(
+                [
+                    "openssl",
+                    "pkeyutl",
+                    "-sign",
+                    "-rawin",
+                    "-inkey",
+                    str(private_key),
+                    "-in",
+                    payload_file.name,
+                ],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ).stdout
+        (root / updater.SIGNATURE_PATH).write_text(
+            base64.b64encode(signed).decode("ascii") + "\n", encoding="ascii"
+        )
+        sentinel = agent_loop / "preserved.txt"
+        sentinel.write_text("not generated\n", encoding="utf-8")
+
+        assert updater.prepare_generated_state_root(root, public_key) is False
+        for generated_path in (
+            updater.STATE_PATH,
+            updater.RENDERED_PATH,
+            updater.LEDGER_PATH,
+            updater.SIGNATURE_PATH,
+        ):
+            assert not (root / generated_path).exists()
+        assert sentinel.read_text(encoding="utf-8") == "not generated\n"
+
+        current = loop_record(updater)
+        updater.apply_merge_record(root, current)
+        updater.sign_generated_state(root, private_key)
+        updater.verify_generated_state_signature(
+            root, public_key, current["source"]["main_sha"]
+        )
+        assert checker.generated_state_failures(root) == []
+
+
+def test_live_and_historical_records_reject_cross_initiative_gates() -> None:
+    """Hash-consistent state still fails when lifecycle authority crosses initiatives."""
+    updater = load_module(
+        "post_merge_cross_scope_state", "scripts/update_post_merge_memory.py"
+    )
+    checker = load_module(
+        "post_merge_cross_scope_checker", "scripts/check_loop_memory_state.py"
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        record = loop_record(updater)
+        record["completed_chunk"]["next_chunk_id"] = "WS-ART-001-02A1"
+        record["completed_chunk"]["next_chunk_title"] = "External Adapter"
+        record["gate"]["next_chunk_id"] = "WS-ART-001-02A1"
+        record["gate"]["next_chunk_title"] = "External Adapter"
+        entry = updater._ledger_entry(record, None)
+        (root / updater.STATE_PATH).parent.mkdir(parents=True)
+        (root / updater.STATE_PATH).write_text(
+            updater._canonical_json(record, pretty=True), encoding="utf-8"
+        )
+        (root / updater.RENDERED_PATH).write_text(
+            updater.render_state(record), encoding="utf-8"
+        )
+        (root / updater.LEDGER_PATH).write_text(
+            f"{updater._canonical_json(entry)}\n", encoding="utf-8"
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater.validate_generated_state(root),
+            "next_chunk_id must belong",
+        )
+        failures = checker.generated_state_failures(root)
+        assert any("next chunk does not belong" in failure for failure in failures)
+
+        valid = loop_record(updater)
+        invalid_gate = json.loads(json.dumps(valid))
+        invalid_gate["gate"]["next_chunk_title"] = "Mismatched"
+        entry = updater._ledger_entry(invalid_gate, None)
+        (root / updater.STATE_PATH).write_text(
+            updater._canonical_json(invalid_gate, pretty=True), encoding="utf-8"
+        )
+        (root / updater.RENDERED_PATH).write_text(
+            updater.render_state(invalid_gate), encoding="utf-8"
+        )
+        (root / updater.LEDGER_PATH).write_text(
+            f"{updater._canonical_json(entry)}\n", encoding="utf-8"
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater.validate_generated_state(root),
+            "next gate does not match",
+        )
+        assert any(
+            "next gate does not match" in failure
+            for failure in checker.generated_state_failures(root)
+        )
+
+
+def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
+    """Schema-v2 trust boundaries reject malformed metadata and state records."""
+    updater = load_module(
+        "post_merge_v2_rejection_matrix", "scripts/update_post_merge_memory.py"
+    )
+    checker = load_module(
+        "post_merge_v2_checker_matrix", "scripts/check_loop_memory_state.py"
+    )
+
+    no_successor_text = valid_loop_intent().replace(
+        '"next_chunk_id":"WS-AUTH-001-07","next_chunk_title":"Authorization Kernel"',
+        '"next_chunk_id":null,"next_chunk_title":null',
+    )
+    no_successor = updater.parse_loop_metadata(no_successor_text)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        updater._validate_local_successor_contract(root, no_successor)
+        updater._validate_remote_successor_contract(
+            SimpleNamespace(get_json=lambda _path: None),
+            "Flow-Research/workstream",
+            "a" * 40,
+            no_successor,
+        )
+    no_successor_record = loop_record(updater)
+    no_successor_record["completed_chunk"] = updater.asdict(no_successor)
+    no_successor_record["gate"] = {
+        "status": "stopped_after_merge",
+        "next_chunk_id": None,
+        "next_chunk_title": None,
+        "next_requires_explicit_start": True,
+    }
+    assert "Next chunk: none recorded" in updater.render_state(no_successor_record)
+
+    assert updater._contract_title("not a contract\n", "WS-AUTH-001-07") is None
+    assert (
+        updater._contract_title(
+            "# Chunk Contract: WS-AUTH-001-07 Authorization Kernel\n",
+            "WS-AUTH-001-07",
+        )
+        == "Authorization Kernel"
+    )
+    assert (
+        updater._contract_title(
+            "# Chunk Contract: WS-AUTH-001-07\n", "WS-AUTH-001-07"
+        )
+        is None
+    )
+
+    metadata_payload = json.loads(valid_loop_intent())
+    metadata_mutations = (
+        ("initiative_id", None),
+        ("chunk_title", ""),
+        ("next_chunk_title", 7),
+        ("next_requires_explicit_start", "yes"),
+    )
+    for field, value in metadata_mutations:
+        malformed = dict(metadata_payload)
+        malformed[field] = value
+        assert_loop_error(
+            updater,
+            lambda malformed=malformed: updater.parse_loop_metadata(
+                json.dumps(malformed)
+            ),
+            "must" if field != "initiative_id" else "required",
+        )
+
+    class RemoteClient:
+        def __init__(self, tree, returned_sha: str = "e" * 40):
+            self.tree = tree
+            self.returned_sha = returned_sha
+
+        def get_json(self, path: str):
+            if "/git/trees/" in path:
+                return self.tree
+            return {
+                "encoding": "base64",
+                "sha": self.returned_sha,
+                "content": updater_base64(
+                    "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n"
+                ),
+            }
+
+    valid_item = {
+        "type": "blob",
+        "path": (
+            ".agent-loop/initiatives/WS-AUTH-001-example/chunks/"
+            "WS-AUTH-001-07-authorization-kernel.md"
+        ),
+        "sha": "e" * 40,
+    }
+    assert_loop_error(
+        updater,
+        lambda: updater._validate_remote_successor_contract(
+            RemoteClient(
+                {
+                    "truncated": False,
+                    "tree": [None, {"type": "tree"}, {"type": "blob"}, valid_item],
+                },
+                returned_sha="f" * 40,
+            ),
+            "Flow-Research/workstream",
+            "a" * 40,
+            updater.parse_loop_metadata(valid_loop_intent()),
+        ),
+        "identity does not match",
+    )
+    invalid_sha_item = dict(valid_item)
+    invalid_sha_item["sha"] = "invalid"
+    assert_loop_error(
+        updater,
+        lambda: updater._validate_remote_successor_contract(
+            RemoteClient({"truncated": False, "tree": [invalid_sha_item]}),
+            "Flow-Research/workstream",
+            "a" * 40,
+            updater.parse_loop_metadata(valid_loop_intent()),
+        ),
+        "canonical blob SHA",
+    )
+
+    assert_loop_error(
+        updater,
+        lambda: updater._git_lines(Path("/not/a/repository"), ["status"], "git failed"),
+        "git failed",
+    )
+    assert_loop_error(
+        updater,
+        lambda: updater._is_ancestor(
+            Path("/not/a/repository"), "a" * 40, "b" * 40
+        ),
+        "cannot resolve main commit ancestry",
+    )
+    assert updater._latest_named(
+        [
+            {},
+            {"name": "gate", "started_at": "2026-01-02"},
+            {"name": "gate", "started_at": "2026-01-01"},
+        ],
+        "name",
+        "started_at",
+    )["gate"]["started_at"] == "2026-01-02"
+    for value, expected in (
+        (None, "ISO timestamp"),
+        ("not-a-time", "ISO timestamp"),
+        ("2026-07-14T20:00:00", "timezone"),
+    ):
+        assert_loop_error(
+            updater,
+            lambda value=value: updater._parse_timestamp(value, "time"),
+            expected,
+        )
+
+    base = loop_record(updater)
+    record_mutations = (
+        (lambda row: row.update(state_branch="main"), "state branch"),
+        (lambda row: row["source"].update(pr_number=True), "positive PR number"),
+        (lambda row: row["source"].update(pr_url="https://invalid"), "PR URL"),
+        (lambda row: row.update(updated_at="2026-07-14T20:01:00Z"), "updated_at"),
+        (lambda row: row.update(completed_chunk=[]), "JSON object"),
+        (lambda row: row["source"].update(intent_path="wrong"), "intent path"),
+        (lambda row: row.update(active={}), "active chunk state"),
+        (lambda row: row.update(checks=[]), "check evidence"),
+        (lambda row: row["checks"].update(required={}), "required-check"),
+        (
+            lambda row: row["checks"]["required"].update({"agent-gates": []}),
+            "invalid for agent-gates",
+        ),
+        (
+            lambda row: row["checks"]["required"]["agent-gates"].update(kind=7),
+            "kind is invalid",
+        ),
+        (
+            lambda row: row["checks"]["required"]["agent-gates"].update(
+                conclusion=7
+            ),
+            "conclusion is invalid",
+        ),
+        (
+            lambda row: row["checks"]["required"]["agent-gates"].update(url=7),
+            "URL is invalid",
+        ),
+        (
+            lambda row: row["checks"].update(all_required_passed=False),
+            "aggregate check evidence",
+        ),
+    )
+    for mutate, expected in record_mutations:
+        malformed = json.loads(json.dumps(base))
+        mutate(malformed)
+        assert_loop_error(
+            updater,
+            lambda malformed=malformed: updater._validate_record(malformed),
+            expected,
+        )
+        assert checker._record_failures(malformed, "record")
+
+    metadata_failure_mutations = (
+        lambda value: value.clear(),
+        lambda value: value.update(schema_version=1),
+        lambda value: value.update(initiative_id="bad"),
+        lambda value: value.update(chunk_id="WS-ART-001-01"),
+        lambda value: value.update(chunk_title=""),
+        lambda value: value.update(next_chunk_title=None),
+        lambda value: value.update(next_chunk_id="WS-ART-001-02"),
+        lambda value: value.update(next_chunk_title=7),
+        lambda value: value.update(next_requires_explicit_start="yes"),
+    )
+    for mutate in metadata_failure_mutations:
+        malformed = json.loads(json.dumps(base["completed_chunk"]))
+        mutate(malformed)
+        assert checker._metadata_failures(malformed, "metadata")
+
+
 def test_generated_loop_memory_prepare_recovers_hostile_path_types() -> None:
     """Directories and symlinks cannot wedge deterministic state reconstruction."""
     updater = load_module(
@@ -1673,6 +2309,7 @@ def test_loop_memory_workflow_isolated_write_boundary() -> None:
     assert "workflow_dispatch" not in workflow
     assert "repository_dispatch" in workflow
     assert "persist-credentials: false" in workflow
+    assert "ref: main" in workflow
     assert "contents: write" in workflow
     assert "pull-requests: read" in workflow
     assert "LOOP_MEMORY_SIGNING_KEY" in workflow
@@ -1684,8 +2321,25 @@ def test_loop_memory_workflow_isolated_write_boundary() -> None:
     assert "HEAD:refs/heads/main" not in workflow
     assert "gh pr create" not in workflow
     assert "plan-commits" in workflow
+    assert "resolve-target" in workflow
+    assert "EVENT_SHA" in workflow
+    assert "TARGET_SHA" in workflow
+    assert "MERGE_SHA" not in workflow
+    assert "replay target is stale" in (
+        ROOT / "scripts/update_post_merge_memory.py"
+    ).read_text(encoding="utf-8")
     assert "--current-sha" in workflow
     assert "update_post_merge_memory.py sign-state" in workflow
+    assert "check_loop_memory_state.py" in workflow
+    assert workflow.index("Resolve trusted protected-main target") < workflow.index(
+        "Prepare generated state branch"
+    )
+    assert workflow.index("prepare-state") < workflow.index("plan-commits")
+    assert workflow.index("plan-commits") < workflow.index("sign-state")
+    assert workflow.index("sign-state") < workflow.index("--expected-main-sha")
+    assert workflow.index("--expected-main-sha") < workflow.index(
+        "check_loop_memory_state.py"
+    )
     assert "validate-merge-intent" in agent_gates
     assert "github.event.pull_request.body" not in agent_gates
 
@@ -1873,7 +2527,29 @@ def test_committed_merge_intent_fails_closed_on_untrusted_github_payloads() -> N
         def get_paginated(self, _path: str):
             return self.files
 
-        def get_json(self, _path: str):
+        def get_json(self, path: str):
+            if "/git/trees/" in path:
+                return {
+                    "truncated": False,
+                    "tree": [
+                        {
+                            "type": "blob",
+                            "path": (
+                                ".agent-loop/initiatives/WS-AUTH-001-example/chunks/"
+                                "WS-AUTH-001-07-authorization-kernel.md"
+                            ),
+                            "sha": "e" * 40,
+                        }
+                    ],
+                }
+            if "/git/blobs/" in path:
+                return {
+                    "encoding": "base64",
+                    "sha": "e" * 40,
+                    "content": updater_base64(
+                        "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n"
+                    ),
+                }
             return self.content
 
     added = [{"filename": canonical_path, "status": "added"}]
@@ -2100,6 +2776,16 @@ def test_post_merge_state_rejects_corrupt_files_and_cli_misuse() -> None:
         intent_path = intent_repo / ".agent-loop/merge-intents/WS-AUTH-001-06.json"
         intent_path.parent.mkdir(parents=True)
         intent_path.write_text(valid_loop_intent(), encoding="utf-8")
+        contract_path = (
+            intent_repo
+            / ".agent-loop/initiatives/WS-AUTH-001-example/chunks/"
+            "WS-AUTH-001-07-authorization-kernel.md"
+        )
+        contract_path.parent.mkdir(parents=True)
+        contract_path.write_text(
+            "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
+            encoding="utf-8",
+        )
         subprocess.run(
             [
                 "git",
@@ -2107,6 +2793,7 @@ def test_post_merge_state_rejects_corrupt_files_and_cli_misuse() -> None:
                 str(intent_repo),
                 "add",
                 intent_path.relative_to(intent_repo),
+                contract_path.relative_to(intent_repo),
             ],
             check=True,
         )
@@ -2219,7 +2906,7 @@ def test_generated_loop_memory_validator_covers_corruption_matrix() -> None:
 
         state_path = valid_root / updater.STATE_PATH
         state = json.loads(state_path.read_text(encoding="utf-8"))
-        state["schema_version"] = 2
+        state["schema_version"] = 1
         state["state_branch"] = "main"
         state_path.write_text(json.dumps(state), encoding="utf-8")
         failures = checker.generated_state_failures(valid_root)
@@ -2316,7 +3003,7 @@ def test_merge_ledger_rejects_schema_record_and_ancestry_corruption() -> None:
         "invalid schema",
     )
     invalid_record = {
-        "schema_version": 1,
+        "schema_version": updater.SCHEMA_VERSION,
         "previous_entry_hash": None,
         "record": [],
         "entry_hash": "bad",
@@ -2334,7 +3021,7 @@ def test_merge_ledger_rejects_schema_record_and_ancestry_corruption() -> None:
         lambda: updater._validate_ledger_entries(
             [updater._ledger_entry(bad_sha_record, None)]
         ),
-        "canonical main SHA",
+        "lowercase hexadecimal",
     )
 
     first = loop_record(updater)
@@ -3577,12 +4264,18 @@ def main() -> int:
         test_stale_wording_catches_multiline_legacy_status_reconstruction,
         test_loop_memory_state_rejects_pre_merge_status,
         test_loop_memory_state_accepts_merged_fixture,
+        test_loop_memory_state_rejects_known_merged_pr_staleness,
         test_post_merge_metadata_is_strict_and_bounded,
+        test_next_chunk_contract_binding_is_exact_locally_and_remotely,
         test_post_merge_state_is_idempotent_and_monotonic,
         test_post_merge_reconciliation_bootstraps_and_recovers_every_commit,
+        test_loop_memory_target_resolution_rejects_stale_replays,
         test_post_merge_collection_binds_exact_pr_and_checks,
         test_generated_loop_memory_validator_detects_drift,
         test_generated_loop_memory_signature_authenticates_every_canonical_file,
+        test_schema_v1_signed_state_is_discarded_before_clean_v2_bootstrap,
+        test_live_and_historical_records_reject_cross_initiative_gates,
+        test_loop_memory_schema_v2_rejection_matrix_is_fail_closed,
         test_generated_loop_memory_prepare_recovers_hostile_path_types,
         test_generated_loop_memory_escapes_markdown_metadata,
         test_loop_memory_workflow_isolated_write_boundary,

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -1313,16 +1313,31 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
             "exactly one chunk contract",
         )
         foreign_contract.unlink()
+        spoof_contract = (
+            root
+            / ".agent-loop/initiatives/WS-AUTH-001-spoof/chunks/"
+            "WS-AUTH-001-07-authorization-kernel.md"
+        )
+        spoof_contract.parent.mkdir(parents=True)
+        spoof_contract.write_text(
+            "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
+            encoding="utf-8",
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater._validate_local_successor_contract(root, metadata),
+            "exactly one initiative directory",
+        )
+        spoof_contract.unlink()
+        spoof_contract.parent.rmdir()
+        spoof_contract.parent.parent.rmdir()
         contract.write_text(
             "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
             encoding="utf-8",
         )
         duplicate = (
-            root
-            / ".agent-loop/initiatives/WS-AUTH-001-duplicate/chunks/"
-            "WS-AUTH-001-07-copy.md"
+            contract.parent / "WS-AUTH-001-07-copy.md"
         )
-        duplicate.parent.mkdir(parents=True)
         duplicate.write_text(contract.read_text(encoding="utf-8"), encoding="utf-8")
         assert_loop_error(
             updater,
@@ -1357,6 +1372,10 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
     foreign_tree_item["path"] = foreign_tree_item["path"].replace(
         "WS-AUTH-001-example", "WS-ART-001-example"
     )
+    spoof_tree_item = dict(tree_item)
+    spoof_tree_item["path"] = spoof_tree_item["path"].replace(
+        "WS-AUTH-001-example", "WS-AUTH-001-spoof"
+    )
     valid_tree = {"truncated": False, "tree": [foreign_tree_item, tree_item]}
     updater._validate_remote_successor_contract(
         RemoteClient(
@@ -1374,6 +1393,11 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
             {"truncated": False, "tree": [foreign_tree_item]},
             "Authorization Kernel",
             "exactly one",
+        ),
+        (
+            {"truncated": False, "tree": [tree_item, spoof_tree_item]},
+            "Authorization Kernel",
+            "exactly one reviewed-head initiative directory",
         ),
         (
             {"truncated": False, "tree": [tree_item, dict(tree_item)]},
@@ -2106,13 +2130,23 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
         )
         is None
     )
-    assert updater._is_owned_chunk_contract_path(
+    assert (
+        updater._initiative_directory_from_path(
         ".agent-loop/initiatives/WS-AUTH-001-example/chunks/WS-AUTH-001-07.md",
         "WS-AUTH-001",
+        )
+        == "WS-AUTH-001-example"
     )
-    assert not updater._is_owned_chunk_contract_path(
+    assert (
+        updater._initiative_directory_from_path(
         ".agent-loop/initiatives/WS-ART-001-example/chunks/WS-AUTH-001-07.md",
         "WS-AUTH-001",
+        )
+        is None
+    )
+    assert updater._is_chunk_contract_path(
+        ".agent-loop/initiatives/WS-AUTH-001-example/chunks/WS-AUTH-001-07.md",
+        "WS-AUTH-001-example",
     )
 
     metadata_payload = json.loads(valid_loop_intent())

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -1246,6 +1246,9 @@ def test_post_merge_metadata_is_strict_and_bounded() -> None:
         "",
         valid_loop_intent() + valid_loop_intent(),
         valid_loop_intent().replace('"schema_version":2', '"schema_version":1'),
+        valid_loop_intent().replace('"schema_version":2', '"schema_version":2.0'),
+        valid_loop_intent().replace('"schema_version":2', '"schema_version":"2"'),
+        valid_loop_intent().replace('"schema_version":2', '"schema_version":true'),
         valid_loop_intent().replace(
             '"chunk_id":"WS-AUTH-001-06"', '"chunk_id":"WS-POL-002-04"'
         ),
@@ -1385,7 +1388,14 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
     spoof_tree_item["path"] = spoof_tree_item["path"].replace(
         "WS-AUTH-001-example", "WS-AUTH-001-spoof"
     )
-    valid_tree = {"truncated": False, "tree": [foreign_tree_item, tree_item]}
+    non_contract_tree_item = dict(tree_item)
+    non_contract_tree_item["path"] = non_contract_tree_item["path"].removesuffix(
+        ".md"
+    ) + ".txt"
+    valid_tree = {
+        "truncated": False,
+        "tree": [foreign_tree_item, non_contract_tree_item, tree_item],
+    }
     updater._validate_remote_successor_contract(
         RemoteClient(
             valid_tree,
@@ -2157,6 +2167,10 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
         ".agent-loop/initiatives/WS-AUTH-001-example/chunks/WS-AUTH-001-07.md",
         "WS-AUTH-001-example",
     )
+    assert not updater._is_chunk_contract_path(
+        ".agent-loop/initiatives/WS-AUTH-001-example/chunks/WS-AUTH-001-07.txt",
+        "WS-AUTH-001-example",
+    )
 
     metadata_payload = json.loads(valid_loop_intent())
     metadata_mutations = (
@@ -2271,6 +2285,9 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
 
     base = loop_record(updater)
     record_mutations = (
+        (lambda row: row.update(schema_version=2.0), "invalid schema"),
+        (lambda row: row.update(schema_version="2"), "invalid schema"),
+        (lambda row: row.update(schema_version=True), "invalid schema"),
         (lambda row: row.update(state_branch="main"), "state branch"),
         (lambda row: row.update(repository=7), "repository must be owner/name"),
         (
@@ -2325,6 +2342,9 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
     metadata_failure_mutations = (
         lambda value: value.clear(),
         lambda value: value.update(schema_version=1),
+        lambda value: value.update(schema_version=2.0),
+        lambda value: value.update(schema_version="2"),
+        lambda value: value.update(schema_version=True),
         lambda value: value.update(initiative_id="bad"),
         lambda value: value.update(initiative_id="WS-" + ("A" * 78)),
         lambda value: value.update(chunk_id="WS-AUTH-" + ("A" * 73)),
@@ -3018,6 +3038,21 @@ def test_generated_loop_memory_validator_covers_corruption_matrix() -> None:
             assert checker.main(["--state-root", str(valid_root)]) == 0
 
         state_path = valid_root / updater.STATE_PATH
+        ledger_path = valid_root / updater.LEDGER_PATH
+        valid_ledger_text = ledger_path.read_text(encoding="utf-8")
+        for malformed_schema_version in (2.0, "2", True):
+            malformed_ledger = json.loads(valid_ledger_text)
+            malformed_ledger["schema_version"] = malformed_schema_version
+            ledger_path.write_text(
+                f"{json.dumps(malformed_ledger)}\n",
+                encoding="utf-8",
+            )
+            assert any(
+                "invalid entry schema" in failure
+                for failure in checker.generated_state_failures(valid_root)
+            )
+        ledger_path.write_text(valid_ledger_text, encoding="utf-8")
+
         state = json.loads(state_path.read_text(encoding="utf-8"))
         state["schema_version"] = 1
         state["state_branch"] = "main"
@@ -3115,6 +3150,16 @@ def test_merge_ledger_rejects_schema_record_and_ancestry_corruption() -> None:
         lambda: updater._validate_ledger_entries([{}]),
         "invalid schema",
     )
+    for malformed_schema_version in (2.0, "2", True):
+        malformed_envelope = updater._ledger_entry(loop_record(updater), None)
+        malformed_envelope["schema_version"] = malformed_schema_version
+        assert_loop_error(
+            updater,
+            lambda malformed_envelope=malformed_envelope: updater._validate_ledger_entries(
+                [malformed_envelope]
+            ),
+            "invalid schema",
+        )
     invalid_record = {
         "schema_version": updater.SCHEMA_VERSION,
         "previous_entry_hash": None,

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -1158,6 +1158,8 @@ def test_loop_memory_state_rejects_known_merged_pr_staleness() -> None:
             "Status: Active planning only"
         ),
         "PR #122 remains active.",
+        "PR publication and external review remain pending.",
+        "PR publication and external checks remain pending.",
     )
     for sample in stale_samples:
         assert any(
@@ -1181,6 +1183,20 @@ def valid_loop_intent() -> str:
         '"next_chunk_id":"WS-AUTH-001-07","next_chunk_title":"Authorization Kernel",'
         '"next_requires_explicit_start":true}\n'
     )
+
+
+def test_pr_templates_share_merge_intent_contract() -> None:
+    """Both human templates must state the same schema-v2 merge-intent contract."""
+
+    def merge_intent_contract(path: Path) -> str:
+        text = path.read_text(encoding="utf-8")
+        start = text.index("Add exactly one new schema-v2 merge-intent file")
+        end = text.index("\n## Goal", start)
+        return " ".join(text[start:end].replace("Trusted ", "").split()).lower()
+
+    assert merge_intent_contract(
+        ROOT / ".agent-loop/templates/PR_TRUST_BUNDLE.md"
+    ) == merge_intent_contract(ROOT / ".github/pull_request_template.md")
 
 
 def updater_base64(value: str) -> str:
@@ -1322,7 +1338,7 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
         assert_loop_error(
             updater,
             lambda: updater._validate_local_successor_contract(root, metadata),
-            "exactly one chunk contract",
+            "another initiative directory",
         )
         foreign_contract.unlink()
         spoof_contract = (
@@ -1347,6 +1363,17 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
             "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
             encoding="utf-8",
         )
+        foreign_contract.parent.mkdir(parents=True, exist_ok=True)
+        foreign_contract.write_text(
+            "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
+            encoding="utf-8",
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater._validate_local_successor_contract(root, metadata),
+            "another initiative directory",
+        )
+        foreign_contract.unlink()
         duplicate = (
             contract.parent / "WS-AUTH-001-07-copy.md"
         )
@@ -1394,7 +1421,7 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
     ) + ".txt"
     valid_tree = {
         "truncated": False,
-        "tree": [foreign_tree_item, non_contract_tree_item, tree_item],
+        "tree": [non_contract_tree_item, tree_item],
     }
     updater._validate_remote_successor_contract(
         RemoteClient(
@@ -1411,7 +1438,12 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
         (
             {"truncated": False, "tree": [foreign_tree_item]},
             "Authorization Kernel",
-            "exactly one",
+            "exactly one reviewed-head initiative directory",
+        ),
+        (
+            {"truncated": False, "tree": [tree_item, foreign_tree_item]},
+            "Authorization Kernel",
+            "another reviewed-head initiative directory",
         ),
         (
             {"truncated": False, "tree": [tree_item, spoof_tree_item]},
@@ -4423,6 +4455,7 @@ def main() -> int:
         test_loop_memory_state_rejects_pre_merge_status,
         test_loop_memory_state_accepts_merged_fixture,
         test_loop_memory_state_rejects_known_merged_pr_staleness,
+        test_pr_templates_share_merge_intent_contract,
         test_post_merge_metadata_is_strict_and_bounded,
         test_next_chunk_contract_binding_is_exact_locally_and_remotely,
         test_post_merge_state_is_idempotent_and_monotonic,

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -2368,6 +2368,9 @@ def test_loop_memory_workflow_isolated_write_boundary() -> None:
     assert "contents: write" in workflow
     assert "pull-requests: read" in workflow
     assert "LOOP_MEMORY_SIGNING_KEY" in workflow
+    assert workflow.count("LOOP_MEMORY_SIGNING_KEY:") == 1
+    assert "LOOP_MEMORY_PRIVATE_KEY" not in workflow
+    assert 'trap \'rm -f "${private_key}"\' EXIT' in workflow
     assert "prepare-state" in workflow
     assert ".agent-loop/STATE.sig" in workflow
     assert 'git -C "${state_dir}" add -f --' in workflow

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -1141,6 +1141,10 @@ def test_loop_memory_state_rejects_known_merged_pr_staleness() -> None:
     )
     stale_samples = (
         "AUTH-05B runtime is reviewed; publication is pending.",
+        (
+            "AUTH-05B runtime SHA is internally reviewed. Its current gate is "
+            "PR publication and external checks."
+        ),
         "| `WS-AUTH-001-05B` | In review | branch | - | pending |",
         "PR #120's branch is ready for review.",
         "`WS-ART-001-OBJECT-STORAGE-AMENDMENT` is Active planning.",
@@ -1293,6 +1297,22 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
             lambda: updater._validate_local_successor_contract(root, metadata),
             "exactly one chunk contract",
         )
+        foreign_contract = (
+            root
+            / ".agent-loop/initiatives/WS-ART-001-example/chunks/"
+            "WS-AUTH-001-07-authorization-kernel.md"
+        )
+        foreign_contract.parent.mkdir(parents=True)
+        foreign_contract.write_text(
+            "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
+            encoding="utf-8",
+        )
+        assert_loop_error(
+            updater,
+            lambda: updater._validate_local_successor_contract(root, metadata),
+            "exactly one chunk contract",
+        )
+        foreign_contract.unlink()
         contract.write_text(
             "# Chunk Contract: WS-AUTH-001-07 - Authorization Kernel\n",
             encoding="utf-8",
@@ -1333,7 +1353,11 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
         ),
         "sha": "e" * 40,
     }
-    valid_tree = {"truncated": False, "tree": [tree_item]}
+    foreign_tree_item = dict(tree_item)
+    foreign_tree_item["path"] = foreign_tree_item["path"].replace(
+        "WS-AUTH-001-example", "WS-ART-001-example"
+    )
+    valid_tree = {"truncated": False, "tree": [foreign_tree_item, tree_item]}
     updater._validate_remote_successor_contract(
         RemoteClient(
             valid_tree,
@@ -1346,6 +1370,11 @@ def test_next_chunk_contract_binding_is_exact_locally_and_remotely() -> None:
     remote_cases = (
         ({"truncated": True, "tree": [tree_item]}, "Authorization Kernel", "incomplete"),
         ({"truncated": False, "tree": []}, "Authorization Kernel", "exactly one"),
+        (
+            {"truncated": False, "tree": [foreign_tree_item]},
+            "Authorization Kernel",
+            "exactly one",
+        ),
         (
             {"truncated": False, "tree": [tree_item, dict(tree_item)]},
             "Authorization Kernel",
@@ -2069,13 +2098,21 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
             "# Chunk Contract: WS-AUTH-001-07 Authorization Kernel\n",
             "WS-AUTH-001-07",
         )
-        == "Authorization Kernel"
+        is None
     )
     assert (
         updater._contract_title(
             "# Chunk Contract: WS-AUTH-001-07\n", "WS-AUTH-001-07"
         )
         is None
+    )
+    assert updater._is_owned_chunk_contract_path(
+        ".agent-loop/initiatives/WS-AUTH-001-example/chunks/WS-AUTH-001-07.md",
+        "WS-AUTH-001",
+    )
+    assert not updater._is_owned_chunk_contract_path(
+        ".agent-loop/initiatives/WS-ART-001-example/chunks/WS-AUTH-001-07.md",
+        "WS-AUTH-001",
     )
 
     metadata_payload = json.loads(valid_loop_intent())
@@ -2188,6 +2225,10 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
         (lambda row: row["source"].update(pr_url="https://invalid"), "PR URL"),
         (lambda row: row.update(updated_at="2026-07-14T20:01:00Z"), "updated_at"),
         (lambda row: row.update(completed_chunk=[]), "JSON object"),
+        (
+            lambda row: row["completed_chunk"].update(chunk_title="valid\ninjected"),
+            "single-line",
+        ),
         (lambda row: row["source"].update(intent_path="wrong"), "intent path"),
         (lambda row: row.update(active={}), "active chunk state"),
         (lambda row: row.update(checks=[]), "check evidence"),
@@ -2231,9 +2272,12 @@ def test_loop_memory_schema_v2_rejection_matrix_is_fail_closed() -> None:
         lambda value: value.update(initiative_id="bad"),
         lambda value: value.update(chunk_id="WS-ART-001-01"),
         lambda value: value.update(chunk_title=""),
+        lambda value: value.update(chunk_title="x" * 161),
+        lambda value: value.update(chunk_title="valid\ninjected"),
         lambda value: value.update(next_chunk_title=None),
         lambda value: value.update(next_chunk_id="WS-ART-001-02"),
         lambda value: value.update(next_chunk_title=7),
+        lambda value: value.update(next_chunk_title="x" * 161),
         lambda value: value.update(next_requires_explicit_start="yes"),
     )
     for mutate in metadata_failure_mutations:
@@ -2325,6 +2369,11 @@ def test_loop_memory_workflow_isolated_write_boundary() -> None:
     assert "EVENT_SHA" in workflow
     assert "TARGET_SHA" in workflow
     assert "MERGE_SHA" not in workflow
+    job_environment = workflow.split("    steps:", 1)[0]
+    assert "GH_TOKEN:" not in job_environment
+    assert "GITHUB_TOKEN:" not in job_environment
+    assert workflow.count("GH_TOKEN: ${{ github.token }}") == 3
+    assert workflow.count("GITHUB_TOKEN: ${{ github.token }}") == 1
     assert "replay target is stale" in (
         ROOT / "scripts/update_post_merge_memory.py"
     ).read_text(encoding="utf-8")

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -1192,7 +1192,7 @@ def test_pr_templates_share_merge_intent_contract() -> None:
         text = path.read_text(encoding="utf-8")
         start = text.index("Add exactly one new schema-v2 merge-intent file")
         end = text.index("\n## Goal", start)
-        return " ".join(text[start:end].replace("Trusted ", "").split()).lower()
+        return " ".join(text[start:end].split())
 
     assert merge_intent_contract(
         ROOT / ".agent-loop/templates/PR_TRUST_BUNDLE.md"

--- a/scripts/update_post_merge_memory.py
+++ b/scripts/update_post_merge_memory.py
@@ -207,16 +207,26 @@ def _intent_path(metadata: LoopMetadata) -> str:
 
 def _contract_title(contract_text: str, chunk_id: str) -> str | None:
     """Return the title from one canonical chunk-contract heading."""
-    first_line = contract_text.splitlines()[0] if contract_text.splitlines() else ""
-    prefix = f"# Chunk Contract: {chunk_id}"
+    lines = contract_text.splitlines()
+    first_line = lines[0] if lines else ""
+    prefix = f"# Chunk Contract: {chunk_id} - "
     if not first_line.startswith(prefix):
         return None
-    remainder = first_line[len(prefix) :]
-    if remainder.startswith(" - "):
-        return remainder[3:].strip()
-    if remainder.startswith(" "):
-        return remainder.strip()
-    return None
+    title = first_line[len(prefix) :].strip()
+    return title or None
+
+
+def _is_owned_chunk_contract_path(path: str, initiative_id: str) -> bool:
+    """Return whether one contract path belongs to the declared initiative."""
+    if not path.startswith(CHUNK_CONTRACT_ROOT):
+        return False
+    parts = path[len(CHUNK_CONTRACT_ROOT) :].split("/")
+    if len(parts) != 3 or parts[1] != "chunks":
+        return False
+    initiative_directory = parts[0]
+    return initiative_directory == initiative_id or initiative_directory.startswith(
+        f"{initiative_id}-"
+    )
 
 
 def _validate_local_successor_contract(
@@ -229,8 +239,13 @@ def _validate_local_successor_contract(
     candidates = sorted(
         path
         for path in initiatives_root.glob("*/chunks/*.md")
-        if path.name == f"{metadata.next_chunk_id}.md"
-        or path.name.startswith(f"{metadata.next_chunk_id}-")
+        if _is_owned_chunk_contract_path(
+            path.relative_to(repository_root).as_posix(), metadata.initiative_id
+        )
+        and (
+            path.name == f"{metadata.next_chunk_id}.md"
+            or path.name.startswith(f"{metadata.next_chunk_id}-")
+        )
     )
     if len(candidates) != 1:
         raise LoopMemoryError(
@@ -295,8 +310,7 @@ def _validate_remote_successor_contract(
             continue
         name = path.rsplit("/", 1)[-1]
         if (
-            path.startswith(CHUNK_CONTRACT_ROOT)
-            and "/chunks/" in path
+            _is_owned_chunk_contract_path(path, metadata.initiative_id)
             and (
                 name == f"{metadata.next_chunk_id}.md"
                 or name.startswith(f"{metadata.next_chunk_id}-")

--- a/scripts/update_post_merge_memory.py
+++ b/scripts/update_post_merge_memory.py
@@ -243,6 +243,13 @@ def _is_chunk_contract_path(path: str, initiative_directory: str) -> bool:
     )
 
 
+def _successor_contract_name_matches(name: str, chunk_id: str) -> bool:
+    """Return whether one Markdown filename claims a successor chunk ID."""
+    return name == f"{chunk_id}.md" or (
+        name.startswith(f"{chunk_id}-") and name.endswith(".md")
+    )
+
+
 def _validate_local_successor_contract(
     repository_root: Path, metadata: LoopMetadata
 ) -> None:
@@ -263,14 +270,26 @@ def _validate_local_successor_contract(
         raise LoopMemoryError(
             "initiative_id must resolve to exactly one initiative directory"
         )
-    chunks_root = initiatives_root / initiative_directories[0] / "chunks"
+    initiative_directory = initiative_directories[0]
+    all_candidates = sorted(
+        path
+        for path in initiatives_root.glob("*/chunks/*.md")
+        if _successor_contract_name_matches(path.name, metadata.next_chunk_id)
+    )
+    foreign_candidates = [
+        path
+        for path in all_candidates
+        if path.parent.parent.name != initiative_directory
+    ]
+    if foreign_candidates:
+        raise LoopMemoryError(
+            "next_chunk_id must not exist under another initiative directory"
+        )
+    chunks_root = initiatives_root / initiative_directory / "chunks"
     candidates = sorted(
         path
         for path in chunks_root.glob("*.md")
-        if (
-            path.name == f"{metadata.next_chunk_id}.md"
-            or path.name.startswith(f"{metadata.next_chunk_id}-")
-        )
+        if _successor_contract_name_matches(path.name, metadata.next_chunk_id)
     )
     if len(candidates) != 1:
         raise LoopMemoryError(
@@ -343,6 +362,7 @@ def _validate_remote_successor_contract(
         )
     initiative_directory = initiative_directories[0]
     candidates = []
+    foreign_candidates = []
     for item in tree["tree"]:
         if not isinstance(item, dict) or item.get("type") != "blob":
             continue
@@ -351,14 +371,24 @@ def _validate_remote_successor_contract(
         if not isinstance(path, str) or not isinstance(blob_sha, str):
             continue
         name = path.rsplit("/", 1)[-1]
+        if not _successor_contract_name_matches(name, metadata.next_chunk_id):
+            continue
+        relative = path.removeprefix(CHUNK_CONTRACT_ROOT)
+        parts = relative.split("/")
         if (
-            _is_chunk_contract_path(path, initiative_directory)
-            and (
-                name == f"{metadata.next_chunk_id}.md"
-                or name.startswith(f"{metadata.next_chunk_id}-")
-            )
+            not path.startswith(CHUNK_CONTRACT_ROOT)
+            or len(parts) != 3
+            or parts[1] != "chunks"
         ):
+            continue
+        if parts[0] != initiative_directory:
+            foreign_candidates.append((path, blob_sha))
+        elif _is_chunk_contract_path(path, initiative_directory):
             candidates.append((path, blob_sha))
+    if foreign_candidates:
+        raise LoopMemoryError(
+            "next_chunk_id must not exist under another reviewed-head initiative directory"
+        )
     if len(candidates) != 1:
         raise LoopMemoryError(
             "next_chunk_id must resolve to exactly one reviewed-head chunk contract"

--- a/scripts/update_post_merge_memory.py
+++ b/scripts/update_post_merge_memory.py
@@ -21,14 +21,15 @@ from pathlib import Path
 from typing import Any
 
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 STATE_BRANCH = "automation/loop-memory"
 STATE_PATH = Path(".agent-loop/STATE.json")
 RENDERED_PATH = Path(".agent-loop/LOOP_STATE.md")
 LEDGER_PATH = Path(".agent-loop/MERGE_LOG.jsonl")
 SIGNATURE_PATH = Path(".agent-loop/STATE.sig")
 INTENT_PREFIX = ".agent-loop/merge-intents/"
-BOOTSTRAP_INTENT_PATH = f"{INTENT_PREFIX}WS-ENG-001-02.json"
+BOOTSTRAP_INTENT_PATH = f"{INTENT_PREFIX}WS-ENG-001-03.json"
+CHUNK_CONTRACT_ROOT = ".agent-loop/initiatives/"
 ID_PATTERN = re.compile(r"^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+$")
 REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
@@ -165,6 +166,10 @@ def parse_loop_metadata(intent_text: str) -> LoopMetadata:
         raise LoopMemoryError(
             "next_chunk_id and next_chunk_title must both be null or both be set"
         )
+    if next_chunk_id is not None and not next_chunk_id.startswith(
+        f"{initiative_id}-"
+    ):
+        raise LoopMemoryError("next_chunk_id must belong to initiative_id")
     explicit_start = payload["next_requires_explicit_start"]
     if not isinstance(explicit_start, bool):
         raise LoopMemoryError("next_requires_explicit_start must be a boolean")
@@ -200,6 +205,123 @@ def _intent_path(metadata: LoopMetadata) -> str:
     return f"{INTENT_PREFIX}{metadata.chunk_id}.json"
 
 
+def _contract_title(contract_text: str, chunk_id: str) -> str | None:
+    """Return the title from one canonical chunk-contract heading."""
+    first_line = contract_text.splitlines()[0] if contract_text.splitlines() else ""
+    prefix = f"# Chunk Contract: {chunk_id}"
+    if not first_line.startswith(prefix):
+        return None
+    remainder = first_line[len(prefix) :]
+    if remainder.startswith(" - "):
+        return remainder[3:].strip()
+    if remainder.startswith(" "):
+        return remainder.strip()
+    return None
+
+
+def _validate_local_successor_contract(
+    repository_root: Path, metadata: LoopMetadata
+) -> None:
+    """Bind a non-null successor to one matching local chunk contract."""
+    if metadata.next_chunk_id is None:
+        return
+    initiatives_root = repository_root / CHUNK_CONTRACT_ROOT
+    candidates = sorted(
+        path
+        for path in initiatives_root.glob("*/chunks/*.md")
+        if path.name == f"{metadata.next_chunk_id}.md"
+        or path.name.startswith(f"{metadata.next_chunk_id}-")
+    )
+    if len(candidates) != 1:
+        raise LoopMemoryError(
+            "next_chunk_id must resolve to exactly one chunk contract"
+        )
+    try:
+        title = _contract_title(
+            candidates[0].read_text(encoding="utf-8"), metadata.next_chunk_id
+        )
+    except (OSError, UnicodeDecodeError) as exc:
+        raise LoopMemoryError("cannot read next chunk contract") from exc
+    if title != metadata.next_chunk_title:
+        raise LoopMemoryError("next chunk contract heading does not match intent")
+
+
+def _decode_github_blob(payload: Any, label: str, maximum: int) -> tuple[str, str]:
+    """Decode one bounded GitHub base64 blob response."""
+    if not isinstance(payload, dict) or payload.get("encoding") != "base64":
+        raise LoopMemoryError(f"{label} content response has an invalid shape")
+    blob_sha = payload.get("sha")
+    content = payload.get("content")
+    if not isinstance(blob_sha, str) or not SHA_PATTERN.fullmatch(blob_sha):
+        raise LoopMemoryError(f"{label} blob has no canonical SHA")
+    if not isinstance(content, str):
+        raise LoopMemoryError(f"{label} blob has no encoded content")
+    try:
+        normalized_content = re.sub(r"[ \t\r\n]", "", content)
+        raw = base64.b64decode(normalized_content, validate=True)
+        if len(raw) > maximum:
+            raise LoopMemoryError(f"{label} document exceeds {maximum} bytes")
+        text = raw.decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise LoopMemoryError(f"{label} content is not valid base64 UTF-8") from exc
+    return text, blob_sha
+
+
+def _validate_remote_successor_contract(
+    client: GitHubClient,
+    repository: str,
+    head_sha: str,
+    metadata: LoopMetadata,
+) -> None:
+    """Bind a non-null successor to one contract on the reviewed PR head."""
+    if metadata.next_chunk_id is None:
+        return
+    tree = client.get_json(
+        f"/repos/{repository}/git/trees/{head_sha}?recursive=1"
+    )
+    if (
+        not isinstance(tree, dict)
+        or tree.get("truncated") is not False
+        or not isinstance(tree.get("tree"), list)
+    ):
+        raise LoopMemoryError("reviewed-head repository tree is incomplete")
+    candidates = []
+    for item in tree["tree"]:
+        if not isinstance(item, dict) or item.get("type") != "blob":
+            continue
+        path = item.get("path")
+        blob_sha = item.get("sha")
+        if not isinstance(path, str) or not isinstance(blob_sha, str):
+            continue
+        name = path.rsplit("/", 1)[-1]
+        if (
+            path.startswith(CHUNK_CONTRACT_ROOT)
+            and "/chunks/" in path
+            and (
+                name == f"{metadata.next_chunk_id}.md"
+                or name.startswith(f"{metadata.next_chunk_id}-")
+            )
+        ):
+            candidates.append((path, blob_sha))
+    if len(candidates) != 1:
+        raise LoopMemoryError(
+            "next_chunk_id must resolve to exactly one reviewed-head chunk contract"
+        )
+    _, blob_sha = candidates[0]
+    if not SHA_PATTERN.fullmatch(blob_sha):
+        raise LoopMemoryError("next chunk contract has no canonical blob SHA")
+    contract_text, returned_sha = _decode_github_blob(
+        client.get_json(f"/repos/{repository}/git/blobs/{blob_sha}"),
+        "next chunk contract",
+        262144,
+    )
+    if returned_sha != blob_sha:
+        raise LoopMemoryError("next chunk contract blob identity does not match tree")
+    title = _contract_title(contract_text, metadata.next_chunk_id)
+    if title != metadata.next_chunk_title:
+        raise LoopMemoryError("next chunk contract heading does not match intent")
+
+
 def load_committed_merge_intent(
     client: GitHubClient,
     repository: str,
@@ -224,25 +346,11 @@ def load_committed_merge_intent(
     payload = client.get_json(
         f"/repos/{repository}/contents/{encoded_path}?ref={head_sha}"
     )
-    if not isinstance(payload, dict) or payload.get("encoding") != "base64":
-        raise LoopMemoryError("merge-intent content response has an invalid shape")
-    blob_sha = payload.get("sha")
-    content = payload.get("content")
-    if not isinstance(blob_sha, str) or not SHA_PATTERN.fullmatch(blob_sha):
-        raise LoopMemoryError("merge-intent blob has no canonical SHA")
-    if not isinstance(content, str):
-        raise LoopMemoryError("merge-intent blob has no encoded content")
-    try:
-        normalized_content = re.sub(r"[ \t\r\n]", "", content)
-        raw = base64.b64decode(normalized_content, validate=True)
-        if len(raw) > 8192:
-            raise LoopMemoryError("merge-intent document exceeds 8192 bytes")
-        text = raw.decode("utf-8")
-    except (ValueError, UnicodeDecodeError) as exc:
-        raise LoopMemoryError("merge-intent content is not valid base64 UTF-8") from exc
+    text, blob_sha = _decode_github_blob(payload, "merge-intent", 8192)
     metadata = parse_loop_metadata(text)
     if path != _intent_path(metadata):
         raise LoopMemoryError("merge-intent path does not match its chunk_id")
+    _validate_remote_successor_contract(client, repository, head_sha, metadata)
     return metadata, path, blob_sha
 
 
@@ -277,6 +385,7 @@ def validate_local_merge_intent(repository_root: Path, base_ref: str) -> LoopMet
         raise LoopMemoryError("cannot read local merge-intent file") from exc
     if path != _intent_path(metadata):
         raise LoopMemoryError("merge-intent path does not match its chunk_id")
+    _validate_local_successor_contract(repository_root, metadata)
     return metadata
 
 
@@ -353,6 +462,30 @@ def plan_reconciliation_commits(
         "cannot enumerate commits after the loop-memory bootstrap",
     )
     return [bootstrap_sha, *successors]
+
+
+def resolve_reconciliation_target(
+    repository_root: Path,
+    event_name: str,
+    event_sha: str,
+    current_main_sha: str,
+) -> str:
+    """Bind one workflow event to the current protected-main commit."""
+    _validate_sha(event_sha)
+    _validate_sha(current_main_sha)
+    if event_name == "repository_dispatch":
+        if event_sha != current_main_sha:
+            raise LoopMemoryError(
+                "replay target is stale; dispatch current protected-main SHA"
+            )
+        return current_main_sha
+    if event_name == "push":
+        if not _is_ancestor(repository_root, event_sha, current_main_sha):
+            raise LoopMemoryError(
+                "push event SHA is not on current protected-main ancestry"
+            )
+        return current_main_sha
+    raise LoopMemoryError("unsupported loop-memory event")
 
 
 def _latest_named(
@@ -660,6 +793,114 @@ def _ledger_entry(record: dict[str, Any], previous_hash: str | None) -> dict[str
     }
 
 
+def _validate_record(record: dict[str, Any]) -> LoopMetadata:
+    """Validate one complete schema-v2 live-state or ledger record."""
+    expected_record_keys = {
+        "schema_version",
+        "repository",
+        "state_branch",
+        "updated_at",
+        "source",
+        "completed_chunk",
+        "active",
+        "gate",
+        "checks",
+    }
+    if set(record) != expected_record_keys or record.get("schema_version") != SCHEMA_VERSION:
+        raise LoopMemoryError("loop-memory record has an invalid schema")
+    if record.get("state_branch") != STATE_BRANCH:
+        raise LoopMemoryError("loop-memory record has an invalid state branch")
+
+    source = record.get("source")
+    expected_source_keys = {
+        "main_sha",
+        "first_parent_sha",
+        "pr_number",
+        "pr_url",
+        "pr_title",
+        "head_sha",
+        "head_ref",
+        "merged_at",
+        "merged_by",
+        "intent_path",
+        "intent_blob_sha",
+    }
+    if not isinstance(source, dict) or set(source) != expected_source_keys:
+        raise LoopMemoryError("loop-memory source has an invalid schema")
+    repository = record.get("repository")
+    _validate_repository_and_sha(repository, source.get("main_sha", ""))
+    _validate_sha(source.get("first_parent_sha", ""))
+    _validate_sha(source.get("head_sha", ""))
+    _validate_sha(source.get("intent_blob_sha", ""))
+    pr_number = source.get("pr_number")
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
+        raise LoopMemoryError("loop-memory source has no positive PR number")
+    if source.get("pr_url") != f"https://github.com/{repository}/pull/{pr_number}":
+        raise LoopMemoryError("loop-memory source has an invalid PR URL")
+    for field, maximum in (
+        ("pr_title", 240),
+        ("head_ref", 240),
+        ("merged_by", 160),
+    ):
+        _bounded_text(source.get(field), field, maximum=maximum)
+    merged_at = source.get("merged_at")
+    _parse_timestamp(merged_at, "merged_at")
+    if record.get("updated_at") != merged_at:
+        raise LoopMemoryError("loop-memory updated_at does not match merged_at")
+
+    completed = record.get("completed_chunk")
+    if not isinstance(completed, dict):
+        raise LoopMemoryError("completed_chunk must be a JSON object")
+    metadata = parse_loop_metadata(_canonical_json(completed))
+    if source.get("intent_path") != _intent_path(metadata):
+        raise LoopMemoryError("loop-memory intent path does not match completed chunk")
+
+    active = record.get("active")
+    if active != {"planning_chunk": None, "implementation_chunk": None}:
+        raise LoopMemoryError("post-merge active chunk state must be empty")
+    gate = record.get("gate")
+    expected_gate = {
+        "status": "stopped_after_merge",
+        "next_chunk_id": metadata.next_chunk_id,
+        "next_chunk_title": metadata.next_chunk_title,
+        "next_requires_explicit_start": metadata.next_requires_explicit_start,
+    }
+    if gate != expected_gate:
+        raise LoopMemoryError("next gate does not match completed chunk metadata")
+
+    checks = record.get("checks")
+    if not isinstance(checks, dict) or set(checks) != {
+        "required",
+        "all_required_passed",
+    }:
+        raise LoopMemoryError("loop-memory check evidence has an invalid schema")
+    required = checks.get("required")
+    if not isinstance(required, dict) or set(required) != set(REQUIRED_CHECKS):
+        raise LoopMemoryError("loop-memory required-check evidence is incomplete")
+    for name in REQUIRED_CHECKS:
+        result = required[name]
+        if not isinstance(result, dict) or set(result) != {
+            "kind",
+            "conclusion",
+            "url",
+        }:
+            raise LoopMemoryError(f"loop-memory check evidence is invalid for {name}")
+        if not isinstance(result.get("kind"), str):
+            raise LoopMemoryError(f"loop-memory check kind is invalid for {name}")
+        if result.get("conclusion") is not None and not isinstance(
+            result.get("conclusion"), str
+        ):
+            raise LoopMemoryError(f"loop-memory check conclusion is invalid for {name}")
+        if result.get("url") is not None and not isinstance(result.get("url"), str):
+            raise LoopMemoryError(f"loop-memory check URL is invalid for {name}")
+    all_passed = all(
+        required[name].get("conclusion") == "success" for name in REQUIRED_CHECKS
+    )
+    if checks.get("all_required_passed") is not all_passed:
+        raise LoopMemoryError("loop-memory aggregate check evidence is inconsistent")
+    return metadata
+
+
 def _validate_ledger_entries(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Validate the full ledger hash and first-parent chains."""
     records: list[dict[str, Any]] = []
@@ -677,6 +918,7 @@ def _validate_ledger_entries(entries: list[dict[str, Any]]) -> list[dict[str, An
         record = entry.get("record")
         if not isinstance(record, dict):
             raise LoopMemoryError("merge ledger entry record must be a JSON object")
+        _validate_record(record)
         if entry.get("previous_entry_hash") != previous_hash:
             raise LoopMemoryError("merge ledger previous hash chain is invalid")
         expected_hash = _ledger_hash(previous_hash, record)
@@ -699,6 +941,7 @@ def _validate_ledger_entries(entries: list[dict[str, Any]]) -> list[dict[str, An
 
 def apply_merge_record(state_root: Path, record: dict[str, Any]) -> bool:
     """Apply one monotonic, idempotent merge record to a state directory."""
+    _validate_record(record)
     state_path = state_root / STATE_PATH
     ledger_path = state_root / LEDGER_PATH
     rendered_path = state_root / RENDERED_PATH
@@ -753,14 +996,7 @@ def validate_generated_state(state_root: Path) -> None:
     state = _load_json(state_root / STATE_PATH)
     if state is None:
         raise LoopMemoryError("generated state file is missing")
-    if (
-        state.get("schema_version") != SCHEMA_VERSION
-        or state.get("state_branch") != STATE_BRANCH
-    ):
-        raise LoopMemoryError("generated state schema or branch is invalid")
-    _validate_repository_and_sha(
-        state.get("repository", ""), state.get("source", {}).get("main_sha", "")
-    )
+    _validate_record(state)
     ledger = _load_ledger(state_root / LEDGER_PATH)
     records = _validate_ledger_entries(ledger)
     if not records or _canonical_json(records[-1]) != _canonical_json(state):
@@ -774,7 +1010,7 @@ def validate_generated_state(state_root: Path) -> None:
 
 def _signature_payload(state_root: Path) -> bytes:
     """Return an unambiguous payload covering every canonical generated file."""
-    payload = bytearray(b"workstream-loop-memory-signature-v1\0")
+    payload = bytearray(b"workstream-loop-memory-signature-v2\0")
     for relative_path in (STATE_PATH, RENDERED_PATH, LEDGER_PATH):
         path_bytes = relative_path.as_posix().encode("ascii")
         content = (state_root / relative_path).read_bytes()
@@ -937,6 +1173,14 @@ def build_parser() -> argparse.ArgumentParser:
     plan_commits.add_argument("--target-sha", required=True)
     plan_commits.add_argument("--current-sha")
 
+    resolve_target = subparsers.add_parser("resolve-target")
+    resolve_target.add_argument("--repository-root", type=Path, default=Path("."))
+    resolve_target.add_argument(
+        "--event-name", choices=("push", "repository_dispatch"), required=True
+    )
+    resolve_target.add_argument("--event-sha", required=True)
+    resolve_target.add_argument("--current-main-sha", required=True)
+
     update = subparsers.add_parser("update")
     update.add_argument("--repository", required=True)
     update.add_argument("--merge-sha", required=True)
@@ -982,6 +1226,15 @@ def main(argv: list[str] | None = None) -> int:
                 args.current_sha,
             ):
                 print(merge_sha)
+        elif args.command == "resolve-target":
+            print(
+                resolve_reconciliation_target(
+                    args.repository_root,
+                    args.event_name,
+                    args.event_sha,
+                    args.current_main_sha,
+                )
+            )
         elif args.command == "update":
             _assert_state_branch(args.state_root)
             token = os.environ.get(args.token_env, "")

--- a/scripts/update_post_merge_memory.py
+++ b/scripts/update_post_merge_memory.py
@@ -216,17 +216,22 @@ def _contract_title(contract_text: str, chunk_id: str) -> str | None:
     return title or None
 
 
-def _is_owned_chunk_contract_path(path: str, initiative_id: str) -> bool:
-    """Return whether one contract path belongs to the declared initiative."""
+def _initiative_directory_from_path(path: str, initiative_id: str) -> str | None:
+    """Return the matching top-level initiative directory from one path."""
     if not path.startswith(CHUNK_CONTRACT_ROOT):
-        return False
-    parts = path[len(CHUNK_CONTRACT_ROOT) :].split("/")
-    if len(parts) != 3 or parts[1] != "chunks":
-        return False
-    initiative_directory = parts[0]
-    return initiative_directory == initiative_id or initiative_directory.startswith(
+        return None
+    initiative_directory = path[len(CHUNK_CONTRACT_ROOT) :].split("/", 1)[0]
+    if initiative_directory == initiative_id or initiative_directory.startswith(
         f"{initiative_id}-"
-    )
+    ):
+        return initiative_directory
+    return None
+
+
+def _is_chunk_contract_path(path: str, initiative_directory: str) -> bool:
+    """Return whether one path is a direct child of one canonical chunks directory."""
+    prefix = f"{CHUNK_CONTRACT_ROOT}{initiative_directory}/chunks/"
+    return path.startswith(prefix) and "/" not in path[len(prefix) :]
 
 
 def _validate_local_successor_contract(
@@ -236,13 +241,24 @@ def _validate_local_successor_contract(
     if metadata.next_chunk_id is None:
         return
     initiatives_root = repository_root / CHUNK_CONTRACT_ROOT
+    initiative_directories = sorted(
+        path.name
+        for path in initiatives_root.iterdir()
+        if path.is_dir()
+        and (
+            path.name == metadata.initiative_id
+            or path.name.startswith(f"{metadata.initiative_id}-")
+        )
+    )
+    if len(initiative_directories) != 1:
+        raise LoopMemoryError(
+            "initiative_id must resolve to exactly one initiative directory"
+        )
+    chunks_root = initiatives_root / initiative_directories[0] / "chunks"
     candidates = sorted(
         path
-        for path in initiatives_root.glob("*/chunks/*.md")
-        if _is_owned_chunk_contract_path(
-            path.relative_to(repository_root).as_posix(), metadata.initiative_id
-        )
-        and (
+        for path in chunks_root.glob("*.md")
+        if (
             path.name == f"{metadata.next_chunk_id}.md"
             or path.name.startswith(f"{metadata.next_chunk_id}-")
         )
@@ -300,6 +316,23 @@ def _validate_remote_successor_contract(
         or not isinstance(tree.get("tree"), list)
     ):
         raise LoopMemoryError("reviewed-head repository tree is incomplete")
+    initiative_directories = sorted(
+        {
+            initiative_directory
+            for item in tree["tree"]
+            if isinstance(item, dict) and isinstance(item.get("path"), str)
+            if (
+                initiative_directory := _initiative_directory_from_path(
+                    item["path"], metadata.initiative_id
+                )
+            )
+        }
+    )
+    if len(initiative_directories) != 1:
+        raise LoopMemoryError(
+            "initiative_id must resolve to exactly one reviewed-head initiative directory"
+        )
+    initiative_directory = initiative_directories[0]
     candidates = []
     for item in tree["tree"]:
         if not isinstance(item, dict) or item.get("type") != "blob":
@@ -310,7 +343,7 @@ def _validate_remote_successor_contract(
             continue
         name = path.rsplit("/", 1)[-1]
         if (
-            _is_owned_chunk_contract_path(path, metadata.initiative_id)
+            _is_chunk_contract_path(path, initiative_directory)
             and (
                 name == f"{metadata.next_chunk_id}.md"
                 or name.startswith(f"{metadata.next_chunk_id}-")

--- a/scripts/update_post_merge_memory.py
+++ b/scripts/update_post_merge_memory.py
@@ -129,6 +129,11 @@ def _optional_id(value: Any, field: str) -> str | None:
     return normalized
 
 
+def _is_current_schema_version(value: Any) -> bool:
+    """Return whether value is exactly the supported integer schema version."""
+    return type(value) is int and value == SCHEMA_VERSION
+
+
 def parse_loop_metadata(intent_text: str) -> LoopMetadata:
     """Parse and strictly validate one committed merge-intent document."""
     if not isinstance(intent_text, str):
@@ -139,7 +144,7 @@ def parse_loop_metadata(intent_text: str) -> LoopMetadata:
         raise LoopMemoryError("merge intent must contain valid JSON") from exc
     if not isinstance(payload, dict) or set(payload) != REQUIRED_METADATA_KEYS:
         raise LoopMemoryError("merge intent has missing or unexpected keys")
-    if payload["schema_version"] != SCHEMA_VERSION:
+    if not _is_current_schema_version(payload["schema_version"]):
         raise LoopMemoryError(
             f"unsupported loop-state schema version: {payload['schema_version']!r}"
         )
@@ -231,7 +236,11 @@ def _initiative_directory_from_path(path: str, initiative_id: str) -> str | None
 def _is_chunk_contract_path(path: str, initiative_directory: str) -> bool:
     """Return whether one path is a direct child of one canonical chunks directory."""
     prefix = f"{CHUNK_CONTRACT_ROOT}{initiative_directory}/chunks/"
-    return path.startswith(prefix) and "/" not in path[len(prefix) :]
+    return (
+        path.startswith(prefix)
+        and "/" not in path[len(prefix) :]
+        and path.endswith(".md")
+    )
 
 
 def _validate_local_successor_contract(
@@ -853,7 +862,9 @@ def _validate_record(record: dict[str, Any]) -> LoopMetadata:
         "gate",
         "checks",
     }
-    if set(record) != expected_record_keys or record.get("schema_version") != SCHEMA_VERSION:
+    if set(record) != expected_record_keys or not _is_current_schema_version(
+        record.get("schema_version")
+    ):
         raise LoopMemoryError("loop-memory record has an invalid schema")
     if record.get("state_branch") != STATE_BRANCH:
         raise LoopMemoryError("loop-memory record has an invalid state branch")
@@ -960,7 +971,9 @@ def _validate_ledger_entries(entries: list[dict[str, Any]]) -> list[dict[str, An
         "entry_hash",
     }
     for entry in entries:
-        if set(entry) != expected_keys or entry.get("schema_version") != SCHEMA_VERSION:
+        if set(entry) != expected_keys or not _is_current_schema_version(
+            entry.get("schema_version")
+        ):
             raise LoopMemoryError("merge ledger entry has an invalid schema")
         record = entry.get("record")
         if not isinstance(record, dict):

--- a/scripts/update_post_merge_memory.py
+++ b/scripts/update_post_merge_memory.py
@@ -185,17 +185,17 @@ def parse_loop_metadata(intent_text: str) -> LoopMetadata:
     )
 
 
-def _validate_sha(merge_sha: str) -> None:
+def _validate_sha(merge_sha: Any) -> None:
     """Validate one untrusted Git commit identifier."""
-    if not SHA_PATTERN.fullmatch(merge_sha):
+    if not isinstance(merge_sha, str) or not SHA_PATTERN.fullmatch(merge_sha):
         raise LoopMemoryError(
             "merge SHA must contain 40 lowercase hexadecimal characters"
         )
 
 
-def _validate_repository_and_sha(repository: str, merge_sha: str) -> None:
+def _validate_repository_and_sha(repository: Any, merge_sha: Any) -> None:
     """Validate untrusted workflow inputs before constructing API paths."""
-    if not REPOSITORY_PATTERN.fullmatch(repository):
+    if not isinstance(repository, str) or not REPOSITORY_PATTERN.fullmatch(repository):
         raise LoopMemoryError("repository must be owner/name")
     _validate_sha(merge_sha)
 


### PR DESCRIPTION
## Chunk

`WS-ENG-001-03` - Initiative-Local Loop Gates

Merge intent: `.agent-loop/merge-intents/WS-ENG-001-03.json`

## Why

The first live generated loop-memory state allowed one initiative to select a chunk from another initiative. Global initiative priority is human-owned and must not be inferred from the most recently merged chunk.

## What changed

- makes schema v2 a clean cut with exact integer validation and no schema-v1 compatibility path
- limits non-null successors to one canonical same-initiative Markdown contract and rejects foreign duplicates
- supports null successors through deterministic persistence, replay, rendering, signing, and verification
- binds replay to current protected `main` and scopes workflow credentials/signing material
- reconciles stale authored state for merged PRs #119, #120, and #122
- keeps the GitHub PR template and canonical trust-bundle merge-intent contract identical

## Evidence

- 71 agent-gate tests passed
- `scripts/update_post_merge_memory.py`: 94% branch coverage
- `scripts/check_loop_memory_state.py`: 94% branch coverage
- all nine internal reviewer tracks passed exact SHA `27302401f5bcb1134241808b5f9afa57fa4ab1ad`
- internal evidence gate, merge-intent validation, loop-state checks, stale scans, Markdown links, compilation, and diff checks passed
- no Workstream product runtime, database, dependency, or coverage-threshold change

## Human review focus

- cross-initiative successor authority fails closed
- schema v1 has no executable acceptance or migration path
- trusted workflow code writes only signed state to `automation/loop-memory`
- AUTH-06 and ART-02A1 remain inactive until separate explicit starts

This PR is ready for review. It must not be merged without explicit user approval.