### PR TITLE
Install typed external service adapter foundation

### DIFF
--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -2,8 +2,12 @@
 
 ## In Progress
 
-None. This authored queue does not select a global next chunk; live post-merge
-state is read from signed `automation/loop-memory` output.
+| Chunk | Title | Risk | Status |
+|---|---|---:|---|
+| `WS-ART-001-02A1` | External Service Adapter Foundation | L1 | Active after explicit user start on 2026-07-15 |
+
+Live post-merge state remains read from signed `automation/loop-memory`
+output. This authored queue records the separately approved active chunk.
 
 ## Planned Next
 
@@ -13,7 +17,6 @@ state is read from signed `automation/loop-memory` output.
 | `WS-QUAL-001-01B2` | Baseline Evidence And CI Ratchet | L1 | Paused for AUTH priority; no valid replacement baseline yet |
 | `WS-QUAL-001-02` | Project Service Coverage | L1 | Inactive until 01B2 merge/memory plus explicit user start |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending relevant authorization proof and a separate explicit user start |
-| `WS-ART-001-02A1` | External Service Adapter Foundation | L1 | Inactive until a separate explicit user start |
 | `WS-ART-001-02A2` | Committed Source And Local Preparation | L1 | Inactive until 02A1 merge and explicit user start |
 | `WS-ART-001-02A3` | ArtifactStore v2 Local Clean Cut | L1 | Inactive until 02A2 merge and explicit user start |
 | `WS-ART-001-02B1` | S3-Compatible MinIO And AWS | L1 | Inactive until 02A3 merge and explicit user start |

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -81,8 +81,8 @@ Coverage R10 merged through PR #108. Do not start 01B2, chunk 02, or another
 coverage implementation chunk from this worktree.
 
 `WS-ART-001-01` and the AWS-first planning amendment are merged. R2 and Flow
-Node are deferred. Do not start 02A1 until the user gives a separate explicit
-start signal.
+Node are deferred. The user explicitly started 02A1 on 2026-07-15; do not start
+02A2 automatically.
 
 Coverage work proceeds independently in its own worktree and is not owned by
 this AUTH queue update.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
@@ -7,7 +7,7 @@ Each chunk is one PR. No later chunk starts automatically.
 | `WS-ART-001-PLAN` | Original artifact planning. | L1 | Merged through PR #97 |
 | `WS-ART-001-01` | Artifact domain and LocalStorage v1 foundation. | L1 | Merged through PR #101 |
 | `WS-ART-001-OBJECT-STORAGE-AMENDMENT` | Make AWS S3 the v0.1 production provider with MinIO local/CI protocol proof; keep optional providers outside v0.1. | L1 | Merged through PR #120 as `4408256` |
-| `WS-ART-001-02A1` | Install only ADR 0014's small typed external-service adapter/factory foundation without migrating a capability. | L1 | Inactive until explicit user start |
+| `WS-ART-001-02A1` | Install only ADR 0014's small typed external-service adapter/factory foundation without migrating a capability. | L1 | Active after explicit user start on 2026-07-15 |
 | `WS-ART-001-02A2` | Add bounded committed-source preparation and inactive scratch-cleanup mechanics without changing the active v1 port. | L1 | Proposed after 02A1 |
 | `WS-ART-001-02A3` | Replace ArtifactStore v1 with byte-only v2, activate API-startup and Celery Beat scratch cleanup, migrate schema/callers/factory, and remove `flow_node` in one atomic clean cut. | L1 | Proposed after 02A2 |
 | `WS-ART-001-02B1` | Implement the S3-compatible adapter, MinIO integration, and AWS S3 production profile. | L1 | Proposed after 02A3 |

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
@@ -24,9 +24,11 @@ approval or reusable evidence. Its source remains on branch
 
 ## Active Work
 
-`WS-ART-001-02A1` is the active implementation chunk. It installs only the
-shared typed external-service adapter/factory foundation and does not migrate
-any capability.
+`WS-ART-001-02A1` implementation and all nine required internal reviewer tracks
+are complete at reviewed code SHA `8224d8c`. The chunk installs only the shared
+typed external-service adapter/factory foundation and does not migrate any
+capability. It is ready for PR publication, GitHub Backend CI, external review,
+and the human merge checkpoint.
 
 ## Next Proposed Chunk
 
@@ -39,5 +41,5 @@ owns MinIO and AWS S3. There is no active R2 chunk.
 
 ## Gate
 
-PR #120 is merged. `WS-ART-001-02A1` is active after the explicit user start.
-No later artifact chunk starts automatically.
+PR #120 is merged. `WS-ART-001-02A1` awaits external and human review. No later
+artifact chunk starts automatically, and only the user may approve merge.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
@@ -24,11 +24,14 @@ approval or reusable evidence. Its source remains on branch
 
 ## Active Work
 
-`WS-ART-001-02A1` implementation and all nine required internal reviewer tracks
-are complete at reviewed code SHA `8224d8c`. The chunk installs only the shared
-typed external-service adapter/factory foundation and does not migrate any
-capability. It is ready for PR publication, GitHub Backend CI, external review,
-and the human merge checkpoint.
+`WS-ART-001-02A1` implementation is complete at reviewed code SHA `05d667a`.
+PR #127 is open. Agent Gates and Backend passed published head `7c8da61`, and
+CodeRabbit's one valid consistency nit is fixed in `05d667a`. Eight technical
+and operational internal tracks passed that exact one-line delta; the docs track
+passed the completed evidence provenance separately. The chunk installs only the
+shared typed external-service adapter/factory foundation and does not migrate
+any capability. Updated-head GitHub checks, external review, and the human merge
+checkpoint remain required.
 
 ## Next Proposed Chunk
 
@@ -41,5 +44,6 @@ owns MinIO and AWS S3. There is no active R2 chunk.
 
 ## Gate
 
-PR #120 is merged. `WS-ART-001-02A1` awaits external and human review. No later
-artifact chunk starts automatically, and only the user may approve merge.
+PR #120 is merged. `WS-ART-001-02A1` is open as PR #127 and awaits updated-head
+external checks plus human review. No later artifact chunk starts automatically,
+and only the user may approve merge.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
@@ -4,7 +4,8 @@
 
 Original planning merged through PR #97, artifact/LocalStorage foundation
 merged through PR #101, and the AWS-first object-storage amendment merged
-through PR #120 as `4408256`. No artifact implementation chunk is active.
+through PR #120 as `4408256`. The user explicitly started
+`WS-ART-001-02A1` on 2026-07-15.
 
 The Flow Node-focused amendment candidate `6cc422d` passed deterministic checks
 but failed internal review on recovery/API completeness. Before repair, the user
@@ -23,13 +24,14 @@ approval or reusable evidence. Its source remains on branch
 
 ## Active Work
 
-None. `WS-ART-001-02A1` remains an inactive candidate requiring a separate
-explicit user start.
+`WS-ART-001-02A1` is the active implementation chunk. It installs only the
+shared typed external-service adapter/factory foundation and does not migrate
+any capability.
 
 ## Next Proposed Chunk
 
-`WS-ART-001-02A1` is proposed only after the user starts it explicitly. It
-installs the shared typed external-service adapter/factory foundation. `02A2`
+`WS-ART-001-02A1` installs the shared typed external-service adapter/factory
+foundation. `02A2`
 adds committed-source preparation and narrows LocalStorage internals without
 changing the active port. `02A3` performs the atomic
 ArtifactStore v2/LocalStorage/schema cut and removes `flow_node`. `02B1` then
@@ -37,5 +39,5 @@ owns MinIO and AWS S3. There is no active R2 chunk.
 
 ## Gate
 
-PR #120 is merged. No later artifact chunk starts automatically. The next
-artifact event requires an explicit user start for `WS-ART-001-02A1`.
+PR #120 is merged. `WS-ART-001-02A1` is active after the explicit user start.
+No later artifact chunk starts automatically.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-02A1-external-service-adapter-foundation.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-02A1-external-service-adapter-foundation.md
@@ -1,6 +1,6 @@
-# Chunk Contract: WS-ART-001-02A1 External Service Adapter Foundation
+# Chunk Contract: WS-ART-001-02A1 - External Service Adapter Foundation
 
-Initiative: `WS-ART-001` | Risk: L1 | Status: Proposed after amendment merge
+Initiative: `WS-ART-001` | Risk: L1 | Status: Active after explicit user start on 2026-07-15
 
 Artifact contract phase: `foundation`
 
@@ -18,6 +18,9 @@ this chunk.
 - `.github/workflows/backend.yml` only to add the exact 90 percent scoped gate
 - `scripts/test_agent_gates.py` only to assert the exact workflow command,
   source set, threshold, and cumulative retention
+- `.agent-loop/merge-intents/WS-ART-001-02A1.json`
+- `WS-ART-001-02A2` chunk heading only, to make the declared successor title
+  machine-verifiable by the schema-v2 merge-memory validator
 - directly related ADR 0014, glossary, and chunk memory
 
 ## Not Allowed
@@ -35,6 +38,9 @@ this chunk.
 - `ExternalServiceAdapter` contains only immutable capability/provider identity
   and root configuration, availability, and protocol error semantics shared by
   every external capability.
+- Root errors retain only stable codes/categories and sanitized adapter
+  identity. They do not retain raw settings, credentials, payloads, or original
+  transport exceptions in public attributes, text, or representation.
 - `ExternalServiceAdapterFactory[TAdapter]` supports explicit typed
   registration and construction and fails closed on duplicate and unknown
   providers.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-02A2-committed-source-local-preparation.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-02A2-committed-source-local-preparation.md
@@ -1,4 +1,4 @@
-# Chunk Contract: WS-ART-001-02A2 Committed Source And Local Preparation
+# Chunk Contract: WS-ART-001-02A2 - Committed Source And Local Preparation
 
 Initiative: `WS-ART-001` | Risk: L1 | Status: Proposed after 02A1
 

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-external-review-response.md
@@ -1,0 +1,50 @@
+# External Review Response: WS-ART-001-02A1
+
+## Reviewed Head
+
+`05d667ae1f4afe0f4cac2050dbe340213437a0bd`
+
+## External Checks
+
+- GitHub Agent Gates passed on published head `7c8da61`.
+- GitHub Backend passed on published head `7c8da61` in 16m18s, including the
+  repository-wide suite and 78 percent coverage floor.
+- CodeRabbit review run `19159bfa-854d-490d-acd0-d7b2c3826747` completed with
+  one trivial security-consistency comment.
+
+## Comments Addressed
+
+CodeRabbit observed that the unexpected-constructor failure branch raised a
+fresh `ExternalServiceConfigurationError` outside the active `except` suite,
+which currently leaves `__context__` empty, but did not state suppression
+explicitly. Commit `05d667a` adds `from None`, matching the sibling sanitized
+root-error branch and making the secret-safety invariant explicit.
+
+## Comments Deferred
+
+None.
+
+## Human Decisions Needed
+
+None for the external finding. The user still owns the PR merge decision.
+
+## Commands Rerun
+
+```bash
+cd backend && .venv/bin/ruff check \
+  app/interfaces/external_services.py tests/test_external_service_adapters.py
+cd backend && .venv/bin/python -m pytest -q \
+  tests/test_external_service_adapters.py \
+  --cov=app.interfaces.external_services \
+  --cov-report=term-missing --cov-fail-under=90
+```
+
+Results: Ruff passed; 15 focused tests passed with 100 percent foundation
+coverage. Eight technical and operational tracks passed the exact delta; the
+docs track passed the completed evidence update separately as run
+`019f65c9-a6c1-7b12-b676-47af7fbe270a`.
+
+## Remaining External Proof
+
+The branch must be pushed and GitHub Agent Gates, Backend, and CodeRabbit must
+complete on the updated exact head before merge.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-internal-review-evidence.md
@@ -82,7 +82,7 @@ python3 scripts/update_post_merge_memory.py validate-merge-intent \
 git diff --check
 ```
 
-Results: Ruff passed; repository docstring coverage passed at 95.4 percent; 15
+Results: Ruff passed; repository docstring coverage passed at 94.5 percent; 15
 focused tests passed with 100 percent coverage of
 `app/interfaces/external_services.py`; 71 agent-gate tests passed; stale
 artifact, stale Workstream wording, Markdown link, merge-intent, and diff

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-internal-review-evidence.md
@@ -10,11 +10,13 @@ valid findings addressed: yes
 
 ## Reviewed Revision
 
-Reviewed code SHA: 8224d8cba45a2eed9304323df3fccb9d9464fd16
+Reviewed code SHA: 05d667ae1f4afe0f4cac2050dbe340213437a0bd
 
-Reviewed at: 2026-07-15T11:36:39Z
+Reviewed at: 2026-07-15T12:27:26Z
 
-Reviewer run IDs: senior-engineering=019f6527-72b0-7d83-979c-4eb6fdfdef96; QA/test=019f6527-82f9-7573-840b-930241a75e17; security/auth=019f6527-9372-7712-8935-ed9376fd95a0; product/ops=019f652c-6005-7881-8ec4-02489108199f; architecture=019f6527-78db-7a80-a285-1242f2be429b; CI-integrity=019f652c-7643-7163-9b2b-26cbc0cdf876; docs=019f6531-f86a-7b00-8750-a52a15e5eb2e; reuse/dedup=019f652c-6b85-78d2-bf89-331044d96dbd; test-delta=019f652c-8338-7170-88cc-7160a62e2636
+Reviewer run IDs: senior-engineering=019f65b3-8c17-79f0-a413-38cd63539972; QA/test=019f65b3-9bd5-7af1-a854-da77fd6454b9; security/auth=019f65b3-abb0-7ea3-9f45-53dc67f4f6f9; product/ops=019f65b8-a180-7831-82ea-eedbc50fb123; architecture=019f65b3-915d-73f1-a4f7-1ed2b2a2d914; CI-integrity=019f65b8-a80c-7822-bf73-7fcd80138b8a; docs=019f65c9-a6c1-7b12-b676-47af7fbe270a; reuse/dedup=019f65b8-a445-7f81-9ede-101b8d45a752; test-delta=019f65b8-af50-7b70-9f18-407ca4ed2110
+
+Foundation review run IDs: senior-engineering=019f6527-72b0-7d83-979c-4eb6fdfdef96; QA/test=019f6527-82f9-7573-840b-930241a75e17; security/auth=019f6527-9372-7712-8935-ed9376fd95a0; product/ops=019f652c-6005-7881-8ec4-02489108199f; architecture=019f6527-78db-7a80-a285-1242f2be429b; CI-integrity=019f652c-7643-7163-9b2b-26cbc0cdf876; docs=019f6531-f86a-7b00-8750-a52a15e5eb2e; reuse/dedup=019f652c-6b85-78d2-bf89-331044d96dbd; test-delta=019f652c-8338-7170-88cc-7160a62e2636
 
 Repair review run IDs: cycle-one senior-engineering=019f6511-ed30-7a72-92e4-ce59e36ddb66, architecture=019f6511-fde3-7081-b2cd-2e145d981fe9, QA/test=019f6512-0f8c-7d32-a183-7cd8de839b83, security/auth=019f6512-4320-77e2-bf6b-7d4026c4f8dd; cycle-two senior-engineering=019f6520-0f44-7e13-b582-d97cfb71a512, architecture=019f6520-1e8b-7c93-8d46-052e760f4d30, QA/test=019f6520-2fe1-7f61-bd32-11f462f7a83c, security/auth=019f6520-4dc6-7902-adc4-0b6c713b7124
 
@@ -63,6 +65,11 @@ After the reviewed SHA, only initiative review evidence and status files change.
 - Constructor-raised shared errors could preserve an earlier transport error
   through `__context__`. The factory remaps each category to a fresh known root
   error and raises it without a provider cause or context.
+- CodeRabbit noted that the unexpected-constructor branch relied on CPython
+  clearing the handled exception before the later raise. The branch now uses
+  explicit `from None`, matching the sibling sanitized-error path. Eight
+  technical and operational reviewer tracks passed the exact one-line code
+  delta; the docs track passed the completed evidence provenance separately.
 
 ## Commands Run
 

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-internal-review-evidence.md
@@ -1,0 +1,107 @@
+# Internal Review Evidence: WS-ART-001-02A1
+
+## Chunk
+
+`WS-ART-001-02A1`: External Service Adapter Foundation
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: 8224d8cba45a2eed9304323df3fccb9d9464fd16
+
+Reviewed at: 2026-07-15T11:36:39Z
+
+Reviewer run IDs: senior-engineering=019f6527-72b0-7d83-979c-4eb6fdfdef96; QA/test=019f6527-82f9-7573-840b-930241a75e17; security/auth=019f6527-9372-7712-8935-ed9376fd95a0; product/ops=019f652c-6005-7881-8ec4-02489108199f; architecture=019f6527-78db-7a80-a285-1242f2be429b; CI-integrity=019f652c-7643-7163-9b2b-26cbc0cdf876; docs=019f6531-f86a-7b00-8750-a52a15e5eb2e; reuse/dedup=019f652c-6b85-78d2-bf89-331044d96dbd; test-delta=019f652c-8338-7170-88cc-7160a62e2636
+
+Repair review run IDs: cycle-one senior-engineering=019f6511-ed30-7a72-92e4-ce59e36ddb66, architecture=019f6511-fde3-7081-b2cd-2e145d981fe9, QA/test=019f6512-0f8c-7d32-a183-7cd8de839b83, security/auth=019f6512-4320-77e2-bf6b-7d4026c4f8dd; cycle-two senior-engineering=019f6520-0f44-7e13-b582-d97cfb71a512, architecture=019f6520-1e8b-7c93-8d46-052e760f4d30, QA/test=019f6520-2fe1-7f61-bd32-11f462f7a83c, security/auth=019f6520-4dc6-7902-adc4-0b6c713b7124
+
+After the reviewed SHA, only initiative review evidence and status files change.
+
+## Reviewed Change
+
+- Added immutable canonical capability/provider identity and shared stable
+  configuration, availability, and protocol error categories.
+- Added an instance-local typed factory with explicit composition-root
+  registration, duplicate and unknown provider rejection, exact identity
+  verification, and secret-safe construction-error remapping.
+- Added focused coverage for malformed keys, identity drift and equality
+  bypasses, secret-bearing subclasses, constructor and identity failures,
+  exception chains, and every shared root-error category.
+- Added the exact scoped 90 percent CI coverage command while preserving the
+  earlier artifact gate and repository-wide 78 percent floor.
+- Did not migrate ArtifactStore, auth, project agents, or any other capability.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS | None | Foundation is small, explicit, centralized, and operationally bounded. |
+| QA/test | PASS | None | Acceptance criteria and adversarial identity/error paths are covered. |
+| security/auth | PASS | None | Canonical identity and provider-exception data cannot escape the factory boundary. |
+| product/ops | PASS | None | No product lifecycle, operator, contributor, reviewer, payment, or reputation behavior changed. |
+| architecture | PASS | None | ADR 0014 boundary is preserved without capability migration or service-location behavior. |
+| CI integrity | PASS WITH LOW RISKS | None | Scoped 90 percent and existing cumulative coverage gates remain fail closed. |
+| docs | PASS | None | ADR, chunk, queue, status, successor, and merge intent remain consistent. |
+| reuse/dedup | PASS | None | No existing shared factory was duplicated and capability-specific entry points remain untouched. |
+| test delta | PASS WITH LOW RISKS | None | Tests are additive, adversarial, and do not weaken existing assertions or exclusions. |
+
+## Valid Findings Addressed
+
+- Constructor and `identity` property exceptions could retain provider secrets.
+  The factory now maps unexpected failures to fresh bounded configuration
+  errors outside the provider exception context.
+- The branch lagged merged AUTH-06 during review. It was rebased onto
+  `f599551`, and the final diff contains no authorization rollback.
+- Root errors accepted arbitrary runtime identity objects. They now retain only
+  an exact `ExternalServiceAdapterIdentity` or `None`.
+- Identity subclasses could carry extra state and adapter-controlled equality
+  could certify a noncanonical identity. The boundary now requires the exact
+  canonical type before equality.
+- Constructor-raised shared errors could preserve an earlier transport error
+  through `__context__`. The factory remaps each category to a fresh known root
+  error and raises it without a provider cause or context.
+
+## Commands Run
+
+```bash
+cd backend && .venv/bin/ruff check app tests scripts
+cd backend && .venv/bin/docstr-coverage --config .docstr.yaml
+cd backend && .venv/bin/python -m pytest -q \
+  tests/test_external_service_adapters.py \
+  --cov=app.interfaces.external_services \
+  --cov-report=term-missing --cov-fail-under=90
+python3 scripts/test_agent_gates.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+python3 scripts/update_post_merge_memory.py validate-merge-intent \
+  --base-ref origin/main
+git diff --check
+```
+
+Results: Ruff passed; repository docstring coverage passed at 95.4 percent; 15
+focused tests passed with 100 percent coverage of
+`app/interfaces/external_services.py`; 71 agent-gate tests passed; stale
+artifact, stale Workstream wording, Markdown link, merge-intent, and diff
+checks passed.
+
+The exact-head isolated PostgreSQL suite reached beyond 79 percent with no
+reported failure before the user directed that the workstation run be stopped
+because host contention makes repository-wide execution take multiple hours.
+That interrupted run is not pass evidence. GitHub Backend CI owns the final
+exact-head repository-wide suite and unchanged 78 percent coverage floor.
+
+## Remaining Risks
+
+- This chunk installs only the convention. No capability consumes it yet.
+- GitHub Backend CI must pass the exact PR head before merge.
+- `WS-ART-001-02A2` remains inactive until this PR merges and the user starts
+  it explicitly.
+
+## Stop Condition
+
+Publish this chunk for external and human review, then stop. Do not start
+`WS-ART-001-02A2` and do not merge without explicit user approval.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-pr-trust-bundle.md
@@ -105,8 +105,14 @@ exception-chain retention were repaired and independently re-reviewed.
 
 ## External Review
 
-Pending PR publication, GitHub checks, CodeRabbit, and human review. External
-checks supplement the completed internal review and do not replace it.
+PR #127 is open. Agent Gates and Backend passed published head `7c8da61`;
+Backend completed the repository-wide suite and 78 percent floor in 16m18s.
+CodeRabbit's one valid consistency nit was fixed in `05d667a`: both
+constructor-error branches now suppress provider exception context explicitly.
+Eight technical and operational tracks passed the exact delta; the docs track
+passed the completed evidence provenance separately. GitHub checks and
+CodeRabbit must rerun on the updated head before the human merge checkpoint.
+External checks supplement the internal review and do not replace it.
 
 ## Remaining Risks
 

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-pr-trust-bundle.md
@@ -1,0 +1,132 @@
+# PR Trust Bundle: WS-ART-001-02A1
+
+## Chunk
+
+`WS-ART-001-02A1` - External Service Adapter Foundation
+
+Merge intent: `.agent-loop/merge-intents/WS-ART-001-02A1.json`
+
+## Goal
+
+Install ADR 0014's small typed construction convention for external service
+adapters without migrating ArtifactStore or any other capability.
+
+## Human-Approved Intent
+
+The user explicitly started 02A1 on 2026-07-15 after approving the AWS-first
+object-storage plan. This chunk standardizes only adapter identity, shared root
+errors, and explicit typed construction. Later capability migration remains in
+separate chunks, and only the user may approve merge.
+
+## What Changed
+
+- Added immutable canonical adapter identity and stable shared root errors.
+- Added an instance-local generic factory with explicit provider registration.
+- Added fail-closed duplicate, unknown, mismatch, malformed identity, and
+  provider-construction handling.
+- Added focused adversarial tests and an exact scoped CI coverage gate.
+- Updated only directly related chunk memory and the schema-v2 merge intent.
+
+## Why It Changed
+
+Without one small construction convention, each external capability can grow
+an ad hoc factory, leak provider selection into product services, or retain
+provider exceptions and credentials at the shared boundary.
+
+## Design Chosen
+
+The common protocol exposes only immutable capability/provider identity.
+Capability-specific ports will extend it later. Registration remains explicit
+and instance-local at a composition root. Construction accepts only exact
+canonical identity and remaps provider failures into fresh bounded root errors
+without retaining original exception chains.
+
+## Alternatives Rejected
+
+- Global registration, import scanning, or runtime discovery: implicit and
+  difficult to audit.
+- One universal `execute` adapter: removes capability type safety.
+- Capability migration in this chunk: violates ownership and review scope.
+- Compatibility aliases or fallback constructors: forbidden in the current
+  pre-production clean-cut architecture.
+
+## Scope Control
+
+The production foundation is 158 lines and the focused test module is 339
+lines. No provider SDK, concrete adapter, route, Celery task, schema migration,
+product service, or existing capability factory changed.
+
+## Product Behavior
+
+None. Operator, contributor, reviewer, checker, revision, payment, reputation,
+and artifact runtime behavior remain unchanged.
+
+## Acceptance Criteria Proof
+
+- Identity is immutable, bounded, canonical, and exact-type checked.
+- Root errors expose stable code/category/retryability plus sanitized identity.
+- Constructor exceptions, malicious equality, identity subclasses, and Python
+  exception chains fail closed under focused regression tests.
+- Registration is typed, explicit, instance-local, and rejects duplicate or
+  unknown providers.
+- CI preserves the artifact 90 percent gate and global 78 percent floor while
+  adding the exact external-service foundation 90 percent gate.
+
+## Tests And Test Delta
+
+- 15 focused tests passed at 100 percent foundation coverage.
+- Ruff, 95.4 percent docstring coverage, 71 agent gates, stale scans, links,
+  merge-intent validation, and diff hygiene passed.
+- No test was removed, skipped, weakened, or excluded.
+- The local full suite was stopped after passing beyond 79 percent because of
+  workstation contention; GitHub Backend CI is the authoritative exact-head
+  global suite and 78 percent coverage proof.
+
+## CI Integrity
+
+- [x] Existing full-suite and scoped coverage commands remain present.
+- [x] Agent gates assert exact command, source set, threshold, order, and
+  cumulative retention.
+- [x] No conditional, continue-on-error, shell, environment, or exclusion
+  bypass was added to the scoped gates.
+- [ ] GitHub Backend CI must pass the published exact head.
+
+## Reviewer Results
+
+| Reviewer group | Result | Blocking findings |
+|---|---:|---|
+| Senior engineering, architecture, QA, security | PASS | None |
+| Product/ops, reuse/dedup, docs | PASS | None |
+| CI integrity, test delta | PASS WITH LOW RISKS | None |
+
+All nine final reviewer sessions are closed. Earlier valid findings around
+branch freshness, canonical identity, malicious equality, subclass state, and
+exception-chain retention were repaired and independently re-reviewed.
+
+## External Review
+
+Pending PR publication, GitHub checks, CodeRabbit, and human review. External
+checks supplement the completed internal review and do not replace it.
+
+## Remaining Risks
+
+- The convention has no capability consumer until later approved chunks.
+- GitHub Backend CI remains required because the local global run was
+  intentionally interrupted under host contention.
+- Later capability factories must preserve explicit composition-root
+  registration and remove their old paths atomically when migrated.
+
+## Follow-Up Work
+
+`WS-ART-001-02A2` may add committed-source preparation only after this PR
+merges and the user explicitly starts it. It does not start automatically.
+
+## Human Review Focus
+
+Inspect whether the common abstraction is truly smaller than every capability,
+whether error sanitization is complete without obscuring stable categories,
+and whether the diff avoids migrating any existing capability.
+
+## Human Merge Ownership
+
+Only the user may approve and merge this PR. Publication is not merge approval.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-02A1-pr-trust-bundle.md
@@ -75,7 +75,7 @@ and artifact runtime behavior remain unchanged.
 ## Tests And Test Delta
 
 - 15 focused tests passed at 100 percent foundation coverage.
-- Ruff, 95.4 percent docstring coverage, 71 agent gates, stale scans, links,
+- Ruff, 94.5 percent docstring coverage, 71 agent gates, stale scans, links,
   merge-intent validation, and diff hygiene passed.
 - No test was removed, skipped, weakened, or excluded.
 - The local full suite was stopped after passing beyond 79 percent because of

--- a/.agent-loop/merge-intents/WS-ART-001-02A1.json
+++ b/.agent-loop/merge-intents/WS-ART-001-02A1.json
@@ -1,0 +1,9 @@
+{
+  "chunk_id": "WS-ART-001-02A1",
+  "chunk_title": "External Service Adapter Foundation",
+  "initiative_id": "WS-ART-001",
+  "next_chunk_id": "WS-ART-001-02A2",
+  "next_chunk_title": "Committed Source And Local Preparation",
+  "next_requires_explicit_start": true,
+  "schema_version": 2
+}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -76,6 +76,14 @@ jobs:
           --precision=2
           --fail-under=90
 
+      - name: External service adapter coverage
+        working-directory: backend
+        run: >-
+          coverage report
+          --include='app/interfaces/external_services.py'
+          --precision=2
+          --fail-under=90
+
       - name: API contract real API e2e
         working-directory: backend
         env:

--- a/backend/app/interfaces/external_services.py
+++ b/backend/app/interfaces/external_services.py
@@ -20,9 +20,7 @@ class ExternalServiceAdapterError(Exception):
 
     def __init__(self, identity: ExternalServiceAdapterIdentity | None = None) -> None:
         """Create an error containing only bounded adapter identity."""
-        self.identity = (
-            identity if isinstance(identity, ExternalServiceAdapterIdentity) else None
-        )
+        self.identity = identity if type(identity) is ExternalServiceAdapterIdentity else None
         super().__init__(self.code)
 
 
@@ -126,14 +124,27 @@ class ExternalServiceAdapterFactory(Generic[AdapterT]):
         if constructor is None:
             raise UnknownExternalServiceProviderError(expected_identity)
 
+        sanitized_error: ExternalServiceAdapterError | None = None
         construction_validation_failed = False
         try:
             adapter = constructor()
-            identity_matches = getattr(adapter, "identity", None) == expected_identity
+            actual_identity = getattr(adapter, "identity", None)
+            identity_matches = (
+                type(actual_identity) is ExternalServiceAdapterIdentity
+                and actual_identity == expected_identity
+            )
+        except ExternalServiceUnavailableError:
+            sanitized_error = ExternalServiceUnavailableError(expected_identity)
+        except ExternalServiceProtocolError:
+            sanitized_error = ExternalServiceProtocolError(expected_identity)
+        except ExternalServiceConfigurationError:
+            sanitized_error = ExternalServiceConfigurationError(expected_identity)
         except ExternalServiceAdapterError:
-            raise
+            sanitized_error = ExternalServiceAdapterError(expected_identity)
         except Exception:
             construction_validation_failed = True
+        if sanitized_error is not None:
+            raise sanitized_error from None
         if construction_validation_failed:
             raise ExternalServiceConfigurationError(expected_identity)
 

--- a/backend/app/interfaces/external_services.py
+++ b/backend/app/interfaces/external_services.py
@@ -146,7 +146,7 @@ class ExternalServiceAdapterFactory(Generic[AdapterT]):
         if sanitized_error is not None:
             raise sanitized_error from None
         if construction_validation_failed:
-            raise ExternalServiceConfigurationError(expected_identity)
+            raise ExternalServiceConfigurationError(expected_identity) from None
 
         if not identity_matches:
             raise ExternalServiceAdapterIdentityMismatchError(expected_identity)

--- a/backend/app/interfaces/external_services.py
+++ b/backend/app/interfaces/external_services.py
@@ -124,17 +124,18 @@ class ExternalServiceAdapterFactory(Generic[AdapterT]):
         if constructor is None:
             raise UnknownExternalServiceProviderError(expected_identity)
 
-        construction_failed = False
+        construction_validation_failed = False
         try:
             adapter = constructor()
+            identity_matches = getattr(adapter, "identity", None) == expected_identity
         except ExternalServiceAdapterError:
             raise
         except Exception:
-            construction_failed = True
-        if construction_failed:
+            construction_validation_failed = True
+        if construction_validation_failed:
             raise ExternalServiceConfigurationError(expected_identity)
 
-        if getattr(adapter, "identity", None) != expected_identity:
+        if not identity_matches:
             raise ExternalServiceAdapterIdentityMismatchError(expected_identity)
         return adapter
 

--- a/backend/app/interfaces/external_services.py
+++ b/backend/app/interfaces/external_services.py
@@ -20,7 +20,9 @@ class ExternalServiceAdapterError(Exception):
 
     def __init__(self, identity: ExternalServiceAdapterIdentity | None = None) -> None:
         """Create an error containing only bounded adapter identity."""
-        self.identity = identity
+        self.identity = (
+            identity if isinstance(identity, ExternalServiceAdapterIdentity) else None
+        )
         super().__init__(self.code)
 
 

--- a/backend/app/interfaces/external_services.py
+++ b/backend/app/interfaces/external_services.py
@@ -1,0 +1,144 @@
+"""Shared construction contracts for external service adapters."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import re
+from typing import Generic, Protocol, TypeVar
+
+
+_ADAPTER_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+class ExternalServiceAdapterError(Exception):
+    """Base class for stable, secret-safe external service failures."""
+
+    code = "external_service_error"
+    category = "external_service"
+    retryable = False
+
+    def __init__(self, identity: ExternalServiceAdapterIdentity | None = None) -> None:
+        """Create an error containing only bounded adapter identity."""
+        self.identity = identity
+        super().__init__(self.code)
+
+
+class ExternalServiceConfigurationError(ExternalServiceAdapterError):
+    """Raised when adapter selection or construction is invalid."""
+
+    code = "external_service_configuration_invalid"
+    category = "configuration"
+
+
+class ExternalServiceUnavailableError(ExternalServiceAdapterError):
+    """Raised when a configured external service is temporarily unavailable."""
+
+    code = "external_service_unavailable"
+    category = "availability"
+    retryable = True
+
+
+class ExternalServiceProtocolError(ExternalServiceAdapterError):
+    """Raised when an external service violates its capability protocol."""
+
+    code = "external_service_protocol_invalid"
+    category = "protocol"
+
+
+class DuplicateExternalServiceProviderError(ExternalServiceConfigurationError):
+    """Raised when one factory receives the same provider more than once."""
+
+    code = "external_service_provider_duplicate"
+
+
+class UnknownExternalServiceProviderError(ExternalServiceConfigurationError):
+    """Raised when a factory has no constructor for the selected provider."""
+
+    code = "external_service_provider_unknown"
+
+
+class ExternalServiceAdapterIdentityMismatchError(ExternalServiceConfigurationError):
+    """Raised when a constructor returns an adapter under another identity."""
+
+    code = "external_service_adapter_identity_mismatch"
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalServiceAdapterIdentity:
+    """Immutable canonical identity for one capability provider."""
+
+    capability_key: str
+    provider_key: str
+
+    def __post_init__(self) -> None:
+        """Reject empty, noncanonical, or unbounded adapter keys."""
+        if not _is_adapter_key(self.capability_key) or not _is_adapter_key(self.provider_key):
+            raise ExternalServiceConfigurationError()
+
+
+class ExternalServiceAdapter(Protocol):
+    """Small common protocol implemented by typed external capabilities."""
+
+    @property
+    def identity(self) -> ExternalServiceAdapterIdentity:
+        """Return this adapter's immutable capability and provider identity."""
+
+
+AdapterT = TypeVar("AdapterT", bound=ExternalServiceAdapter)
+AdapterConstructor = Callable[[], AdapterT]
+
+
+class ExternalServiceAdapterFactory(Generic[AdapterT]):
+    """Explicit per-capability registry and constructor for typed adapters."""
+
+    __slots__ = ("_capability_key", "_constructors")
+
+    def __init__(self, capability_key: str) -> None:
+        """Create one empty, instance-local capability factory."""
+        if not _is_adapter_key(capability_key):
+            raise ExternalServiceConfigurationError()
+        self._capability_key = capability_key
+        self._constructors: dict[str, AdapterConstructor[AdapterT]] = {}
+
+    @property
+    def capability_key(self) -> str:
+        """Return the immutable capability key owned by this factory."""
+        return self._capability_key
+
+    def register(self, provider_key: str, constructor: AdapterConstructor[AdapterT]) -> None:
+        """Register one provider constructor explicitly at a composition root."""
+        if not _is_adapter_key(provider_key) or not callable(constructor):
+            raise ExternalServiceConfigurationError()
+        identity = ExternalServiceAdapterIdentity(self._capability_key, provider_key)
+        if provider_key in self._constructors:
+            raise DuplicateExternalServiceProviderError(identity)
+        self._constructors[provider_key] = constructor
+
+    def create(self, provider_key: str) -> AdapterT:
+        """Construct the selected typed adapter and verify its identity."""
+        if not _is_adapter_key(provider_key):
+            raise ExternalServiceConfigurationError()
+        expected_identity = ExternalServiceAdapterIdentity(self._capability_key, provider_key)
+        constructor = self._constructors.get(provider_key)
+        if constructor is None:
+            raise UnknownExternalServiceProviderError(expected_identity)
+
+        construction_failed = False
+        try:
+            adapter = constructor()
+        except ExternalServiceAdapterError:
+            raise
+        except Exception:
+            construction_failed = True
+        if construction_failed:
+            raise ExternalServiceConfigurationError(expected_identity)
+
+        if getattr(adapter, "identity", None) != expected_identity:
+            raise ExternalServiceAdapterIdentityMismatchError(expected_identity)
+        return adapter
+
+
+def _is_adapter_key(value: object) -> bool:
+    """Return whether a value is one bounded lowercase adapter key."""
+    return isinstance(value, str) and _ADAPTER_KEY_PATTERN.fullmatch(value) is not None

--- a/backend/tests/test_external_service_adapters.py
+++ b/backend/tests/test_external_service_adapters.py
@@ -80,7 +80,16 @@ def test_root_errors_drop_noncanonical_identity_without_retaining_it() -> None:
         def __repr__(self) -> str:
             return secret
 
-    for malformed_identity in (secret, SecretBearingIdentity()):
+    class SecretBearingIdentitySubclass(ExternalServiceAdapterIdentity):
+        def __init__(self) -> None:
+            super().__init__("artifact_store", "local")
+            object.__setattr__(self, "secret", secret)
+
+    for malformed_identity in (
+        secret,
+        SecretBearingIdentity(),
+        SecretBearingIdentitySubclass(),
+    ):
         error = ExternalServiceConfigurationError(
             cast(ExternalServiceAdapterIdentity, malformed_identity)
         )
@@ -170,6 +179,29 @@ def test_factory_rejects_identity_mismatch() -> None:
     assert str(error.value) == "external_service_adapter_identity_mismatch"
 
 
+def test_factory_rejects_noncanonical_identity_that_claims_equality() -> None:
+    """Adapter-controlled equality cannot bypass canonical identity validation."""
+
+    class EqualityBypass:
+        def __eq__(self, other: object) -> bool:
+            return True
+
+    class EqualityBypassAdapter:
+        @property
+        def identity(self) -> object:
+            return EqualityBypass()
+
+    factory = ExternalServiceAdapterFactory[EqualityBypassAdapter]("artifact_store")
+    factory.register("local", EqualityBypassAdapter)
+
+    with pytest.raises(ExternalServiceAdapterIdentityMismatchError) as captured:
+        factory.create("local")
+
+    assert captured.value.identity == ExternalServiceAdapterIdentity(
+        "artifact_store", "local"
+    )
+
+
 def test_factory_maps_untrusted_constructor_failure_without_retaining_it() -> None:
     """Unexpected constructor errors become stable errors without secret chaining."""
     secret = "access_key=do-not-retain"
@@ -216,8 +248,8 @@ def test_factory_maps_identity_validation_failure_without_retaining_it() -> None
     assert set(vars(error)) == {"identity"}
 
 
-def test_factory_preserves_already_sanitized_root_errors() -> None:
-    """Capability constructors may return one stable shared failure unchanged."""
+def test_factory_remaps_already_sanitized_root_errors() -> None:
+    """Capability constructor failures leave through a fresh stable root error."""
     identity = ExternalServiceAdapterIdentity("artifact_store", "local")
     expected = ExternalServiceUnavailableError(identity)
 
@@ -229,10 +261,36 @@ def test_factory_preserves_already_sanitized_root_errors() -> None:
 
     with pytest.raises(ExternalServiceUnavailableError) as captured:
         factory.create("local")
-    assert captured.value is expected
+    assert captured.value is not expected
+    assert captured.value.identity == identity
+    assert captured.value.__cause__ is None
+    assert captured.value.__context__ is None
 
 
-def test_factory_preserves_root_error_only_after_identity_is_sanitized() -> None:
+def test_factory_remaps_protocol_and_base_root_errors() -> None:
+    """Every shared constructor-error category leaves as a fresh bounded error."""
+    identity = ExternalServiceAdapterIdentity("artifact_store", "local")
+
+    for error_type in (ExternalServiceProtocolError, ExternalServiceAdapterError):
+        expected = error_type(identity)
+
+        def root_failure() -> ExampleAdapter:
+            raise expected
+
+        factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+        factory.register("local", root_failure)
+
+        with pytest.raises(error_type) as captured:
+            factory.create("local")
+
+        assert type(captured.value) is error_type
+        assert captured.value is not expected
+        assert captured.value.identity == identity
+        assert captured.value.__cause__ is None
+        assert captured.value.__context__ is None
+
+
+def test_factory_remaps_root_error_only_after_identity_is_sanitized() -> None:
     """A malformed shared error cannot smuggle constructor secrets through the factory."""
     secret = "credential=do-not-retain"
     expected = ExternalServiceConfigurationError(
@@ -248,7 +306,34 @@ def test_factory_preserves_root_error_only_after_identity_is_sanitized() -> None
     with pytest.raises(ExternalServiceConfigurationError) as captured:
         factory.create("local")
 
-    assert captured.value is expected
-    assert captured.value.identity is None
+    assert captured.value is not expected
+    assert captured.value.identity == ExternalServiceAdapterIdentity(
+        "artifact_store", "local"
+    )
     assert secret not in str(captured.value)
     assert secret not in repr(captured.value)
+
+
+def test_factory_removes_secret_bearing_root_error_context() -> None:
+    """Provider exceptions cannot leave through a shared root error chain."""
+    secret = "token=do-not-retain"
+    identity = ExternalServiceAdapterIdentity("artifact_store", "local")
+
+    def chained_failure() -> ExampleAdapter:
+        try:
+            raise RuntimeError(secret)
+        except RuntimeError:
+            raise ExternalServiceUnavailableError(identity)
+
+    factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    factory.register("local", chained_failure)
+
+    with pytest.raises(ExternalServiceUnavailableError) as captured:
+        factory.create("local")
+
+    error = captured.value
+    assert error.identity == identity
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert secret not in str(error)
+    assert secret not in repr(error)

--- a/backend/tests/test_external_service_adapters.py
+++ b/backend/tests/test_external_service_adapters.py
@@ -1,0 +1,189 @@
+"""Tests for the shared external service adapter construction convention."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from typing import cast
+
+import pytest
+
+from app.interfaces.external_services import (
+    AdapterConstructor,
+    DuplicateExternalServiceProviderError,
+    ExternalServiceAdapterError,
+    ExternalServiceAdapterFactory,
+    ExternalServiceAdapterIdentity,
+    ExternalServiceAdapterIdentityMismatchError,
+    ExternalServiceConfigurationError,
+    ExternalServiceProtocolError,
+    ExternalServiceUnavailableError,
+    UnknownExternalServiceProviderError,
+)
+
+
+class ExampleAdapter:
+    """Minimal typed capability adapter used by the focused factory tests."""
+
+    def __init__(self, capability_key: str, provider_key: str) -> None:
+        """Create an adapter under one immutable identity."""
+        self._identity = ExternalServiceAdapterIdentity(capability_key, provider_key)
+
+    @property
+    def identity(self) -> ExternalServiceAdapterIdentity:
+        """Return the adapter identity."""
+        return self._identity
+
+
+def test_adapter_identity_is_immutable_and_canonical() -> None:
+    """Identity accepts bounded lowercase keys and cannot drift after creation."""
+    identity = ExternalServiceAdapterIdentity("artifact_store", "s3_compatible")
+
+    assert identity.capability_key == "artifact_store"
+    assert identity.provider_key == "s3_compatible"
+    with pytest.raises(FrozenInstanceError):
+        identity.provider_key = "local"  # type: ignore[misc]
+
+    for invalid_key in ("", "Uppercase", "has-dash", " has_space", "a" * 65, 7):
+        with pytest.raises(ExternalServiceConfigurationError) as error:
+            ExternalServiceAdapterIdentity(cast(str, invalid_key), "local")
+        assert str(error.value) == "external_service_configuration_invalid"
+        assert error.value.identity is None
+
+
+def test_root_errors_are_stable_bounded_and_secret_safe() -> None:
+    """Shared errors expose only stable facts and sanitized adapter identity."""
+    identity = ExternalServiceAdapterIdentity("artifact_store", "local")
+    errors = (
+        ExternalServiceAdapterError(identity),
+        ExternalServiceConfigurationError(identity),
+        ExternalServiceUnavailableError(identity),
+        ExternalServiceProtocolError(identity),
+    )
+
+    assert [(error.code, error.category, error.retryable) for error in errors] == [
+        ("external_service_error", "external_service", False),
+        ("external_service_configuration_invalid", "configuration", False),
+        ("external_service_unavailable", "availability", True),
+        ("external_service_protocol_invalid", "protocol", False),
+    ]
+    for error in errors:
+        assert error.identity == identity
+        assert str(error) == error.code
+        assert set(vars(error)) == {"identity"}
+
+
+def test_factory_registers_and_constructs_one_typed_provider() -> None:
+    """An explicit provider registration constructs an identity-matched adapter."""
+    factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    factory.register("local", lambda: ExampleAdapter("artifact_store", "local"))
+
+    first = factory.create("local")
+    second = factory.create("local")
+
+    assert factory.capability_key == "artifact_store"
+    assert first.identity == ExternalServiceAdapterIdentity("artifact_store", "local")
+    assert second.identity == first.identity
+    assert second is not first
+
+
+def test_factories_are_instance_local() -> None:
+    """Registration in one capability factory never creates global state."""
+    first = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    second = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    first.register("local", lambda: ExampleAdapter("artifact_store", "local"))
+
+    assert first.create("local").identity.provider_key == "local"
+    with pytest.raises(UnknownExternalServiceProviderError):
+        second.create("local")
+
+
+def test_duplicate_and_unknown_providers_fail_closed() -> None:
+    """Duplicate ownership and unknown selection have stable configuration errors."""
+    factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+
+    def constructor() -> ExampleAdapter:
+        return ExampleAdapter("artifact_store", "local")
+
+    factory.register("local", constructor)
+
+    with pytest.raises(DuplicateExternalServiceProviderError) as duplicate:
+        factory.register("local", constructor)
+    with pytest.raises(UnknownExternalServiceProviderError) as unknown:
+        factory.create("s3_compatible")
+
+    assert duplicate.value.identity == ExternalServiceAdapterIdentity("artifact_store", "local")
+    assert duplicate.value.code == "external_service_provider_duplicate"
+    assert unknown.value.identity == ExternalServiceAdapterIdentity(
+        "artifact_store", "s3_compatible"
+    )
+    assert unknown.value.code == "external_service_provider_unknown"
+
+
+def test_factory_rejects_invalid_registration_without_retaining_input() -> None:
+    """Malformed capability/provider inputs never enter the registry or an error."""
+    with pytest.raises(ExternalServiceConfigurationError) as capability_error:
+        ExternalServiceAdapterFactory[ExampleAdapter]("invalid provider")
+    assert capability_error.value.identity is None
+
+    factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    with pytest.raises(ExternalServiceConfigurationError) as provider_error:
+        factory.register("secret=value", lambda: ExampleAdapter("artifact_store", "local"))
+    with pytest.raises(ExternalServiceConfigurationError):
+        factory.register(
+            "local",
+            cast(AdapterConstructor[ExampleAdapter], None),
+        )
+    with pytest.raises(ExternalServiceConfigurationError) as create_error:
+        factory.create("secret=value")
+    assert provider_error.value.identity is None
+    assert create_error.value.identity is None
+
+
+def test_factory_rejects_identity_mismatch() -> None:
+    """A constructor cannot register one provider and return another identity."""
+    factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    factory.register("local", lambda: ExampleAdapter("artifact_store", "s3_compatible"))
+
+    with pytest.raises(ExternalServiceAdapterIdentityMismatchError) as error:
+        factory.create("local")
+
+    assert error.value.identity == ExternalServiceAdapterIdentity("artifact_store", "local")
+    assert str(error.value) == "external_service_adapter_identity_mismatch"
+
+
+def test_factory_maps_untrusted_constructor_failure_without_retaining_it() -> None:
+    """Unexpected constructor errors become stable errors without secret chaining."""
+    secret = "access_key=do-not-retain"
+
+    def broken_constructor() -> ExampleAdapter:
+        raise RuntimeError(secret)
+
+    factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    factory.register("local", broken_constructor)
+
+    with pytest.raises(ExternalServiceConfigurationError) as captured:
+        factory.create("local")
+
+    error = captured.value
+    assert error.identity == ExternalServiceAdapterIdentity("artifact_store", "local")
+    assert secret not in str(error)
+    assert secret not in repr(error)
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert set(vars(error)) == {"identity"}
+
+
+def test_factory_preserves_already_sanitized_root_errors() -> None:
+    """Capability constructors may return one stable shared failure unchanged."""
+    identity = ExternalServiceAdapterIdentity("artifact_store", "local")
+    expected = ExternalServiceUnavailableError(identity)
+
+    def unavailable_constructor() -> ExampleAdapter:
+        raise expected
+
+    factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    factory.register("local", unavailable_constructor)
+
+    with pytest.raises(ExternalServiceUnavailableError) as captured:
+        factory.create("local")
+    assert captured.value is expected

--- a/backend/tests/test_external_service_adapters.py
+++ b/backend/tests/test_external_service_adapters.py
@@ -72,6 +72,25 @@ def test_root_errors_are_stable_bounded_and_secret_safe() -> None:
         assert set(vars(error)) == {"identity"}
 
 
+def test_root_errors_drop_noncanonical_identity_without_retaining_it() -> None:
+    """Runtime misuse cannot attach a secret-bearing object to a shared error."""
+    secret = "token=do-not-retain"
+
+    class SecretBearingIdentity:
+        def __repr__(self) -> str:
+            return secret
+
+    for malformed_identity in (secret, SecretBearingIdentity()):
+        error = ExternalServiceConfigurationError(
+            cast(ExternalServiceAdapterIdentity, malformed_identity)
+        )
+
+        assert error.identity is None
+        assert secret not in str(error)
+        assert secret not in repr(error)
+        assert set(vars(error)) == {"identity"}
+
+
 def test_factory_registers_and_constructs_one_typed_provider() -> None:
     """An explicit provider registration constructs an identity-matched adapter."""
     factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
@@ -211,3 +230,25 @@ def test_factory_preserves_already_sanitized_root_errors() -> None:
     with pytest.raises(ExternalServiceUnavailableError) as captured:
         factory.create("local")
     assert captured.value is expected
+
+
+def test_factory_preserves_root_error_only_after_identity_is_sanitized() -> None:
+    """A malformed shared error cannot smuggle constructor secrets through the factory."""
+    secret = "credential=do-not-retain"
+    expected = ExternalServiceConfigurationError(
+        cast(ExternalServiceAdapterIdentity, secret)
+    )
+
+    def invalid_configuration() -> ExampleAdapter:
+        raise expected
+
+    factory = ExternalServiceAdapterFactory[ExampleAdapter]("artifact_store")
+    factory.register("local", invalid_configuration)
+
+    with pytest.raises(ExternalServiceConfigurationError) as captured:
+        factory.create("local")
+
+    assert captured.value is expected
+    assert captured.value.identity is None
+    assert secret not in str(captured.value)
+    assert secret not in repr(captured.value)

--- a/backend/tests/test_external_service_adapters.py
+++ b/backend/tests/test_external_service_adapters.py
@@ -173,6 +173,30 @@ def test_factory_maps_untrusted_constructor_failure_without_retaining_it() -> No
     assert set(vars(error)) == {"identity"}
 
 
+def test_factory_maps_identity_validation_failure_without_retaining_it() -> None:
+    """Secret-bearing identity access failures cannot escape factory construction."""
+    secret = "password=do-not-retain"
+
+    class BrokenIdentityAdapter:
+        @property
+        def identity(self) -> ExternalServiceAdapterIdentity:
+            raise RuntimeError(secret)
+
+    factory = ExternalServiceAdapterFactory[BrokenIdentityAdapter]("artifact_store")
+    factory.register("local", BrokenIdentityAdapter)
+
+    with pytest.raises(ExternalServiceConfigurationError) as captured:
+        factory.create("local")
+
+    error = captured.value
+    assert error.identity == ExternalServiceAdapterIdentity("artifact_store", "local")
+    assert secret not in str(error)
+    assert secret not in repr(error)
+    assert error.__cause__ is None
+    assert error.__context__ is None
+    assert set(vars(error)) == {"identity"}
+
+
 def test_factory_preserves_already_sanitized_root_errors() -> None:
     """Capability constructors may return one stable shared failure unchanged."""
     identity = ExternalServiceAdapterIdentity("artifact_store", "local")

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -4179,7 +4179,9 @@ def test_artifact_chunk_verification_commands_are_isolated_and_rerunnable() -> N
     )
     active_phase = active_artifact_coverage_phase()
     assert artifact_contract_phase_for(active_phase) == gate.ARTIFACT_CONTRACT_PHASE
-    mismatched_phase = "02A3" if active_phase == "foundation" else "foundation"
+    mismatched_phase = (
+        "02A3" if gate.ARTIFACT_CONTRACT_PHASE == "foundation" else "foundation"
+    )
     assert artifact_contract_phase_for(mismatched_phase) != gate.ARTIFACT_CONTRACT_PHASE
     with tempfile.TemporaryDirectory() as temp_dir:
         cleanup = subprocess.run(


### PR DESCRIPTION
# PR Trust Bundle: WS-ART-001-02A1

## Chunk

`WS-ART-001-02A1` - External Service Adapter Foundation

Merge intent: `.agent-loop/merge-intents/WS-ART-001-02A1.json`

## Goal

Install ADR 0014's small typed construction convention for external service
adapters without migrating ArtifactStore or any other capability.

## Human-Approved Intent

The user explicitly started 02A1 on 2026-07-15 after approving the AWS-first
object-storage plan. This chunk standardizes only adapter identity, shared root
errors, and explicit typed construction. Later capability migration remains in
separate chunks, and only the user may approve merge.

## What Changed

- Added immutable canonical adapter identity and stable shared root errors.
- Added an instance-local generic factory with explicit provider registration.
- Added fail-closed duplicate, unknown, mismatch, malformed identity, and
  provider-construction handling.
- Added focused adversarial tests and an exact scoped CI coverage gate.
- Updated only directly related chunk memory and the schema-v2 merge intent.

## Why It Changed

Without one small construction convention, each external capability can grow
an ad hoc factory, leak provider selection into product services, or retain
provider exceptions and credentials at the shared boundary.

## Design Chosen

The common protocol exposes only immutable capability/provider identity.
Capability-specific ports will extend it later. Registration remains explicit
and instance-local at a composition root. Construction accepts only exact
canonical identity and remaps provider failures into fresh bounded root errors
without retaining original exception chains.

## Alternatives Rejected

- Global registration, import scanning, or runtime discovery: implicit and
  difficult to audit.
- One universal `execute` adapter: removes capability type safety.
- Capability migration in this chunk: violates ownership and review scope.
- Compatibility aliases or fallback constructors: forbidden in the current
  pre-production clean-cut architecture.

## Scope Control

The production foundation is 158 lines and the focused test module is 339
lines. No provider SDK, concrete adapter, route, Celery task, schema migration,
product service, or existing capability factory changed.

## Product Behavior

None. Operator, contributor, reviewer, checker, revision, payment, reputation,
and artifact runtime behavior remain unchanged.

## Acceptance Criteria Proof

- Identity is immutable, bounded, canonical, and exact-type checked.
- Root errors expose stable code/category/retryability plus sanitized identity.
- Constructor exceptions, malicious equality, identity subclasses, and Python
  exception chains fail closed under focused regression tests.
- Registration is typed, explicit, instance-local, and rejects duplicate or
  unknown providers.
- CI preserves the artifact 90 percent gate and global 78 percent floor while
  adding the exact external-service foundation 90 percent gate.

## Tests And Test Delta

- 15 focused tests passed at 100 percent foundation coverage.
- Ruff, 94.5 percent docstring coverage, 71 agent gates, stale scans, links,
  merge-intent validation, and diff hygiene passed.
- No test was removed, skipped, weakened, or excluded.
- The local full suite was stopped after passing beyond 79 percent because of
  workstation contention; GitHub Backend CI is the authoritative exact-head
  global suite and 78 percent coverage proof.

## CI Integrity

- [x] Existing full-suite and scoped coverage commands remain present.
- [x] Agent gates assert exact command, source set, threshold, order, and
  cumulative retention.
- [x] No conditional, continue-on-error, shell, environment, or exclusion
  bypass was added to the scoped gates.
- [x] GitHub Backend CI must pass the published exact head.

## Reviewer Results

| Reviewer group | Result | Blocking findings |
|---|---:|---|
| Senior engineering, architecture, QA, security | PASS | None |
| Product/ops, reuse/dedup, docs | PASS | None |
| CI integrity, test delta | PASS WITH LOW RISKS | None |

All nine final reviewer sessions are closed. Earlier valid findings around
branch freshness, canonical identity, malicious equality, subclass state, and
exception-chain retention were repaired and independently re-reviewed.

## External Review

Pending PR publication, GitHub checks, CodeRabbit, and human review. External
checks supplement the completed internal review and do not replace it.

## Remaining Risks

- The convention has no capability consumer until later approved chunks.
- GitHub Backend CI remains required because the local global run was
  intentionally interrupted under host contention.
- Later capability factories must preserve explicit composition-root
  registration and remove their old paths atomically when migrated.

## Follow-Up Work

`WS-ART-001-02A2` may add committed-source preparation only after this PR
merges and the user explicitly starts it. It does not start automatically.

## Human Review Focus

Inspect whether the common abstraction is truly smaller than every capability,
whether error sanitization is complete without obscuring stable categories,
and whether the diff avoids migrating any existing capability.

## Human Merge Ownership

Only the user may approve and merge this PR. Publication is not merge approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a typed foundation for constructing external service adapters with validated identities and provider registration.
  * Added stable, sanitized error handling that prevents sensitive configuration, credentials, payloads, and transport details from being exposed.
  * Added explicit workflow tracking and review documentation for the active artifact-storage work.

* **Bug Fixes**
  * Improved validation of adapter construction and identity mismatches.
  * Corrected automated gate checks to use the configured contract phase.

* **Tests**
  * Added comprehensive adapter, error-safety, isolation, and coverage checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->