### PR TITLE
Clean-cut contributor attribution to canonical human actors

### DIFF
--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -34,9 +34,9 @@
 - Active implementation chunk: `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`, explicitly
   started by the user on 2026-07-19 from trusted `main` at `93dd392`. Current
   exact contract `2a21166d` passed required L1 preimplementation review;
-  initial exact-SHA review findings are repaired with deterministic proof, and
-  fresh exact-SHA internal review is the current gate. GitHub Backend must still
-  prove the 78/90 percent aggregate coverage gates. It changes no action
+  initial findings are repaired, and exact code SHA `4d1fc507` passed all nine
+  required internal tracks. PR publication and external checks are the current
+  gate; Backend must still prove 78/90 percent aggregate coverage. It changes no action
   availability, and no service caller becomes executable before AUTH-09E.
 - Scope checkpoint: AWS S3 is the only v0.1 production provider; MinIO is
   local/CI S3 protocol proof; LocalStorage is focused development/test; R2 and
@@ -60,7 +60,7 @@
   ART-02C1 remains inactive.
 - Authorization checkpoint: AUTH-07B through AUTH-09D-B merged through PRs
   #130, #131, #132, #143, #146, #148, and #152. The contributor foundation is
-  in fresh exact-SHA internal review after bounded repair; AUTH-09E remains
+  internally approved at code SHA `4d1fc507`; AUTH-09E remains
   inactive.
 - Parallel coverage work: `WS-QUAL-001-01B2` remains paused. Its last official
   whole-app result is `6466/8159` statements (`79.249908%`); no replacement

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -40,11 +40,11 @@
   Flow Node are deferred. Product modules receive narrow artifact capabilities,
   and AWS cannot instantiate in production without release-bound live proof.
 - Authorization checkpoint: trusted main contains 74 PermissionIds and 65
-  ActionIds, with 15 active actions: the two actor-self actions, seven AUTH-08
+  ActionIds, with 17 active actions: the two actor-self actions, seven AUTH-08
   administrative actions, AUTH-09B `actor.service.provision`, AUTH-09C
   `actor.profile.read` plus `actor.identity_link.read`, and the three merged
-  AUTH-09D-A profile lifecycle actions. PR #152 activates only the two 09D-B
-  identity-link lifecycle actions, producing a candidate total of 17.
+  AUTH-09D-A profile lifecycle actions, and the two AUTH-09D-B identity-link
+  lifecycle actions.
   Merged AUTH-09A defines seven fixed artifact
   service identities and eleven exact planned static matrix memberships. ART
   feature chunks supply hidden canonical behavior/resource composition. Merged
@@ -55,9 +55,9 @@
   merged through PRs #127, #129, #141, and #151. ART-02B1 adds real MinIO
   protocol proof plus a fail-closed, runtime-ineligible native AWS profile;
   ART-02C1 remains inactive.
-- Authorization checkpoint: AUTH-07B through AUTH-09D-A merged through PRs
-  #130, #131, #132, #143, #146, and #148. AUTH-09D-B is the reviewed PR #152
-  candidate; its contributor foundation and AUTH-09E remain inactive.
+- Authorization checkpoint: AUTH-07B through AUTH-09D-B merged through PRs
+  #130, #131, #132, #143, #146, #148, and #152. The contributor foundation is
+  in active contract review; AUTH-09E remains inactive.
 - Parallel coverage work: `WS-QUAL-001-01B2` remains paused. Its last official
   whole-app result is `6466/8159` statements (`79.249908%`); no replacement
   evidence exists.

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -23,22 +23,18 @@
   ART-02C1 remains inactive pending signed memory and a separate explicit start.
 - AUTH-09D-A merged through PR #148 as `99ae4c9`; signed schema-v2 memory at
   `cf8a3e8` recorded the stopped gate and exact 09D-B successor.
-- PR-ready implementation chunk: `WS-AUTH-001-09D-B` in PR #152 on
-  `codex/ws-auth-001-09d-b-identity-link-lifecycle`, started from trusted
-  `main` at `99ae4c9` after the user's explicit start signal. Contract repair
-  passed required L1 preimplementation review at exact contract `9ec6390b`.
-  Implementation, deterministic proof, and required internal review pass; the
-  branch now integrates trusted `main` at `1b5422f`.
+- AUTH-09D-B merged through PR #152 as `93dd392`; signed schema-v2 memory at
+  `912a6254` stopped and named the contributor foundation as its exact
+  successor.
 - PR #119 merged `WS-AUTH-001-05B` as `ad71c7e`.
 - PR #120 merged `WS-ART-001-OBJECT-STORAGE-AMENDMENT` as `4408256`.
 - PR #122 merged the first automated post-merge memory implementation as
   `fc89fb6`; its schema-v1 cross-initiative next pointer is superseded by the
   schema-v2 initiative-local clean cut.
-- Current gate: refreshed external checks and explicit human review for PR
-  #152. The inactive
-  `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` is the next same-initiative gate; it
-  changes no action availability. No service caller becomes executable before
-  AUTH-09E.
+- Active implementation chunk: `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`, explicitly
+  started by the user on 2026-07-19 from trusted `main` at `93dd392`. Current
+  gate is required L1 preimplementation review. It changes no action
+  availability, and no service caller becomes executable before AUTH-09E.
 - Scope checkpoint: AWS S3 is the only v0.1 production provider; MinIO is
   local/CI S3 protocol proof; LocalStorage is focused development/test; R2 and
   Flow Node are deferred. Product modules receive narrow artifact capabilities,

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -34,8 +34,9 @@
 - Active implementation chunk: `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`, explicitly
   started by the user on 2026-07-19 from trusted `main` at `93dd392`. Current
   exact contract `2a21166d` passed required L1 preimplementation review;
-  implementation and deterministic evidence are complete, and exact-SHA
-  internal review is the current gate. It changes no action
+  initial exact-SHA review findings are repaired with deterministic proof, and
+  fresh exact-SHA internal review is the current gate. GitHub Backend must still
+  prove the 78/90 percent aggregate coverage gates. It changes no action
   availability, and no service caller becomes executable before AUTH-09E.
 - Scope checkpoint: AWS S3 is the only v0.1 production provider; MinIO is
   local/CI S3 protocol proof; LocalStorage is focused development/test; R2 and
@@ -59,7 +60,7 @@
   ART-02C1 remains inactive.
 - Authorization checkpoint: AUTH-07B through AUTH-09D-B merged through PRs
   #130, #131, #132, #143, #146, #148, and #152. The contributor foundation is
-  in exact-SHA internal review after deterministic proof; AUTH-09E remains
+  in fresh exact-SHA internal review after bounded repair; AUTH-09E remains
   inactive.
 - Parallel coverage work: `WS-QUAL-001-01B2` remains paused. Its last official
   whole-app result is `6466/8159` statements (`79.249908%`); no replacement

--- a/.agent-loop/LOOP_STATE.md
+++ b/.agent-loop/LOOP_STATE.md
@@ -33,7 +33,9 @@
   schema-v2 initiative-local clean cut.
 - Active implementation chunk: `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`, explicitly
   started by the user on 2026-07-19 from trusted `main` at `93dd392`. Current
-  gate is required L1 preimplementation review. It changes no action
+  exact contract `2a21166d` passed required L1 preimplementation review;
+  implementation and deterministic evidence are complete, and exact-SHA
+  internal review is the current gate. It changes no action
   availability, and no service caller becomes executable before AUTH-09E.
 - Scope checkpoint: AWS S3 is the only v0.1 production provider; MinIO is
   local/CI S3 protocol proof; LocalStorage is focused development/test; R2 and
@@ -57,7 +59,8 @@
   ART-02C1 remains inactive.
 - Authorization checkpoint: AUTH-07B through AUTH-09D-B merged through PRs
   #130, #131, #132, #143, #146, #148, and #152. The contributor foundation is
-  in active contract review; AUTH-09E remains inactive.
+  in exact-SHA internal review after deterministic proof; AUTH-09E remains
+  inactive.
 - Parallel coverage work: `WS-QUAL-001-01B2` remains paused. Its last official
   whole-app result is `6466/8159` statements (`79.249908%`); no replacement
   evidence exists.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,15 @@
 # Review Log
 
+## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Internal Review Passed
+
+- Exact code SHA `4d1fc507c343d483677a332c2a91885e32571693` passed senior,
+  QA/test, security/auth, product/ops, architecture, CI integrity, docs,
+  reuse/dedup, and test-delta review after all valid findings were repaired.
+- Internal review evidence and the PR trust bundle record deterministic proof,
+  repair history, human focus, and the mandatory external 78/90 coverage gate.
+- PR publication and external GitHub checks are current. AUTH-09E remains
+  inactive and requires a later merge/memory/explicit-start sequence.
+
 ## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Review Repair Evidenced
 
 - Malformed preflight values are now replaced with a fixed redacted marker;

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,16 @@
 # Review Log
 
+## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Contract Review Failed
+
+- Exact candidate `33f645b0` was rejected before runtime edits. Review found a
+  stale-link race, underspecified 403/503 mapping, unlocked task resources,
+  ambiguous migration diagnostics and downgrade dependencies, an overbroad
+  clean-cut claim, missing persistent task coverage, and stale agent-gate state.
+- Repair keeps actor/link validation actor-owned, preserves the exact
+  profile-link-task-assignment order, removes REV-02C attribution inference,
+  names every schema object and SQLSTATE, defines 12 observed PostgreSQL races,
+  and changes no action, permission, grant, or availability.
+
 ## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Explicitly Started
 
 - PR #152 merged AUTH-09D-B as `93dd392`; signed schema-v2 memory `912a6254`

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,32 @@
 # Review Log
 
+## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Evidence Complete
+
+- The clean `contributor_id` migration, canonical-human database guard,
+  transaction-local actor revalidation, task/assignment locks, API mappings,
+  current docs, persistent task coverage gate, and merge intent are implemented.
+- Two comprehensive migration tests passed in 89.20 seconds. All 12 named real
+  PostgreSQL lifecycle/task interleavings passed in 601.93 seconds, and the
+  repaired canonical API-error test passed in 63.79 seconds.
+- Actor/task focused unit and database behavior tests passed, the real HTTP API
+  contract drill passed, and Ruff, docstring coverage, stale-wording scans,
+  Markdown links, diff integrity, one Alembic head, and all 88 agent gates pass.
+- GitHub Backend remains authoritative for the unchanged 78 percent global and
+  persistent 90 percent actor/task subsystem reports. Exact-SHA internal review
+  is the current gate; AUTH-09E remains inactive.
+
+## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Plan Review Passed
+
+- Exact repaired contract `2a21166daa747d3233845064826bce6573a85dbb`
+  passed senior/security/product, QA/migration/CI, and
+  architecture/reuse/docs/REV tracks after the initial preimplementation fail.
+- The approved boundary is actor-owned profile/link revalidation, exact
+  profile-link-task-assignment lock order, independent database lineage checks,
+  12 observed PostgreSQL races, persistent 90 percent actor/task coverage, and
+  no authorization action, permission, grant, decision, or availability change.
+- All 88 agent gates and diff integrity pass. Bounded implementation may begin
+  for this chunk only.
+
 ## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Contract Review Failed
 
 - Exact candidate `33f645b0` was rejected before runtime edits. Review found a

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,19 +1,46 @@
 # Review Log
 
-## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Evidence Complete
+## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Review Repair Evidenced
+
+- Malformed preflight values are now replaced with a fixed redacted marker;
+  realistic email/token-like inputs never appear, and each 22-row unsafe class
+  reports its total with only 20 sorted rows.
+- The repaired migration matrix passed two tests in 102.35 seconds, including
+  zero/extra/absent trigger arguments, nullable delegation, and missing/service
+  INSERT/UPDATE parity on both contributor tables.
+- All 12 repaired PostgreSQL races passed in 636.24 seconds. Lifecycle-first
+  submission cases prove zero checker/enqueue calls; task-write-first cases
+  prove exactly one of each after the valid contributor write commits.
+- Current docs name the reusable function, triggers, foreign keys, and indexes
+  without stale human-worker wording. Fresh exact-SHA internal review is the
+  current gate; Backend remains mandatory for aggregate 78/90 coverage.
+
+## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Implementation Review Failed
+
+- Exact candidate `e41c33c0db501152694e862d9f3a02877e42cfce` failed required
+  internal review. A malformed legacy attribution value could leak through the
+  migration refusal diagnostic, direct-SQL trigger branches and invocation
+  counts were not fully proved, two current docs used stale human terminology,
+  and aggregate coverage had not yet been produced by GitHub Backend.
+- Repair redacts malformed values, bounds each class, closes the PostgreSQL and
+  race-test matrix, names every database object for operators/REV, and treats
+  the unchanged 78/90 percent reports as mandatory external pre-merge gates.
+
+## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Targeted Evidence Collected
 
 - The clean `contributor_id` migration, canonical-human database guard,
   transaction-local actor revalidation, task/assignment locks, API mappings,
   current docs, persistent task coverage gate, and merge intent are implemented.
-- Two comprehensive migration tests passed in 89.20 seconds. All 12 named real
-  PostgreSQL lifecycle/task interleavings passed in 601.93 seconds, and the
+- The repaired migration matrix passed two comprehensive tests in 102.35
+  seconds. The repaired 12 named real PostgreSQL lifecycle/task interleavings
+  passed in 636.24 seconds, and the
   repaired canonical API-error test passed in 63.79 seconds.
 - Actor/task focused unit and database behavior tests passed, the real HTTP API
-  contract drill passed, and Ruff, docstring coverage, stale-wording scans,
-  Markdown links, diff integrity, one Alembic head, and all 88 agent gates pass.
-- GitHub Backend remains authoritative for the unchanged 78 percent global and
-  persistent 90 percent actor/task subsystem reports. Exact-SHA internal review
-  is the current gate; AUTH-09E remains inactive.
+  contract drill passed, and Ruff, docstring coverage, Markdown links, diff
+  integrity, and one Alembic head passed before reviewer repair.
+- GitHub Backend must still prove the unchanged 78 percent global and persistent
+  90 percent actor/task subsystem reports before merge. AUTH-09E remains
+  inactive.
 
 ## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Plan Review Passed
 

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -1,5 +1,14 @@
 # Review Log
 
+## 2026-07-19 - WS-AUTH-001-CONTRIBUTOR-FOUNDATION Explicitly Started
+
+- PR #152 merged AUTH-09D-B as `93dd392`; signed schema-v2 memory `912a6254`
+  stopped and named this chunk as the same-initiative successor.
+- The user explicitly started the contributor foundation. Trusted `main` has
+  one Alembic head, `0026_actor_profile_lifecycle`; exact migration, lineage,
+  lock-order, rollback, and clean-cut behavior are undergoing required L1
+  preimplementation review before runtime edits.
+
 ## 2026-07-18 - WS-AUTH-001-09D-B Internal Review Passed
 
 - Identity-link revoke/reactivate implementation, real PostgreSQL concurrency,

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Review findings repaired with deterministic proof; fresh exact-SHA review active; aggregate coverage pending Backend |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Internal review passed at `4d1fc507`; PR/external checks pending; aggregate coverage mandatory in Backend |
 
 Live post-merge state remains read from signed `automation/loop-memory`
 output. This authored queue records the separately approved parallel chunks.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-AUTH-001-09D-B` | Identity-Link Lifecycle And Race Closure | L1 | PR #152 open; trusted main `1b5422f` integrated; refreshed checks and explicit human review pending |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Active contract review from trusted main `93dd392` after explicit user start |
 
 Live post-merge state remains read from signed `automation/loop-memory`
 output. This authored queue records the separately approved parallel chunks.
@@ -14,7 +14,6 @@ output. This authored queue records the separately approved parallel chunks.
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
 | `WS-QUAL-001-01B2` | Baseline Evidence And CI Ratchet | L1 | Paused for AUTH priority; no valid replacement baseline yet |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Inactive until 09D-B merge/memory and explicit user start |
 | `WS-AUTH-001-09E` | Fixed Service Runtime Admission | L1 | Inactive until contributor-foundation merge/memory and explicit user start |
 | `WS-QUAL-001-02` | Project Service Coverage | L1 | Inactive until 01B2 merge/memory plus explicit user start |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending relevant authorization proof and a separate explicit user start |

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -94,12 +94,12 @@ stopped. AUTH-09B merged through PR #143 as `053242b`; the user then explicitly
 started AUTH-09C. PR #146 merged it as `0ffdabf`; signed memory at `eeb3dc2`
 stopped. The user explicitly started AUTH-09D, and required review split it
 before runtime edits. PR #148 merged 09D-A as `99ae4c9`; signed memory
-`cf8a3e8` stopped and named 09D-B. The user explicitly started 09D-B; exact
-contract `9ec6390b` passed required L1 review. Implementation, deterministic
-proof, and required internal review pass. PR #152 is open and integrates trusted
-main at `1b5422f`; refreshed external checks and explicit human review are the
-current gate. The contributor foundation is the next AUTH gate; 09E and
-POL-002-04 remain inactive pending their own gates and explicit starts.
+`cf8a3e8` stopped and named 09D-B. PR #152 merged 09D-B as `93dd392`; signed
+memory `912a6254` passed and stopped. The user explicitly started the
+contributor foundation from that trusted head. Its first L1 review rejected the
+underspecified contract before runtime edits; exact contract repair and
+rereview are current. AUTH-09E and POL-002-04 remain inactive pending their own
+gates and explicit starts.
 
 Coverage R10 merged through PR #108. Do not start 01B2, chunk 02, or another
 coverage implementation chunk from this worktree.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Implementation and deterministic evidence complete; exact-SHA internal review active |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Review findings repaired with deterministic proof; fresh exact-SHA review active; aggregate coverage pending Backend |
 
 Live post-merge state remains read from signed `automation/loop-memory`
 output. This authored queue records the separately approved parallel chunks.

--- a/.agent-loop/WORK_QUEUE.md
+++ b/.agent-loop/WORK_QUEUE.md
@@ -4,7 +4,7 @@
 
 | Chunk | Title | Risk | Status |
 |---|---|---:|---|
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Active contract review from trusted main `93dd392` after explicit user start |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Implementation and deterministic evidence complete; exact-SHA internal review active |
 
 Live post-merge state remains read from signed `automation/loop-memory`
 output. This authored queue records the separately approved parallel chunks.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -35,7 +35,7 @@ stopped.
 | `WS-AUTH-001-09D` | Actor And Identity-Link Lifecycle Mutations | L1 | Split before runtime implementation into 09D-A and 09D-B |
 | `WS-AUTH-001-09D-A` | Profile Lifecycle And Evidence Repair | L1 | Merged through PR #148 as `99ae4c9`; signed memory `cf8a3e8` passed |
 | `WS-AUTH-001-09D-B` | Identity-Link Lifecycle And Race Closure | L1 | Merged through PR #152 as `93dd392`; signed memory `912a6254` passed |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Findings repaired/proved; fresh exact-SHA review active; aggregate coverage pending Backend |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Internal review passed at `4d1fc507`; PR/external checks pending; Backend coverage mandatory |
 | `WS-AUTH-001-09E` | Fixed Service Runtime Admission | L1 | Inactive until contributor-foundation merge/memory and explicit start |
 | `WS-AUTH-001-ART-CUSTODY` | ART Activation Custody Transfer | L1 | Inactive until 09E merge/memory and explicit start |
 | `WS-AUTH-001-REV-CUSTODY` | REV Activation Custody Transfer | L1 | Inactive until 09E merge/memory and explicit start |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -35,7 +35,7 @@ stopped.
 | `WS-AUTH-001-09D` | Actor And Identity-Link Lifecycle Mutations | L1 | Split before runtime implementation into 09D-A and 09D-B |
 | `WS-AUTH-001-09D-A` | Profile Lifecycle And Evidence Repair | L1 | Merged through PR #148 as `99ae4c9`; signed memory `cf8a3e8` passed |
 | `WS-AUTH-001-09D-B` | Identity-Link Lifecycle And Race Closure | L1 | Merged through PR #152 as `93dd392`; signed memory `912a6254` passed |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Implementation/evidence complete; exact-SHA internal review active |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Findings repaired/proved; fresh exact-SHA review active; aggregate coverage pending Backend |
 | `WS-AUTH-001-09E` | Fixed Service Runtime Admission | L1 | Inactive until contributor-foundation merge/memory and explicit start |
 | `WS-AUTH-001-ART-CUSTODY` | ART Activation Custody Transfer | L1 | Inactive until 09E merge/memory and explicit start |
 | `WS-AUTH-001-REV-CUSTODY` | REV Activation Custody Transfer | L1 | Inactive until 09E merge/memory and explicit start |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -203,7 +203,8 @@ AUTH-09D. Required preimplementation review rejected the combined lifecycle
 contract before runtime edits, so it was split into 09D-A and 09D-B. PR #148
 merged 09D-A as `99ae4c9`; signed memory `cf8a3e8` stopped and named 09D-B. The
 user explicitly started 09D-B; exact contract `9ec6390b` passed required L1
-review. Implementation, deterministic proof, and required internal review pass;
-ready PR publication is the current gate. The contributor foundation is the next
-same-initiative gate; 09E and POL-002-04 remain inactive pending their own gates
-and explicit starts.
+review. PR #152 merged it as `93dd392`; signed memory `912a6254` passed and
+stopped. The user explicitly started the contributor foundation. Its first L1
+review rejected the underspecified contract before runtime edits; exact repair
+and rereview are current. AUTH-09E and POL-002-04 remain inactive pending their
+own gates and explicit starts.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -35,7 +35,7 @@ stopped.
 | `WS-AUTH-001-09D` | Actor And Identity-Link Lifecycle Mutations | L1 | Split before runtime implementation into 09D-A and 09D-B |
 | `WS-AUTH-001-09D-A` | Profile Lifecycle And Evidence Repair | L1 | Merged through PR #148 as `99ae4c9`; signed memory `cf8a3e8` passed |
 | `WS-AUTH-001-09D-B` | Identity-Link Lifecycle And Race Closure | L1 | Merged through PR #152 as `93dd392`; signed memory `912a6254` passed |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Active contract review after explicit user start |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Implementation/evidence complete; exact-SHA internal review active |
 | `WS-AUTH-001-09E` | Fixed Service Runtime Admission | L1 | Inactive until contributor-foundation merge/memory and explicit start |
 | `WS-AUTH-001-ART-CUSTODY` | ART Activation Custody Transfer | L1 | Inactive until 09E merge/memory and explicit start |
 | `WS-AUTH-001-REV-CUSTODY` | REV Activation Custody Transfer | L1 | Inactive until 09E merge/memory and explicit start |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -34,8 +34,8 @@ stopped.
 | `WS-AUTH-001-09C` | Actor And Identity-Link Administration Reads | L1 | Merged through PR #146 as `0ffdabf` |
 | `WS-AUTH-001-09D` | Actor And Identity-Link Lifecycle Mutations | L1 | Split before runtime implementation into 09D-A and 09D-B |
 | `WS-AUTH-001-09D-A` | Profile Lifecycle And Evidence Repair | L1 | Merged through PR #148 as `99ae4c9`; signed memory `cf8a3e8` passed |
-| `WS-AUTH-001-09D-B` | Identity-Link Lifecycle And Race Closure | L1 | Implemented; deterministic proof and required internal review pass; ready PR publication |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Inactive until 09D-B merge/memory and explicit start |
+| `WS-AUTH-001-09D-B` | Identity-Link Lifecycle And Race Closure | L1 | Merged through PR #152 as `93dd392`; signed memory `912a6254` passed |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And Canonical-Human Lineage | L1 | Active contract review after explicit user start |
 | `WS-AUTH-001-09E` | Fixed Service Runtime Admission | L1 | Inactive until contributor-foundation merge/memory and explicit start |
 | `WS-AUTH-001-ART-CUSTODY` | ART Activation Custody Transfer | L1 | Inactive until 09E merge/memory and explicit start |
 | `WS-AUTH-001-REV-CUSTODY` | REV Activation Custody Transfer | L1 | Inactive until 09E merge/memory and explicit start |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -102,8 +102,10 @@ from that trusted head. Exact contract `9ec6390b` passed required L1
 preimplementation review. Implementation, deterministic proof, required
 internal review, and external checks passed before PR #152 merged as
 `93dd392`; signed memory `912a6254` stopped and named the contributor
-foundation. The user explicitly started that chunk; required L1 contract
-review is current. No service caller or consumer feature action is active.
+foundation. The user explicitly started that chunk; exact contract `2a21166d`
+passed required L1 review. Implementation and deterministic evidence are
+complete, and exact-SHA internal review is current. No service caller or
+consumer feature action is active.
 
 ## Active planning chunk
 
@@ -112,8 +114,9 @@ None. `WS-AUTH-001-XINT` merged through PR #140.
 ## Active implementation chunk
 
 `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` - Contributor Fields And Canonical-Human
-Lineage. Explicitly started from trusted `main` at `93dd392`; required L1
-contract review is the current gate.
+Lineage. Explicitly started from trusted `main` at `93dd392`; exact contract
+`2a21166d` passed required L1 review. Implementation/evidence are complete and
+exact-SHA internal review is current.
 
 ## Current review branch
 
@@ -147,7 +150,7 @@ contract review is the current gate.
 | `WS-AUTH-001-09D` | Split | `codex/ws-auth-001-09d-actor-identity-lifecycle` | - | Required L1 review rejected the combined contract before runtime edits. |
 | `WS-AUTH-001-09D-A` | Merged | `codex/ws-auth-001-09d-actor-identity-lifecycle` | #148 | Merged as `99ae4c9`; signed memory `cf8a3e8` passed and stopped. |
 | `WS-AUTH-001-09D-B` | Merged | `codex/ws-auth-001-09d-b-identity-link-lifecycle` | #152 | Merged as `93dd392`; signed memory `912a6254` passed and stopped. |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contract review | `codex/ws-auth-001-contributor-foundation` | - | Explicitly started from trusted `main` at `93dd392`; no runtime edits before L1 review passes. |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | In review | `codex/ws-auth-001-contributor-foundation` | - | Implementation/evidence complete; exact-SHA internal review active. |
 | `WS-AUTH-001-09E` | Proposed | - | - | Fixed service runtime admission after the contributor foundation. |
 | `WS-AUTH-001-ART-CUSTODY` | Proposed | - | - | Availability-neutral 25-row ART owner transfer after 09E. |
 | `WS-AUTH-001-REV-CUSTODY` | Proposed | - | - | Availability-neutral 19-row REV owner transfer after 09E. |
@@ -171,8 +174,10 @@ AUTH-09D-A as `99ae4c9`; and PR #152 merged AUTH-09D-B as `93dd392`. Signed
 memory `912a6254` passed and stopped. The user explicitly started the
 contributor foundation. Its first L1 review rejected an underspecified
 identity-link race, migration diagnostic, resource-lock, clean-cut, and CI
-contract before runtime edits; contract repair and exact-SHA rereview are the
-current gate. AUTH-09E remains inactive behind that foundation.
+contract before runtime edits. Exact repaired contract `2a21166d` passed every
+required L1 track; implementation and deterministic evidence are complete, and
+exact-SHA internal review is current. AUTH-09E remains inactive behind that
+foundation.
 
 The four proposed REV lifecycle actions and review-evidence binding action are
 blocked on complete feature-owned typed manifests. REV fixed services are also

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -105,9 +105,9 @@ internal review, and external checks passed before PR #152 merged as
 foundation. The user explicitly started that chunk; exact contract `2a21166d`
 passed required L1 review. Initial exact-SHA implementation review found
 diagnostic-privacy and proof gaps; bounded repair and deterministic evidence are
-complete, fresh exact-SHA review is current, and aggregate coverage remains a
-mandatory GitHub Backend gate. No service caller or consumer feature action is
-active.
+complete, and exact code SHA `4d1fc507` passed all nine internal tracks. PR and
+external checks are current; aggregate coverage remains a mandatory GitHub
+Backend gate. No service caller or consumer feature action is active.
 
 ## Active planning chunk
 
@@ -117,8 +117,9 @@ None. `WS-AUTH-001-XINT` merged through PR #140.
 
 `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` - Contributor Fields And Canonical-Human
 Lineage. Explicitly started from trusted `main` at `93dd392`; exact contract
-`2a21166d` passed required L1 review. Initial findings are repaired/proved;
-fresh exact-SHA review is current and aggregate coverage remains pending Backend.
+`2a21166d` passed required L1 review. Internal review passed at code SHA
+`4d1fc507`; PR/external checks are current and aggregate coverage is mandatory
+in Backend.
 
 ## Current review branch
 
@@ -152,7 +153,7 @@ fresh exact-SHA review is current and aggregate coverage remains pending Backend
 | `WS-AUTH-001-09D` | Split | `codex/ws-auth-001-09d-actor-identity-lifecycle` | - | Required L1 review rejected the combined contract before runtime edits. |
 | `WS-AUTH-001-09D-A` | Merged | `codex/ws-auth-001-09d-actor-identity-lifecycle` | #148 | Merged as `99ae4c9`; signed memory `cf8a3e8` passed and stopped. |
 | `WS-AUTH-001-09D-B` | Merged | `codex/ws-auth-001-09d-b-identity-link-lifecycle` | #152 | Merged as `93dd392`; signed memory `912a6254` passed and stopped. |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | In review | `codex/ws-auth-001-contributor-foundation` | - | Findings repaired/proved; fresh exact-SHA review active; aggregate coverage pending Backend. |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | PR ready | `codex/ws-auth-001-contributor-foundation` | - | Internal review passed at `4d1fc507`; PR/external checks pending; Backend coverage mandatory. |
 | `WS-AUTH-001-09E` | Proposed | - | - | Fixed service runtime admission after the contributor foundation. |
 | `WS-AUTH-001-ART-CUSTODY` | Proposed | - | - | Availability-neutral 25-row ART owner transfer after 09E. |
 | `WS-AUTH-001-REV-CUSTODY` | Proposed | - | - | Availability-neutral 19-row REV owner transfer after 09E. |
@@ -179,8 +180,9 @@ identity-link race, migration diagnostic, resource-lock, clean-cut, and CI
 contract before runtime edits. Exact repaired contract `2a21166d` passed every
 required L1 track. Initial implementation candidate `e41c33c0` failed privacy,
 proof, docs, and evidence review. Bounded repair and deterministic evidence are
-complete; fresh exact-SHA review is current and aggregate coverage remains
-pending Backend. AUTH-09E remains inactive behind that foundation.
+complete; exact code SHA `4d1fc507` passed all nine internal tracks. PR/external
+checks are current and aggregate coverage remains mandatory in Backend.
+AUTH-09E remains inactive behind that foundation.
 
 The four proposed REV lifecycle actions and review-evidence binding action are
 blocked on complete feature-owned typed manifests. REV fixed services are also

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -99,24 +99,25 @@ split into 09D-A and 09D-B. After bounded external repair and exact-head review,
 PR #148 merged AUTH-09D-A as `99ae4c9`; signed schema-v2 memory `cf8a3e8`
 recorded the stopped gate and named 09D-B. The user explicitly started 09D-B
 from that trusted head. Exact contract `9ec6390b` passed required L1
-preimplementation review. Implementation, deterministic proof, and required
-internal review pass; ready PR publication is current. No service caller or
-consumer feature action is active.
+preimplementation review. Implementation, deterministic proof, required
+internal review, and external checks passed before PR #152 merged as
+`93dd392`; signed memory `912a6254` stopped and named the contributor
+foundation. The user explicitly started that chunk; required L1 contract
+review is current. No service caller or consumer feature action is active.
 
 ## Active planning chunk
 
 None. `WS-AUTH-001-XINT` merged through PR #140.
 
-## PR-ready implementation chunk
+## Active implementation chunk
 
-`WS-AUTH-001-09D-B` - Identity-Link Lifecycle And Race Closure. Exact contract
-`9ec6390b` passed required L1 preimplementation review. Implementation,
-deterministic proof, and required internal review pass. Ready PR publication is
-the current gate.
+`WS-AUTH-001-CONTRIBUTOR-FOUNDATION` - Contributor Fields And Canonical-Human
+Lineage. Explicitly started from trusted `main` at `93dd392`; required L1
+contract review is the current gate.
 
 ## Current review branch
 
-`codex/ws-auth-001-09d-b-identity-link-lifecycle`
+`codex/ws-auth-001-contributor-foundation`
 
 ## Chunk status
 
@@ -145,8 +146,8 @@ the current gate.
 | `WS-AUTH-001-09C` | Merged | `codex/ws-auth-001-09c-actor-identity-admin-reads` | #146 | Merged as `0ffdabf`; signed memory `eeb3dc2` passed and stopped. |
 | `WS-AUTH-001-09D` | Split | `codex/ws-auth-001-09d-actor-identity-lifecycle` | - | Required L1 review rejected the combined contract before runtime edits. |
 | `WS-AUTH-001-09D-A` | Merged | `codex/ws-auth-001-09d-actor-identity-lifecycle` | #148 | Merged as `99ae4c9`; signed memory `cf8a3e8` passed and stopped. |
-| `WS-AUTH-001-09D-B` | Ready for PR | `codex/ws-auth-001-09d-b-identity-link-lifecycle` | - | Implementation, deterministic proof, and required internal review pass. |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Proposed | - | - | Contributor-field clean cut and canonical-human lineage after 09D-B. |
+| `WS-AUTH-001-09D-B` | Merged | `codex/ws-auth-001-09d-b-identity-link-lifecycle` | #152 | Merged as `93dd392`; signed memory `912a6254` passed and stopped. |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contract review | `codex/ws-auth-001-contributor-foundation` | - | Explicitly started from trusted `main` at `93dd392`; no runtime edits before L1 review passes. |
 | `WS-AUTH-001-09E` | Proposed | - | - | Fixed service runtime admission after the contributor foundation. |
 | `WS-AUTH-001-ART-CUSTODY` | Proposed | - | - | Availability-neutral 25-row ART owner transfer after 09E. |
 | `WS-AUTH-001-REV-CUSTODY` | Proposed | - | - | Availability-neutral 19-row REV owner transfer after 09E. |
@@ -165,16 +166,13 @@ merged feature manifests and separate human starts exist.
 
 ## Blockers
 
-AUTH-09C has no remaining blocker. PR #146 merged as `0ffdabf` and signed
-memory passed at `eeb3dc2`. PR #148 merged AUTH-09D-A as `99ae4c9`; signed
-memory `cf8a3e8` passed and stopped. The user explicitly started AUTH-09D-B;
-exact contract `9ec6390b` passed required L1 review. Implementation,
-deterministic proof, and required internal review pass; ready PR publication is
-the current gate. It must not add service grants,
-dynamic assignments, token-role authority, service admission, or consumer
-feature-action activation. The contributor foundation is the next
-same-initiative gate but remains inactive until merge/memory and an explicit
-start. AUTH-09E remains inactive behind that foundation.
+AUTH-09C has no remaining blocker. PR #146 merged as `0ffdabf`; PR #148 merged
+AUTH-09D-A as `99ae4c9`; and PR #152 merged AUTH-09D-B as `93dd392`. Signed
+memory `912a6254` passed and stopped. The user explicitly started the
+contributor foundation. Its first L1 review rejected an underspecified
+identity-link race, migration diagnostic, resource-lock, clean-cut, and CI
+contract before runtime edits; contract repair and exact-SHA rereview are the
+current gate. AUTH-09E remains inactive behind that foundation.
 
 The four proposed REV lifecycle actions and review-evidence binding action are
 blocked on complete feature-owned typed manifests. REV fixed services are also

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -103,9 +103,11 @@ preimplementation review. Implementation, deterministic proof, required
 internal review, and external checks passed before PR #152 merged as
 `93dd392`; signed memory `912a6254` stopped and named the contributor
 foundation. The user explicitly started that chunk; exact contract `2a21166d`
-passed required L1 review. Implementation and deterministic evidence are
-complete, and exact-SHA internal review is current. No service caller or
-consumer feature action is active.
+passed required L1 review. Initial exact-SHA implementation review found
+diagnostic-privacy and proof gaps; bounded repair and deterministic evidence are
+complete, fresh exact-SHA review is current, and aggregate coverage remains a
+mandatory GitHub Backend gate. No service caller or consumer feature action is
+active.
 
 ## Active planning chunk
 
@@ -115,8 +117,8 @@ None. `WS-AUTH-001-XINT` merged through PR #140.
 
 `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` - Contributor Fields And Canonical-Human
 Lineage. Explicitly started from trusted `main` at `93dd392`; exact contract
-`2a21166d` passed required L1 review. Implementation/evidence are complete and
-exact-SHA internal review is current.
+`2a21166d` passed required L1 review. Initial findings are repaired/proved;
+fresh exact-SHA review is current and aggregate coverage remains pending Backend.
 
 ## Current review branch
 
@@ -150,7 +152,7 @@ exact-SHA internal review is current.
 | `WS-AUTH-001-09D` | Split | `codex/ws-auth-001-09d-actor-identity-lifecycle` | - | Required L1 review rejected the combined contract before runtime edits. |
 | `WS-AUTH-001-09D-A` | Merged | `codex/ws-auth-001-09d-actor-identity-lifecycle` | #148 | Merged as `99ae4c9`; signed memory `cf8a3e8` passed and stopped. |
 | `WS-AUTH-001-09D-B` | Merged | `codex/ws-auth-001-09d-b-identity-link-lifecycle` | #152 | Merged as `93dd392`; signed memory `912a6254` passed and stopped. |
-| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | In review | `codex/ws-auth-001-contributor-foundation` | - | Implementation/evidence complete; exact-SHA internal review active. |
+| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | In review | `codex/ws-auth-001-contributor-foundation` | - | Findings repaired/proved; fresh exact-SHA review active; aggregate coverage pending Backend. |
 | `WS-AUTH-001-09E` | Proposed | - | - | Fixed service runtime admission after the contributor foundation. |
 | `WS-AUTH-001-ART-CUSTODY` | Proposed | - | - | Availability-neutral 25-row ART owner transfer after 09E. |
 | `WS-AUTH-001-REV-CUSTODY` | Proposed | - | - | Availability-neutral 19-row REV owner transfer after 09E. |
@@ -175,9 +177,10 @@ memory `912a6254` passed and stopped. The user explicitly started the
 contributor foundation. Its first L1 review rejected an underspecified
 identity-link race, migration diagnostic, resource-lock, clean-cut, and CI
 contract before runtime edits. Exact repaired contract `2a21166d` passed every
-required L1 track; implementation and deterministic evidence are complete, and
-exact-SHA internal review is current. AUTH-09E remains inactive behind that
-foundation.
+required L1 track. Initial implementation candidate `e41c33c0` failed privacy,
+proof, docs, and evidence review. Bounded repair and deterministic evidence are
+complete; fresh exact-SHA review is current and aggregate coverage remains
+pending Backend. AUTH-09E remains inactive behind that foundation.
 
 The four proposed REV lifecycle actions and review-evidence binding action are
 blocked on complete feature-owned typed manifests. REV fixed services are also

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
@@ -2,9 +2,11 @@
 
 ## Status
 
-Proposed and inactive. It may start only after AUTH-09D-B merges, automated
-memory records this same-initiative successor, trusted `main` is refreshed, and
-the user gives a separate explicit start.
+Active contract review. PR #152 merged AUTH-09D-B as `93dd392`; signed
+schema-v2 memory at `912a6254` stopped and named this same-initiative
+successor. The user explicitly started this chunk on 2026-07-19. Its branch
+starts from trusted `main` at `93dd392`, whose single Alembic head is
+`0026_actor_profile_lifecycle`.
 
 ## Parent initiative
 
@@ -127,6 +129,36 @@ compatibility aliases, dual fields, fallback reads/writes, or data duplication
   one Alembic head.
 - Changed actor, authorization, and task modules remain at or above 90 percent
   focused coverage; repository-wide coverage does not fall below 78 percent.
+
+## Proposed implementation
+
+1. Allocate migration `0027_contributor_foundation` from the confirmed single
+   head. Under an access-exclusive lock on `actor_profiles`,
+   `task_assignments`, and `submissions`, preflight bounded identifiers and
+   attribution consistency, rename both columns and their generated indexes,
+   and add non-null foreign keys to `actor_profiles.id` without rewriting
+   values.
+2. Install one reusable PostgreSQL trigger function whose column name is an
+   explicit trigger argument. Its table-specific triggers reject any new or
+   changed contributor reference whose referenced profile is not human. The
+   foreign keys own existence; the trigger owns kind. Actor status is not part
+   of historical lineage, so later suspension or deactivation remains valid.
+3. Add one authorization repository/service operation that locks the exact
+   `ActorProfile` row with `FOR UPDATE`, refreshes it in the current
+   transaction, and returns only success/failure for `human` plus `active`.
+   It does not inspect identity links, grants, roles, actions, token claims, or
+   permissions.
+4. Invoke that guard after the existing coarse role check but before loading
+   task or assignment resources in claim and submission creation. Map failure
+   to one stable task-layer 403 and keep caller-owned commit/rollback behavior.
+5. Clean-cut ORM, response, audit, checker-context, script, test, and current
+   documentation reads to `contributor_id`. Keep `worker_attestation` and
+   legacy role/eligibility cutover fields unchanged because AUTH-13/14 own
+   those separate compatibility removals.
+6. Prove migration refusal and preservation, direct-SQL lineage enforcement,
+   claim/submission behavior and rollback, and both lock orders against profile
+   suspension/deactivation before the focused and repository-wide evidence
+   gates.
 
 ## Verification commands
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Fresh exact-SHA internal review. PR #152 merged AUTH-09D-B as `93dd392`; signed
+Internal review passed. PR #152 merged AUTH-09D-B as `93dd392`; signed
 schema-v2 memory at `912a6254` stopped and named this same-initiative
 successor. The user explicitly started this chunk on 2026-07-19. Its branch
 starts from trusted `main` at `93dd392`, whose single Alembic head is
@@ -11,7 +11,8 @@ L1 preimplementation reviewer tracks before runtime edits began.
 Initial candidate `e41c33c0` failed diagnostic-privacy, exact proof, docs, and
 evidence review. Bounded repair and deterministic evidence are complete; GitHub
 Backend must still prove the full-suite 78 percent and actor/task 90 percent
-reports before merge.
+reports before merge. Exact code SHA `4d1fc507` passed all nine required
+internal tracks; PR publication and external checks are current.
 
 ## Parent initiative
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
@@ -47,23 +47,22 @@ P1
 ## Allowed files
 
 ```text
-backend/app/modules/actors/{models,repository}.py
-backend/app/modules/authorization/{repository,service,runtime}.py
-backend/app/modules/tasks/{models,schemas,repository,service}.py
-backend/app/modules/checkers/** only for exact renamed contributor-ID reads
+backend/app/modules/actors/{models,repository,service}.py
+backend/app/modules/tasks/{models,schemas,repository,router,service}.py
 backend/app/db/models.py
-backend/alembic/versions/<then-current-next>_contributor_foundation.py
+backend/alembic/versions/0027_contributor_foundation.py
 backend/tests/test_actors.py
 backend/tests/test_authorization.py
 backend/tests/test_auth.py
 backend/tests/test_tasks.py
-backend/tests/test_checkers.py
 backend/tests/test_alembic.py
 backend/scripts/api_contract_e2e.py
-.github/workflows/backend.yml only if a persistent focused coverage command is missing
+.github/workflows/backend.yml
+scripts/test_agent_gates.py
 docs/architecture_data_model.md
 docs/operations_authorization_service.md
 docs/spec_authorization_service.md
+docs/spec_chunk_5_submission_packet_foundation.md
 .agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/**
 .agent-loop/merge-intents/WS-AUTH-001-CONTRIBUTOR-FOUNDATION.json
 .agent-loop/LOOP_STATE.md
@@ -83,101 +82,165 @@ Submission task-assignment lineage, predecessor chains, or guide stamps owned by
 renaming the separately enumerated AUTH-14 attestation and contributor-facing fields
 token-role removal, legacy workflow eligibility removal, or AUTH-13/14 route cutover
 compatibility aliases, dual fields, fallback reads/writes, or data duplication
+AuthorizationService, authorization runtime/resource contexts, authorization
+repositories, permissions, decisions, or authority evidence
+skip/xfail additions, assertion weakening, test deletion, coverage exclusion, or
+coverage-threshold reduction
 ```
 
 ## Acceptance criteria
 
 - The retired `TaskAssignment` human-owner field is clean-cut to
-  `contributor_id` across the
-  PostgreSQL column and index, SQLAlchemy model, Pydantic response, service and
-  repository references, audit payloads, scripts, and tests. The old name is
-  absent; no property, response alias, shadow column, or dual write remains.
+  `contributor_id` across the live PostgreSQL column and index, SQLAlchemy
+  model, Pydantic response, service and repository references, new audit
+  payloads, scripts, current docs, and generated OpenAPI. No property, response
+  alias, shadow column, or dual write remains.
 - The retired `Submission` human-owner field receives the same clean cut.
   Existing task,
   submission, checker, and revision behavior and attribution remain unchanged
   apart from the intentional response-field rename and fail-closed
   transaction-local active-human write revalidation.
-- Both `contributor_id` columns are non-null foreign keys to the canonical
-  `actor_profiles.id` root. A single reviewed, reusable PostgreSQL lineage
-  primitive rejects a service ActorProfile for either field and is suitable for
-  later canonical-human actor fields without creating another actor registry.
-- The migration preflight reports every missing ActorProfile, non-human
-  ActorProfile, malformed identifier, and inconsistent assignment/submission
-  attribution with bounded row identifiers, then aborts atomically. It never
-  guesses an actor, maps by email, selects the latest profile, or fabricates
-  remediation data.
-- Existing valid values are preserved exactly by column rename. Upgrade and
-  downgrade preserve values and indexes; downgrade refuses if a downstream
-  constraint depends on the reusable lineage primitive.
-- Direct SQL tests reject missing and service ActorProfiles for both tables,
-  accept canonical human ActorProfiles, and prove later suspension or
-  deactivation does not rewrite immutable historical attribution.
-- AUTH exposes one narrow transaction-local operation that locks and
-  revalidates an exact ActorProfile as active and human under the canonical
-  profile-before-resource order. It returns no grants or identity claims and
-  introduces no second authorization path.
-- Task claim and submission creation consume that operation at their sensitive
-  write boundary without changing their existing role, task-state, assignment,
-  checker, or commit semantics. Profile suspension/deactivation racing either
-  write is proved in both lock orders; the losing write leaves no assignment,
-  submission, checker result, audit mutation, or partial evidence.
+- Both `contributor_id` columns are non-null `varchar(36)` foreign keys to the
+  canonical `actor_profiles.id` root. The exact foreign keys are
+  `fk_task_assignments_contributor_id_actor_profiles` and
+  `fk_submissions_contributor_id_actor_profiles`. A single reviewed, reusable
+  PostgreSQL lineage primitive rejects a service ActorProfile for either field.
+- Preflight classifies each source row independently and in this order:
+  `malformed` when the value does not match
+  `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`; `missing`
+  only for a well-formed value without an ActorProfile; and `service` only for a
+  well-formed existing service ActorProfile. There is no assignment/submission
+  cross-table inference in this chunk; REV-02C owns exact assignment lineage.
+  One deterministic diagnostic contains total count plus at most 20 sorted
+  `(row_id, actor_profile_id)` pairs per table/class and no issuer, subject,
+  email, display name, or token data. Any class aborts atomically.
+- Preflight refusal from exact head `0026` leaves the Alembic revision, both old
+  column names/types/values, old index names/definitions, and the absence of
+  new foreign keys, functions, and triggers unchanged. It never guesses an
+  actor, maps by email, selects a current/latest assignment or profile, or
+  fabricates remediation data.
+- Existing valid values are preserved byte-for-byte while each column is
+  renamed and narrowed from `varchar(100)` to `varchar(36)`. The indexes
+  `ix_task_assignments_worker_id` and `ix_submissions_worker_id` are renamed to
+  `ix_task_assignments_contributor_id` and
+  `ix_submissions_contributor_id` with the same ordering and uniqueness.
+- The exact invoker-rights function
+  `require_human_actor_profile_reference()` accepts exactly one trigger argument
+  naming a field present in `to_jsonb(NEW)`, uses that safe field extraction
+  without dynamic SQL, and reads `public.actor_profiles`. A missing/extra
+  argument or absent field fails with SQLSTATE `55000`; null returns `NEW` so
+  the owning column decides nullability; no matching profile returns `NEW` so
+  the foreign key emits `23503`; a found service profile fails with `23514`.
+  Actor kind is immutable, and status is deliberately not checked by this
+  historical-lineage trigger.
+- Exact triggers `task_assignments_contributor_human` and
+  `submissions_contributor_human` run before INSERT or UPDATE OF
+  `contributor_id`. Direct SQL proves INSERT and contributor-ID UPDATE reject
+  missing/service profiles, unrelated UPDATE does not invoke the guard, and
+  active/suspended/deactivated human profiles remain valid without historical
+  rewrite.
+- Downgrade locks all three tables, checks for every non-owned trigger/dependency
+  on `require_human_actor_profile_reference()`, and reports at most 20 sorted
+  dependent object names. Any dependency refuses before DDL and leaves the
+  upgraded schema intact. Otherwise it drops the two owned triggers and
+  foreign keys, uses `DROP FUNCTION ... RESTRICT`, restores exact old index and
+  column names/types, and preserves every ID, value, and row count.
+- The actors module exposes exactly one transaction participant,
+  `ActorService.require_active_human_write_actor(actor: ActorContext) -> None`.
+  It reuses `ActorRepository.get_actor_profile(..., for_update=True)` with
+  `populate_existing`, requires human/active, then locks the exact canonical
+  identity link selected by verified issuer/subject, checks it belongs to that
+  profile and is active, and returns no profile, link, grant, role, permission,
+  action, claim, or decision data. This is identity revalidation, not a second
+  authorization path.
+- Claim and submission keep current coarse-role checks first, then use lock
+  order `ActorProfile -> exact ActorIdentityLink -> WorkstreamTask -> active
+  TaskAssignment`. `TaskRepository.get_task(..., for_update=True)` and
+  `get_active_assignment(..., for_update=True)` refresh the locked rows;
+  submission version allocation occurs while the task lock is held. Existing
+  task-state, assignment, checker, and caller-owned commit behavior remains.
+- Non-human, suspended, deactivated, or revoked-link callers receive stable
+  non-disclosing 403 code `active_contributor_required` and message `Active
+  contributor identity required`. A missing/mismatched canonical profile/link
+  or SQL/lock failure rolls back and returns retryable 503 code
+  `contributor_identity_unavailable` and message `Contributor identity
+  verification unavailable`. Invalid legacy roles still fail before identity
+  revalidation; active callers reach existing resource concealment rules.
+- Named independent PostgreSQL sessions and observed
+  `pg_stat_activity.wait_event_type='Lock'`, never timing sleeps, prove claim and
+  submission against profile suspension and terminal deactivation in both lock
+  orders (eight cases), plus identity-link revocation in both lock orders (four
+  cases). Lifecycle-first makes the task write lose with no assignment,
+  submission, evidence, checker result/call/enqueue, audit mutation,
+  idempotency row, or partial state. Task-write-first proves the valid write
+  commits before the later lifecycle transition and preserves its history.
 - Behavior tests preserve claim, start, initial submit, checker-caused revision
   resubmission, audit history, idempotency, concealment, and rollback behavior
   while asserting the canonical `contributor_id` response and evidence shape.
 - Migration tests cover valid upgrade/downgrade/upgrade, each unsafe preflight
   refusal, direct-SQL kind enforcement, dependency-aware downgrade refusal, and
   one Alembic head.
-- Changed actor, authorization, and task modules remain at or above 90 percent
-  focused coverage; repository-wide coverage does not fall below 78 percent.
+- Changed actor and task modules remain at or above 90 percent focused
+  coverage. CI adds a persistent task-subsystem 90 percent report without
+  changing existing actor/authorization gates or the repository-wide 78
+  percent command. Whole-app coverage remains at or above 78 percent.
+- The clean-cut corpus is live tables/indexes/constraints, `backend/app`, public
+  schemas/OpenAPI, `backend/scripts`, and the current docs allowed above.
+  Historical migrations `0003`/`0004`, immutable pre-0027 audit rows, archived
+  loop/reference evidence, migration tests that exercise the prior schema,
+  legacy role/eligibility tokens, `WorkstreamTask.assigned_to`, and the
+  separately owned `worker_attestation` are explicit exclusions. Existing
+  audit rows are never rewritten; every new assignment/submission audit payload
+  uses `contributor_id`.
 
 ## Proposed implementation
 
 1. Allocate migration `0027_contributor_foundation` from the confirmed single
    head. Under an access-exclusive lock on `actor_profiles`,
-   `task_assignments`, and `submissions`, preflight bounded identifiers and
-   attribution consistency, rename both columns and their generated indexes,
-   and add non-null foreign keys to `actor_profiles.id` without rewriting
-   values.
-2. Install one reusable PostgreSQL trigger function whose column name is an
-   explicit trigger argument. Its table-specific triggers reject any new or
-   changed contributor reference whose referenced profile is not human. The
-   foreign keys own existence; the trigger owns kind. Actor status is not part
-   of historical lineage, so later suspension or deactivation remains valid.
-3. Add one authorization repository/service operation that locks the exact
-   `ActorProfile` row with `FOR UPDATE`, refreshes it in the current
-   transaction, and returns only success/failure for `human` plus `active`.
-   It does not inspect identity links, grants, roles, actions, token claims, or
-   permissions.
-4. Invoke that guard after the existing coarse role check but before loading
-   task or assignment resources in claim and submission creation. Map failure
-   to one stable task-layer 403 and keep caller-owned commit/rollback behavior.
-5. Clean-cut ORM, response, audit, checker-context, script, test, and current
-   documentation reads to `contributor_id`. Keep `worker_attestation` and
-   legacy role/eligibility cutover fields unchanged because AUTH-13/14 own
-   those separate compatibility removals.
-6. Prove migration refusal and preservation, direct-SQL lineage enforcement,
-   claim/submission behavior and rollback, and both lock orders against profile
-   suspension/deactivation before the focused and repository-wide evidence
-   gates.
+   `task_assignments`, and `submissions`, run the exact three-class independent
+   preflight, rename/narrow both columns and rename their indexes, then add the
+   two named non-null foreign keys without changing any value.
+2. Install the named invoker-rights trigger function and two named triggers.
+   Foreign keys alone own existence, the trigger owns only immutable human kind,
+   and normal column constraints own nullability.
+3. Add the one actor-owned service operation that locks/revalidates the exact
+   profile followed by the exact verified identity link. Do not edit
+   authorization repositories, runtime contexts, decisions, grants, evidence,
+   actions, or permissions.
+4. Invoke it after the existing coarse role check and before the newly locked
+   task/assignment reads in claim and submission creation. Implement the exact
+   403/503 mappings and roll back every failed revalidation before responding.
+5. Clean-cut the exact live corpus to `contributor_id`, including new audit
+   evidence and OpenAPI. Preserve the enumerated historical/legacy exclusions;
+   AUTH-13/14 and REV retain their separately declared work.
+6. Prove migration refusal/preservation, direct-SQL behavior, the 12 observed
+   lock races, existing task/revision behavior, focused 90 percent actor/task
+   coverage, unchanged authorization coverage, and whole-app 78 percent before
+   reviewer fanout.
 
 ## Verification commands
 
 ```bash
 (cd backend && .venv/bin/python -m ruff check app tests scripts)
-(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
-  tests/test_actors.py tests/test_auth.py tests/test_alembic.py \
+(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python \
+  scripts/run_isolated_tests.py --metadata-json <actor-metadata> \
+  --timeout-seconds 3600 -- .venv/bin/python -m pytest -q tests/test_actors.py \
+  tests/test_auth.py tests/test_tasks.py tests/test_alembic.py \
   --cov=app.modules.actors --cov-report=term-missing --cov-fail-under=90)
-(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
-  tests/test_authorization.py tests/test_auth.py tests/test_alembic.py \
-  --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
-(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q \
-  tests/test_tasks.py tests/test_checkers.py tests/test_alembic.py \
-  --cov=app.modules.tasks --cov-report=term-missing --cov-fail-under=90)
-(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/python -m pytest -q)
-(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
-(cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)
-(cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic downgrade -1)
-(cd backend && WORKSTREAM_DATABASE_URL=<isolated-test-db> .venv/bin/alembic upgrade head)
+(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python \
+  scripts/run_isolated_tests.py --metadata-json <task-metadata> \
+  --timeout-seconds 3600 -- .venv/bin/python -m pytest -q tests/test_tasks.py \
+  tests/test_alembic.py --cov=app.modules.tasks --cov-report=term-missing \
+  --cov-fail-under=90)
+(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python \
+  scripts/run_isolated_tests.py --metadata-json <full-metadata> \
+  --timeout-seconds 12600 -- .venv/bin/python -m pytest -q \
+  --ignore=tests/test_isolated_database_runner.py --cov=app \
+  --cov-report=term-missing --cov-fail-under=78)
+(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python \
+  scripts/run_isolated_tests.py --metadata-json <api-metadata> \
+  --timeout-seconds 3600 -- .venv/bin/python scripts/api_contract_e2e.py)
+python3 scripts/test_agent_gates.py
 python3 scripts/check_stale_workstream_wording.py
 python3 scripts/check_stale_authorization_docs.py
 python3 scripts/check_markdown_links.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
@@ -2,11 +2,14 @@
 
 ## Status
 
-Active contract review. PR #152 merged AUTH-09D-B as `93dd392`; signed
+Exact-SHA internal review. PR #152 merged AUTH-09D-B as `93dd392`; signed
 schema-v2 memory at `912a6254` stopped and named this same-initiative
 successor. The user explicitly started this chunk on 2026-07-19. Its branch
 starts from trusted `main` at `93dd392`, whose single Alembic head is
-`0026_actor_profile_lifecycle`.
+`0026_actor_profile_lifecycle`. Exact contract `2a21166d` passed all required
+L1 preimplementation reviewer tracks before runtime edits began.
+Implementation and deterministic evidence are complete; GitHub Backend remains
+authoritative for the full-suite 78 percent and actor/task 90 percent reports.
 
 ## Parent initiative
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-contributor-fields-human-lineage.md
@@ -2,14 +2,16 @@
 
 ## Status
 
-Exact-SHA internal review. PR #152 merged AUTH-09D-B as `93dd392`; signed
+Fresh exact-SHA internal review. PR #152 merged AUTH-09D-B as `93dd392`; signed
 schema-v2 memory at `912a6254` stopped and named this same-initiative
 successor. The user explicitly started this chunk on 2026-07-19. Its branch
 starts from trusted `main` at `93dd392`, whose single Alembic head is
 `0026_actor_profile_lifecycle`. Exact contract `2a21166d` passed all required
 L1 preimplementation reviewer tracks before runtime edits began.
-Implementation and deterministic evidence are complete; GitHub Backend remains
-authoritative for the full-suite 78 percent and actor/task 90 percent reports.
+Initial candidate `e41c33c0` failed diagnostic-privacy, exact proof, docs, and
+evidence review. Bounded repair and deterministic evidence are complete; GitHub
+Backend must still prove the full-suite 78 percent and actor/task 90 percent
+reports before merge.
 
 ## Parent initiative
 
@@ -115,8 +117,10 @@ coverage-threshold reduction
   well-formed existing service ActorProfile. There is no assignment/submission
   cross-table inference in this chunk; REV-02C owns exact assignment lineage.
   One deterministic diagnostic contains total count plus at most 20 sorted
-  `(row_id, actor_profile_id)` pairs per table/class and no issuer, subject,
-  email, display name, or token data. Any class aborts atomically.
+  `(row_id, actor_profile_id)` pairs per table/class. Malformed source values
+  are replaced with `<redacted-malformed>`; well-formed missing/service UUIDs
+  remain actionable. No issuer, subject, email, display name, or token data is
+  emitted. Any class aborts atomically.
 - Preflight refusal from exact head `0026` leaves the Alembic revision, both old
   column names/types/values, old index names/definitions, and the absence of
   new foreign keys, functions, and triggers unchanged. It never guesses an
@@ -192,7 +196,7 @@ coverage-threshold reduction
   Historical migrations `0003`/`0004`, immutable pre-0027 audit rows, archived
   loop/reference evidence, migration tests that exercise the prior schema,
   legacy role/eligibility tokens, `WorkstreamTask.assigned_to`, and the
-  separately owned `worker_attestation` are explicit exclusions. Existing
+  separately owned attestation field is an explicit exclusion. Existing
   audit rows are never rewritten; every new assignment/submission audit payload
   uses `contributor_id`.
 
@@ -217,9 +221,10 @@ coverage-threshold reduction
    evidence and OpenAPI. Preserve the enumerated historical/legacy exclusions;
    AUTH-13/14 and REV retain their separately declared work.
 6. Prove migration refusal/preservation, direct-SQL behavior, the 12 observed
-   lock races, existing task/revision behavior, focused 90 percent actor/task
-   coverage, unchanged authorization coverage, and whole-app 78 percent before
-   reviewer fanout.
+   lock races, and existing task/revision behavior before reviewer fanout.
+   GitHub Backend is the mandatory pre-merge proof for focused 90 percent
+   actor/task coverage, unchanged authorization coverage, and whole-app 78
+   percent; do not merge unless every report passes.
 
 ## Verification commands
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-internal-review-evidence.md
@@ -1,13 +1,13 @@
 # WS-AUTH-001-CONTRIBUTOR-FOUNDATION Internal Review Evidence
 
-Reviewed code SHA: `4db178147bae457d9fccb3643fe6bd3919ba41c2`
+Reviewed code SHA: `b48aa3dd8ba5ddc74b89524169a7df0a52a3fb27`
 
 Reviewed implementation SHA: `4d1fc507c343d483677a332c2a91885e32571693`
 
 Reviewed against trusted main:
 `93dd392484b397cfdfaaa833631dc2c27f591ed7`
 
-Reviewed at: `2026-07-19T06:14:30Z`
+Reviewed at: `2026-07-19T07:14:31Z`
 
 Reviewer run IDs: `auth_xint_roles`, `auth_xint_art_service`
 
@@ -29,6 +29,11 @@ architecture, CI integrity, docs, reuse/dedup, and test delta
 - Actor/task unit and focused database behavior tests passed. The repaired
   canonical API-error test passed in 63.79 seconds, and the real HTTP API
   contract drill passed with canonical `contributor_id` claim/submission output.
+- The eight Alembic tests implicated by the first Backend run passed in their CI
+  order on one isolated PostgreSQL database in 959.71 seconds. The three root
+  lifecycle tests also passed independently in 339.89 seconds. Lifecycle tests
+  now target their owned `0026` revision; general-head and dedicated `0027`
+  contributor-foundation coverage remain unchanged.
 - Ruff, 90.3 percent repository docstring coverage, both stale-wording scans,
   Markdown links, diff integrity, one Alembic head, and all 88 agent gates pass.
 - No skip, xfail, assertion weakening, test deletion, coverage exclusion,
@@ -70,6 +75,14 @@ coverage as a mandatory external pre-merge gate. Fresh exact-SHA implementation
 review passed all nine tracks with no remaining findings. A final exact-head
 confirmation passed the same tracks on `4db178147`, whose only additional
 committed delta synchronizes lifecycle state and strict agent-gate assertions.
+The first GitHub Backend run then exposed five stale uses of `head` in tests
+whose assertions explicitly owned revision `0026`; PostgreSQL correctly rolled
+back the full `0027` to `0025` downgrade transaction when the `0026` evidence
+guard refused, so the asserted revision remained `0027`. Test-only repair
+`b48aa3dd` scopes those tests to `0026`. Fresh exact-SHA senior, QA/test,
+security/auth, product/ops, architecture, CI-integrity, docs, reuse/dedup, and
+test-delta review passed with no findings and confirmed that `0027` behavior is
+still covered by full-head and contributor-foundation tests.
 
 ## Remaining Risk And Gate
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-internal-review-evidence.md
@@ -1,0 +1,80 @@
+# WS-AUTH-001-CONTRIBUTOR-FOUNDATION Internal Review Evidence
+
+Reviewed code SHA: `4db178147bae457d9fccb3643fe6bd3919ba41c2`
+
+Reviewed implementation SHA: `4d1fc507c343d483677a332c2a91885e32571693`
+
+Reviewed against trusted main:
+`93dd392484b397cfdfaaa833631dc2c27f591ed7`
+
+Reviewed at: `2026-07-19T06:14:30Z`
+
+Reviewer run IDs: `auth_xint_roles`, `auth_xint_art_service`
+
+Reviewer tracks: senior engineering, QA/test, security/auth, product/ops,
+architecture, CI integrity, docs, reuse/dedup, and test delta
+
+## Deterministic Evidence
+
+- The repaired contributor migration matrix passed two real PostgreSQL tests in
+  102.35 seconds. It proves upgrade/downgrade/upgrade preservation, atomic
+  refusal, secret-safe bounded diagnostics, exact trigger arguments and
+  SQLSTATEs, nullable delegation, both-table INSERT/UPDATE parity, historical
+  human lineage, one Alembic head, and dependency-safe downgrade refusal.
+- All 12 named PostgreSQL lifecycle/task interleavings passed in 636.24 seconds
+  with observed `pg_stat_activity` lock waits. Lifecycle-first denial preserves
+  every task-owned surface and calls neither checker nor enqueue; task-write-first
+  commits canonical contributor attribution and calls each exactly once before
+  the later lifecycle mutation.
+- Actor/task unit and focused database behavior tests passed. The repaired
+  canonical API-error test passed in 63.79 seconds, and the real HTTP API
+  contract drill passed with canonical `contributor_id` claim/submission output.
+- Ruff, 90.3 percent repository docstring coverage, both stale-wording scans,
+  Markdown links, diff integrity, one Alembic head, and all 88 agent gates pass.
+- No skip, xfail, assertion weakening, test deletion, coverage exclusion,
+  threshold reduction, action/permission/grant change, or compatibility field
+  was introduced.
+- GitHub Backend is the mandatory pre-merge proof for the unchanged 78 percent
+  repository-wide floor and the persistent 90 percent actor, authorization,
+  and task subsystem reports. Internal evidence does not claim those aggregate
+  reports before CI produces them.
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---|---|---|
+| senior engineering | PASS AFTER FIXES | none | Clean field cutover, transaction ownership, lock order, and chunk boundary are maintainable. |
+| QA/test | PASS AFTER FIXES | none | Migration, API, rollback, preservation, and all 12 observed races cover the declared behavior. |
+| security/auth | PASS AFTER FIXES | none | Malformed diagnostics are redacted; lineage and active-identity checks fail closed without a second authorization path. |
+| product/ops | PASS AFTER FIXES | none | Human attribution is Contributor-safe; later legacy role/attestation cleanup remains separately owned. |
+| architecture | PASS | none | Actor-owned revalidation and database lineage add no action, grant, evaluator, or availability path. |
+| CI integrity | PASS AFTER FIXES | none | The 90 percent task report is additive; all existing thresholds remain mandatory. |
+| docs | PASS AFTER FIXES | none | Current docs name the exact reusable function, triggers, foreign keys, indexes, remediation, and later boundaries. |
+| reuse/dedup | PASS | none | Existing ActorRepository and TaskRepository transaction participants are reused. |
+| test delta | PASS AFTER FIXES | none | Assertions were strengthened for privacy, exact SQL branches, invocation counts, and races. |
+
+## Findings Resolved
+
+Valid findings addressed: yes
+
+Open sub-agent sessions: none
+
+Initial candidate `e41c33c0` failed because malformed legacy values could be
+serialized into deployment diagnostics, the direct-SQL matrix omitted closed
+trigger branches, lifecycle-first races did not count transient checker/enqueue
+calls, current docs omitted exact reusable object names and contained two stale
+human terms, and aggregate coverage language was overstated. Candidate
+`4d1fc507` redacts before serialization, bounds and tests realistic canaries,
+closes the SQL and invocation matrices, corrects the docs, and records Backend
+coverage as a mandatory external pre-merge gate. Fresh exact-SHA implementation
+review passed all nine tracks with no remaining findings. A final exact-head
+confirmation passed the same tracks on `4db178147`, whose only additional
+committed delta synchronizes lifecycle state and strict agent-gate assertions.
+
+## Remaining Risk And Gate
+
+External GitHub Backend, Agent Gates, CodeRabbit, and explicit human review
+remain. Backend must pass the unchanged global 78 percent floor and every
+persistent 90 percent subsystem report before merge. This chunk activates no
+authorization action or service caller. `WS-AUTH-001-09E` remains inactive
+until this PR merges, signed memory passes, and the user explicitly starts it.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-internal-review-evidence.md
@@ -1,13 +1,13 @@
 # WS-AUTH-001-CONTRIBUTOR-FOUNDATION Internal Review Evidence
 
-Reviewed code SHA: `b48aa3dd8ba5ddc74b89524169a7df0a52a3fb27`
+Reviewed code SHA: `0ca5a6326a893e6671848dacde484b7c784b7bd0`
 
 Reviewed implementation SHA: `4d1fc507c343d483677a332c2a91885e32571693`
 
 Reviewed against trusted main:
 `93dd392484b397cfdfaaa833631dc2c27f591ed7`
 
-Reviewed at: `2026-07-19T07:14:31Z`
+Reviewed at: `2026-07-19T08:13:01Z`
 
 Reviewer run IDs: `auth_xint_roles`, `auth_xint_art_service`
 
@@ -34,6 +34,12 @@ architecture, CI integrity, docs, reuse/dedup, and test delta
   lifecycle tests also passed independently in 339.89 seconds. Lifecycle tests
   now target their owned `0026` revision; general-head and dedicated `0027`
   contributor-foundation coverage remain unchanged.
+- The second Backend run passed the full 1,567-test suite and the global,
+  actor, and authorization coverage gates, then correctly failed the new task
+  subsystem gate at 84.14 percent. Twenty-four direct task-service behavior
+  cases now pass in 16.62 seconds and execute 92 statements from that exact CI
+  missing set, projecting the unchanged task gate to about 90.90 percent.
+  GitHub Backend remains the authority for the combined result.
 - Ruff, 90.3 percent repository docstring coverage, both stale-wording scans,
   Markdown links, diff integrity, one Alembic head, and all 88 agent gates pass.
 - No skip, xfail, assertion weakening, test deletion, coverage exclusion,
@@ -83,6 +89,15 @@ guard refused, so the asserted revision remained `0027`. Test-only repair
 security/auth, product/ops, architecture, CI-integrity, docs, reuse/dedup, and
 test-delta review passed with no findings and confirmed that `0027` behavior is
 still covered by full-head and contributor-foundation tests.
+The next Backend run passed every test but exposed the newly persistent task
+subsystem floor at 84.14 percent. Test-only candidate `0ca5a632` adds direct
+service-boundary proof for canonical attribution, visibility and operator
+scope, transaction ownership, exact assignment-based start, locked-submission
+repair, bounded dispatch-failure evidence, lock-conflict recovery, provenance
+failure, and malformed locked-policy types. Fresh exact-SHA review passed all
+nine tracks with no findings and confirmed that mocks stop at established
+repository, queue, checker, and response seams while production authorization
+and fail-closed decisions execute unchanged.
 
 ## Remaining Risk And Gate
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-pr-trust-bundle.md
@@ -33,6 +33,10 @@ attestation/profile route cleanup remain AUTH-13/14 work. AUTH-09E stays inactiv
 - All eight Alembic tests implicated by the first Backend run passed in CI order
   on one isolated PostgreSQL database in 959.71 seconds; the three root
   lifecycle tests passed independently in 339.89 seconds.
+- The second Backend run passed all 1,567 tests and every earlier coverage gate,
+  then exposed task subsystem coverage at 84.14 percent. Twenty-four new direct
+  task-service behavior cases pass and execute 92 statements from the exact CI
+  missing set, projecting the unchanged task gate to about 90.90 percent.
 - Real HTTP API contract drill: passed.
 - Focused actor/task unit and database behavior tests: passed.
 - Ruff, docstring gate (90.3 percent), stale scanners, Markdown links, diff
@@ -53,6 +57,11 @@ Test-only Backend repair `b48aa3dd8ba5ddc74b89524169a7df0a52a3fb27`
 then passed fresh exact-SHA review across the same tracks with no findings. The
 review confirmed that revision-specific lifecycle tests no longer conflate
 `head` with `0026`, while general-head and dedicated `0027` coverage remain.
+Task-coverage repair `0ca5a6326a893e6671848dacde484b7c784b7bd0`
+also passed fresh exact-SHA review across all nine tracks with no findings.
+Reviewers confirmed that the tests exercise production authorization,
+attribution, fail-closed parsing, evidence bounds, and lock-conflict decisions;
+mocks remain limited to existing orchestration seams.
 
 ## Human Review Focus
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-pr-trust-bundle.md
@@ -1,0 +1,62 @@
+# WS-AUTH-001-CONTRIBUTOR-FOUNDATION PR Trust Bundle
+
+## Goal
+
+Clean-cut task-assignment and submission human attribution to canonical
+`contributor_id`, enforce human ActorProfile lineage at the database boundary,
+and revalidate the exact active caller inside contributor-write transactions.
+
+## Changes
+
+- Renames and narrows both live owner columns and indexes with no alias, fallback,
+  dual field, guessed identity mapping, or historical audit rewrite.
+- Adds exact foreign keys plus one reusable invoker-rights human-lineage trigger
+  function and named triggers for both tables.
+- Adds actor-owned profile/link locking and task-owned task/assignment locking in
+  canonical order for claim and submission, with stable 403 and retryable 503
+  responses and rollback.
+- Updates public schemas, new audit evidence, the real API drill, current docs,
+  persistent task coverage reporting, agent gates, and the schema-v2 merge intent.
+
+## Boundary
+
+This PR changes no ActionId, PermissionId, evaluator, grant, role behavior,
+authorization decision/evidence path, service admission, task lifecycle, review
+or revision behavior. The temporary legacy role token and separately owned
+attestation/profile route cleanup remain AUTH-13/14 work. AUTH-09E stays inactive.
+
+## Proof
+
+- Repaired migration matrix: 2 passed in 102.35 seconds.
+- Full observed contributor/lifecycle race matrix: 12 passed in 636.24 seconds.
+- Canonical API-error mapping: 1 passed in 63.79 seconds.
+- Real HTTP API contract drill: passed.
+- Focused actor/task unit and database behavior tests: passed.
+- Ruff, docstring gate (90.3 percent), stale scanners, Markdown links, diff
+  integrity, one Alembic head, and 88 agent gates: passed.
+- No skips, xfails, weakened assertions, exclusions, or threshold reductions.
+
+GitHub Backend remains the authoritative mandatory proof for global 78 percent
+and persistent actor/authorization/task 90 percent coverage before merge.
+
+## Internal Review
+
+Exact implementation SHA `4d1fc507c343d483677a332c2a91885e32571693` and
+closeout head `4db178147bae457d9fccb3643fe6bd3919ba41c2` against trusted main
+`93dd392484b397cfdfaaa833631dc2c27f591ed7` passed senior engineering,
+QA/test, security/auth, product/ops, architecture, CI integrity, docs,
+reuse/dedup, and test-delta review after every valid finding was repaired.
+
+## Human Review Focus
+
+Review migration refusal/redaction and reversible preservation, exact database
+object names, profile-to-link-to-task-to-assignment lock order, lifecycle race
+outcomes, 403/503 privacy and rollback, clean `contributor_id` API/evidence
+shape, and absence of authorization availability or later AUTH-13/14 behavior.
+
+## Merge Ownership
+
+The agent may publish and repair this branch but may not merge it. Only the
+human may approve this PR for merge. After merge, trusted-main automation owns
+schema-v2 memory generation; no manual post-merge memory PR should be opened
+when that workflow succeeds.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-CONTRIBUTOR-FOUNDATION-pr-trust-bundle.md
@@ -30,6 +30,9 @@ attestation/profile route cleanup remain AUTH-13/14 work. AUTH-09E stays inactiv
 - Repaired migration matrix: 2 passed in 102.35 seconds.
 - Full observed contributor/lifecycle race matrix: 12 passed in 636.24 seconds.
 - Canonical API-error mapping: 1 passed in 63.79 seconds.
+- All eight Alembic tests implicated by the first Backend run passed in CI order
+  on one isolated PostgreSQL database in 959.71 seconds; the three root
+  lifecycle tests passed independently in 339.89 seconds.
 - Real HTTP API contract drill: passed.
 - Focused actor/task unit and database behavior tests: passed.
 - Ruff, docstring gate (90.3 percent), stale scanners, Markdown links, diff
@@ -46,6 +49,10 @@ closeout head `4db178147bae457d9fccb3643fe6bd3919ba41c2` against trusted main
 `93dd392484b397cfdfaaa833631dc2c27f591ed7` passed senior engineering,
 QA/test, security/auth, product/ops, architecture, CI integrity, docs,
 reuse/dedup, and test-delta review after every valid finding was repaired.
+Test-only Backend repair `b48aa3dd8ba5ddc74b89524169a7df0a52a3fb27`
+then passed fresh exact-SHA review across the same tracks with no findings. The
+review confirmed that revision-specific lifecycle tests no longer conflate
+`head` with `0026`, while general-head and dedicated `0027` coverage remain.
 
 ## Human Review Focus
 

--- a/.agent-loop/merge-intents/WS-AUTH-001-CONTRIBUTOR-FOUNDATION.json
+++ b/.agent-loop/merge-intents/WS-AUTH-001-CONTRIBUTOR-FOUNDATION.json
@@ -1,0 +1,9 @@
+{
+  "chunk_id": "WS-AUTH-001-CONTRIBUTOR-FOUNDATION",
+  "chunk_title": "Contributor Fields And Canonical-Human Lineage",
+  "initiative_id": "WS-AUTH-001",
+  "next_chunk_id": "WS-AUTH-001-09E",
+  "next_chunk_title": "Fixed Service Runtime Admission",
+  "next_requires_explicit_start": true,
+  "schema_version": 2
+}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -158,6 +158,14 @@ jobs:
           --precision=2
           --fail-under=90
 
+      - name: Task subsystem coverage
+        working-directory: backend
+        run: >-
+          coverage report
+          --include='app/modules/tasks/*'
+          --precision=2
+          --fail-under=90
+
       - name: Auth verifier boundary coverage
         working-directory: backend
         run: >-

--- a/backend/alembic/versions/0027_contributor_foundation.py
+++ b/backend/alembic/versions/0027_contributor_foundation.py
@@ -66,8 +66,13 @@ def _preflight() -> None:
             bucket["total"] = int(bucket["total"]) + 1
             bounded_rows = bucket["rows"]
             if isinstance(bounded_rows, list) and len(bounded_rows) < 20:
+                actor_profile_id = (
+                    "<redacted-malformed>"
+                    if failure_class == "malformed"
+                    else str(row["actor_profile_id"])
+                )
                 bounded_rows.append(
-                    [str(row["row_id"]), str(row["actor_profile_id"])]
+                    [str(row["row_id"]), actor_profile_id]
                 )
         if table_failures:
             failures[table] = table_failures

--- a/backend/alembic/versions/0027_contributor_foundation.py
+++ b/backend/alembic/versions/0027_contributor_foundation.py
@@ -1,0 +1,276 @@
+"""clean-cut contributor attribution to canonical human actors
+
+Revision ID: 0027_contributor_foundation
+Revises: 0026_actor_profile_lifecycle
+Create Date: 2026-07-19
+"""
+
+from __future__ import annotations
+
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0027_contributor_foundation"
+down_revision = "0026_actor_profile_lifecycle"
+branch_labels = depends_on = None
+
+UUID_PATTERN = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+FUNCTION_NAME = "require_human_actor_profile_reference"
+LINEAGE_OBJECTS = (
+    (
+        "task_assignments",
+        "task_assignments_contributor_human",
+        "fk_task_assignments_contributor_id_actor_profiles",
+    ),
+    (
+        "submissions",
+        "submissions_contributor_human",
+        "fk_submissions_contributor_id_actor_profiles",
+    ),
+)
+
+
+def _preflight() -> None:
+    """Reject source rows that cannot become canonical human references."""
+    bind = op.get_bind()
+    failures: dict[str, dict[str, dict[str, object]]] = {}
+    for table in ("task_assignments", "submissions"):
+        rows = bind.execute(
+            sa.text(
+                f"""
+                select source.id as row_id, source.worker_id as actor_profile_id,
+                       case
+                         when source.worker_id !~ :uuid_pattern then 'malformed'
+                         when profile.id is null then 'missing'
+                         when profile.actor_kind <> 'human' then 'service'
+                       end as failure_class
+                from {table} source
+                left join actor_profiles profile on profile.id = source.worker_id
+                where source.worker_id !~ :uuid_pattern
+                   or profile.id is null
+                   or profile.actor_kind <> 'human'
+                order by failure_class, source.id, source.worker_id
+                """
+            ),
+            {"uuid_pattern": UUID_PATTERN},
+        ).mappings()
+        table_failures: dict[str, dict[str, object]] = {}
+        for row in rows:
+            failure_class = str(row["failure_class"])
+            bucket = table_failures.setdefault(
+                failure_class,
+                {"total": 0, "rows": []},
+            )
+            bucket["total"] = int(bucket["total"]) + 1
+            bounded_rows = bucket["rows"]
+            if isinstance(bounded_rows, list) and len(bounded_rows) < 20:
+                bounded_rows.append(
+                    [str(row["row_id"]), str(row["actor_profile_id"])]
+                )
+        if table_failures:
+            failures[table] = table_failures
+    if failures:
+        raise RuntimeError(
+            "contributor foundation preflight failed: "
+            + json.dumps(failures, sort_keys=True, separators=(",", ":"))
+        )
+
+
+def _create_lineage_function() -> None:
+    op.execute(
+        f"""
+        create function public.{FUNCTION_NAME}() returns trigger
+        language plpgsql security invoker as $$
+        declare referenced_id text; referenced_kind text;
+        begin
+          if tg_nargs <> 1 or tg_argv[0] is null
+             or not (to_jsonb(new) ? tg_argv[0]) then
+            raise exception 'human actor reference trigger is misconfigured'
+              using errcode='55000';
+          end if;
+          referenced_id := to_jsonb(new) ->> tg_argv[0];
+          if referenced_id is null then return new; end if;
+          select profile.actor_kind into referenced_kind
+          from public.actor_profiles profile where profile.id=referenced_id;
+          if not found then return new; end if;
+          if referenced_kind <> 'human' then
+            raise exception 'actor reference must identify a human profile'
+              using errcode='23514', constraint='{FUNCTION_NAME}';
+          end if;
+          return new;
+        end $$
+        """
+    )
+
+
+def _downstream_dependencies() -> tuple[int, tuple[str, ...]]:
+    """Return bounded descriptions of dependencies beyond this migration's triggers."""
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            f"""
+            with owned_triggers as (
+              select trigger_row.oid
+              from pg_trigger trigger_row
+              join pg_class table_row on table_row.oid=trigger_row.tgrelid
+              join pg_namespace namespace_row on namespace_row.oid=table_row.relnamespace
+              where namespace_row.nspname='public'
+                and (table_row.relname,trigger_row.tgname) in (
+                  ('task_assignments','task_assignments_contributor_human'),
+                  ('submissions','submissions_contributor_human')
+                )
+            )
+            select description, total
+            from (
+              select
+                pg_describe_object(
+                  dependency.classid,
+                  dependency.objid,
+                  dependency.objsubid
+                ) as description,
+                count(*) over () as total
+              from pg_depend dependency
+              where dependency.refclassid='pg_proc'::regclass
+                and dependency.refobjid='public.{FUNCTION_NAME}()'::regprocedure
+                and not (
+                  dependency.classid='pg_trigger'::regclass
+                  and dependency.objid in (select oid from owned_triggers)
+                )
+            ) dependencies
+            order by description
+            limit 20
+            """
+        )
+    ).all()
+    if not rows:
+        return 0, ()
+    return int(rows[0].total), tuple(str(row.description) for row in rows)
+
+
+def upgrade() -> None:
+    """Install canonical-human contributor attribution without guessing data."""
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "lock table actor_profiles, task_assignments, submissions "
+            "in access exclusive mode"
+        )
+    )
+    _preflight()
+
+    op.alter_column(
+        "task_assignments",
+        "worker_id",
+        new_column_name="contributor_id",
+        existing_type=sa.String(100),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "task_assignments",
+        "contributor_id",
+        type_=sa.String(36),
+        existing_type=sa.String(100),
+        existing_nullable=False,
+    )
+    op.execute(
+        "alter index ix_task_assignments_worker_id "
+        "rename to ix_task_assignments_contributor_id"
+    )
+    op.alter_column(
+        "submissions",
+        "worker_id",
+        new_column_name="contributor_id",
+        existing_type=sa.String(100),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "submissions",
+        "contributor_id",
+        type_=sa.String(36),
+        existing_type=sa.String(100),
+        existing_nullable=False,
+    )
+    op.execute(
+        "alter index ix_submissions_worker_id rename to ix_submissions_contributor_id"
+    )
+
+    for table, _, foreign_key in LINEAGE_OBJECTS:
+        op.create_foreign_key(
+            foreign_key,
+            table,
+            "actor_profiles",
+            ["contributor_id"],
+            ["id"],
+        )
+    _create_lineage_function()
+    for table, trigger, _ in LINEAGE_OBJECTS:
+        op.execute(
+            f"create trigger {trigger} before insert or update of contributor_id "
+            f"on {table} for each row execute function "
+            f"public.{FUNCTION_NAME}('contributor_id')"
+        )
+
+
+def downgrade() -> None:
+    """Restore prior names only while no later lineage consumer depends on them."""
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "lock table actor_profiles, task_assignments, submissions "
+            "in access exclusive mode"
+        )
+    )
+    dependency_total, dependencies = _downstream_dependencies()
+    if dependency_total:
+        raise RuntimeError(
+            "cannot downgrade contributor lineage dependencies: "
+            + json.dumps(
+                {"total": dependency_total, "objects": dependencies},
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+
+    for table, trigger, _ in LINEAGE_OBJECTS:
+        op.execute(f"drop trigger {trigger} on {table}")
+    for table, _, foreign_key in LINEAGE_OBJECTS:
+        op.drop_constraint(foreign_key, table, type_="foreignkey")
+    op.execute(f"drop function public.{FUNCTION_NAME}() restrict")
+
+    op.execute(
+        "alter index ix_task_assignments_contributor_id "
+        "rename to ix_task_assignments_worker_id"
+    )
+    op.alter_column(
+        "task_assignments",
+        "contributor_id",
+        type_=sa.String(100),
+        existing_type=sa.String(36),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "task_assignments",
+        "contributor_id",
+        new_column_name="worker_id",
+        existing_type=sa.String(100),
+        existing_nullable=False,
+    )
+    op.execute(
+        "alter index ix_submissions_contributor_id rename to ix_submissions_worker_id"
+    )
+    op.alter_column(
+        "submissions",
+        "contributor_id",
+        type_=sa.String(100),
+        existing_type=sa.String(36),
+        existing_nullable=False,
+    )
+    op.alter_column(
+        "submissions",
+        "contributor_id",
+        new_column_name="worker_id",
+        existing_type=sa.String(100),
+        existing_nullable=False,
+    )

--- a/backend/app/modules/actors/service.py
+++ b/backend/app/modules/actors/service.py
@@ -77,6 +77,17 @@ class ActorProfileDisabled(ActorRegistryError):
     code = "legacy_workflow_eligibility_disabled"
 
 
+class ActiveHumanWriteActorRequired(ActorRegistryError):
+    """The exact canonical caller is not currently eligible to write."""
+
+    status_code = 403
+    code = "active_contributor_required"
+
+
+class CanonicalWriteActorUnavailable(RuntimeError):
+    """Canonical profile/link state is missing or internally inconsistent."""
+
+
 @dataclass(frozen=True)
 class ResolvedActor:
     """Canonical profile and exact verified identity link for one request."""
@@ -218,6 +229,26 @@ class ActorService:
         ):
             raise RuntimeError("resolved actor identity changed")
         return ResolvedActor(profile=profile, identity_link=link)
+
+    async def require_active_human_write_actor(self, actor: ActorContext) -> None:
+        """Lock and revalidate one exact human caller in the current transaction."""
+        profile = await self._repo.get_actor_profile(actor.actor_id, for_update=True)
+        if profile is None:
+            raise CanonicalWriteActorUnavailable("canonical actor profile is missing")
+        if profile.actor_kind != "human" or profile.status != "active":
+            raise ActiveHumanWriteActorRequired("active contributor identity required")
+
+        link = await self._repo.get_identity_link(
+            actor.external_issuer,
+            actor.external_subject,
+            for_update=True,
+        )
+        if link is None:
+            raise CanonicalWriteActorUnavailable("canonical identity link is missing")
+        if link.actor_profile_id != profile.id or link.subject_kind != "human":
+            raise CanonicalWriteActorUnavailable("canonical identity link is inconsistent")
+        if link.status != "active":
+            raise ActiveHumanWriteActorRequired("active contributor identity required")
 
     async def update_self(
         self,

--- a/backend/app/modules/tasks/models.py
+++ b/backend/app/modules/tasks/models.py
@@ -214,7 +214,7 @@ class WorkstreamTask(Base):
 
 
 class TaskAssignment(Base):
-    """Worker assignment record for a task claim."""
+    """Contributor assignment record for a task claim."""
 
     __tablename__ = "task_assignments"
     __table_args__ = (
@@ -232,7 +232,12 @@ class TaskAssignment(Base):
         nullable=False,
         index=True,
     )
-    worker_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    contributor_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("actor_profiles.id"),
+        nullable=False,
+        index=True,
+    )
     assigned_by: Mapped[str] = mapped_column(String(100), nullable=False)
     assigned_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
@@ -243,7 +248,7 @@ class TaskAssignment(Base):
 
 
 class Submission(Base):
-    """Immutable worker submission packet version for a task."""
+    """Immutable contributor submission packet version for a task."""
 
     __tablename__ = "submissions"
     __table_args__ = (
@@ -381,7 +386,12 @@ class Submission(Base):
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     task_id: Mapped[str] = mapped_column(ForeignKey("workstream_tasks.id"), nullable=False, index=True)
-    worker_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    contributor_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("actor_profiles.id"),
+        nullable=False,
+        index=True,
+    )
     version: Mapped[int] = mapped_column(Integer, nullable=False)
     status: Mapped[str] = mapped_column(String(30), nullable=False, default="submitted", index=True)
     summary: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/modules/tasks/repository.py
+++ b/backend/app/modules/tasks/repository.py
@@ -45,16 +45,27 @@ class TaskRepository:
         await self._session.refresh(task)
         return task
 
-    async def get_task(self, task_id: str) -> WorkstreamTask | None:
+    async def get_task(
+        self,
+        task_id: str,
+        *,
+        for_update: bool = False,
+    ) -> WorkstreamTask | None:
         """Load one task by primary key.
 
         Args:
             task_id: Task id to load.
+            for_update: Whether to lock and refresh the selected row.
 
         Returns:
             Task model when found; otherwise ``None``.
         """
-        return await self._session.get(WorkstreamTask, task_id)
+        statement = select(WorkstreamTask).where(WorkstreamTask.id == task_id)
+        if for_update:
+            statement = statement.with_for_update()
+        return await self._session.scalar(
+            statement.execution_options(populate_existing=True)
+        )
 
     async def add_assignment(self, assignment: TaskAssignment) -> TaskAssignment:
         """Persist an assignment and refresh generated database fields.
@@ -70,20 +81,29 @@ class TaskRepository:
         await self._session.refresh(assignment)
         return assignment
 
-    async def get_active_assignment(self, task_id: str) -> TaskAssignment | None:
+    async def get_active_assignment(
+        self,
+        task_id: str,
+        *,
+        for_update: bool = False,
+    ) -> TaskAssignment | None:
         """Load the active assignment for a task.
 
         Args:
             task_id: Task id whose active assignment should be loaded.
+            for_update: Whether to lock and refresh the selected row.
 
         Returns:
             Active assignment when present; otherwise ``None``.
         """
+        statement = select(TaskAssignment).where(
+            TaskAssignment.task_id == task_id,
+            TaskAssignment.status == "active",
+        )
+        if for_update:
+            statement = statement.with_for_update()
         result = await self._session.execute(
-            select(TaskAssignment).where(
-                TaskAssignment.task_id == task_id,
-                TaskAssignment.status == "active",
-            )
+            statement.execution_options(populate_existing=True)
         )
         return result.scalar_one_or_none()
 

--- a/backend/app/modules/tasks/router.py
+++ b/backend/app/modules/tasks/router.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps.auth import actor_registry_http_error, get_registered_actor
-from app.core.api_controls import error_response
+from app.core.api_controls import StructuredHTTPException, error_response
 from app.core.permissions import PermissionDenied
 from app.db.session import get_db_session
 from app.modules.actors.schemas import (
@@ -82,6 +82,16 @@ def task_http_error(exc: TaskServiceError) -> HTTPException:
     Returns:
         HTTP exception carrying the service error details.
     """
+    code = getattr(exc, "code", None)
+    if code is not None:
+        message = getattr(exc, "message", str(exc))
+        return StructuredHTTPException(
+            status_code=exc.status_code,
+            detail=message,
+            error_code=code,
+            error_message=message,
+            retryable=getattr(exc, "retryable", False),
+        )
     return HTTPException(status_code=exc.status_code, detail=str(exc))
 
 
@@ -92,6 +102,8 @@ def task_domain_error_response(request: Request, exc: TaskServiceError) -> JSONR
     message = {
         "pre_submission_checker_failed": "Pre-submission checks failed",
         "task_locked_context_invalid": "Task locked context is invalid",
+        "active_contributor_required": "Active contributor identity required",
+        "contributor_identity_unavailable": "Contributor identity verification unavailable",
     }[code]
     return error_response(
         request,
@@ -99,6 +111,7 @@ def task_domain_error_response(request: Request, exc: TaskServiceError) -> JSONR
         code=code,
         message=message,
         details=details,
+        retryable=getattr(exc, "retryable", False),
         compatibility={"code": code, "details": details},
     )
 
@@ -218,7 +231,7 @@ async def get_task_submission_requirements(
     actor: Annotated[ActorContext, Depends(get_registered_actor)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> SubmissionRequirementsResponse | JSONResponse:
-    """Return exact worker submission requirements from locked policy context."""
+    """Return exact contributor submission requirements from locked policy context."""
     try:
         return await TaskService(session).get_task_submission_requirements(actor, task_id)
     except PermissionDenied as exc:

--- a/backend/app/modules/tasks/router.py
+++ b/backend/app/modules/tasks/router.py
@@ -201,7 +201,7 @@ async def get_task_work_context(
     actor: Annotated[ActorContext, Depends(get_registered_actor)],
     session: Annotated[AsyncSession, Depends(get_db_session)],
 ) -> TaskWorkContextResponse | JSONResponse:
-    """Return worker-safe locked guide, policy, and lifecycle context."""
+    """Return contributor-safe locked guide, policy, and lifecycle context."""
     try:
         return await TaskService(session).get_task_work_context(actor, task_id)
     except PermissionDenied as exc:

--- a/backend/app/modules/tasks/schemas.py
+++ b/backend/app/modules/tasks/schemas.py
@@ -373,7 +373,7 @@ class AssignmentResponse(BaseModel):
 
     id: str
     task_id: str
-    worker_id: str
+    contributor_id: str
     assigned_by: str
     assigned_at: datetime
     accepted_at: datetime | None
@@ -420,7 +420,7 @@ class SubmissionResponse(BaseModel):
 
     id: str
     task_id: str
-    worker_id: str
+    contributor_id: str
     version: int
     status: str
     summary: str

--- a/backend/app/modules/tasks/service.py
+++ b/backend/app/modules/tasks/service.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.hashing import canonical_json_hash
@@ -28,7 +28,12 @@ from app.modules.checkers.service import (
     pre_review_gate_system_actor,
 )
 from app.modules.actors.models import LegacyWorkflowEligibility
-from app.modules.actors.service import LegacyWorkflowEligibilityCompatibility
+from app.modules.actors.service import (
+    ActiveHumanWriteActorRequired,
+    ActorService,
+    CanonicalWriteActorUnavailable,
+    LegacyWorkflowEligibilityCompatibility,
+)
 from app.modules.projects.models import (
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
@@ -100,7 +105,7 @@ TASK_START_OPERATOR_ROLES = {"admin", "project_manager"}
 SUBMISSION_FINALIZE_ROLES = {"admin", "project_manager"}
 SUBMISSION_FINALIZED_EVENT_TYPE = "submission_finalized"
 PRE_REVIEW_GATE_DISPATCH_FAILED_EVENT_TYPE = "pre_review_gate_dispatch_failed"
-WORKER_VISIBLE_AUDIT_PAYLOAD_KEYS = {
+CONTRIBUTOR_VISIBLE_AUDIT_PAYLOAD_KEYS = {
     "assignment_id",
     "locked_guide_version",
     "locked_review_policy_version",
@@ -110,9 +115,9 @@ WORKER_VISIBLE_AUDIT_PAYLOAD_KEYS = {
     "submission_id",
     "submission_version",
     "supersedes_submission_id",
-    "worker_id",
+    "contributor_id",
 }
-WORKER_REDACTED_AUDIT_EVENTS = {
+CONTRIBUTOR_REDACTED_AUDIT_EVENTS = {
     "pre_review_gate_started",
     "pre_review_gate_passed",
     "pre_review_gate_needs_revision",
@@ -178,6 +183,23 @@ class TaskAssignmentConflict(TaskServiceError):
     """Raised when a task already has an active Contributor assignment."""
 
     status_code = 409
+
+
+class ActiveContributorRequired(TaskServiceError):
+    """Raised when the canonical caller cannot perform a contributor write."""
+
+    status_code = 403
+    code = "active_contributor_required"
+    message = "Active contributor identity required"
+
+
+class ContributorIdentityUnavailable(TaskServiceError):
+    """Raised when canonical contributor identity cannot be revalidated."""
+
+    status_code = 503
+    code = "contributor_identity_unavailable"
+    message = "Contributor identity verification unavailable"
+    retryable = True
 
 
 class LegacySubmitterEligibilityRequired(TaskServiceError):
@@ -269,6 +291,7 @@ class TaskService:
         self._session = session
         self._repo = TaskRepository(session)
         self._project_repo = ProjectRepository(session)
+        self._actors = ActorService(session)
         self._legacy_workflow_eligibility = LegacyWorkflowEligibilityCompatibility(session)
 
     async def create_task(
@@ -543,16 +566,17 @@ class TaskService:
             TaskAssignmentConflict: If an active assignment already exists.
         """
         require_any_role(actor, TASK_CLAIM_ROLES)
-        task = await self._get_task(task_id)
+        await self._require_active_contributor(actor)
+        task = await self._get_task(task_id, for_update=True)
         self._ensure_transition_allowed(task.status, TASK_STATUS_CLAIMED)
         await self._require_legacy_submitter_eligibility(actor)
-        if await self._repo.get_active_assignment(task_id) is not None:
+        if await self._repo.get_active_assignment(task_id, for_update=True) is not None:
             raise TaskAssignmentConflict("task already has an active assignment")
 
         assignment = TaskAssignment(
             id=str(uuid4()),
             task_id=task.id,
-            worker_id=actor.actor_id,
+            contributor_id=actor.actor_id,
             assigned_by=actor.actor_id,
             accepted_at=datetime.now(UTC),
             status="active",
@@ -565,7 +589,10 @@ class TaskService:
                 task,
                 TASK_STATUS_CLAIMED,
                 reason,
-                event_payload={"assignment_id": assignment.id, "worker_id": assignment.worker_id},
+                event_payload={
+                    "assignment_id": assignment.id,
+                    "contributor_id": assignment.contributor_id,
+                },
             )
             await self._session.commit()
         except IntegrityError as exc:
@@ -604,10 +631,10 @@ class TaskService:
         assignment = await self._repo.get_active_assignment(task_id)
         if assignment is None:
             raise TaskTransitionBlocked("task has no active assignment")
-        is_operator_override = assignment.worker_id != actor.actor_id and bool(
+        is_operator_override = assignment.contributor_id != actor.actor_id and bool(
             set(actor.roles).intersection(TASK_START_OPERATOR_ROLES)
         )
-        if assignment.worker_id != actor.actor_id and not is_operator_override:
+        if assignment.contributor_id != actor.actor_id and not is_operator_override:
             raise TaskTransitionBlocked("actor is not assigned to this task")
         if not is_operator_override:
             await self._require_legacy_submitter_eligibility(actor)
@@ -620,7 +647,7 @@ class TaskService:
             reason,
             event_payload={
                 "assignment_id": assignment.id,
-                "worker_id": assignment.worker_id,
+                "contributor_id": assignment.contributor_id,
                 "operator_override": bool(is_operator_override),
             },
             event_type="task_start_override" if is_operator_override else "task_status_changed",
@@ -653,14 +680,15 @@ class TaskService:
             SubmissionVersionConflict: If concurrent version allocation conflicts.
         """
         require_any_role(actor, TASK_SUBMIT_ROLES)
-        task = await self._get_task(task_id)
+        await self._require_active_contributor(actor)
+        task = await self._get_task(task_id, for_update=True)
         if "worker" in actor.roles and task.assigned_to not in {None, actor.actor_id}:
             raise TaskNotFound("task not found")
         await self._require_legacy_submitter_eligibility(actor)
-        assignment = await self._repo.get_active_assignment(task_id)
+        assignment = await self._repo.get_active_assignment(task_id, for_update=True)
         if assignment is None:
             raise TaskTransitionBlocked("task has no active assignment")
-        if assignment.worker_id != actor.actor_id or task.assigned_to != actor.actor_id:
+        if assignment.contributor_id != actor.actor_id or task.assigned_to != actor.actor_id:
             raise TaskNotFound("task not found")
         if task.status not in {
             TASK_STATUS_IN_PROGRESS,
@@ -699,7 +727,7 @@ class TaskService:
         submission = Submission(
             id=str(uuid4()),
             task_id=task.id,
-            worker_id=actor.actor_id,
+            contributor_id=actor.actor_id,
             version=next_version,
             status="submitted",
             summary=payload.summary,
@@ -1140,7 +1168,12 @@ class TaskService:
             raise SubmissionNotFound("submission not found")
         return submission
 
-    async def _get_task(self, task_id: str) -> WorkstreamTask:
+    async def _get_task(
+        self,
+        task_id: str,
+        *,
+        for_update: bool = False,
+    ) -> WorkstreamTask:
         """Load a task or raise a service error.
 
         Args:
@@ -1152,10 +1185,23 @@ class TaskService:
         Raises:
             TaskNotFound: If the task id is unknown.
         """
-        task = await self._repo.get_task(task_id)
+        task = await self._repo.get_task(task_id, for_update=for_update)
         if task is None:
             raise TaskNotFound("task not found")
         return task
+
+    async def _require_active_contributor(self, actor: ActorContext) -> None:
+        """Revalidate the exact canonical caller before contributor writes."""
+        try:
+            await self._actors.require_active_human_write_actor(actor)
+        except ActiveHumanWriteActorRequired as exc:
+            await self._session.rollback()
+            raise ActiveContributorRequired(ActiveContributorRequired.message) from exc
+        except (CanonicalWriteActorUnavailable, SQLAlchemyError) as exc:
+            await self._session.rollback()
+            raise ContributorIdentityUnavailable(
+                ContributorIdentityUnavailable.message
+            ) from exc
 
     @staticmethod
     def _submission_audit_payload(submission: Submission) -> dict:
@@ -1170,7 +1216,7 @@ class TaskService:
         return {
             "submission_id": submission.id,
             "submission_version": submission.version,
-            "worker_id": submission.worker_id,
+            "contributor_id": submission.contributor_id,
             "package_hash": submission.package_hash,
             "artifact_hash_manifest": submission.artifact_hash_manifest,
             "supersedes_submission_id": submission.supersedes_submission_id,
@@ -2283,9 +2329,9 @@ class TaskService:
             response.event_payload = {
                 key: value
                 for key, value in response.event_payload.items()
-                if key in WORKER_VISIBLE_AUDIT_PAYLOAD_KEYS
+                if key in CONTRIBUTOR_VISIBLE_AUDIT_PAYLOAD_KEYS
             }
-            if response.event_type in WORKER_REDACTED_AUDIT_EVENTS:
+            if response.event_type in CONTRIBUTOR_REDACTED_AUDIT_EVENTS:
                 response.event_type = "post_submit_checks_processing"
                 response.from_status = None
                 response.to_status = None

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -1397,6 +1397,11 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
             worker_token,
             {"reason": "real worker claim"},
         )
+        ensure(
+            claim["assignment"]["contributor_id"]
+            == canonical_actor["actor_profile_id"],
+            "task claim did not return canonical contributor attribution",
+        )
         await request_json(
             client,
             "GET",
@@ -1454,6 +1459,10 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
                 ],
             },
             201,
+        )
+        ensure(
+            submission["contributor_id"] == canonical_actor["actor_profile_id"],
+            "submission did not return canonical contributor attribution",
         )
         for internal_field in (
             "artifact_hash_manifest",

--- a/backend/tests/test_actors.py
+++ b/backend/tests/test_actors.py
@@ -34,9 +34,11 @@ from app.modules.actors.schemas import (
     LegacyWorkflowEligibilityActivationRequest,
 )
 from app.modules.actors.service import (
+    ActiveHumanWriteActorRequired,
     ActorDeactivated,
     ActorProfileDisabled,
     ActorService,
+    CanonicalWriteActorUnavailable,
     IdentityLinkRevoked,
     LegacyWorkflowEligibilityCompatibility,
     ResolvedActor,
@@ -406,6 +408,119 @@ async def test_actor_authorization_lock_rejects_disappearance_and_identity_drift
     locked = await service.lock_actor_self_for_authorization(resolved)
     assert locked.profile is profile
     assert locked.identity_link is link
+
+
+async def test_active_human_write_actor_revalidates_exact_profile_then_link() -> None:
+    actor = legacy_actor("contributor-write")
+    profile = ActorProfile(
+        id=actor.actor_id,
+        actor_kind="human",
+        status="active",
+        provisioning_method="automatic_first_access",
+        created_by=actor.actor_id,
+    )
+    link = ActorIdentityLink(
+        id=str(uuid4()),
+        actor_profile_id=profile.id,
+        issuer=actor.external_issuer,
+        subject=actor.external_subject,
+        subject_kind="human",
+        status="active",
+        linked_by=profile.id,
+        last_verified_at=datetime.now(UTC),
+    )
+
+    class Repository:
+        locked_profile = profile
+        locked_link = link
+        calls: list[tuple[str, str, str]] = []
+
+        async def get_actor_profile(self, actor_profile_id, *, for_update=False):
+            assert for_update is True
+            self.calls.append(("profile", actor_profile_id, ""))
+            return self.locked_profile
+
+        async def get_identity_link(self, issuer, subject, *, for_update=False):
+            assert for_update is True
+            self.calls.append(("link", issuer, subject))
+            return self.locked_link
+
+    repository = Repository()
+    service = ActorService(object())  # type: ignore[arg-type]
+    service._repo = repository  # type: ignore[assignment]
+
+    assert await service.require_active_human_write_actor(actor) is None
+    assert repository.calls == [
+        ("profile", actor.actor_id, ""),
+        ("link", actor.external_issuer, actor.external_subject),
+    ]
+
+    unavailable_cases = (
+        (None, link, "profile is missing"),
+        (
+            profile,
+            ActorIdentityLink(
+                id=link.id,
+                actor_profile_id=str(uuid4()),
+                issuer=link.issuer,
+                subject=link.subject,
+                subject_kind="human",
+                status="active",
+                linked_by=profile.id,
+                last_verified_at=link.last_verified_at,
+            ),
+            "link is inconsistent",
+        ),
+        (profile, None, "link is missing"),
+    )
+    for locked_profile, locked_link, message in unavailable_cases:
+        repository.locked_profile = locked_profile
+        repository.locked_link = locked_link
+        repository.calls = []
+        with pytest.raises(CanonicalWriteActorUnavailable, match=message):
+            await service.require_active_human_write_actor(actor)
+
+    for actor_kind, profile_status, link_status in (
+        ("service", "active", "active"),
+        ("human", "suspended", "active"),
+        ("human", "deactivated", "active"),
+        ("human", "active", "revoked"),
+    ):
+        repository.locked_profile = ActorProfile(
+            id=profile.id,
+            actor_kind=actor_kind,
+            status=profile_status,
+            provisioning_method=(
+                "manual_service_provisioning"
+                if actor_kind == "service"
+                else "automatic_first_access"
+            ),
+            service_identity=(
+                "workstream.artifact.verifier" if actor_kind == "service" else None
+            ),
+            created_by=profile.id,
+        )
+        repository.locked_link = ActorIdentityLink(
+            id=link.id,
+            actor_profile_id=profile.id,
+            issuer=link.issuer,
+            subject=link.subject,
+            subject_kind="human",
+            status=link_status,
+            linked_by=profile.id,
+            last_verified_at=link.last_verified_at,
+            revoked_by=profile.id if link_status == "revoked" else None,
+            revoked_at=datetime.now(UTC) if link_status == "revoked" else None,
+            revoked_reason="revoked for test" if link_status == "revoked" else None,
+        )
+        repository.calls = []
+        with pytest.raises(
+            ActiveHumanWriteActorRequired,
+            match="active contributor identity required",
+        ):
+            await service.require_active_human_write_actor(actor)
+        expected_calls = ["profile"] if actor_kind == "service" or profile_status != "active" else ["profile", "link"]
+        assert [call[0] for call in repository.calls] == expected_calls
 
 
 async def test_actor_timestamp_touch_fails_closed_before_writes_on_missing_rows() -> None:

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -1364,11 +1364,11 @@ def test_actor_profile_lifecycle_fresh_and_prior_head_upgrade(
             command.downgrade(config, "base")
             command.upgrade(config, "0025_artifact_store_v2")
             assert asyncio.run(shape()) == ("0025_artifact_store_v2", False, False)
-            command.upgrade(config, "head")
+            command.upgrade(config, "0026_actor_profile_lifecycle")
             assert asyncio.run(shape()) == ("0026_actor_profile_lifecycle", True, True)
             command.downgrade(config, "0025_artifact_store_v2")
             assert asyncio.run(shape()) == ("0025_artifact_store_v2", False, False)
-            command.upgrade(config, "head")
+            command.upgrade(config, "0026_actor_profile_lifecycle")
             assert asyncio.run(shape()) == ("0026_actor_profile_lifecycle", True, True)
         finally:
             command.downgrade(config, "base")
@@ -1805,10 +1805,10 @@ def test_actor_profile_lifecycle_safe_downgrade_and_reupgrade(
     with migration_lock():
         try:
             command.downgrade(config, "base")
-            command.upgrade(config, "head")
+            command.upgrade(config, "0026_actor_profile_lifecycle")
             command.downgrade(config, "0025_artifact_store_v2")
             assert asyncio.run(_current_revision(isolated_database_env)) == "0025_artifact_store_v2"
-            command.upgrade(config, "head")
+            command.upgrade(config, "0026_actor_profile_lifecycle")
             assert asyncio.run(_current_revision(isolated_database_env)) == "0026_actor_profile_lifecycle"
         finally:
             command.downgrade(config, "base")
@@ -2020,7 +2020,7 @@ def test_actor_profile_lifecycle_downgrade_refuses_forward_evidence(
     with migration_lock():
         try:
             command.downgrade(config, "base")
-            command.upgrade(config, "head")
+            command.upgrade(config, "0026_actor_profile_lifecycle")
             asyncio.run(seed_actor())
             asyncio.run(write_profile_reactivation())
             refuse_downgrade_without_change()

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -2039,6 +2039,138 @@ def test_actor_profile_lifecycle_downgrade_refuses_forward_evidence(
             command.downgrade(config, "base")
 
 
+def test_contributor_foundation_upgrade_guards_and_reversible_preservation(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """Preserve valid attribution and enforce canonical-human lineage in PostgreSQL."""
+    config = _alembic_config()
+    human_id = str(uuid4())
+
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "0026_actor_profile_lifecycle")
+            fixture = asyncio.run(
+                _seed_contributor_prior_head(
+                    isolated_database_env,
+                    assignment_values=(human_id,),
+                    submission_values=(human_id,),
+                    human_ids=(human_id,),
+                )
+            )
+            before = asyncio.run(_contributor_foundation_shape(isolated_database_env))
+            assert before["revision"] == "0026_actor_profile_lifecycle"
+            assert before["assignment_column"] == ("worker_id", 100)
+            assert before["submission_column"] == ("worker_id", 100)
+
+            command.upgrade(config, "0027_contributor_foundation")
+            upgraded = asyncio.run(_contributor_foundation_shape(isolated_database_env))
+            assert upgraded == {
+                "revision": "0027_contributor_foundation",
+                "assignment_column": ("contributor_id", 36),
+                "submission_column": ("contributor_id", 36),
+                "assignment_index": "ix_task_assignments_contributor_id",
+                "submission_index": "ix_submissions_contributor_id",
+                "foreign_keys": (
+                    "fk_submissions_contributor_id_actor_profiles",
+                    "fk_task_assignments_contributor_id_actor_profiles",
+                ),
+                "function": True,
+                "triggers": (
+                    "submissions_contributor_human",
+                    "task_assignments_contributor_human",
+                ),
+                "assignment_values": (human_id,),
+                "submission_values": (human_id,),
+            }
+            direct_sql = asyncio.run(
+                _exercise_contributor_lineage_guards(
+                    isolated_database_env,
+                    fixture=fixture,
+                    human_id=human_id,
+                )
+            )
+            assert direct_sql == {
+                "missing_assignment": "23503",
+                "service_assignment": "23514",
+                "service_assignment_update": "23514",
+                "missing_submission": "23503",
+                "service_submission": "23514",
+                "suspended_human_inserted": True,
+                "deactivated_human_inserted": True,
+                "unrelated_update_preserved": True,
+            }
+
+            asyncio.run(_add_contributor_function_dependency(isolated_database_env))
+            intact = asyncio.run(_contributor_foundation_shape(isolated_database_env))
+            with pytest.raises(RuntimeError, match='"total":1'):
+                command.downgrade(config, "0026_actor_profile_lifecycle")
+            assert asyncio.run(_contributor_foundation_shape(isolated_database_env)) == intact
+            asyncio.run(_drop_contributor_function_dependency(isolated_database_env))
+
+            command.downgrade(config, "0026_actor_profile_lifecycle")
+            restored = asyncio.run(_contributor_foundation_shape(isolated_database_env))
+            assert restored["revision"] == "0026_actor_profile_lifecycle"
+            assert restored["assignment_column"] == ("worker_id", 100)
+            assert restored["submission_column"] == ("worker_id", 100)
+            assert restored["assignment_index"] == "ix_task_assignments_worker_id"
+            assert restored["submission_index"] == "ix_submissions_worker_id"
+            assert human_id in restored["assignment_values"]
+            assert restored["submission_values"] == (human_id,)
+
+            command.upgrade(config, "0027_contributor_foundation")
+            assert asyncio.run(_current_revision(isolated_database_env)) == (
+                "0027_contributor_foundation"
+            )
+        finally:
+            command.downgrade(config, "0023_service_actor_identity")
+            asyncio.run(_clear_contributor_migration_fixtures(isolated_database_env))
+            command.downgrade(config, "base")
+
+
+def test_contributor_foundation_preflight_refuses_all_unsafe_classes_atomically(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """Classify both source tables without guessing or partially changing schema."""
+    config = _alembic_config()
+    missing_ids = (str(uuid4()), str(uuid4()))
+
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "0026_actor_profile_lifecycle")
+            fixture = asyncio.run(
+                _seed_contributor_prior_head(
+                    isolated_database_env,
+                    assignment_values=("not-a-uuid", missing_ids[0], "service"),
+                    submission_values=("also-not-a-uuid", missing_ids[1], "service"),
+                )
+            )
+            service_id = str(fixture["service_id"])
+            before = asyncio.run(_contributor_foundation_shape(isolated_database_env))
+
+            with pytest.raises(RuntimeError, match="contributor foundation preflight") as failure:
+                command.upgrade(config, "0027_contributor_foundation")
+
+            message = str(failure.value)
+            assert "malformed" in message
+            assert "missing" in message
+            assert "service" in message
+            assert service_id in message
+            for row_id in fixture["assignment_ids"] + fixture["submission_ids"]:
+                assert row_id in message
+            assert "issuer" not in message
+            assert "subject" not in message
+            assert "email" not in message
+            assert asyncio.run(_contributor_foundation_shape(isolated_database_env)) == before
+        finally:
+            command.downgrade(config, "0023_service_actor_identity")
+            asyncio.run(_clear_contributor_migration_fixtures(isolated_database_env))
+            command.downgrade(config, "base")
+
+
 def test_api_rate_control_schema_preserves_domain_and_guards_downgrade(
     isolated_database_env: str,
     migration_lock,
@@ -6247,6 +6379,496 @@ async def _remove_fixed_service_actor(database_url: str, actor_profile_id: str) 
             )
             await connection.execute(text("alter table actor_profiles enable trigger user"))
             await connection.execute(text("alter table actor_identity_links enable trigger user"))
+    finally:
+        await engine.dispose()
+
+
+async def _seed_contributor_prior_head(
+    database_url: str,
+    *,
+    assignment_values: tuple[str, ...],
+    submission_values: tuple[str, ...],
+    human_ids: tuple[str, ...] = (),
+) -> dict[str, tuple[str, ...] | str]:
+    engine = create_async_engine(database_url)
+    assignment_ids = tuple(str(uuid4()) for _ in assignment_values)
+    runtime_ids = {
+        name: str(uuid4())
+        for name in (
+            "project",
+            "guide",
+            "snapshot",
+            "submission_policy",
+            "effective_policy",
+            "pre_submit_policy",
+            "policy",
+            "review_policy",
+            "revision_policy",
+            "payment_policy",
+            "task",
+            "submission",
+            "run",
+        )
+    }
+    submission_ids = (runtime_ids["submission"],) + tuple(
+        str(uuid4()) for _ in submission_values[1:]
+    )
+    service_id = str(uuid4())
+    try:
+        await _seed_artifact_prior_head_runtime_rows(database_url, runtime_ids)
+        async with engine.begin() as connection:
+            for human_id in human_ids:
+                await connection.execute(
+                    text(
+                        "insert into actor_profiles "
+                        "(id,actor_kind,status,provisioning_method,created_by) values "
+                        "(:id,'human','active','automatic_first_access',:id)"
+                    ),
+                    {"id": human_id},
+                )
+                await connection.execute(
+                    text(
+                        "insert into actor_identity_links "
+                        "(id,actor_profile_id,issuer,subject,subject_kind,status,"
+                        "linked_by,last_verified_at) values "
+                        "(:link,:actor,'https://identity.test',:subject,'human',"
+                        "'active',:actor,clock_timestamp())"
+                    ),
+                    {
+                        "link": str(uuid4()),
+                        "actor": human_id,
+                        "subject": f"contributor-{human_id}",
+                    },
+                )
+            await connection.execute(
+                text(
+                    "insert into actor_profiles "
+                    "(id,actor_kind,status,provisioning_method,service_identity,created_by) "
+                    "values (:id,'service','active','manual_service_provisioning',"
+                    ":identity,:id)"
+                ),
+                {
+                    "id": service_id,
+                    "identity": ServiceIdentity.ARTIFACT_VERIFIER.value,
+                },
+            )
+            await connection.execute(
+                text(
+                    "insert into actor_identity_links "
+                    "(id,actor_profile_id,issuer,subject,subject_kind,status,linked_by,"
+                    "last_verified_at) values "
+                    "(:link,:actor,'workstream-local',:subject,'service','active',"
+                    ":actor,clock_timestamp())"
+                ),
+                {
+                    "link": str(uuid4()),
+                    "actor": service_id,
+                    "subject": ServiceIdentity.ARTIFACT_VERIFIER.value,
+                },
+            )
+            resolved_assignment_values = tuple(
+                service_id if value == "service" else value
+                for value in assignment_values
+            )
+            for index, value in enumerate(assignment_values):
+                await connection.execute(
+                    text(
+                        "insert into task_assignments "
+                        "(id,task_id,worker_id,assigned_by,status) values "
+                        "(:id,:task,:actor,'migration-test',:status)"
+                    ),
+                    {
+                        "id": assignment_ids[index],
+                        "task": runtime_ids["task"],
+                        "actor": resolved_assignment_values[index],
+                        "status": "active" if index == 0 else "released",
+                    },
+                )
+            resolved_submission_values = tuple(
+                service_id if value == "service" else value for value in submission_values
+            )
+            await connection.execute(
+                text("update submissions set worker_id=:actor where id=:id"),
+                {
+                    "id": submission_ids[0],
+                    "actor": resolved_submission_values[0],
+                },
+            )
+            for index, value in enumerate(resolved_submission_values[1:], start=1):
+                await connection.execute(
+                    text(
+                        "insert into submissions "
+                        "(id,task_id,worker_id,version,status,summary,package_uri,"
+                        "package_hash,artifact_hash_manifest,worker_attestation,"
+                        "locked_guide_version,locked_post_submit_checker_policy_id,"
+                        "locked_post_submit_checker_policy_version,"
+                        "locked_post_submit_checker_policy_hash,"
+                        "locked_post_submit_checker_policy_body,"
+                        "locked_review_policy_version,locked_revision_policy_version,"
+                        "locked_payment_policy_version,locked_guide_source_snapshot_id,"
+                        "locked_guide_source_snapshot_hash,"
+                        "locked_effective_project_submission_artifact_policy_id,"
+                        "locked_effective_project_submission_artifact_policy_hash,"
+                        "locked_pre_submit_checker_policy_id,"
+                        "locked_pre_submit_checker_bundle_hash,submitted_at,locked_at,"
+                        "supersedes_submission_id) "
+                        "select :id,task_id,:actor,:version,"
+                        "status,summary,package_uri,package_hash,artifact_hash_manifest,"
+                        "worker_attestation,locked_guide_version,"
+                        "locked_post_submit_checker_policy_id,"
+                        "locked_post_submit_checker_policy_version,"
+                        "locked_post_submit_checker_policy_hash,"
+                        "locked_post_submit_checker_policy_body,"
+                        "locked_review_policy_version,locked_revision_policy_version,"
+                        "locked_payment_policy_version,locked_guide_source_snapshot_id,"
+                        "locked_guide_source_snapshot_hash,"
+                        "locked_effective_project_submission_artifact_policy_id,"
+                        "locked_effective_project_submission_artifact_policy_hash,"
+                        "locked_pre_submit_checker_policy_id,"
+                        "locked_pre_submit_checker_bundle_hash,submitted_at,locked_at,null "
+                        "from submissions where id=:source"
+                    ),
+                    {
+                        "id": submission_ids[index],
+                        "actor": value,
+                        "version": index + 1,
+                        "source": submission_ids[0],
+                    },
+                )
+        return {
+            "assignment_ids": assignment_ids,
+            "submission_ids": submission_ids,
+            "assignment_task": runtime_ids["task"],
+            "submission_task": runtime_ids["task"],
+            "service_id": service_id,
+        }
+    finally:
+        await engine.dispose()
+
+
+async def _clear_contributor_migration_fixtures(database_url: str) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text("alter table actor_identity_links disable trigger user")
+            )
+            await connection.execute(text("alter table actor_profiles disable trigger user"))
+            await connection.execute(text("delete from actor_identity_links"))
+            await connection.execute(text("delete from actor_profiles"))
+            await connection.execute(text("alter table actor_profiles enable trigger user"))
+            await connection.execute(
+                text("alter table actor_identity_links enable trigger user")
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _contributor_foundation_shape(database_url: str) -> dict[str, object]:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            async def column(table: str) -> tuple[str, int]:
+                row = (
+                    await connection.execute(
+                        text(
+                            "select column_name,character_maximum_length "
+                            "from information_schema.columns where table_schema='public' "
+                            "and table_name=:table and column_name in "
+                            "('worker_id','contributor_id')"
+                        ),
+                        {"table": table},
+                    )
+                ).one()
+                return str(row[0]), int(row[1])
+
+            async def index(table: str) -> str:
+                value = await connection.scalar(
+                    text(
+                        "select indexname from pg_indexes where schemaname='public' "
+                        "and tablename=:table and indexname like "
+                        "'ix_%_worker_id' or schemaname='public' and tablename=:table "
+                        "and indexname like 'ix_%_contributor_id'"
+                    ),
+                    {"table": table},
+                )
+                assert value is not None
+                return str(value)
+
+            function_exists = bool(
+                await connection.scalar(
+                    text(
+                        "select to_regprocedure("
+                        "'public.require_human_actor_profile_reference()') is not null"
+                    )
+                )
+            )
+            foreign_keys = tuple(
+                str(row)
+                for row in (
+                    await connection.execute(
+                        text(
+                            "select conname from pg_constraint where conname in "
+                            "('fk_task_assignments_contributor_id_actor_profiles',"
+                            "'fk_submissions_contributor_id_actor_profiles') order by conname"
+                        )
+                    )
+                ).scalars()
+            )
+            triggers = tuple(
+                str(row)
+                for row in (
+                    await connection.execute(
+                        text(
+                            "select tgname from pg_trigger where not tgisinternal and tgname in "
+                            "('task_assignments_contributor_human',"
+                            "'submissions_contributor_human') order by tgname"
+                        )
+                    )
+                ).scalars()
+            )
+            assignment_field = "contributor_id" if function_exists else "worker_id"
+            submission_field = "contributor_id" if function_exists else "worker_id"
+            assignment_values = tuple(
+                str(row)
+                for row in (
+                    await connection.execute(
+                        text(f"select {assignment_field} from task_assignments order by id")
+                    )
+                ).scalars()
+            )
+            submission_values = tuple(
+                str(row)
+                for row in (
+                    await connection.execute(
+                        text(f"select {submission_field} from submissions order by id")
+                    )
+                ).scalars()
+            )
+            return {
+                "revision": await connection.scalar(
+                    text("select version_num from alembic_version")
+                ),
+                "assignment_column": await column("task_assignments"),
+                "submission_column": await column("submissions"),
+                "assignment_index": await index("task_assignments"),
+                "submission_index": await index("submissions"),
+                "foreign_keys": foreign_keys,
+                "function": function_exists,
+                "triggers": triggers,
+                "assignment_values": assignment_values,
+                "submission_values": submission_values,
+            }
+    finally:
+        await engine.dispose()
+
+
+def _database_error_sqlstate(error: DBAPIError) -> str | None:
+    return getattr(error.orig, "sqlstate", None)
+
+
+async def _exercise_contributor_lineage_guards(
+    database_url: str,
+    *,
+    fixture: dict[str, tuple[str, ...] | str],
+    human_id: str,
+) -> dict[str, object]:
+    engine = create_async_engine(database_url)
+    service_id = str(fixture["service_id"])
+    assignment_task = str(fixture["assignment_task"])
+    submission_task = str(fixture["submission_task"])
+    assignment_id = str(tuple(fixture["assignment_ids"])[0])
+    missing_id = str(uuid4())
+    suspended_id = str(uuid4())
+    deactivated_id = str(uuid4())
+    results: dict[str, object] = {}
+    try:
+        for name, statement, values in (
+            (
+                "missing_assignment",
+                "insert into task_assignments "
+                "(id,task_id,contributor_id,assigned_by,status) values "
+                "(:id,:task,:actor,'test','released')",
+                {"id": str(uuid4()), "task": assignment_task, "actor": missing_id},
+            ),
+            (
+                "service_assignment",
+                "insert into task_assignments "
+                "(id,task_id,contributor_id,assigned_by,status) values "
+                "(:id,:task,:actor,'test','released')",
+                {"id": str(uuid4()), "task": assignment_task, "actor": service_id},
+            ),
+            (
+                "service_assignment_update",
+                "update task_assignments set contributor_id=:actor where id=:id",
+                {"id": assignment_id, "actor": service_id},
+            ),
+            (
+                "missing_submission",
+                "insert into submissions "
+                "(id,task_id,contributor_id,version,status,summary,package_uri,"
+                "package_hash,artifact_hash_manifest,worker_attestation,"
+                "locked_guide_version,locked_post_submit_checker_policy_id,"
+                "locked_post_submit_checker_policy_version,"
+                "locked_post_submit_checker_policy_hash,"
+                "locked_post_submit_checker_policy_body,"
+                "locked_review_policy_version,locked_revision_policy_version,"
+                "locked_payment_policy_version,locked_guide_source_snapshot_id,"
+                "locked_guide_source_snapshot_hash,"
+                "locked_effective_project_submission_artifact_policy_id,"
+                "locked_effective_project_submission_artifact_policy_hash,"
+                "locked_pre_submit_checker_policy_id,"
+                "locked_pre_submit_checker_bundle_hash,submitted_at,locked_at,"
+                "supersedes_submission_id) "
+                "select :id,task_id,:actor,2,status,summary,"
+                "package_uri,package_hash,artifact_hash_manifest,worker_attestation,"
+                "locked_guide_version,locked_post_submit_checker_policy_id,"
+                "locked_post_submit_checker_policy_version,"
+                "locked_post_submit_checker_policy_hash,"
+                "locked_post_submit_checker_policy_body,locked_review_policy_version,"
+                "locked_revision_policy_version,locked_payment_policy_version,"
+                "locked_guide_source_snapshot_id,locked_guide_source_snapshot_hash,"
+                "locked_effective_project_submission_artifact_policy_id,"
+                "locked_effective_project_submission_artifact_policy_hash,"
+                "locked_pre_submit_checker_policy_id,locked_pre_submit_checker_bundle_hash,"
+                "submitted_at,locked_at,null from submissions where task_id=:task",
+                {"id": str(uuid4()), "task": submission_task, "actor": missing_id},
+            ),
+            (
+                "service_submission",
+                "insert into submissions "
+                "(id,task_id,contributor_id,version,status,summary,package_uri,"
+                "package_hash,artifact_hash_manifest,worker_attestation,"
+                "locked_guide_version,locked_post_submit_checker_policy_id,"
+                "locked_post_submit_checker_policy_version,"
+                "locked_post_submit_checker_policy_hash,"
+                "locked_post_submit_checker_policy_body,"
+                "locked_review_policy_version,locked_revision_policy_version,"
+                "locked_payment_policy_version,locked_guide_source_snapshot_id,"
+                "locked_guide_source_snapshot_hash,"
+                "locked_effective_project_submission_artifact_policy_id,"
+                "locked_effective_project_submission_artifact_policy_hash,"
+                "locked_pre_submit_checker_policy_id,"
+                "locked_pre_submit_checker_bundle_hash,submitted_at,locked_at,"
+                "supersedes_submission_id) "
+                "select :id,task_id,:actor,3,status,summary,"
+                "package_uri,package_hash,artifact_hash_manifest,worker_attestation,"
+                "locked_guide_version,locked_post_submit_checker_policy_id,"
+                "locked_post_submit_checker_policy_version,"
+                "locked_post_submit_checker_policy_hash,"
+                "locked_post_submit_checker_policy_body,locked_review_policy_version,"
+                "locked_revision_policy_version,locked_payment_policy_version,"
+                "locked_guide_source_snapshot_id,locked_guide_source_snapshot_hash,"
+                "locked_effective_project_submission_artifact_policy_id,"
+                "locked_effective_project_submission_artifact_policy_hash,"
+                "locked_pre_submit_checker_policy_id,locked_pre_submit_checker_bundle_hash,"
+                "submitted_at,locked_at,null from submissions where task_id=:task",
+                {"id": str(uuid4()), "task": submission_task, "actor": service_id},
+            ),
+        ):
+            try:
+                async with engine.begin() as connection:
+                    await connection.execute(text(statement), values)
+            except DBAPIError as error:
+                results[name] = _database_error_sqlstate(error)
+            else:
+                results[name] = None
+
+        async with engine.begin() as connection:
+            await connection.execute(
+                text("update task_assignments set assigned_by='updated' where id=:id"),
+                {"id": assignment_id},
+            )
+            results["unrelated_update_preserved"] = (
+                await connection.scalar(
+                    text("select contributor_id=:actor from task_assignments where id=:id"),
+                    {"id": assignment_id, "actor": human_id},
+                )
+                is True
+            )
+            for actor_id, status in (
+                (suspended_id, "suspended"),
+                (deactivated_id, "deactivated"),
+            ):
+                await connection.execute(
+                    text(
+                        "insert into actor_profiles "
+                        "(id,actor_kind,status,provisioning_method,created_by) values "
+                        "(:id,'human','active','automatic_first_access',:id)"
+                    ),
+                    {"id": actor_id},
+                )
+                await connection.execute(
+                    text(
+                        "insert into actor_identity_links "
+                        "(id,actor_profile_id,issuer,subject,subject_kind,status,"
+                        "linked_by,last_verified_at) values "
+                        "(:link,:actor,'https://identity.test',:subject,'human',"
+                        "'active',:actor,clock_timestamp())"
+                    ),
+                    {
+                        "link": str(uuid4()),
+                        "actor": actor_id,
+                        "subject": f"historical-{actor_id}",
+                    },
+                )
+                if status == "suspended":
+                    await connection.execute(
+                        text(
+                            "update actor_profiles set status='suspended',"
+                            "suspended_by=:actor,suspended_at=clock_timestamp(),"
+                            "suspension_reason='migration test' where id=:actor"
+                        ),
+                        {"actor": actor_id},
+                    )
+                else:
+                    await connection.execute(
+                        text(
+                            "update actor_profiles set status='deactivated',"
+                            "deactivated_by=:actor,deactivated_at=clock_timestamp(),"
+                            "deactivation_reason='migration test' where id=:actor"
+                        ),
+                        {"actor": actor_id},
+                    )
+                await connection.execute(
+                    text(
+                        "insert into task_assignments "
+                        "(id,task_id,contributor_id,assigned_by,status) values "
+                        "(:id,:task,:actor,'test','released')"
+                    ),
+                    {"id": str(uuid4()), "task": assignment_task, "actor": actor_id},
+                )
+                results[f"{status}_human_inserted"] = True
+        return results
+    finally:
+        await engine.dispose()
+
+
+async def _add_contributor_function_dependency(database_url: str) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "create trigger task_assignments_contributor_dependency "
+                    "before update of contributor_id on task_assignments for each row "
+                    "execute function require_human_actor_profile_reference('contributor_id')"
+                )
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _drop_contributor_function_dependency(database_url: str) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "drop trigger task_assignments_contributor_dependency "
+                    "on task_assignments"
+                )
+            )
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -2094,12 +2094,25 @@ def test_contributor_foundation_upgrade_guards_and_reversible_preservation(
             assert direct_sql == {
                 "missing_assignment": "23503",
                 "service_assignment": "23514",
+                "missing_assignment_update": "23503",
                 "service_assignment_update": "23514",
                 "missing_submission": "23503",
                 "service_submission": "23514",
+                "missing_submission_update": "23503",
+                "service_submission_update": "23514",
                 "suspended_human_inserted": True,
                 "deactivated_human_inserted": True,
                 "unrelated_update_preserved": True,
+            }
+            assert asyncio.run(
+                _exercise_contributor_lineage_function_contract(
+                    isolated_database_env
+                )
+            ) == {
+                "zero_arguments": "55000",
+                "extra_arguments": "55000",
+                "absent_field": "55000",
+                "nullable_field_accepted": True,
             }
 
             asyncio.run(_add_contributor_function_dependency(isolated_database_env))
@@ -2136,6 +2149,13 @@ def test_contributor_foundation_preflight_refuses_all_unsafe_classes_atomically(
     """Classify both source tables without guessing or partially changing schema."""
     config = _alembic_config()
     missing_ids = (str(uuid4()), str(uuid4()))
+    assignment_malformed = tuple(
+        f"private.person.{index}@example.test" for index in range(22)
+    )
+    submission_malformed = tuple(
+        f"eyJhbGciOiJSUzI1NiJ9.secret-token-material-{index}"
+        for index in range(22)
+    )
 
     with migration_lock():
         try:
@@ -2144,8 +2164,10 @@ def test_contributor_foundation_preflight_refuses_all_unsafe_classes_atomically(
             fixture = asyncio.run(
                 _seed_contributor_prior_head(
                     isolated_database_env,
-                    assignment_values=("not-a-uuid", missing_ids[0], "service"),
-                    submission_values=("also-not-a-uuid", missing_ids[1], "service"),
+                    assignment_values=assignment_malformed
+                    + (missing_ids[0], "service"),
+                    submission_values=submission_malformed
+                    + (missing_ids[1], "service"),
                 )
             )
             service_id = str(fixture["service_id"])
@@ -2159,11 +2181,32 @@ def test_contributor_foundation_preflight_refuses_all_unsafe_classes_atomically(
             assert "missing" in message
             assert "service" in message
             assert service_id in message
-            for row_id in fixture["assignment_ids"] + fixture["submission_ids"]:
-                assert row_id in message
+            assert all(missing_id in message for missing_id in missing_ids)
+            diagnostic = json.loads(message.split("preflight failed: ", 1)[1])
+            for table in ("task_assignments", "submissions"):
+                malformed = diagnostic[table]["malformed"]
+                assert malformed["total"] == 22
+                assert len(malformed["rows"]) == 20
+                assert [row[0] for row in malformed["rows"]] == sorted(
+                    row[0] for row in malformed["rows"]
+                )
+                assert all(
+                    row[1] == "<redacted-malformed>"
+                    for row in malformed["rows"]
+                )
+            assert all(
+                value not in message
+                for value in assignment_malformed + submission_malformed
+            )
+            assert all(
+                row_id in message
+                for row_id in (
+                    tuple(fixture["assignment_ids"])[-2:]
+                    + tuple(fixture["submission_ids"])[-2:]
+                )
+            )
             assert "issuer" not in message
             assert "subject" not in message
-            assert "email" not in message
             assert asyncio.run(_contributor_foundation_shape(isolated_database_env)) == before
         finally:
             command.downgrade(config, "0023_service_actor_identity")
@@ -6678,6 +6721,7 @@ async def _exercise_contributor_lineage_guards(
     assignment_task = str(fixture["assignment_task"])
     submission_task = str(fixture["submission_task"])
     assignment_id = str(tuple(fixture["assignment_ids"])[0])
+    submission_id = str(tuple(fixture["submission_ids"])[0])
     missing_id = str(uuid4())
     suspended_id = str(uuid4())
     deactivated_id = str(uuid4())
@@ -6697,6 +6741,11 @@ async def _exercise_contributor_lineage_guards(
                 "(id,task_id,contributor_id,assigned_by,status) values "
                 "(:id,:task,:actor,'test','released')",
                 {"id": str(uuid4()), "task": assignment_task, "actor": service_id},
+            ),
+            (
+                "missing_assignment_update",
+                "update task_assignments set contributor_id=:actor where id=:id",
+                {"id": assignment_id, "actor": missing_id},
             ),
             (
                 "service_assignment_update",
@@ -6764,6 +6813,16 @@ async def _exercise_contributor_lineage_guards(
                 "locked_pre_submit_checker_policy_id,locked_pre_submit_checker_bundle_hash,"
                 "submitted_at,locked_at,null from submissions where task_id=:task",
                 {"id": str(uuid4()), "task": submission_task, "actor": service_id},
+            ),
+            (
+                "missing_submission_update",
+                "update submissions set contributor_id=:actor where id=:id",
+                {"id": submission_id, "actor": missing_id},
+            ),
+            (
+                "service_submission_update",
+                "update submissions set contributor_id=:actor where id=:id",
+                {"id": submission_id, "actor": service_id},
             ),
         ):
             try:
@@ -6839,6 +6898,64 @@ async def _exercise_contributor_lineage_guards(
                     {"id": str(uuid4()), "task": assignment_task, "actor": actor_id},
                 )
                 results[f"{status}_human_inserted"] = True
+        return results
+    finally:
+        await engine.dispose()
+
+
+async def _exercise_contributor_lineage_function_contract(
+    database_url: str,
+) -> dict[str, object]:
+    """Prove closed trigger arguments and nullable-field delegation."""
+    engine = create_async_engine(database_url)
+    results: dict[str, object] = {}
+    try:
+        for name, arguments in (
+            ("zero_arguments", ""),
+            ("extra_arguments", "'contributor_id','extra'"),
+            ("absent_field", "'missing_field'"),
+        ):
+            try:
+                async with engine.begin() as connection:
+                    await connection.execute(
+                        text("create temporary table lineage_probe (contributor_id text)")
+                    )
+                    await connection.execute(
+                        text(
+                            "create trigger lineage_probe_guard before insert on "
+                            "lineage_probe for each row execute function public."
+                            f"require_human_actor_profile_reference({arguments})"
+                        )
+                    )
+                    await connection.execute(
+                        text(
+                            "insert into lineage_probe (contributor_id) values "
+                            "('not-a-canonical-id')"
+                        )
+                    )
+            except DBAPIError as error:
+                results[name] = _database_error_sqlstate(error)
+            else:
+                results[name] = None
+
+        async with engine.begin() as connection:
+            await connection.execute(
+                text("create temporary table lineage_nullable (contributor_id text)")
+            )
+            await connection.execute(
+                text(
+                    "create trigger lineage_nullable_guard before insert on "
+                    "lineage_nullable for each row execute function public."
+                    "require_human_actor_profile_reference('contributor_id')"
+                )
+            )
+            await connection.execute(
+                text("insert into lineage_nullable (contributor_id) values (null)")
+            )
+            results["nullable_field_accepted"] = (
+                await connection.scalar(text("select count(*) from lineage_nullable"))
+                == 1
+            )
         return results
     finally:
         await engine.dispose()

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -16,8 +16,8 @@ from alembic.config import Config
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import func, inspect, select, text
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession, create_async_engine
 from sqlalchemy.schema import CreateIndex
 
 from app.adapters.auth.dev import actor_id_from_external_identity
@@ -35,7 +35,11 @@ from app.modules.actors.models import (
     LegacyWorkflowEligibility,
 )
 from app.modules.actors.schemas import LegacyWorkflowEligibilityActivationRequest
-from app.modules.actors.service import ActorService
+from app.modules.actors.service import (
+    ActiveHumanWriteActorRequired,
+    ActorService,
+    CanonicalWriteActorUnavailable,
+)
 from app.modules.projects.models import (
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
@@ -60,7 +64,13 @@ from app.modules.tasks.models import (
     WorkstreamTask,
 )
 from app.modules.tasks.repository import TaskRepository
-from app.modules.tasks.service import TaskService, TaskServiceError
+from app.modules.tasks.schemas import SubmissionCreate
+from app.modules.tasks.service import (
+    ActiveContributorRequired,
+    ContributorIdentityUnavailable,
+    TaskService,
+    TaskServiceError,
+)
 from app.schemas.auth import ActorContext
 
 
@@ -81,6 +91,52 @@ async def test_task_repository_delegates_audit_persistence() -> None:
     repository._audit_repository.list_audit_events.assert_awaited_once_with(
         "task", "task-1"
     )
+
+
+async def test_task_contributor_revalidation_maps_failures_and_rolls_back() -> None:
+    actor = ActorContext(
+        actor_id=actor_id("write-actor"),
+        external_subject="write-actor",
+        external_issuer="flow-test",
+        roles=("worker",),
+        claim_snapshot={},
+        auth_source="dev_mock",
+        is_dev_auth=True,
+    )
+    session = MagicMock(spec=AsyncSession)
+    session.rollback = AsyncMock()
+    service = TaskService(session)
+    service._actors.require_active_human_write_actor = AsyncMock(return_value=None)
+
+    assert await service._require_active_contributor(actor) is None
+    session.rollback.assert_not_awaited()
+
+    cases = (
+        (
+            ActiveHumanWriteActorRequired("inactive"),
+            ActiveContributorRequired,
+            "active_contributor_required",
+        ),
+        (
+            CanonicalWriteActorUnavailable("missing"),
+            ContributorIdentityUnavailable,
+            "contributor_identity_unavailable",
+        ),
+        (
+            OperationalError("select", {}, RuntimeError("database unavailable")),
+            ContributorIdentityUnavailable,
+            "contributor_identity_unavailable",
+        ),
+    )
+    for source_error, expected_error, code in cases:
+        service._actors.require_active_human_write_actor = AsyncMock(
+            side_effect=source_error
+        )
+        with pytest.raises(expected_error) as failure:
+            await service._require_active_contributor(actor)
+        assert failure.value.code == code
+
+    assert session.rollback.await_count == len(cases)
 
 
 async def delete_audit_fixture_as_owner(session: AsyncSession, event_id: str) -> None:
@@ -768,6 +824,553 @@ async def seed_worker_profile(subject: str, *, skill_tags: list[str] | None = No
     return worker_actor_id
 
 
+async def _wait_for_task_database_lock(
+    database_url: str,
+    application_name: str,
+) -> None:
+    """Wait until one named race participant is blocked on a PostgreSQL lock."""
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            for _ in range(5000):
+                waiting = await connection.scalar(
+                    text(
+                        "select exists(select 1 from pg_stat_activity where "
+                        "application_name = :application_name "
+                        "and wait_event_type = 'Lock')"
+                    ),
+                    {"application_name": application_name},
+                )
+                if waiting:
+                    return
+                await asyncio.sleep(0)
+    finally:
+        await engine.dispose()
+    raise AssertionError(f"{application_name} never reached the PostgreSQL lock")
+
+
+async def _task_contributor_race_snapshot(
+    connection: AsyncConnection,
+    task_id: str,
+) -> dict[str, object]:
+    """Capture every task-owned write surface relevant to contributor races."""
+    task = (
+        await connection.execute(
+            text(
+                "select status, assigned_to from workstream_tasks "
+                "where id = :task_id"
+            ),
+            {"task_id": task_id},
+        )
+    ).one()
+    assignments = (
+        await connection.execute(
+            text(
+                "select id, contributor_id, assigned_by, status, accepted_at, released_at "
+                "from task_assignments where task_id = :task_id order by id"
+            ),
+            {"task_id": task_id},
+        )
+    ).all()
+    submissions = (
+        await connection.execute(
+            text(
+                "select id, contributor_id, version, status, locked_at "
+                "from submissions where task_id = :task_id order by version"
+            ),
+            {"task_id": task_id},
+        )
+    ).all()
+    evidence_count = await connection.scalar(
+        text(
+            "select count(*) from evidence_items evidence "
+            "join submissions submission on submission.id = evidence.submission_id "
+            "where submission.task_id = :task_id"
+        ),
+        {"task_id": task_id},
+    )
+    checker_run_count = await connection.scalar(
+        text("select count(*) from checker_runs where task_id = :task_id"),
+        {"task_id": task_id},
+    )
+    checker_result_count = await connection.scalar(
+        text("select count(*) from checker_results where task_id = :task_id"),
+        {"task_id": task_id},
+    )
+    audit_events = (
+        await connection.execute(
+            text(
+                "select id, event_type, from_status, to_status, actor_id, event_payload "
+                "from audit_events where entity_type = 'task' and entity_id = :task_id "
+                "order by created_at, id"
+            ),
+            {"task_id": task_id},
+        )
+    ).all()
+    idempotency_count = await connection.scalar(
+        text("select count(*) from authority_idempotency_records")
+    )
+    return {
+        "task": tuple(task),
+        "assignments": [tuple(row) for row in assignments],
+        "submissions": [tuple(row) for row in submissions],
+        "evidence_count": evidence_count,
+        "checker_run_count": checker_run_count,
+        "checker_result_count": checker_result_count,
+        "audit_events": [tuple(row) for row in audit_events],
+        "idempotency_count": idempotency_count,
+    }
+
+
+async def _read_task_contributor_race_snapshot(
+    database_url: str,
+    task_id: str,
+) -> dict[str, object]:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            return await _task_contributor_race_snapshot(connection, task_id)
+    finally:
+        await engine.dispose()
+
+
+async def _run_contributor_lifecycle_write(
+    database_url: str,
+    *,
+    actor_profile_id: str,
+    identity_link_id: str,
+    transition: str,
+    task_id: str,
+    application_name: str,
+    entered: asyncio.Event,
+    locked: asyncio.Event | None = None,
+    release: asyncio.Event | None = None,
+    observe_task_after_lock: bool = False,
+) -> dict[str, object] | None:
+    """Apply one canonical-order lifecycle write in an independent transaction."""
+    engine = create_async_engine(database_url)
+    observed: dict[str, object] | None = None
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text("select set_config('application_name', :name, true)"),
+                {"name": application_name},
+            )
+            entered.set()
+            await connection.execute(
+                text("select id from actor_profiles where id = :id for update"),
+                {"id": actor_profile_id},
+            )
+            await connection.execute(
+                text("select id from actor_identity_links where id = :id for update"),
+                {"id": identity_link_id},
+            )
+            if locked is not None:
+                locked.set()
+            if release is not None:
+                await release.wait()
+            if observe_task_after_lock:
+                observed = await _task_contributor_race_snapshot(connection, task_id)
+
+            if transition == "suspend":
+                await connection.execute(
+                    text(
+                        "update actor_profiles set status = 'suspended', "
+                        "suspended_by = :actor_id, suspended_at = clock_timestamp(), "
+                        "suspension_reason = 'contributor lock race' where id = :actor_id"
+                    ),
+                    {"actor_id": actor_profile_id},
+                )
+            elif transition == "deactivate":
+                await connection.execute(
+                    text(
+                        "update actor_profiles set status = 'deactivated', "
+                        "deactivated_by = :actor_id, deactivated_at = clock_timestamp(), "
+                        "deactivation_reason = 'contributor lock race' where id = :actor_id"
+                    ),
+                    {"actor_id": actor_profile_id},
+                )
+            else:
+                assert transition == "revoke_link"
+                await connection.execute(
+                    text(
+                        "update actor_identity_links set status = 'revoked', "
+                        "revoked_by = :actor_id, revoked_at = clock_timestamp(), "
+                        "revoked_reason = 'contributor lock race' where id = :link_id"
+                    ),
+                    {"actor_id": actor_profile_id, "link_id": identity_link_id},
+                )
+        return observed
+    finally:
+        await engine.dispose()
+
+
+async def _run_task_contributor_write(
+    database_url: str,
+    *,
+    actor: ActorContext,
+    task_id: str,
+    operation: str,
+    application_name: str,
+    entered: asyncio.Event,
+) -> object:
+    """Run one task write in its own named PostgreSQL session."""
+    engine = create_async_engine(database_url)
+    try:
+        async with AsyncSession(engine, expire_on_commit=False) as session:
+            await session.execute(
+                text("select set_config('application_name', :name, true)"),
+                {"name": application_name},
+            )
+            entered.set()
+            service = TaskService(session)
+            if operation == "claim":
+                return await service.claim_task(actor, task_id, "contributor lock race")
+            assert operation == "submission"
+            return await service.create_submission(
+                actor,
+                task_id,
+                SubmissionCreate.model_validate(complete_submission_payload()),
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _read_contributor_lifecycle_state(
+    database_url: str,
+    actor_profile_id: str,
+    identity_link_id: str,
+) -> tuple[str, str]:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            profile_status = await connection.scalar(
+                text("select status from actor_profiles where id = :id"),
+                {"id": actor_profile_id},
+            )
+            link_status = await connection.scalar(
+                text("select status from actor_identity_links where id = :id"),
+                {"id": identity_link_id},
+            )
+            assert isinstance(profile_status, str)
+            assert isinstance(link_status, str)
+            return profile_status, link_status
+    finally:
+        await engine.dispose()
+
+
+async def _restore_contributor_after_lifecycle_race(
+    database_url: str,
+    actor_profile_id: str,
+    identity_link_id: str,
+) -> None:
+    """Return a terminal test actor to active state under explicit test custody."""
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            reset = await connection.begin()
+            try:
+                await connection.execute(
+                    text(
+                        "alter table actor_profiles disable trigger "
+                        "actor_profile_history_guard"
+                    )
+                )
+                await connection.execute(
+                    text(
+                        "alter table actor_identity_links disable trigger "
+                        "actor_identity_link_history_guard"
+                    )
+                )
+                await connection.execute(
+                    text(
+                        "update actor_profiles set status = 'active', "
+                        "suspended_by = null, suspended_at = null, "
+                        "suspension_reason = null, reactivated_by = null, "
+                        "reactivated_at = null, reactivation_reason = null, "
+                        "deactivated_by = null, deactivated_at = null, "
+                        "deactivation_reason = null where id = :id"
+                    ),
+                    {"id": actor_profile_id},
+                )
+                await connection.execute(
+                    text(
+                        "update actor_identity_links set status = 'active', "
+                        "revoked_by = null, revoked_at = null, revoked_reason = null, "
+                        "reactivated_by = null, reactivated_at = null, "
+                        "reactivation_reason = null where id = :id"
+                    ),
+                    {"id": identity_link_id},
+                )
+                await reset.commit()
+            except BaseException:
+                await reset.rollback()
+                raise
+            finally:
+                enable = await connection.begin()
+                try:
+                    await connection.execute(
+                        text(
+                            "alter table actor_identity_links enable trigger "
+                            "actor_identity_link_history_guard"
+                        )
+                    )
+                    await connection.execute(
+                        text(
+                            "alter table actor_profiles enable trigger "
+                            "actor_profile_history_guard"
+                        )
+                    )
+                    await enable.commit()
+                except BaseException:
+                    await enable.rollback()
+                    raise
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+async def contributor_lifecycle_race_cleanup(
+    task_database_env: str,
+) -> AsyncIterator[list[tuple[str, str]]]:
+    """Restore lifecycle race actors before the migration fixture downgrades."""
+    actors: list[tuple[str, str]] = []
+    yield actors
+    for actor_profile_id, identity_link_id in actors:
+        await _restore_contributor_after_lifecycle_race(
+            task_database_env,
+            actor_profile_id,
+            identity_link_id,
+        )
+
+
+_CONTRIBUTOR_LOCK_RACE_CASES = [
+    (operation, transition, ordering)
+    for operation in ("claim", "submission")
+    for transition in ("suspend", "deactivate", "revoke_link")
+    for ordering in ("lifecycle_first", "task_write_first")
+]
+
+
+@pytest.mark.parametrize(
+    ("operation", "transition", "ordering"),
+    _CONTRIBUTOR_LOCK_RACE_CASES,
+    ids=["-".join(case) for case in _CONTRIBUTOR_LOCK_RACE_CASES],
+)
+async def test_contributor_task_writes_serialize_with_lifecycle_changes(
+    task_client: AsyncClient,
+    task_database_env: str,
+    contributor_lifecycle_race_cleanup: list[tuple[str, str]],
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+    transition: str,
+    ordering: str,
+) -> None:
+    """Prove all twelve contributor-write and lifecycle lock order outcomes."""
+    project = await create_active_project(task_client)
+    subject = f"race-{operation}-{transition}-{ordering}"
+    contributor_id = actor_id(subject)
+    if operation == "claim":
+        task = await create_ready_task(task_client, project["id"])
+        await seed_worker_profile(subject)
+    else:
+        task = await create_started_task(
+            task_client,
+            project["id"],
+            monkeypatch,
+            subject,
+        )
+        monkeypatch.setattr(
+            "app.modules.tasks.service.enqueue_pre_review_gate",
+            hold_pre_review_enqueue,
+        )
+
+    async with db_session.get_session_factory()() as session:
+        identity_link_id = await session.scalar(
+            select(ActorIdentityLink.id).where(
+                ActorIdentityLink.actor_profile_id == contributor_id
+            )
+        )
+    assert identity_link_id is not None
+    contributor_lifecycle_race_cleanup.append((contributor_id, identity_link_id))
+
+    actor = ActorContext(
+        actor_id=contributor_id,
+        external_subject=subject,
+        external_issuer="flow-test",
+        roles=("worker",),
+        claim_snapshot={"roles": ["worker"]},
+        auth_source="dev_mock",
+        is_dev_auth=True,
+    )
+    task_id = task["id"]
+    before = await _read_task_contributor_race_snapshot(task_database_env, task_id)
+    task_application_name = f"ws-race-{operation}-{transition}-{ordering}-task"
+    lifecycle_application_name = (
+        f"ws-race-{operation}-{transition}-{ordering}-lifecycle"
+    )
+
+    if ordering == "lifecycle_first":
+        lifecycle_entered = asyncio.Event()
+        lifecycle_locked = asyncio.Event()
+        release_lifecycle = asyncio.Event()
+        lifecycle_call = asyncio.create_task(
+            _run_contributor_lifecycle_write(
+                task_database_env,
+                actor_profile_id=contributor_id,
+                identity_link_id=identity_link_id,
+                transition=transition,
+                task_id=task_id,
+                application_name=lifecycle_application_name,
+                entered=lifecycle_entered,
+                locked=lifecycle_locked,
+                release=release_lifecycle,
+            ),
+            name=lifecycle_application_name,
+        )
+        await lifecycle_entered.wait()
+        await lifecycle_locked.wait()
+        task_entered = asyncio.Event()
+        task_call = asyncio.create_task(
+            _run_task_contributor_write(
+                task_database_env,
+                actor=actor,
+                task_id=task_id,
+                operation=operation,
+                application_name=task_application_name,
+                entered=task_entered,
+            ),
+            name=task_application_name,
+        )
+        await task_entered.wait()
+        lock_error: AssertionError | None = None
+        try:
+            await _wait_for_task_database_lock(
+                task_database_env,
+                task_application_name,
+            )
+        except AssertionError as exc:
+            lock_error = exc
+        finally:
+            release_lifecycle.set()
+        lifecycle_result, task_result = await asyncio.gather(
+            lifecycle_call,
+            task_call,
+            return_exceptions=True,
+        )
+        if lock_error is not None:
+            raise lock_error
+        assert lifecycle_result is None
+        assert isinstance(task_result, ActiveContributorRequired)
+        assert task_result.code == "active_contributor_required"
+        assert await _read_task_contributor_race_snapshot(
+            task_database_env,
+            task_id,
+        ) == before
+    else:
+        task_locked = asyncio.Event()
+        release_task = asyncio.Event()
+        original_guard = ActorService.require_active_human_write_actor
+
+        async def hold_task_after_contributor_lock(
+            service: ActorService,
+            current_actor: ActorContext,
+        ) -> None:
+            await original_guard(service, current_actor)
+            if current_actor.actor_id == contributor_id:
+                task_locked.set()
+                await release_task.wait()
+
+        monkeypatch.setattr(
+            ActorService,
+            "require_active_human_write_actor",
+            hold_task_after_contributor_lock,
+        )
+        task_entered = asyncio.Event()
+        task_call = asyncio.create_task(
+            _run_task_contributor_write(
+                task_database_env,
+                actor=actor,
+                task_id=task_id,
+                operation=operation,
+                application_name=task_application_name,
+                entered=task_entered,
+            ),
+            name=task_application_name,
+        )
+        await task_entered.wait()
+        await task_locked.wait()
+        lifecycle_entered = asyncio.Event()
+        lifecycle_call = asyncio.create_task(
+            _run_contributor_lifecycle_write(
+                task_database_env,
+                actor_profile_id=contributor_id,
+                identity_link_id=identity_link_id,
+                transition=transition,
+                task_id=task_id,
+                application_name=lifecycle_application_name,
+                entered=lifecycle_entered,
+                observe_task_after_lock=True,
+            ),
+            name=lifecycle_application_name,
+        )
+        await lifecycle_entered.wait()
+        lock_error = None
+        try:
+            await _wait_for_task_database_lock(
+                task_database_env,
+                lifecycle_application_name,
+            )
+        except AssertionError as exc:
+            lock_error = exc
+        finally:
+            release_task.set()
+        task_result, observed_after_task_commit = await asyncio.gather(
+            task_call,
+            lifecycle_call,
+            return_exceptions=True,
+        )
+        if lock_error is not None:
+            raise lock_error
+        if isinstance(task_result, BaseException):
+            raise task_result
+        if isinstance(observed_after_task_commit, BaseException):
+            raise observed_after_task_commit
+        assert isinstance(observed_after_task_commit, dict)
+        if operation == "claim":
+            assert task_result.assignment.contributor_id == contributor_id
+            assert observed_after_task_commit["task"] == (
+                "claimed",
+                contributor_id,
+            )
+            assignments = observed_after_task_commit["assignments"]
+            assert isinstance(assignments, list)
+            assert len(assignments) == 1
+            assert assignments[0][1] == contributor_id
+        else:
+            assert task_result.contributor_id == contributor_id
+            assert observed_after_task_commit["task"] == (
+                "submitted",
+                contributor_id,
+            )
+            submissions = observed_after_task_commit["submissions"]
+            assert isinstance(submissions, list)
+            assert len(submissions) == 1
+            assert submissions[0][1] == contributor_id
+
+    profile_status, link_status = await _read_contributor_lifecycle_state(
+        task_database_env,
+        contributor_id,
+        identity_link_id,
+    )
+    if transition == "suspend":
+        assert (profile_status, link_status) == ("suspended", "active")
+    elif transition == "deactivate":
+        assert (profile_status, link_status) == ("deactivated", "active")
+    else:
+        assert (profile_status, link_status) == ("active", "revoked")
+
+
 async def seed_actor_profile(
     subject: str,
     *,
@@ -1087,6 +1690,38 @@ async def test_task_router_service_errors_use_canonical_request_context(
     assert denied.status_code == 403
     assert denied.json()["detail"] == "bounded permission failure"
     assert denied.json()["error"]["code"] == "permission_not_granted"
+
+    async def fail_inactive_contributor(*_args, **_kwargs):
+        raise ActiveContributorRequired(ActiveContributorRequired.message)
+
+    monkeypatch.setattr(TaskService, "claim_task", fail_inactive_contributor)
+    inactive = await task_client.post(
+        "/api/v1/tasks/task-id/claim",
+        headers=auth_headers(),
+        json={"reason": "claim"},
+    )
+
+    assert inactive.status_code == 403
+    assert inactive.json()["detail"] == "Active contributor identity required"
+    assert inactive.json()["error"]["code"] == "active_contributor_required"
+    assert inactive.json()["error"]["retryable"] is False
+
+    async def fail_contributor_lookup(*_args, **_kwargs):
+        raise ContributorIdentityUnavailable(ContributorIdentityUnavailable.message)
+
+    monkeypatch.setattr(TaskService, "create_submission", fail_contributor_lookup)
+    unavailable = await task_client.post(
+        "/api/v1/tasks/task-id/submissions",
+        headers=auth_headers(),
+        json=complete_submission_payload(),
+    )
+
+    assert unavailable.status_code == 503
+    assert unavailable.json()["error"]["message"] == (
+        "Contributor identity verification unavailable"
+    )
+    assert unavailable.json()["error"]["code"] == "contributor_identity_unavailable"
+    assert unavailable.json()["error"]["retryable"] is True
 
 
 async def test_legacy_eligibility_service_updates_existing_submitter_row(
@@ -2054,7 +2689,7 @@ async def test_full_task_claim_start_flow_writes_audit_events(
     )
     assert claim.status_code == 200, claim.text
     assert claim.json()["task"]["status"] == "claimed"
-    assert claim.json()["assignment"]["worker_id"] == worker_actor_id
+    assert claim.json()["assignment"]["contributor_id"] == worker_actor_id
 
     start = await task_client.post(
         f"/api/v1/tasks/{ready_task['id']}/start",
@@ -2381,7 +3016,7 @@ async def test_worker_can_create_profile_before_claiming_task(
 
     assert claim.status_code == 200, claim.text
     assert claim.json()["task"]["status"] == "claimed"
-    assert claim.json()["assignment"]["worker_id"] == actor_id("worker-self-profile")
+    assert claim.json()["assignment"]["contributor_id"] == actor_id("worker-self-profile")
 
 
 async def test_worker_profile_response_excludes_identity_display_fields(
@@ -2648,7 +3283,7 @@ async def test_assigned_worker_submit_auto_enters_pre_review_gate(
     assert response.status_code == 201, response.text
     submission = response.json()
     assert submission["task_id"] == started_task["id"]
-    assert submission["worker_id"] == worker_actor_id
+    assert submission["contributor_id"] == worker_actor_id
     assert submission["version"] == 1
     assert submission["status"] == "submitted"
     assert submission["finalized_at"] is not None
@@ -2786,7 +3421,7 @@ async def test_submission_schema_rejects_worker_supplied_locked_context(
     payload = complete_submission_payload()
     payload.update(
         {
-            "worker_id": actor_id("worker-one"),
+            "contributor_id": actor_id("worker-one"),
             "version": 1,
             "status": "submitted",
             "locked_guide_version": "malicious",
@@ -3476,7 +4111,7 @@ async def test_database_rejects_submission_without_post_submit_policy_context(
         submission = Submission(
             id=str(uuid4()),
             task_id=task.id,
-            worker_id=actor_id("worker-one"),
+            contributor_id=actor_id("worker-one"),
             version=1,
             status="submitted",
             summary="Bypass submission without post-submit policy provenance.",
@@ -5449,7 +6084,7 @@ async def test_database_enforces_unique_submission_version(
             Submission(
                 id=str(uuid4()),
                 task_id=body["task_id"],
-                worker_id=body["worker_id"],
+                contributor_id=body["contributor_id"],
                 version=body["version"],
                 status="submitted",
                 summary="duplicate",
@@ -5531,6 +6166,8 @@ async def test_invalid_transitions_are_rejected(task_client: AsyncClient) -> Non
 async def test_database_enforces_one_active_assignment_per_task(task_client: AsyncClient) -> None:
     project = await create_active_project(task_client)
     ready_task = await create_ready_task(task_client, project["id"])
+    first_contributor_id = await seed_worker_profile("assignment-contributor-one")
+    second_contributor_id = await seed_worker_profile("assignment-contributor-two")
 
     async with db_session.get_session_factory()() as session:
         session.add_all(
@@ -5538,14 +6175,14 @@ async def test_database_enforces_one_active_assignment_per_task(task_client: Asy
                 TaskAssignment(
                     id=str(uuid4()),
                     task_id=ready_task["id"],
-                    worker_id="worker-1",
+                    contributor_id=first_contributor_id,
                     assigned_by="operator",
                     status="active",
                 ),
                 TaskAssignment(
                     id=str(uuid4()),
                     task_id=ready_task["id"],
-                    worker_id="worker-2",
+                    contributor_id=second_contributor_id,
                     assigned_by="operator",
                     status="active",
                 ),
@@ -5560,6 +6197,8 @@ async def test_released_assignment_does_not_block_new_active_assignment(
 ) -> None:
     project = await create_active_project(task_client)
     ready_task = await create_ready_task(task_client, project["id"])
+    first_contributor_id = await seed_worker_profile("released-contributor-one")
+    second_contributor_id = await seed_worker_profile("released-contributor-two")
 
     async with db_session.get_session_factory()() as session:
         session.add_all(
@@ -5567,14 +6206,14 @@ async def test_released_assignment_does_not_block_new_active_assignment(
                 TaskAssignment(
                     id=str(uuid4()),
                     task_id=ready_task["id"],
-                    worker_id="worker-1",
+                    contributor_id=first_contributor_id,
                     assigned_by="operator",
                     status="released",
                 ),
                 TaskAssignment(
                     id=str(uuid4()),
                     task_id=ready_task["id"],
-                    worker_id="worker-2",
+                    contributor_id=second_contributor_id,
                     assigned_by="operator",
                     status="active",
                 ),

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -65,12 +65,14 @@ from app.modules.tasks.models import (
     WorkstreamTask,
 )
 from app.modules.tasks.repository import TaskRepository
-from app.modules.tasks.schemas import SubmissionCreate
+from app.modules.tasks.schemas import SubmissionCreate, TaskCreate
 from app.modules.tasks.service import (
     ActiveContributorRequired,
     ContributorIdentityUnavailable,
+    TaskLockedContextInvalid,
     TaskService,
     TaskServiceError,
+    TaskTransitionBlocked,
 )
 from app.schemas.auth import ActorContext
 
@@ -138,6 +140,440 @@ async def test_task_contributor_revalidation_maps_failures_and_rolls_back() -> N
         assert failure.value.code == code
 
     assert session.rollback.await_count == len(cases)
+
+
+def task_service_actor(*roles: str) -> ActorContext:
+    """Build a verified actor for direct task-service behavior tests."""
+    return ActorContext(
+        actor_id=actor_id("task-service-actor"),
+        external_subject="task-service-actor",
+        external_issuer="flow-test",
+        roles=roles,
+        claim_snapshot={},
+        auth_source="dev_mock",
+        is_dev_auth=True,
+    )
+
+
+async def test_task_service_create_persists_canonical_attribution_and_audit() -> None:
+    actor = task_service_actor("project_manager")
+    session = MagicMock(spec=AsyncSession)
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    service = TaskService(session)
+    service._project_repo.get_project = AsyncMock(return_value=MagicMock())
+    service._repo.add_task = AsyncMock(side_effect=lambda task: task)
+    service._write_task_audit = AsyncMock()
+    response = MagicMock(name="task_response")
+    service._task_response = MagicMock(return_value=response)
+    payload = TaskCreate.model_validate(complete_task_payload())
+
+    result = await service.create_task(actor, "project-1", payload)
+
+    task = service._repo.add_task.await_args.args[0]
+    assert result is response
+    assert isinstance(task, WorkstreamTask)
+    assert task.project_id == "project-1"
+    assert task.created_by == actor.actor_id
+    assert task.status == "draft"
+    assert task.title == payload.title
+    service._write_task_audit.assert_awaited_once_with(
+        actor,
+        task,
+        event_type="task_created",
+        from_status=None,
+        to_status="draft",
+        reason=None,
+        event_payload={"source_type": payload.source_type},
+    )
+    session.commit.assert_awaited_once_with()
+    session.refresh.assert_awaited_once_with(task)
+    service._task_response.assert_called_once_with(actor, task)
+
+
+async def test_task_service_read_contexts_preserve_visibility_and_operator_scope() -> None:
+    actor = task_service_actor("project_manager")
+    session = MagicMock(spec=AsyncSession)
+    service = TaskService(session)
+    task = MagicMock(spec=WorkstreamTask)
+    task.id = "task-1"
+    task.created_by = actor.actor_id
+    context = MagicMock(name="locked_context")
+    eligibility = MagicMock(name="legacy_eligibility")
+    task_response = MagicMock(name="task_response")
+    work_response = MagicMock(name="work_response")
+    requirements_response = MagicMock(name="requirements_response")
+    locked_response = MagicMock(name="locked_response")
+    service._get_task = AsyncMock(return_value=task)
+    service._ensure_task_visible = AsyncMock()
+    service._load_locked_task_context = AsyncMock(return_value=context)
+    service._legacy_workflow_eligibility.get_active_submitter_eligibility = AsyncMock(
+        return_value=eligibility
+    )
+    service._task_response = MagicMock(return_value=task_response)
+    service._work_context_response = MagicMock(return_value=work_response)
+    service._submission_requirements_response = MagicMock(
+        return_value=requirements_response
+    )
+    service._locked_context_response = MagicMock(return_value=locked_response)
+
+    assert await service.get_task(actor, task.id) is task_response
+    assert await service.get_task_work_context(actor, task.id) is work_response
+    assert (
+        await service.get_task_submission_requirements(actor, task.id)
+        is requirements_response
+    )
+    assert await service.get_task_locked_context(actor, task.id) is locked_response
+
+    assert service._get_task.await_count == 4
+    assert service._ensure_task_visible.await_count == 3
+    assert service._load_locked_task_context.await_count == 3
+    service._work_context_response.assert_called_once_with(
+        actor,
+        task,
+        context,
+        has_active_submitter_eligibility=False,
+    )
+    service._submission_requirements_response.assert_called_once_with(task, context)
+    service._locked_context_response.assert_called_once_with(task, context)
+
+
+async def test_task_service_screen_and_release_own_transaction_boundaries() -> None:
+    actor = task_service_actor("project_manager")
+    session = MagicMock(spec=AsyncSession)
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    service = TaskService(session)
+    draft_task = MagicMock(spec=WorkstreamTask)
+    draft_task.id = "task-1"
+    draft_task.project_id = "project-1"
+    draft_task.status = "draft"
+    screened_task = MagicMock(spec=WorkstreamTask)
+    screened_task.id = draft_task.id
+    screened_task.project_id = draft_task.project_id
+    screened_task.status = "screening"
+    active_context = tuple(MagicMock(name=f"policy_{index}") for index in range(8))
+    screen_response = MagicMock(name="screen_response")
+    release_response = MagicMock(name="release_response")
+    service._get_task = AsyncMock(side_effect=(draft_task, screened_task))
+    service._ensure_transition_allowed = MagicMock()
+    service._load_active_policy_context = AsyncMock(return_value=active_context)
+    service._validate_task_contract_fields = MagicMock()
+    service._stamp_locked_context = MagicMock()
+    service._change_task_status = AsyncMock()
+    service._ensure_locked_context = MagicMock()
+    service._load_locked_task_context = AsyncMock(return_value=MagicMock())
+    service._task_response = MagicMock(side_effect=(screen_response, release_response))
+
+    assert (
+        await service.move_to_screening(actor, draft_task.id, "screening complete")
+        is screen_response
+    )
+    assert (
+        await service.release_to_ready(actor, screened_task.id, "release approved")
+        is release_response
+    )
+
+    service._stamp_locked_context.assert_called_once_with(draft_task, *active_context)
+    assert service._change_task_status.await_args_list[0].args == (
+        actor,
+        draft_task,
+        "screening",
+        "screening complete",
+    )
+    assert service._change_task_status.await_args_list[1].args == (
+        actor,
+        screened_task,
+        "ready",
+        "release approved",
+    )
+    service._ensure_locked_context.assert_called_once_with(screened_task)
+    service._load_locked_task_context.assert_awaited_once_with(screened_task)
+    assert session.commit.await_count == 2
+    assert session.refresh.await_args_list[0].args == (draft_task,)
+    assert session.refresh.await_args_list[1].args == (screened_task,)
+
+
+async def test_task_service_contributor_start_uses_exact_active_assignment() -> None:
+    actor = task_service_actor("worker")
+    session = MagicMock(spec=AsyncSession)
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    service = TaskService(session)
+    task = MagicMock(spec=WorkstreamTask)
+    task.id = "task-1"
+    task.status = "claimed"
+    assignment = MagicMock(spec=TaskAssignment)
+    assignment.id = "assignment-1"
+    assignment.contributor_id = actor.actor_id
+    response = MagicMock(name="task_response")
+    service._get_task = AsyncMock(return_value=task)
+    service._ensure_transition_allowed = MagicMock()
+    service._repo.get_active_assignment = AsyncMock(return_value=assignment)
+    service._require_legacy_submitter_eligibility = AsyncMock(return_value=MagicMock())
+    service._change_task_status = AsyncMock()
+    service._task_response = MagicMock(return_value=response)
+
+    result = await service.start_task(actor, task.id, "starting work")
+
+    assert result is response
+    service._require_legacy_submitter_eligibility.assert_awaited_once_with(actor)
+    service._change_task_status.assert_awaited_once_with(
+        actor,
+        task,
+        "in_progress",
+        "starting work",
+        event_payload={
+            "assignment_id": assignment.id,
+            "contributor_id": actor.actor_id,
+            "operator_override": False,
+        },
+        event_type="task_status_changed",
+    )
+    session.commit.assert_awaited_once_with()
+    session.refresh.assert_awaited_once_with(task)
+
+
+async def test_task_service_finalize_requeues_locked_latest_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    actor = task_service_actor("project_manager")
+    session = MagicMock(spec=AsyncSession)
+    service = TaskService(session)
+    task = MagicMock(spec=WorkstreamTask)
+    task.id = "task-1"
+    task.created_by = actor.actor_id
+    submission = MagicMock(spec=Submission)
+    submission.id = "submission-1"
+    submission.task_id = task.id
+    submission.status = "submitted"
+    submission.locked_at = datetime.now(UTC)
+    persisted = MagicMock(spec=Submission)
+    repair_snapshot = {"status": "failed", "repairable": True}
+    requester_provenance = {"request_id": "request-1", "correlation_id": "correlation-1"}
+    checker_service = MagicMock()
+    checker_service.pre_review_gate_repair_snapshot = AsyncMock(
+        return_value=repair_snapshot
+    )
+    monkeypatch.setattr(
+        "app.modules.tasks.service.CheckerService",
+        MagicMock(return_value=checker_service),
+    )
+    response = MagicMock(name="submission_response")
+    service._get_submission = AsyncMock(return_value=submission)
+    service._get_task = AsyncMock(return_value=task)
+    service._ensure_submission_finalize_authorized = AsyncMock()
+    service._repo.get_latest_submission_for_task = AsyncMock(return_value=submission)
+    service._submission_finalization_requester_provenance = AsyncMock(
+        return_value=requester_provenance
+    )
+    service._enqueue_pre_review_gate_after_commit = AsyncMock(return_value="queue-task-1")
+    service._repo.get_submission = AsyncMock(return_value=persisted)
+    service._submission_response = MagicMock(return_value=response)
+
+    result = await service.finalize_submission(actor, submission.id)
+
+    assert result is response
+    service._ensure_submission_finalize_authorized.assert_awaited_once_with(actor, task)
+    checker_service.pre_review_gate_repair_snapshot.assert_awaited_once_with(submission.id)
+    service._submission_finalization_requester_provenance.assert_awaited_once_with(
+        task,
+        submission,
+    )
+    service._enqueue_pre_review_gate_after_commit.assert_awaited_once_with(
+        actor,
+        submission.id,
+        requester_provenance=requester_provenance,
+        repair_snapshot=repair_snapshot,
+    )
+    service._submission_response.assert_called_once_with(
+        actor,
+        persisted,
+        has_operator_access=True,
+    )
+
+
+@pytest.mark.parametrize("task_status", ["submitted", "in_progress"])
+async def test_task_service_dispatch_failure_records_bounded_repair_evidence(
+    monkeypatch: pytest.MonkeyPatch,
+    task_status: str,
+) -> None:
+    session = MagicMock(spec=AsyncSession)
+    session.commit = AsyncMock()
+    service = TaskService(session)
+    submission = MagicMock(spec=Submission)
+    submission.id = "submission-1"
+    submission.task_id = "task-1"
+    submission.version = 3
+    task = MagicMock(spec=WorkstreamTask)
+    task.id = submission.task_id
+    task.status = task_status
+    system_actor = task_service_actor("admin")
+    monkeypatch.setattr(
+        "app.modules.tasks.service.pre_review_gate_system_actor",
+        MagicMock(return_value=system_actor),
+    )
+    service._get_submission = AsyncMock(return_value=submission)
+    service._get_task = AsyncMock(return_value=task)
+    service._change_task_status = AsyncMock()
+    service._write_task_audit = AsyncMock()
+    requester_payload = {"request_id": "request-1", "correlation_id": "correlation-1"}
+
+    await service._mark_pre_review_gate_dispatch_failed(
+        submission.id,
+        "checker-run-1",
+        "x" * 1200,
+        requester_payload,
+    )
+
+    expected_payload = {
+        "submission_id": submission.id,
+        "submission_version": submission.version,
+        "checker_run_id": "checker-run-1",
+        "failure_code": "pre_review_gate_enqueue_failed",
+        "failure_message": "x" * 1000,
+        **requester_payload,
+    }
+    if task_status == "submitted":
+        service._change_task_status.assert_awaited_once_with(
+            system_actor,
+            task,
+            "evaluation_pending",
+            reason="automatic pre-review gate dispatch failed; operator repair required",
+            event_payload=expected_payload,
+            event_type="pre_review_gate_dispatch_failed",
+        )
+        service._write_task_audit.assert_not_awaited()
+    else:
+        service._write_task_audit.assert_awaited_once_with(
+            system_actor,
+            task,
+            event_type="pre_review_gate_dispatch_failed",
+            from_status=task.status,
+            to_status=task.status,
+            reason="automatic pre-review gate dispatch failed; operator repair required",
+            event_payload=expected_payload,
+        )
+        service._change_task_status.assert_not_awaited()
+    session.commit.assert_awaited_once_with()
+
+
+async def test_task_service_finalization_provenance_fails_closed_without_lock_audit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session = MagicMock(spec=AsyncSession)
+    service = TaskService(session)
+    task = MagicMock(spec=WorkstreamTask)
+    task.id = "task-1"
+    submission = MagicMock(spec=Submission)
+    submission.id = "submission-1"
+    events = [MagicMock(spec=AuditEvent)]
+    service._repo.list_audit_events = AsyncMock(return_value=events)
+    provenance = {"request_id": "request-1", "correlation_id": "correlation-1"}
+    finder = MagicMock(side_effect=(provenance, None))
+    monkeypatch.setattr(
+        "app.modules.tasks.service.find_submission_requester_provenance",
+        finder,
+    )
+
+    assert (
+        await service._submission_finalization_requester_provenance(task, submission)
+        == provenance
+    )
+    with pytest.raises(
+        TaskTransitionBlocked,
+        match="submission lock audit provenance is missing",
+    ):
+        await service._submission_finalization_requester_provenance(task, submission)
+
+    assert service._repo.list_audit_events.await_count == 2
+    assert finder.call_count == 2
+
+
+async def test_task_service_submission_lock_conflict_recovers_only_persisted_lock() -> None:
+    actor = task_service_actor("project_manager")
+    session = MagicMock(spec=AsyncSession)
+    service = TaskService(session)
+    task = MagicMock(spec=WorkstreamTask)
+    task.status = "submitted"
+    submission = MagicMock(spec=Submission)
+    submission.id = "submission-1"
+    submission.locked_at = None
+    persisted = MagicMock(spec=Submission)
+    persisted.locked_at = datetime.now(UTC)
+    service._repo.finalize_submission_if_unlocked = AsyncMock(return_value=False)
+    service._repo.get_submission = AsyncMock(side_effect=(persisted, None))
+    service._repo.lock_submission_evidence = AsyncMock()
+    service._write_task_audit = AsyncMock()
+
+    await service._finalize_submission_for_evaluation(actor, task, submission)
+
+    assert submission.locked_at == persisted.locked_at
+    service._repo.lock_submission_evidence.assert_not_awaited()
+    service._write_task_audit.assert_not_awaited()
+
+    submission.locked_at = None
+    with pytest.raises(TaskTransitionBlocked, match="submission lock conflicted; retry"):
+        await service._finalize_submission_for_evaluation(actor, task, submission)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args", "expected_field"),
+    [
+        ("_policy_list", ({"items": "not-a-list"}, "items"), "effective_policy.items"),
+        ("_policy_string_list", ({"items": [1]}, "items"), "effective_policy.items"),
+        ("_policy_bool", ({"flag": "true"}, "flag"), "effective_policy.flag"),
+        ("_policy_object", ({"rules": []}, "rules"), "effective_policy.rules"),
+        ("_optional_policy_text", ({"note": ""}, "note"), "effective_policy.note"),
+        ("_optional_policy_non_negative_int", ({"limit": -1}, "limit"), "effective_policy.limit"),
+        (
+            "_required_packet_fields",
+            ({"required_packet_fields": "summary"},),
+            "effective_policy.required_packet_fields",
+        ),
+        (
+            "_required_packet_fields",
+            ({"required_packet_fields": [""]},),
+            "effective_policy.required_packet_fields",
+        ),
+        ("_policy_rule_text", ([], "path", "files"), "effective_policy.files"),
+        (
+            "_policy_rule_text",
+            ({}, "path", "files"),
+            "effective_policy.files.path",
+        ),
+        ("_optional_policy_rule_text", ([], "note", "files"), "effective_policy.files"),
+        (
+            "_optional_policy_rule_text",
+            ({"note": ""}, "note", "files"),
+            "effective_policy.files.note",
+        ),
+        ("_policy_rule_bool", ([], "required", "files"), "effective_policy.files"),
+        (
+            "_policy_rule_bool",
+            ({"required": "true"}, "required", "files"),
+            "effective_policy.files.required",
+        ),
+    ],
+)
+def test_task_service_locked_policy_helpers_fail_closed_on_wrong_types(
+    method_name: str,
+    args: tuple[object, ...],
+    expected_field: str,
+) -> None:
+    service = TaskService(MagicMock(spec=AsyncSession))
+
+    with pytest.raises(TaskLockedContextInvalid) as failure:
+        getattr(service, method_name)(*args)
+
+    assert failure.value.details == {"field": expected_field}
+
+
+def test_task_service_optional_locked_policy_helpers_preserve_absence() -> None:
+    service = TaskService(MagicMock(spec=AsyncSession))
+
+    assert service._optional_policy_text({}, "note") is None
+    assert service._optional_policy_non_negative_int({}, "limit") is None
 
 
 async def delete_audit_fixture_as_owner(session: AsyncSession, event_id: str) -> None:

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -40,6 +40,7 @@ from app.modules.actors.service import (
     ActorService,
     CanonicalWriteActorUnavailable,
 )
+from app.modules.checkers.service import CheckerService
 from app.modules.projects.models import (
     EffectiveProjectSubmissionArtifactPolicy,
     GuideSourceSnapshot,
@@ -1170,6 +1171,8 @@ async def test_contributor_task_writes_serialize_with_lifecycle_changes(
     project = await create_active_project(task_client)
     subject = f"race-{operation}-{transition}-{ordering}"
     contributor_id = actor_id(subject)
+    checker_calls: list[str] = []
+    enqueue_calls: list[str] = []
     if operation == "claim":
         task = await create_ready_task(task_client, project["id"])
         await seed_worker_profile(subject)
@@ -1180,9 +1183,31 @@ async def test_contributor_task_writes_serialize_with_lifecycle_changes(
             monkeypatch,
             subject,
         )
+        original_pre_submit_check = CheckerService.pre_submit_check
+
+        async def count_pre_submit_check(self, *args, **kwargs):
+            checker_calls.append(task["id"])
+            return await original_pre_submit_check(self, *args, **kwargs)
+
+        def count_pre_review_enqueue(
+            *,
+            checker_run_id: str,
+            requester_provenance: dict,
+        ) -> str:
+            enqueue_calls.append(checker_run_id)
+            return hold_pre_review_enqueue(
+                checker_run_id=checker_run_id,
+                requester_provenance=requester_provenance,
+            )
+
+        monkeypatch.setattr(
+            CheckerService,
+            "pre_submit_check",
+            count_pre_submit_check,
+        )
         monkeypatch.setattr(
             "app.modules.tasks.service.enqueue_pre_review_gate",
-            hold_pre_review_enqueue,
+            count_pre_review_enqueue,
         )
 
     async with db_session.get_session_factory()() as session:
@@ -1267,6 +1292,9 @@ async def test_contributor_task_writes_serialize_with_lifecycle_changes(
             task_database_env,
             task_id,
         ) == before
+        if operation == "submission":
+            assert checker_calls == []
+            assert enqueue_calls == []
     else:
         task_locked = asyncio.Event()
         release_task = asyncio.Event()
@@ -1349,6 +1377,8 @@ async def test_contributor_task_writes_serialize_with_lifecycle_changes(
             assert assignments[0][1] == contributor_id
         else:
             assert task_result.contributor_id == contributor_id
+            assert checker_calls == [task_id]
+            assert len(enqueue_calls) == 1
             assert observed_after_task_commit["task"] == (
                 "submitted",
                 contributor_id,

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -1157,6 +1157,13 @@ Fields:
 - `released_at`
 - `status`
 
+Migration `0027_contributor_foundation` clean-cuts the persisted human owner
+from `worker_id` to `contributor_id`. The non-null `varchar(36)` value is a
+foreign key to `ActorProfile.id`; an invoker-rights PostgreSQL trigger rejects
+service profiles. The trigger deliberately permits suspended and deactivated
+human profiles because this column preserves historical attribution rather
+than current authority.
+
 ## Submission
 
 Fields:
@@ -1193,6 +1200,14 @@ Fields:
 - `supersedes_submission_id`
 - `remediation_source_checker_run_id` (checker-remediation submissions only)
 - `revision_context_preparation_id` (human-Review revision submissions only)
+
+The current Submission `contributor_id` uses the same migration, foreign-key,
+and canonical-human trigger contract as TaskAssignment. Claim and submission
+creation additionally lock and revalidate the caller's exact active human
+ActorProfile and active issuer/subject identity link before locking the task
+and active assignment. That transaction participant establishes current
+identity eligibility only; project roles, grants, actions, and resource policy
+remain owned by the authorization service.
 
 The contributor submission packet supplies the task id, summary, outputs,
 artifact hashes, evidence references, and contributor attestation. Workstream assigns the

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -1157,12 +1157,14 @@ Fields:
 - `released_at`
 - `status`
 
-Migration `0027_contributor_foundation` clean-cuts the persisted human owner
-from `worker_id` to `contributor_id`. The non-null `varchar(36)` value is a
-foreign key to `ActorProfile.id`; an invoker-rights PostgreSQL trigger rejects
-service profiles. The trigger deliberately permits suspended and deactivated
-human profiles because this column preserves historical attribution rather
-than current authority.
+Migration `0027_contributor_foundation` clean-cuts the retired persisted human
+owner to `contributor_id`. The non-null `varchar(36)` value is protected by
+foreign key `fk_task_assignments_contributor_id_actor_profiles`, index
+`ix_task_assignments_contributor_id`, and trigger
+`task_assignments_contributor_human`. The trigger reuses invoker-rights function
+`public.require_human_actor_profile_reference()` to reject service profiles.
+It deliberately permits suspended and deactivated human profiles because this
+column preserves historical attribution rather than current authority.
 
 ## Submission
 
@@ -1200,6 +1202,11 @@ Fields:
 - `supersedes_submission_id`
 - `remediation_source_checker_run_id` (checker-remediation submissions only)
 - `revision_context_preparation_id` (human-Review revision submissions only)
+
+The submission contributor uses foreign key
+`fk_submissions_contributor_id_actor_profiles`, index
+`ix_submissions_contributor_id`, and trigger
+`submissions_contributor_human`, backed by the same reusable lineage function.
 
 The current Submission `contributor_id` uses the same migration, foreign-key,
 and canonical-human trigger contract as TaskAssignment. Claim and submission

--- a/docs/operations_authorization_service.md
+++ b/docs/operations_authorization_service.md
@@ -250,6 +250,39 @@ intake. Operator start override does not use the bridge. AUTH-13 removes the
 claim and start consumers; AUTH-14 removes the final submission consumer,
 compatibility route, and adapter.
 
+## Contributor Attribution Migration And Runtime Guard
+
+Migration `0027_contributor_foundation` clean-cuts `task_assignments.worker_id`
+and `submissions.worker_id` to `contributor_id`. Before any DDL, it locks
+`actor_profiles`, `task_assignments`, and `submissions` and independently
+classifies every old value as malformed UUID, missing ActorProfile, or service
+ActorProfile. Failure reports only bounded row/profile ID pairs and counts. It
+does not inspect issuer, subject, email, token claims, current assignment, or
+another table to infer a replacement.
+
+Remediate a refusal only from authoritative canonical-actor evidence. Create or
+repair the canonical human ActorProfile through its owning reviewed process,
+or correct a demonstrably wrong attribution through a separately reviewed data
+repair. Do not map by email or display name, select a latest profile, convert a
+service identity, fabricate an ActorProfile, or edit immutable audit history.
+Rerun from exact head `0026_actor_profile_lifecycle` and retain the bounded
+preflight result with the deployment evidence.
+
+After upgrade, both columns are non-null `varchar(36)` foreign keys. PostgreSQL
+rejects a missing profile with SQLSTATE `23503` and a service profile with
+`23514`. Suspended and deactivated human profiles remain valid historical
+references. Downgrade first locks the same tables and refuses before DDL when
+any non-owned dependency uses the shared lineage function; remove or migrate
+that dependent schema through its owning release before retrying.
+
+Claim and submission also revalidate current identity inside their mutation
+transaction in lock order ActorProfile, exact issuer/subject identity link,
+task, active assignment. An inactive or non-human identity returns HTTP 403
+`active_contributor_required`. Missing, mismatched, database-unavailable, or
+lock-failed canonical identity state rolls back and returns retryable HTTP 503
+`contributor_identity_unavailable`. These responses are identity eligibility,
+not permission decisions; grant and resource authorization remain separate.
+
 ## PostgreSQL Rate Controls
 
 First human access now uses the AUTH-04B PostgreSQL control. Future

--- a/docs/operations_authorization_service.md
+++ b/docs/operations_authorization_service.md
@@ -252,13 +252,15 @@ compatibility route, and adapter.
 
 ## Contributor Attribution Migration And Runtime Guard
 
-Migration `0027_contributor_foundation` clean-cuts `task_assignments.worker_id`
-and `submissions.worker_id` to `contributor_id`. Before any DDL, it locks
+Migration `0027_contributor_foundation` clean-cuts the retired assignment and
+submission human-owner columns to `contributor_id`. Before any DDL, it locks
 `actor_profiles`, `task_assignments`, and `submissions` and independently
 classifies every old value as malformed UUID, missing ActorProfile, or service
 ActorProfile. Failure reports only bounded row/profile ID pairs and counts. It
-does not inspect issuer, subject, email, token claims, current assignment, or
-another table to infer a replacement.
+redacts malformed source values completely while retaining safe row IDs and
+well-formed missing/service profile IDs. It does not inspect issuer, subject,
+email, token claims, current assignment, or another table to infer a
+replacement.
 
 Remediate a refusal only from authoritative canonical-actor evidence. Create or
 repair the canonical human ActorProfile through its owning reviewed process,
@@ -267,6 +269,15 @@ repair. Do not map by email or display name, select a latest profile, convert a
 service identity, fabricate an ActorProfile, or edit immutable audit history.
 Rerun from exact head `0026_actor_profile_lifecycle` and retain the bounded
 preflight result with the deployment evidence.
+
+The reusable primitive is
+`public.require_human_actor_profile_reference()`. Exact triggers
+`task_assignments_contributor_human` and `submissions_contributor_human` enforce
+human lineage. Exact foreign keys
+`fk_task_assignments_contributor_id_actor_profiles` and
+`fk_submissions_contributor_id_actor_profiles` enforce existence, while renamed
+indexes `ix_task_assignments_contributor_id` and
+`ix_submissions_contributor_id` preserve lookup behavior.
 
 After upgrade, both columns are non-null `varchar(36)` foreign keys. PostgreSQL
 rejects a missing profile with SQLSTATE `23503` and a service profile with

--- a/docs/spec_authorization_service.md
+++ b/docs/spec_authorization_service.md
@@ -720,6 +720,17 @@ route family remains planned. Project-scoped
 `GET /api/v1/actors/me/authorization-context` begins in AUTH-10 after
 exact-project grant and canonical project capability composition exists.
 
+`WS-AUTH-001-CONTRIBUTOR-FOUNDATION` adds no permission or authorization path.
+It clean-cuts TaskAssignment and Submission attribution to `contributor_id`,
+binds both fields to canonical human ActorProfiles in PostgreSQL, and exposes
+one actor-owned transaction participant for claim and submission. The
+participant locks the exact profile and verified issuer/subject link, requires
+both to be active human identity state, returns no identity or authority data,
+and runs after coarse legacy role admission but before resource locks. A
+non-human or inactive identity returns `active_contributor_required`; missing,
+mismatched, or unavailable canonical identity state returns retryable
+`contributor_identity_unavailable`.
+
 ## Migration And Compatibility
 
 The implementation order is fixed by the WS-AUTH-001 chunk map:
@@ -741,16 +752,19 @@ The implementation order is fixed by the WS-AUTH-001 chunk map:
     reactivate, and terminal deactivate;
 13. `WS-AUTH-001-09D-B`: identity-link revoke/reactivate and mixed lifecycle
     race closure;
-14. `WS-AUTH-001-09E`: fixed service runtime admission without human grant
+14. `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`: canonical-human TaskAssignment and
+    Submission attribution plus transaction-local active identity
+    revalidation;
+15. `WS-AUTH-001-09E`: fixed service runtime admission without human grant
     evaluation or feature action activation;
-15. `WS-AUTH-001-ART-CUSTODY` and `WS-AUTH-001-REV-CUSTODY`:
+16. `WS-AUTH-001-ART-CUSTODY` and `WS-AUTH-001-REV-CUSTODY`:
     availability-neutral transfer to exact AUTH activation owners;
-16. `WS-AUTH-001-PREP`: prepared mutation authorization protocol;
-17. `WS-AUTH-001-10`: independent project contributor grants;
-18. `WS-AUTH-001-11` through `WS-AUTH-001-14`: complete resource-family
+17. `WS-AUTH-001-PREP`: prepared mutation authorization protocol;
+18. `WS-AUTH-001-10`: independent project contributor grants;
+19. `WS-AUTH-001-11` through `WS-AUTH-001-14`: complete resource-family
     cutovers;
-19. `WS-AUTH-001-15`: obsolete authority removal and scanner enforcement;
-20. `WS-AUTH-001-16`: conformance, observability, concurrency, and live API
+20. `WS-AUTH-001-15`: obsolete authority removal and scanner enforcement;
+21. `WS-AUTH-001-16`: conformance, observability, concurrency, and live API
     proof.
 
 No implementation may add a compatibility alias, fallback authority source,

--- a/docs/spec_chunk_5_submission_packet_foundation.md
+++ b/docs/spec_chunk_5_submission_packet_foundation.md
@@ -232,7 +232,7 @@ Repair outcomes:
 
 ## Evidence Identity
 
-Workstream generates evidence item ids at persistence time. Worker-provided manifest rows may include artifact paths or URIs, but the persisted evidence item id is the stable Workstream evidence id for later checker and review records.
+Workstream generates evidence item ids at persistence time. Contributor-provided manifest rows may include artifact paths or URIs, but the persisted evidence item id is the stable Workstream evidence id for later checker and review records.
 
 ## Audit Scope
 

--- a/docs/spec_chunk_5_submission_packet_foundation.md
+++ b/docs/spec_chunk_5_submission_packet_foundation.md
@@ -2,7 +2,13 @@
 
 ## Purpose
 
-This chunk adds the backend record for worker submission packets. A worker submits against a task id, Workstream runs pre-submit intake checks from the locked project pre-submit checker policy, stamps the task's locked guide source snapshot, effective project submission artifact policy, project pre-submit checker bundle, post-submit checker, review, revision, and payment context, and every submitted packet version becomes immutable during successful submission creation before checker execution is queued.
+This chunk adds the backend record for Contributor submission packets. A
+Contributor submits against a task id, Workstream runs pre-submit intake checks
+from the locked project pre-submit checker policy, stamps the task's locked
+guide source snapshot, effective project submission artifact policy, project
+pre-submit checker bundle, post-submit checker, review, revision, and payment
+context, and every submitted packet version becomes immutable during successful
+submission creation before checker execution is queued.
 
 This completes the Week 1 backend lifecycle through `SUBMITTED`.
 
@@ -36,7 +42,7 @@ Chunk 5 stores package and evidence references. Actual file storage still belong
 
 - `id`
 - `task_id`
-- `worker_id`
+- `contributor_id`
 - `version`
 - `status`
 - `summary`
@@ -67,7 +73,7 @@ including guide-source snapshot provenance, effective project submission
 artifact policy provenance, project pre-submit checker compiled bundle hash
 provenance, and explicit post-submit checker policy provenance. The locked
 post-submit checker policy body is internal runtime provenance, copied from the
-task and hidden from worker-facing responses. This prevents task-owned locked
+task and hidden from Contributor-facing responses. This prevents task-owned locked
 context from changing silently after a submission has been recorded.
 
 `evidence_items`
@@ -112,7 +118,10 @@ Response body:
 
 POST `/api/v1/tasks/{task_id}/submissions`
 
-Runs pre-submit checks from the locked project pre-submit checker policy for the assigned worker's draft packet. Creates and locks a new submission version only when blocking pre-submit checks pass, then enqueues the automatic Celery pre-review checker gate.
+Runs pre-submit checks from the locked project pre-submit checker policy for the
+assigned Contributor's draft packet. Creates and locks a new submission version
+only when blocking pre-submit checks pass, then enqueues the automatic Celery
+pre-review checker gate.
 
 Request body:
 
@@ -180,7 +189,7 @@ Repair outcomes:
 
 ## Lifecycle Rules
 
-- a worker can submit only when assigned to the task
+- a Contributor can submit only when assigned to the task
 - first submission requires task status `IN_PROGRESS`
 - Workstream loads the locked effective project submission artifact policy hash before creating a submission
 - Workstream loads the locked generated project pre-submit checker compiled bundle hash before creating a submission
@@ -190,7 +199,8 @@ Repair outcomes:
 - later replacement submissions are allowed only after the task reaches `NEEDS_REVISION`
 - submission packet content must satisfy the locked project pre-submit checker policy
 - every submission creation writes a task audit event
-- the audit event includes submission id, submission version, worker id, package hash, and artifact hash manifest
+- the audit event includes submission id, submission version, contributor id,
+  package hash, and artifact hash manifest
 - successful submission creation writes both `submission_created` and
   `submission_finalized` audit events in the same server-owned handoff
 - only the latest submission version for a task can enter or repair the automatic
@@ -205,14 +215,16 @@ Repair outcomes:
 
 - Workstream still verifies external Flow auth only
 - no Workstream-owned login or primary auth session is added
-- only the assigned worker can create a submission for the task
+- only the assigned Contributor can create a submission for the task
 - admins can read submissions and can repair the automatic pre-review checker gate
   for operational recovery
 - project managers can read submissions and repair the automatic pre-review
   checker gate only for tasks they created in v0.1; assigned submitters lock
   their own submitted packet through the normal submission flow
-- workers can read their own task submissions
-- response payloads are role-sensitive: operators can inspect server-stamped locked provenance for source snapshots and policy context, while worker-facing payloads hide internal policy ids, hashes, and bodies
+- Contributors can read their own task submissions
+- response payloads are role-sensitive: operators can inspect server-stamped
+  locked provenance for source snapshots and policy context, while
+  Contributor-facing payloads hide internal policy ids, hashes, and bodies
 - package and evidence URIs are stored as object references, not signed URLs or credentials
 - persisted storage references are Workstream-issued opaque object references or validated object-storage adapter references
 - raw signed URLs, credential-bearing URLs, query strings, local filesystem paths, bucket secrets, and token-bearing references are rejected before persistence
@@ -228,11 +240,18 @@ Chunk 5 writes task audit events with submission identifiers in `event_payload`.
 
 ## Conditions Of Satisfaction
 
-- worker submits a draft packet against `task_id` and Workstream assigns version `1` after blocking pre-submit checks pass
-- worker does not provide locked guide source snapshot, effective project submission artifact policy, project pre-submit checker, or guide/checker/review/revision/payment policy context
-- worker-provided locked guide source snapshot, effective project submission artifact policy, project pre-submit checker, or guide/checker/review/revision/payment policy context fields are rejected by the API schema
-- worker-provided submission version fields are rejected by the API schema
-- worker-provided checker names, checker outcomes, evidence ids, and checker run ids are rejected by the API schema
+- Contributor submits a draft packet against `task_id` and Workstream assigns
+  version `1` after blocking pre-submit checks pass
+- Contributor does not provide locked guide source snapshot, effective project
+  submission artifact policy, project pre-submit checker, or
+  guide/checker/review/revision/payment policy context
+- Contributor-provided locked guide source snapshot, effective project
+  submission artifact policy, project pre-submit checker, or
+  guide/checker/review/revision/payment policy context fields are rejected by
+  the API schema
+- Contributor-provided submission version fields are rejected by the API schema
+- Contributor-provided checker names, checker outcomes, evidence ids, and
+  checker run ids are rejected by the API schema
 - preflight failures return `PreSubmitCheckResponse(status="failed", eligible_to_submit=false, results=[...])`
 - blocked submission-create attempts return `DomainError(code="pre_submission_checker_failed")` with structured pass/fail/warning details and create no submission row, no submission version, no task transition to `SUBMITTED`, and no submission-created audit event
 - Workstream stamps locked guide source snapshot ids/hashes, effective project submission artifact policy ids/hashes, project pre-submit checker policy ids/bundle hashes, and guide/checker/review/revision/payment policy versions from task context
@@ -241,7 +260,8 @@ Chunk 5 writes task audit events with submission identifiers in `event_payload`.
 - dispatch failures after packet locking are visible as repairable automatic
   gate failures rather than failed contributor submissions
 - replacing an artifact creates a new submission version instead of mutating v1
-- submission audit events include task, worker, version, package, and artifact context
+- submission audit events include task, contributor, version, package, and
+  artifact context
 - submission and immutability tests pass
 
 ## Verifier Agents

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -4188,8 +4188,8 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
         assert stale_text not in auth_map
         assert stale_text not in work_queue
     assert (
-        "Review findings repaired with deterministic proof; fresh exact-SHA "
-        "review active; aggregate coverage pending Backend" in work_queue
+        "Internal review passed at `4d1fc507`; PR/external checks pending; "
+        "aggregate coverage mandatory in Backend" in work_queue
     )
     assert (
         "Active implementation chunk: `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`"
@@ -4201,11 +4201,11 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
     assert "five 09D-A/09D-B lifecycle actions" not in loop_state
     assert (
         "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And "
-        "Canonical-Human Lineage | L1 | Findings repaired/proved; fresh exact-SHA "
-        "review active; aggregate coverage pending Backend" in auth_map
+        "Canonical-Human Lineage | L1 | Internal review passed at `4d1fc507`; "
+        "PR/external checks pending; Backend coverage mandatory" in auth_map
     )
     assert (
-        "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | In review |" in auth_status
+        "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | PR ready |" in auth_status
     )
     assert (
         "| `WS-AUTH-001-09E` | Fixed Service Runtime Admission | L1 | "

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -4188,8 +4188,8 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
         assert stale_text not in auth_map
         assert stale_text not in work_queue
     assert (
-        "Implementation and deterministic evidence complete; exact-SHA internal "
-        "review active" in work_queue
+        "Review findings repaired with deterministic proof; fresh exact-SHA "
+        "review active; aggregate coverage pending Backend" in work_queue
     )
     assert (
         "Active implementation chunk: `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`"
@@ -4201,8 +4201,8 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
     assert "five 09D-A/09D-B lifecycle actions" not in loop_state
     assert (
         "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And "
-        "Canonical-Human Lineage | L1 | Implementation/evidence complete; "
-        "exact-SHA internal review active" in auth_map
+        "Canonical-Human Lineage | L1 | Findings repaired/proved; fresh exact-SHA "
+        "review active; aggregate coverage pending Backend" in auth_map
     )
     assert (
         "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | In review |" in auth_status

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -4169,9 +4169,12 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
     assert "| `WS-AUTH-001-09D` | Split |" in auth_status
     assert "Merged through PR #148 as `99ae4c9`" in auth_map
     assert "| `WS-AUTH-001-09D-A` | Merged |" in auth_status
-    assert "| `WS-AUTH-001-09D-B` | Ready for PR |" in auth_status
-    assert "PR-ready implementation chunk\n\n`WS-AUTH-001-09D-B`" in auth_status
-    assert "`codex/ws-auth-001-09d-b-identity-link-lifecycle`" in auth_status
+    assert "| `WS-AUTH-001-09D-B` | Merged |" in auth_status
+    assert (
+        "Active implementation chunk\n\n"
+        "`WS-AUTH-001-CONTRIBUTOR-FOUNDATION`" in auth_status
+    )
+    assert "`codex/ws-auth-001-contributor-foundation`" in auth_status
     assert "PR #148 is open" not in auth_status
     stale_auth_09d_state = (
         "Only 09D-A implementation is active",
@@ -4184,35 +4187,22 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
         assert stale_text not in auth_status
         assert stale_text not in auth_map
         assert stale_text not in work_queue
+    assert "Active contract review from trusted main `93dd392`" in work_queue
     assert (
-        "| `WS-AUTH-001-09D-B` | Identity-Link Lifecycle And Race Closure | L1 | "
-        "PR #152 open; trusted main `1b5422f` integrated; refreshed checks and "
-        "explicit human review pending"
-        in work_queue
-    )
-    assert (
-        "PR-ready implementation chunk: `WS-AUTH-001-09D-B` in PR #152"
+        "Active implementation chunk: `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`"
         in loop_state
     )
-    assert (
-        "Current gate: refreshed external checks and explicit human review for PR\n"
-        "  #152" in loop_state
-    )
-    assert "ActionIds, with 15 active actions" in loop_state
-    assert (
-        "PR #152 activates only the two 09D-B\n"
-        "  identity-link lifecycle actions, producing a candidate total of 17"
-        in loop_state
-    )
+    assert "ActionIds, with 17 active actions" in loop_state
+    assert "candidate total of 17" not in loop_state
     assert "with 12 active actions" not in loop_state
     assert "five 09D-A/09D-B lifecycle actions" not in loop_state
     assert (
         "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And "
-        "Canonical-Human Lineage | L1 | Inactive until 09D-B merge/memory and "
-        "explicit start" in auth_map
+        "Canonical-Human Lineage | L1 | Active contract review after explicit "
+        "user start" in auth_map
     )
     assert (
-        "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Proposed |" in auth_status
+        "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contract review |" in auth_status
     )
     assert (
         "| `WS-AUTH-001-09E` | Fixed Service Runtime Admission | L1 | "
@@ -4225,8 +4215,8 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
         "Inactive until contributor-foundation merge/memory and explicit user start"
         in work_queue
     )
-    assert (
-        "No service caller becomes executable before\n  AUTH-09E" in loop_state
+    assert "no service caller becomes executable before AUTH-09E" in loop_state.replace(
+        "\n", " "
     )
     assert "Merged through PR #129 as `9a04434`" in artifact_map
     assert "Merged through PR #141 as `a10d901`" in artifact_map

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -144,6 +144,7 @@ AUTH_09B_COVERAGE_COMMANDS = (
     "coverage report --include='app/modules/actors/*' --precision=2 --fail-under=90",
     "coverage report --include='app/modules/authorization/*' "
     "--precision=2 --fail-under=90",
+    "coverage report --include='app/modules/tasks/*' --precision=2 --fail-under=90",
     "coverage report "
     "--include='app/interfaces/auth.py,app/core/auth.py,app/adapters/auth/dev.py,"
     "app/adapters/auth/flow.py' --precision=2 --fail-under=90",
@@ -4170,9 +4171,8 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
     assert "Merged through PR #148 as `99ae4c9`" in auth_map
     assert "| `WS-AUTH-001-09D-A` | Merged |" in auth_status
     assert "| `WS-AUTH-001-09D-B` | Merged |" in auth_status
-    assert (
-        "Active implementation chunk\n\n"
-        "`WS-AUTH-001-CONTRIBUTOR-FOUNDATION`" in auth_status
+    assert "Active implementation chunk\n\n`WS-AUTH-001-CONTRIBUTOR-FOUNDATION`" in (
+        auth_status
     )
     assert "`codex/ws-auth-001-contributor-foundation`" in auth_status
     assert "PR #148 is open" not in auth_status
@@ -4187,7 +4187,10 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
         assert stale_text not in auth_status
         assert stale_text not in auth_map
         assert stale_text not in work_queue
-    assert "Active contract review from trusted main `93dd392`" in work_queue
+    assert (
+        "Implementation and deterministic evidence complete; exact-SHA internal "
+        "review active" in work_queue
+    )
     assert (
         "Active implementation chunk: `WS-AUTH-001-CONTRIBUTOR-FOUNDATION`"
         in loop_state
@@ -4198,11 +4201,11 @@ def test_parallel_initiative_status_matches_trusted_main() -> None:
     assert "five 09D-A/09D-B lifecycle actions" not in loop_state
     assert (
         "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contributor Fields And "
-        "Canonical-Human Lineage | L1 | Active contract review after explicit "
-        "user start" in auth_map
+        "Canonical-Human Lineage | L1 | Implementation/evidence complete; "
+        "exact-SHA internal review active" in auth_map
     )
     assert (
-        "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | Contract review |" in auth_status
+        "| `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` | In review |" in auth_status
     )
     assert (
         "| `WS-AUTH-001-09E` | Fixed Service Runtime Admission | L1 | "


### PR DESCRIPTION
# WS-AUTH-001-CONTRIBUTOR-FOUNDATION PR Trust Bundle

## Goal

Clean-cut task-assignment and submission human attribution to canonical
`contributor_id`, enforce human ActorProfile lineage at the database boundary,
and revalidate the exact active caller inside contributor-write transactions.

## Changes

- Renames and narrows both live owner columns and indexes with no alias, fallback,
  dual field, guessed identity mapping, or historical audit rewrite.
- Adds exact foreign keys plus one reusable invoker-rights human-lineage trigger
  function and named triggers for both tables.
- Adds actor-owned profile/link locking and task-owned task/assignment locking in
  canonical order for claim and submission, with stable 403 and retryable 503
  responses and rollback.
- Updates public schemas, new audit evidence, the real API drill, current docs,
  persistent task coverage reporting, agent gates, and the schema-v2 merge intent.

## Boundary

This PR changes no ActionId, PermissionId, evaluator, grant, role behavior,
authorization decision/evidence path, service admission, task lifecycle, review
or revision behavior. The temporary legacy role token and separately owned
attestation/profile route cleanup remain AUTH-13/14 work. AUTH-09E stays inactive.

## Proof

- Repaired migration matrix: 2 passed in 102.35 seconds.
- Full observed contributor/lifecycle race matrix: 12 passed in 636.24 seconds.
- Canonical API-error mapping: 1 passed in 63.79 seconds.
- Real HTTP API contract drill: passed.
- Focused actor/task unit and database behavior tests: passed.
- Ruff, docstring gate (90.3 percent), stale scanners, Markdown links, diff
  integrity, one Alembic head, and 88 agent gates: passed.
- No skips, xfails, weakened assertions, exclusions, or threshold reductions.

GitHub Backend remains the authoritative mandatory proof for global 78 percent
and persistent actor/authorization/task 90 percent coverage before merge.

## Internal Review

Exact implementation SHA `4d1fc507c343d483677a332c2a91885e32571693` and
closeout head `4db178147bae457d9fccb3643fe6bd3919ba41c2` against trusted main
`93dd392484b397cfdfaaa833631dc2c27f591ed7` passed senior engineering,
QA/test, security/auth, product/ops, architecture, CI integrity, docs,
reuse/dedup, and test-delta review after every valid finding was repaired.

## Human Review Focus

Review migration refusal/redaction and reversible preservation, exact database
object names, profile-to-link-to-task-to-assignment lock order, lifecycle race
outcomes, 403/503 privacy and rollback, clean `contributor_id` API/evidence
shape, and absence of authorization availability or later AUTH-13/14 behavior.

## Merge Ownership

The agent may publish and repair this branch but may not merge it. Only the
human may approve this PR for merge. After merge, trusted-main automation owns
schema-v2 memory generation; no manual post-merge memory PR should be opened
when that workflow succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task assignments and submissions now attribute work to canonical contributors and revalidate eligible active contributor identity during claim and submission flows.
  * Added explicit, structured error handling for inactive/invalid/unavailable contributor identity states.
  * Added a migration/runtime guard to enforce human-only contributor attribution and stable enforcement behavior.
* **Breaking Changes**
  * API payloads now use `contributor_id` instead of `worker_id` for assignments and submissions.
* **Documentation**
  * Updated authorization, data model, operations, and submission guidance for contributor attribution and migration behavior. 
* **Chores**
  * Strengthened CI coverage reporting/gates for the tasks module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->