### PR TITLE
fix(loop-memory): recover exact R4 activation

### DIFF
--- a/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/CHUNK_MAP.md
@@ -5,13 +5,14 @@
 | 0 | `WS-ENG-007-00R1` | Repair planning-intake file/tree parity and recover PR #187 exactly once | L1/P0 | Merged; recovery superseded after rerun-cardinality failure |
 | 0 | `WS-ENG-007-00R2` | Canonicalize repeated trusted check evidence and reconcile PRs #187 and #188 exactly once | L1/P0 | Merged; superseded by mutable-history failure |
 | 0 | `WS-ENG-007-00R3` | Freeze accepted checks at merge time and give explicit starts deterministic recovery parity | L1/P0 | Merged; exposed cross-initiative projection mixing |
-| 0 | `WS-ENG-007-00R4` | Separate global merge evidence from initiative-local authority projections | L1/P0 | Active fail-closed recovery after the first cross-initiative start exposed projection mixing |
-| 1 | `WS-ENG-007-01` | Add deterministic reviewed-patch identity and conservative base-delta review preservation | L1 | Blocked on 00R4 merge, successful reconciliation, and explicit start |
+| 0 | `WS-ENG-007-00R4` | Separate global merge evidence from initiative-local authority projections | L1/P0 | Merged as PR #191; awaiting exact R5 reconciliation |
+| 0 | `WS-ENG-007-00R5` | Reconcile exact merged R4 and activate its closed authority-projection repair | L1/P0 | Active fail-closed recovery after R4 merged without signed-start evidence |
+| 1 | `WS-ENG-007-01` | Add deterministic reviewed-patch identity and conservative base-delta review preservation | L1 | Blocked on 00R5 merge, successful reconciliation, and explicit start |
 | 2 | `WS-ENG-007-02` | Add structured reviewer-track and upstream-finding reconciliation | L1 | Blocked on 01 merge and explicit start |
 | 3 | `WS-ENG-007-03` | Add merge-group CI parity and queue-readiness proof | L1 | Blocked on 02 merge and explicit start |
 
-Recovery chunks are exceptional ordered prerequisites; `00R4` preserves the
-merge-bound evidence fixed by `00R3` while repairing cross-initiative authority
-projection composition. Implementation chunks
+Recovery chunks are exceptional ordered prerequisites; `00R5` consumes the
+exact unsigned R4 recovery merge while preserving R4's authority-projection
+repair. Implementation chunks
 remain one PR each and stop after merge. Every successor requires a separate
 explicit signed start.

--- a/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/STATUS.md
+++ b/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/STATUS.md
@@ -15,5 +15,6 @@
   `9bf16d478f669d48172810c83cdf6a7d2b8992ed`, but post-merge memory rejected it
   because recovery chunk R4 had no signed start. Signed state remains at PR #190;
   no successor is active.
-- Review gate: exact two-merge recovery certificate and internal review in
-  progress.
+- Review gate: all nine internal tracks passed exact implementation head
+  `10159497b3f3ca3464cbbbfd10f16945ade1879a`; awaiting external checks and the
+  user-owned merge decision.

--- a/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/STATUS.md
+++ b/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/STATUS.md
@@ -1,19 +1,19 @@
 # STATUS: WS-ENG-007 - Concurrent PR Review Reconciliation
 
-- Phase: cross-initiative authority-projection recovery
+- Phase: R4 activation recovery
 - Gate: fail-closed automation repair
 - Active planning chunk: none
 - Active implementation chunk: none
-- Completed but unreconciled recovery chunk: `WS-ENG-007-00R1`
-- Merged but unreconciled recovery chunk: `WS-ENG-007-00R2`
+- Reconciled recovery history: `WS-ENG-007-00R1`, `WS-ENG-007-00R2`,
+  `WS-ENG-007-00R3`
 - Completed recovery chunk: `WS-ENG-007-00R3`
-- Active recovery chunk: `WS-ENG-007-00R4`
+- Merged recovery chunk: `WS-ENG-007-00R4`
+- Active recovery chunk: `WS-ENG-007-00R5`
 - Proposed implementation successor after recovery: `WS-ENG-007-01`
 - Separate explicit start required: true
-- Current gate: PR #190 reconciled signed memory through
-  `a3eecadcf847ac70fc28c58dad642f2d761015e0`, but the first ENG-006 start failed
-  because authority validation mixed ENG-006 lifecycle identity with ENG-007
-  protected-check evidence. No successor is active.
-- Review gate: all nine internal tracks passed exact implementation head
-  `c59bff278945c3d8e63a6ea776a6bf6206df8af8`; awaiting external checks and the
-  user-owned merge decision.
+- Current gate: PR #191 merged as
+  `9bf16d478f669d48172810c83cdf6a7d2b8992ed`, but post-merge memory rejected it
+  because recovery chunk R4 had no signed start. Signed state remains at PR #190;
+  no successor is active.
+- Review gate: exact two-merge recovery certificate and internal review in
+  progress.

--- a/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/chunks/WS-ENG-007-00R5-r4-activation-recovery.md
+++ b/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/chunks/WS-ENG-007-00R5-r4-activation-recovery.md
@@ -1,0 +1,95 @@
+# Chunk Contract: WS-ENG-007-00R5 — R4 Activation Recovery
+
+## Parent initiative
+
+`WS-ENG-007` — Concurrent PR Review Reconciliation
+
+## Goal
+
+Reconcile exact merged recovery chunk `WS-ENG-007-00R4` and this activation
+chunk into signed loop memory so ordinary cross-initiative starts can resume.
+
+## Why this chunk exists
+
+PR #191 fixed cross-initiative authority projection composition, but its own
+merge had no signed start because the mechanism being repaired was unavailable.
+The post-merge workflow therefore rejected PR #191 before exercising the fix.
+
+## Risk class
+
+L1 / P0 signed-memory recovery.
+
+## Start phase
+
+Recovery implementation. Signed state cannot start this chunk until the exact
+unrecorded predecessor is reconciled.
+
+## Allowed files
+
+```text
+.agent-loop/policies/loop-memory-recovery.json
+scripts/test_update_post_merge_memory.py
+scripts/test_agent_gates.py
+scripts/update_post_merge_memory.py
+.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/**
+.agent-loop/merge-intents/WS-ENG-007-00R5.json
+```
+
+## Not allowed
+
+```text
+workflow, generator, checker, permission, authority, CI, or coverage changes
+application, API, database, auth, payment, or product changes
+wildcard, persistent, reordered, or reusable exemptions
+automatic successor starts
+```
+
+## Acceptance criteria
+
+- [ ] Schema-v5 recovery binds signed basis `a3eecadc…` and names exact merged
+      PR #191 / `WS-ENG-007-00R4` /
+      `9bf16d478f669d48172810c83cdf6a7d2b8992ed` as its sole predecessor.
+- [ ] Activation names only `WS-ENG-007-00R5`; the target merge identity is
+      collected from GitHub and must match it exactly.
+- [ ] Planned history must be exactly `[9bf16d4…, target]`, first-parent adjacent
+      from current signed `a3eecadc…` through the target.
+- [ ] Both merges must carry successful merge-bound `agent-gates` and `test`
+      provenance. CodeRabbit remains supplementary and mutable reruns cannot
+      rewrite or block accepted evidence.
+- [ ] Both exemptions are consumed before signing and cannot persist or replay.
+- [ ] Exactly one merge intent stops at `WS-ENG-007-01` and requires a separate
+      explicit start.
+- [ ] ENG-006 remains idle until a fresh signed start after successful recovery.
+
+## Verification commands
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q scripts/test_update_post_merge_memory.py scripts/test_check_loop_memory_state.py scripts/test_agent_gates.py
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/update_post_merge_memory.py validate-merge-intent --repository-root . --base-ref origin/main
+git diff --check
+```
+
+## Required reviewers
+
+- senior engineering
+- QA/test
+- security/auth
+- product/ops
+- architecture
+- CI integrity
+- docs
+- reuse/dedup
+- test delta
+
+## Human review focus
+
+Confirm the certificate is exact, adjacent, check-bound, consumed, and unable to
+authorize any chunk other than `00R4` plus this activation.
+
+## Stop conditions
+
+Stop if recovery requires a wildcard exemption, missing required checks,
+non-adjacent history, persisted authority, or an automatic successor start.

--- a/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/reviews/WS-ENG-007-00R5-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/reviews/WS-ENG-007-00R5-external-review-response.md
@@ -1,0 +1,30 @@
+# External Review Response: WS-ENG-007-00R5
+
+## Comments addressed
+
+- CodeRabbit correctly identified that the internal evidence described all of
+  ENG-007 as inactive even though R5 recovery is active.
+- The stop condition now distinguishes active R5 recovery from inactive ENG-006
+  and inactive successor `WS-ENG-007-01`.
+
+## Comments deferred
+
+None.
+
+## Human decisions needed
+
+None. This is an evidence-wording correction only.
+
+## Commands rerun
+
+```bash
+python3 scripts/check_internal_review_evidence.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+git diff --check
+```
+
+## Remaining risks
+
+The updated exact PR head must pass all GitHub checks and the CodeRabbit thread
+must be resolved before human merge review.

--- a/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/reviews/WS-ENG-007-00R5-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/reviews/WS-ENG-007-00R5-internal-review-evidence.md
@@ -66,5 +66,5 @@ publish signed state before ENG-006 can start.
 
 ## Stop Condition
 
-Neither ENG-006 nor ENG-007 is active. R5 stops at `WS-ENG-007-01`, which still
-requires a separate explicit start.
+ENG-006 and `WS-ENG-007-01` are not active. R5 recovery is active and stops at
+`WS-ENG-007-01`, which still requires a separate explicit start.

--- a/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/reviews/WS-ENG-007-00R5-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/reviews/WS-ENG-007-00R5-internal-review-evidence.md
@@ -1,0 +1,70 @@
+# Internal Review Evidence: WS-ENG-007-00R5
+
+## Chunk
+
+`WS-ENG-007-00R5` — R4 Activation Recovery
+
+open sub-agent sessions: none
+
+valid findings addressed: yes
+
+## Reviewed Revision
+
+Reviewed code SHA: 10159497b3f3ca3464cbbbfd10f16945ade1879a
+
+Reviewed at: 2026-07-23T11:58:47Z
+
+The `/root/eng006_*` sessions were explicitly reassigned to this R5 recovery
+review. Every track is bound to the reviewed SHA above; session names grant no
+cross-initiative authority.
+
+Reviewer run IDs: senior-engineering=/root/eng006_senior_arch_docs; QA/test=/root/eng006_qa_ci_tests; security/auth=/root/eng006_security_ops_reuse; product/ops=/root/eng006_security_ops_reuse; architecture=/root/eng006_senior_arch_docs; docs=/root/eng006_senior_arch_docs; CI-integrity=/root/eng006_qa_ci_tests; reuse/dedup=/root/eng006_security_ops_reuse; test-delta=/root/eng006_qa_ci_tests
+
+## Reviewer Results
+
+| Reviewer | Result | Blocking findings | Notes |
+|---|---:|---|---|
+| senior engineering | PASS AFTER FIXES | None | Exact schema-v5 bridge and signed-basis binding accepted. |
+| QA/test | PASS AFTER FIXES | None | Mutable schema-v3 authority rejected; exact functional proof added. |
+| security/auth | PASS AFTER FIXES | None | Merge-bound evidence, consumption, and replay boundaries accepted. |
+| product/ops | PASS | None | No product behavior or automatic successor start. |
+| architecture | PASS AFTER FIXES | None | Minimal closed extension of the existing recovery reducer. |
+| CI integrity | PASS | None | 297 tests; updater 90.46 percent and checker 90.40 percent. |
+| docs | PASS AFTER FIXES | None | R1–R4 history and R5 live gate are consistent. |
+| reuse/dedup | PASS | None | No parallel workflow or recovery implementation. |
+| test delta | PASS AFTER FIXES | None | Exact R4→R5, wrong basis, consumption, replay, and CodeRabbit cases. |
+
+## Valid Findings Addressed
+
+- Rejected schema v3 because it re-queried mutable post-merge checks and made
+  CodeRabbit part of recovery authority.
+- Added schema v5 with an exact signed basis, exactly one recovered predecessor,
+  and persisted merge-bound `agent-gates` plus `test` evidence.
+- Added functional proof that CodeRabbit may be absent, mutable check validation
+  is never called, exemptions are consumed, replay is inert, and a wrong basis
+  fails closed.
+- Corrected authored lifecycle docs so reconciled R1–R3 history, merged R4, and
+  active R5 recovery do not conflict.
+
+## Commands Run
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q scripts/test_update_post_merge_memory.py scripts/test_check_loop_memory_state.py scripts/test_agent_gates.py
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -p pytest_cov.plugin -q --cov=scripts.update_post_merge_memory --cov-branch --cov-report=term --cov-fail-under=90 --cov-precision=2 scripts/test_agent_gates.py scripts/test_update_post_merge_memory.py scripts/test_check_loop_memory_state.py
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -p pytest_cov.plugin -q --cov=scripts.check_loop_memory_state --cov-branch --cov-report=term --cov-fail-under=90 --cov-precision=2 scripts/test_agent_gates.py scripts/test_update_post_merge_memory.py scripts/test_check_loop_memory_state.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/update_post_merge_memory.py validate-merge-intent --repository-root . --base-ref origin/main
+git diff --check
+```
+
+## Remaining Risks
+
+Any intervening `main` merge breaks exact adjacency and must fail closed. After
+R5 merges, the post-merge workflow—not this PR—must prove full consumption and
+publish signed state before ENG-006 can start.
+
+## Stop Condition
+
+Neither ENG-006 nor ENG-007 is active. R5 stops at `WS-ENG-007-01`, which still
+requires a separate explicit start.

--- a/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/reviews/WS-ENG-007-00R5-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ENG-007-concurrent-pr-review-reconciliation/reviews/WS-ENG-007-00R5-pr-trust-bundle.md
@@ -1,0 +1,44 @@
+# PR Trust Bundle: WS-ENG-007-00R5
+
+## Intent
+
+Reconcile exact merged R4 and activate its authority-projection repair without
+restoring mutable check authority or starting any successor.
+
+## Scope
+
+- Pin signed basis `a3eecadc…`.
+- Recover only PR #191 / R4 / `9bf16d47…`.
+- Activate only R5.
+- Require merge-bound `agent-gates` and `test` evidence for both records.
+- Consume both exemptions before signed publication.
+
+## Reviewed Revision
+
+`10159497b3f3ca3464cbbbfd10f16945ade1879a`
+
+## CI Integrity
+
+- 297 focused tests pass.
+- Updater branch coverage is 90.46 percent.
+- Independent-checker branch coverage is 90.40 percent.
+- No workflow, threshold, permission, required check, signed start, or human
+  merge checkpoint is weakened.
+
+## Reviewer Result
+
+All nine required internal tracks passed after rejecting the initial schema-v3
+approach. No Critical, High, or Medium finding remains open.
+
+## Human Review Focus
+
+- Confirm schema v5 requires exactly one recovered predecessor and exact signed
+  basis.
+- Confirm CodeRabbit is supplementary and mutable reruns are not authority.
+- Confirm exemptions are exact, adjacent, consumed, and non-replayable.
+- Confirm R5 stops and starts neither ENG-006 nor ENG-007-01.
+
+## Remaining Risk
+
+An intervening protected-main merge invalidates adjacency and must require a new
+reviewed certificate rather than reinterpretation.

--- a/.agent-loop/merge-intents/WS-ENG-007-00R5.json
+++ b/.agent-loop/merge-intents/WS-ENG-007-00R5.json
@@ -1,0 +1,9 @@
+{
+  "chunk_id": "WS-ENG-007-00R5",
+  "chunk_title": "R4 Activation Recovery",
+  "initiative_id": "WS-ENG-007",
+  "next_chunk_id": "WS-ENG-007-01",
+  "next_chunk_title": "Reviewed Patch and Base-Delta Reconciliation",
+  "next_requires_explicit_start": true,
+  "schema_version": 2
+}

--- a/.agent-loop/policies/loop-memory-recovery.json
+++ b/.agent-loop/policies/loop-memory-recovery.json
@@ -1,28 +1,16 @@
 {
   "activation": {
-    "chunk_id": "WS-ENG-007-00R3",
+    "chunk_id": "WS-ENG-007-00R5",
     "initiative_id": "WS-ENG-007"
   },
-  "signed_basis": "73b457925b02301587b83d01ced0adb66319d134",
+  "signed_basis": "a3eecadcf847ac70fc28c58dad642f2d761015e0",
   "recovered_merges": [
     {
-      "chunk_id": "WS-ENG-007-PLAN",
+      "chunk_id": "WS-ENG-007-00R4",
       "initiative_id": "WS-ENG-007",
-      "merge_sha": "8928ba80eeaf31e609dbdeda7d2cc22e9ea482c8",
-      "pr_number": 187
-    },
-    {
-      "chunk_id": "WS-ENG-007-00R1",
-      "initiative_id": "WS-ENG-007",
-      "merge_sha": "c65633f8f0991dbefe7b0635e053aab0df8f9af8",
-      "pr_number": 188
-    },
-    {
-      "chunk_id": "WS-ENG-007-00R2",
-      "initiative_id": "WS-ENG-007",
-      "merge_sha": "d3321698fb856f3fac320cdc7bc598f813fe1953",
-      "pr_number": 189
+      "merge_sha": "9bf16d478f669d48172810c83cdf6a7d2b8992ed",
+      "pr_number": 191
     }
   ],
-  "schema_version": 4
+  "schema_version": 5
 }

--- a/scripts/test_agent_gates.py
+++ b/scripts/test_agent_gates.py
@@ -2148,31 +2148,19 @@ def test_ws_eng_007_recovery_policy_is_exactly_pinned() -> None:
     policy = json.loads(Path(".agent-loop/policies/loop-memory-recovery.json").read_text())
     assert policy == {
         "activation": {
-            "chunk_id": "WS-ENG-007-00R3",
+            "chunk_id": "WS-ENG-007-00R5",
             "initiative_id": "WS-ENG-007",
         },
-        "signed_basis": "73b457925b02301587b83d01ced0adb66319d134",
+        "signed_basis": "a3eecadcf847ac70fc28c58dad642f2d761015e0",
         "recovered_merges": [
             {
-                "chunk_id": "WS-ENG-007-PLAN",
+                "chunk_id": "WS-ENG-007-00R4",
                 "initiative_id": "WS-ENG-007",
-                "merge_sha": "8928ba80eeaf31e609dbdeda7d2cc22e9ea482c8",
-                "pr_number": 187,
-            },
-            {
-                "chunk_id": "WS-ENG-007-00R1",
-                "initiative_id": "WS-ENG-007",
-                "merge_sha": "c65633f8f0991dbefe7b0635e053aab0df8f9af8",
-                "pr_number": 188,
-            },
-            {
-                "chunk_id": "WS-ENG-007-00R2",
-                "initiative_id": "WS-ENG-007",
-                "merge_sha": "d3321698fb856f3fac320cdc7bc598f813fe1953",
-                "pr_number": 189,
+                "merge_sha": "9bf16d478f669d48172810c83cdf6a7d2b8992ed",
+                "pr_number": 191,
             },
         ],
-        "schema_version": 4,
+        "schema_version": 5,
     }
 
 

--- a/scripts/test_update_post_merge_memory.py
+++ b/scripts/test_update_post_merge_memory.py
@@ -2038,6 +2038,109 @@ def _merge_bound_record() -> dict:
     return record
 
 
+def _set_merge_identity(
+    record: dict, *, chunk_id: str, pr_number: int, main_sha: str,
+    first_parent_sha: str, head_sha: str,
+) -> None:
+    record["source"].update(
+        main_sha=main_sha,
+        first_parent_sha=first_parent_sha,
+        head_sha=head_sha,
+        pr_number=pr_number,
+        pr_url=f"https://github.com/Flow-Research/workstream/pull/{pr_number}",
+        intent_path=f".agent-loop/merge-intents/{chunk_id}.json",
+    )
+    record["completed_chunk"].update(
+        initiative_id="WS-ENG-007",
+        chunk_id=chunk_id,
+        chunk_title=chunk_id,
+        next_chunk_id="WS-ENG-007-01",
+        next_chunk_title="Reviewed Patch and Base-Delta Reconciliation",
+    )
+    record["gate"].update(
+        next_chunk_id="WS-ENG-007-01",
+        next_chunk_title="Reviewed Patch and Base-Delta Reconciliation",
+    )
+    selected = record["protected_checks"]["selected"]
+    for item in selected.values():
+        item["head_sha"] = head_sha
+    record["protected_checks"]["sha256"] = loop.hashlib.sha256(
+        loop._canonical_json(selected).encode()
+    ).hexdigest()
+    record["checks"]["required"]["CodeRabbit"] = {
+        "kind": "missing", "conclusion": None, "url": None,
+    }
+    record["checks"]["all_required_passed"] = False
+
+
+def test_prepare_recovery_v5_uses_merge_bound_evidence_and_consumes_exact_r4(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_root = tmp_path / "state"
+    base = _record()
+    base["source"]["main_sha"] = "a" * 40
+    loop.apply_merge_record(state_root, base)
+    recovered = _merge_bound_record()
+    target = _merge_bound_record()
+    _set_merge_identity(
+        recovered, chunk_id="WS-ENG-007-00R4", pr_number=191,
+        main_sha="c" * 40, first_parent_sha="a" * 40, head_sha="4" * 40,
+    )
+    _set_merge_identity(
+        target, chunk_id="WS-ENG-007-00R5", pr_number=192,
+        main_sha="d" * 40, first_parent_sha="c" * 40, head_sha="5" * 40,
+    )
+    policy = {
+        "schema_version": 5,
+        "signed_basis": "a" * 40,
+        "activation": {
+            "initiative_id": "WS-ENG-007", "chunk_id": "WS-ENG-007-00R5",
+        },
+        "recovered_merges": [{
+            "initiative_id": "WS-ENG-007", "chunk_id": "WS-ENG-007-00R4",
+            "pr_number": 191, "merge_sha": "c" * 40,
+        }],
+    }
+    records = {"c" * 40: recovered, "d" * 40: target}
+    monkeypatch.setattr(loop, "_load_json_at_commit", lambda *_args: policy)
+    monkeypatch.setattr(
+        loop, "collect_merge_record",
+        lambda _client, _repository, sha: json.loads(json.dumps(records[sha])),
+    )
+    monkeypatch.setattr(
+        loop, "_validate_protected_actions_checks",
+        lambda *_args: pytest.fail("schema-v5 must not query mutable check authority"),
+    )
+
+    exemptions = loop.prepare_recovery_exemptions(
+        object(), "Flow-Research/workstream", repository_root=tmp_path,
+        state_root=state_root, target_sha="d" * 40,
+        planned_shas=["c" * 40, "d" * 40],
+    )
+    assert [item["chunk_id"] for item in exemptions] == [
+        "WS-ENG-007-00R4", "WS-ENG-007-00R5",
+    ]
+    assert loop.apply_merge_record(state_root, recovered, exemptions)
+    assert loop.apply_merge_record(state_root, target, exemptions)
+    loop.assert_recovery_consumed(state_root, "d" * 40, exemptions)
+    assert loop.prepare_recovery_exemptions(
+        object(), "Flow-Research/workstream", repository_root=tmp_path,
+        state_root=state_root, target_sha="d" * 40, planned_shas=[],
+    ) == []
+
+    wrong_basis = json.loads(json.dumps(policy))
+    wrong_basis["signed_basis"] = "b" * 40
+    monkeypatch.setattr(loop, "_load_json_at_commit", lambda *_args: wrong_basis)
+    fresh = tmp_path / "wrong-basis"
+    loop.apply_merge_record(fresh, base)
+    with pytest.raises(loop.LoopMemoryError, match="signed basis"):
+        loop.prepare_recovery_exemptions(
+            object(), "Flow-Research/workstream", repository_root=tmp_path,
+            state_root=fresh, target_sha="d" * 40,
+            planned_shas=["c" * 40, "d" * 40],
+        )
+
+
 def _cross_initiative_merge_bound_state(tmp_path: Path) -> tuple[Path, Path]:
     state_root, repository_root = tmp_path / "state", tmp_path / "repo"
     _contract(repository_root)
@@ -2195,7 +2298,20 @@ def test_protected_selector_rejects_eligible_provenance_mutations(mutation, mess
 
 
 def test_recovery_policy_v4_rejects_closed_schema_mutations() -> None:
-    policy = json.loads((Path(__file__).parents[1] / ".agent-loop/policies/loop-memory-recovery.json").read_text())
+    policy = {
+        "schema_version": 4,
+        "signed_basis": "a" * 40,
+        "activation": {
+            "initiative_id": "WS-ENG-007", "chunk_id": "WS-ENG-007-00R5",
+        },
+        "recovered_merges": [
+            {
+                "initiative_id": "WS-ENG-007", "chunk_id": f"WS-ENG-007-00R{index}",
+                "pr_number": 186 + index, "merge_sha": str(index) * 40,
+            }
+            for index in range(1, 4)
+        ],
+    }
     assert loop._validate_recovery_policy(policy) == policy
     mutations = []
     bad = json.loads(json.dumps(policy)); bad["signed_basis"] = "bad"; mutations.append(bad)

--- a/scripts/update_post_merge_memory.py
+++ b/scripts/update_post_merge_memory.py
@@ -2291,11 +2291,12 @@ def _validate_recovery_policy(payload: Any) -> dict[str, Any]:
         2: {"schema_version", "activation", "mode"},
         3: {"schema_version", "activation", "recovered_merges"},
         4: {"schema_version", "signed_basis", "activation", "recovered_merges"},
+        5: {"schema_version", "signed_basis", "activation", "recovered_merges"},
     }.get(version, set())
     if set(payload) != expected:
         raise LoopMemoryError("recovery policy has an invalid schema")
     activation = payload.get("activation")
-    if version not in {1, 2, 3, 4} or not isinstance(activation, dict):
+    if version not in {1, 2, 3, 4, 5} or not isinstance(activation, dict):
         raise LoopMemoryError("recovery policy is unsupported")
     if set(activation) != {"initiative_id", "chunk_id"} or not _is_valid_exemption_id(
         activation.get("initiative_id"), activation.get("chunk_id")
@@ -2305,12 +2306,17 @@ def _validate_recovery_policy(payload: Any) -> dict[str, Any]:
         if payload.get("mode") != "exact_single_target":
             raise LoopMemoryError("recovery policy mode is unsupported")
         return json.loads(_canonical_json(payload))
-    if version in {3, 4}:
+    if version in {3, 4, 5}:
         recovered_merges = payload.get("recovered_merges")
-        valid_length = (1 <= len(recovered_merges) <= 2) if isinstance(recovered_merges, list) and version == 3 else (isinstance(recovered_merges, list) and len(recovered_merges) == 3)
+        valid_length = (
+            1 <= len(recovered_merges) <= 2
+            if isinstance(recovered_merges, list) and version == 3
+            else isinstance(recovered_merges, list)
+            and len(recovered_merges) == (3 if version == 4 else 1)
+        )
         if not valid_length:
             raise LoopMemoryError("recovered merge inventory is invalid")
-        if version == 4:
+        if version in {4, 5}:
             _validate_sha(payload.get("signed_basis"))
         chunk_identities: set[tuple[str, str]] = set()
         pr_numbers: set[int] = set()
@@ -2424,7 +2430,7 @@ def prepare_recovery_exemptions(
         if not isinstance(existing, list) or exemption in existing:
             raise LoopMemoryError("recovery exemption collides with signed state")
         return [exemption]
-    if policy["schema_version"] in {3, 4}:
+    if policy["schema_version"] in {3, 4, 5}:
         recovered_policies = policy["recovered_merges"]
         expected_shas = [item["merge_sha"] for item in recovered_policies] + [target_sha]
         if planned_shas != expected_shas:
@@ -2451,7 +2457,7 @@ def prepare_recovery_exemptions(
             if _event_type(state) in {"start", "cancel"}
             else state.get("source", {}).get("main_sha")
         )
-        if policy["schema_version"] == 4 and signed_main != policy["signed_basis"]:
+        if policy["schema_version"] in {4, 5} and signed_main != policy["signed_basis"]:
             raise LoopMemoryError("recovery signed basis does not match canonical state")
         records = [*recovered_records, target_record]
         expected_parent = signed_main


### PR DESCRIPTION
# PR Trust Bundle: WS-ENG-007-00R5

## Intent

Reconcile exact merged R4 and activate its authority-projection repair without
restoring mutable check authority or starting any successor.

## Scope

- Pin signed basis `a3eecadc…`.
- Recover only PR #191 / R4 / `9bf16d47…`.
- Activate only R5.
- Require merge-bound `agent-gates` and `test` evidence for both records.
- Consume both exemptions before signed publication.

## Reviewed Revision

`10159497b3f3ca3464cbbbfd10f16945ade1879a`

## CI Integrity

- 297 focused tests pass.
- Updater branch coverage is 90.46 percent.
- Independent-checker branch coverage is 90.40 percent.
- No workflow, threshold, permission, required check, signed start, or human
  merge checkpoint is weakened.

## Reviewer Result

All nine required internal tracks passed after rejecting the initial schema-v3
approach. No Critical, High, or Medium finding remains open.

## Human Review Focus

- Confirm schema v5 requires exactly one recovered predecessor and exact signed
  basis.
- Confirm CodeRabbit is supplementary and mutable reruns are not authority.
- Confirm exemptions are exact, adjacent, consumed, and non-replayable.
- Confirm R5 stops and starts neither ENG-006 nor ENG-007-01.

## Remaining Risk

An intervening protected-main merge invalidates adjacency and must require a new
reviewed certificate rather than reinterpretation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery handling for the R4 activation scenario, including exact predecessor and merge evidence validation.
  * Added schema version 5 support for signed recovery policies and merge-bound recovery records.
  * Added safeguards to consume recovery exemptions exactly once and reject mismatched recovery bases.
  * Added configuration for the next recovery step, requiring explicit activation.

* **Documentation**
  * Updated recovery plans, status tracking, review evidence, trust documentation, and acceptance criteria.

* **Tests**
  * Added regression coverage for schema validation, evidence matching, exemption consumption, and replay protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->