### PR TITLE
feat(auth): add project role grant mutations

### DIFF
--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -2844,3 +2844,17 @@ inline finding. Its unexplained 37.61 percent docstring warning is
 non-actionable because the unchanged repository gate independently passes the
 same head at 87.6 percent against the 80 percent floor. Human review and
 explicit approval of PR #178 remain.
+
+## 2026-07-23 - WS-AUTH-001-10C Internal Implementation Review
+
+AUTH-10C exact implementation SHA
+`0d05b7096eb7a2cf7c68a1770c0b35f07d5b55df` activates the two
+Project-Manager-only project-role mutations with PREP-bound lexical principal
+locking, deterministic absence serialization, strict replay, immutable
+qualification evidence, lifecycle-independent revoke, and typed invalidation.
+The repair loop closed real named-index fallback and residue, lifecycle
+attribution, database-observed cancellation rollback, committed same-key retry,
+and crossed-principal ordering proof. Senior engineering, architecture,
+reuse/dedup, security/auth, QA/test, test delta, product/ops, docs, and CI
+integrity all pass with no open finding. GitHub full CI/coverage, hosted API E2E,
+CodeRabbit, and human review remain.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -2861,6 +2861,9 @@ CodeRabbit, and human review remain.
 
 ## 2026-07-24 - WS-AUTH-001-10C Migration And External Review Repair
 
+Repaired implementation SHA:
+`bb08fc8f2fba902b926c2ce7feff8369b1c2f80d`.
+
 AUTH-10C now includes migration 0034 with frozen predecessor/forward evidence
 definitions, exact issue-event ordering, and actor/grant/target-bound revoke
 invalidation. Internal repair closed definition drift, incompatible pending
@@ -2868,5 +2871,8 @@ state, downgrade refusal, concealment/zero-mutation, project lifecycle, and
 linked-target proof gaps. CodeRabbit identified a valid qualification-reference
 coercion concern; field-level strict token and canonical UUID admission preserve
 valid FastAPI JSON while rejecting numeric and byte coercion. The PR body and
-review provenance were refreshed. All nine internal tracks pass the repaired
-tree; fresh GitHub Backend, Agent Gates, CodeRabbit, and human review remain.
+review provenance were refreshed. The final CodeRabbit repair also closed the
+SQL-NULL facts bypass, made trigger-fixture restoration exception-safe, bounded
+lock polling, corrected the exact constraint drop, and repaired the intended
+request-binding test path. All nine internal tracks pass the repaired tree;
+fresh GitHub Backend, Agent Gates, CodeRabbit, and human review remain.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -2858,3 +2858,15 @@ and crossed-principal ordering proof. Senior engineering, architecture,
 reuse/dedup, security/auth, QA/test, test delta, product/ops, docs, and CI
 integrity all pass with no open finding. GitHub full CI/coverage, hosted API E2E,
 CodeRabbit, and human review remain.
+
+## 2026-07-24 - WS-AUTH-001-10C Migration And External Review Repair
+
+AUTH-10C now includes migration 0034 with frozen predecessor/forward evidence
+definitions, exact issue-event ordering, and actor/grant/target-bound revoke
+invalidation. Internal repair closed definition drift, incompatible pending
+state, downgrade refusal, concealment/zero-mutation, project lifecycle, and
+linked-target proof gaps. CodeRabbit identified a valid qualification-reference
+coercion concern; field-level strict token and canonical UUID admission preserve
+valid FastAPI JSON while rejecting numeric and byte coercion. The PR body and
+review provenance were refreshed. All nine internal tracks pass the repaired
+tree; fresh GitHub Backend, Agent Gates, CodeRabbit, and human review remain.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -2862,7 +2862,7 @@ CodeRabbit, and human review remain.
 ## 2026-07-24 - WS-AUTH-001-10C Migration And External Review Repair
 
 Repaired implementation SHA:
-`8aa0be94252f0c7f0753b036192007cb9f357586`.
+`84c94a9697ee34d75697f4de274df9e8ded4ecdd`.
 
 AUTH-10C now includes migration 0034 with frozen predecessor/forward evidence
 definitions, exact issue-event ordering, and actor/grant/target-bound revoke
@@ -2879,5 +2879,7 @@ request-binding test path. Hosted API E2E then exposed and closed a stale
 comparison that included per-request correlation metadata. All nine internal
 tracks pass the repaired tree; the final assertion excludes only
 `correlation_id` and preserves equality for code, message, details, and
-retryability.
+retryability. Full GitHub shards then exposed and closed a stale linked-event
+matrix classification plus legacy-fixture trigger/constraint cleanup residue;
+the exact isolated audit case and sequential upgrade/downgrade matrices pass.
 fresh GitHub Backend, Agent Gates, CodeRabbit, and human review remain.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -2862,7 +2862,7 @@ CodeRabbit, and human review remain.
 ## 2026-07-24 - WS-AUTH-001-10C Migration And External Review Repair
 
 Repaired implementation SHA:
-`cee9ead16cb1dafd18b57d08c0209fdbdeacd251`.
+`8aa0be94252f0c7f0753b036192007cb9f357586`.
 
 AUTH-10C now includes migration 0034 with frozen predecessor/forward evidence
 definitions, exact issue-event ordering, and actor/grant/target-bound revoke
@@ -2877,5 +2877,7 @@ lock polling, corrected the exact constraint drop, and repaired the intended
 request-binding test path. Hosted API E2E then exposed and closed a stale
 `id`/`identity_link_id` script reference and an unstable whole-error-envelope
 comparison that included per-request correlation metadata. All nine internal
-tracks pass the repaired tree;
+tracks pass the repaired tree; the final assertion excludes only
+`correlation_id` and preserves equality for code, message, details, and
+retryability.
 fresh GitHub Backend, Agent Gates, CodeRabbit, and human review remain.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -2862,7 +2862,7 @@ CodeRabbit, and human review remain.
 ## 2026-07-24 - WS-AUTH-001-10C Migration And External Review Repair
 
 Repaired implementation SHA:
-`bb08fc8f2fba902b926c2ce7feff8369b1c2f80d`.
+`c90e660f23097cb5016001ba779b0ebeb3faf0aa`.
 
 AUTH-10C now includes migration 0034 with frozen predecessor/forward evidence
 definitions, exact issue-event ordering, and actor/grant/target-bound revoke
@@ -2874,5 +2874,7 @@ valid FastAPI JSON while rejecting numeric and byte coercion. The PR body and
 review provenance were refreshed. The final CodeRabbit repair also closed the
 SQL-NULL facts bypass, made trigger-fixture restoration exception-safe, bounded
 lock polling, corrected the exact constraint drop, and repaired the intended
-request-binding test path. All nine internal tracks pass the repaired tree;
+request-binding test path. Hosted API E2E then exposed and closed a stale
+`id`/`identity_link_id` script reference before publication. All nine internal
+tracks pass the repaired tree;
 fresh GitHub Backend, Agent Gates, CodeRabbit, and human review remain.

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -2862,7 +2862,7 @@ CodeRabbit, and human review remain.
 ## 2026-07-24 - WS-AUTH-001-10C Migration And External Review Repair
 
 Repaired implementation SHA:
-`c90e660f23097cb5016001ba779b0ebeb3faf0aa`.
+`cee9ead16cb1dafd18b57d08c0209fdbdeacd251`.
 
 AUTH-10C now includes migration 0034 with frozen predecessor/forward evidence
 definitions, exact issue-event ordering, and actor/grant/target-bound revoke
@@ -2875,6 +2875,7 @@ review provenance were refreshed. The final CodeRabbit repair also closed the
 SQL-NULL facts bypass, made trigger-fixture restoration exception-safe, bounded
 lock polling, corrected the exact constraint drop, and repaired the intended
 request-binding test path. Hosted API E2E then exposed and closed a stale
-`id`/`identity_link_id` script reference before publication. All nine internal
+`id`/`identity_link_id` script reference and an unstable whole-error-envelope
+comparison that included per-request correlation metadata. All nine internal
 tracks pass the repaired tree;
 fresh GitHub Backend, Agent Gates, CodeRabbit, and human review remain.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
@@ -47,12 +47,20 @@ backend/tests/test_authorization.py
 backend/tests/test_api_controls.py
 backend/tests/test_projects.py
 backend/scripts/api_contract_e2e.py
+backend/pyproject.toml
 docs/operations_authorization_service.md
 docs/spec_authorization_service.md
 .agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/**
 .agent-loop/merge-intents/WS-AUTH-001-10C.json
 .agent-loop/REVIEW_LOG.md
 ```
+
+`backend/pyproject.toml` is allowed only for the bounded integration repair
+that caps Ruff below 0.16. GitHub resolved the previously open `<1.0` range to
+Ruff 0.16.0 on 2026-07-24, which introduced 381 repository-wide lint findings
+outside AUTH-10C. This chunk must not mass-rewrite unrelated subsystems; it
+retains the last repository-compatible minor line until a dedicated lint
+adoption change reviews the new rules.
 
 ## Not allowed changes
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
@@ -35,6 +35,7 @@ P1
 ```text
 backend/app/modules/actors/repository.py
 backend/app/modules/authorization/**
+backend/app/modules/audit/schemas.py
 backend/app/modules/projects/repository.py
 backend/app/api/router.py
 backend/tests/test_actors.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
@@ -37,6 +37,9 @@ backend/app/modules/actors/repository.py
 backend/app/modules/authorization/**
 backend/app/modules/audit/schemas.py
 backend/alembic/versions/0034_project_role_issue_evidence.py
+backend/tests/conftest.py
+backend/tests/test_alembic.py
+backend/tests/test_audit.py
 backend/app/modules/projects/repository.py
 backend/app/api/router.py
 backend/tests/test_actors.py
@@ -204,18 +207,50 @@ The existing database idempotency completion guard predates the 10A evidence
 shape and requires one success plus one invalidation for every operation. That
 would either reject 10C issue or force a false invalidation. Migration 0034 is
 therefore the sole permitted durable change in this chunk. It replaces only the
-idempotency completion guard so `project_role_grant.issue` requires exactly two
-ordered non-invalidation events —
+exact bodies of `guard_authority_idempotency_record()` and
+`validate_linked_authority_event()`, and extends only the existing audit privacy
+check constraint's resource registry with `qualification_snapshot`, so
+`project_role_grant.issue` requires exactly two non-invalidation events —
 `ProjectRoleQualificationSnapshotCaptured` followed by
 `ProjectRoleGrantIssued` — with the qualification event bound to the same
-idempotency record, request/correlation pair, actor, permission, project, and
-issued-grant resource. It requires zero invalidations for issue. Every other
-operation retains the existing exactly-one-success plus exactly-one-invalidation
-rule. Upgrade refuses unexpected installed function/trigger definitions and
-pre-existing incompatible pending/committed project-role issue evidence without
-changing data. Downgrade refuses any committed 10C issue record or new evidence
-shape that the prior guard cannot represent, then restores the exact prior
-function. No table, column, index, enum, or product row changes are permitted.
+idempotency record, request/correlation pair, actor, permission, project, target
+actor, and matched Project Manager grant. The qualification event's
+entity/resource/target kind and ID are exactly its snapshot ID. The issued event's
+entity/resource/target are exactly the response grant ID. The linked-event guard
+admits qualification capture only for a pending issue record with no prior linked
+event, and admits grant-issued only after exactly one matching qualification
+event exists; it rejects reversed, duplicate, extra, cross-record, cross-request,
+cross-correlation, cross-actor, cross-permission, cross-project, cross-target,
+cross-manager, or false-invalidation shapes. Application tests prove writer call
+order; the durable schema claims exact cardinality and predecessor presence, not
+a total order derived from timestamp or UUID. Completion additionally requires
+the persisted grant's qualification snapshot, project, actor, and role tuple to
+match the persisted snapshot and request tuple. It requires zero invalidations
+for issue.
+
+Every other operation retains the exact existing success-event allowlist,
+response resource/type/status/version binding, one success plus one invalidation,
+invalidation cause pointing to that success, actor/project/permission/request/
+correlation/idempotency linkage, target projection, and before/after predicates.
+
+Migration 0034 has `down_revision = "0033_authorization_read_rate"`. Upgrade and
+downgrade lock `authority_idempotency_records` then `audit_events`, both in
+`ACCESS EXCLUSIVE` mode, before definition or row inspection and retain those
+locks through replacement. They require frozen predecessor/forward hashes for
+both functions, the `authority_idempotency_guard` and
+`audit_events_validate_idempotency` trigger names, enabled state, timing, event,
+table, function attachment, non-deferrability, and the exact privacy constraint
+definition. Upgrade permits a pending project-role issue only when it has zero
+linked evidence and all response fields are null. It refuses every committed
+issue record, every other pending issue shape, linked orphan/mixed/cross-record
+issue evidence, and any definition/binding drift. Downgrade refuses every
+committed issue record, any linked qualification event, any zero-invalidation
+issue shape, and any pending evidence/response shape the predecessor cannot
+represent. Each refusal is transactional and leaves Alembic head, both function
+and trigger hashes/bindings, the privacy constraint, and all rows unchanged.
+Empty safe downgrade restores the exact predecessor definitions; re-upgrade is
+deterministic. No table, column, index, enum, trigger identity, or product row
+change is permitted beyond those two function bodies and one registry member.
 
 ## Acceptance criteria
 
@@ -250,10 +285,15 @@ function. No table, column, index, enum, or product row changes are permitted.
   concurrently.
 - Cancellation and injected failure at snapshot, grant, idempotency, audit,
   invalidation, flush, and commit leave no orphan row or partial evidence.
-- Migration 0034 proves exact upgrade/downgrade function replacement, strict
+- Migration 0034 proves exact upgrade/downgrade function/constraint replacement, strict
   refusal/no-mutation on unexpected definitions and incompatible evidence,
-  two linked issue events with zero invalidation, and unchanged one-success/
-  one-invalidation enforcement for every other authority operation.
+  two linked issue events with zero invalidation, and unchanged per-operation
+  success/invalidation enforcement for every other authority operation. Focused
+  Alembic tests cover prior-head upgrade, fresh head, safe downgrade/re-upgrade,
+  each definition/trigger/constraint drift, each incompatible evidence predicate
+  alone and combined, transactional no-mutation snapshots, concurrent writer
+  races, wrong/reversed/extra/cross-linked issue events, false invalidation, and
+  a parameterized regression over every non-issue authority operation.
 - PostgreSQL tests cover identical-role issue, different-role issue, crossed
   managers, revoke versus regrant, revoke versus authorization, replay after
   authority loss, timeout, and cancellation. PostgreSQL and API tests also
@@ -299,7 +339,8 @@ function. No table, column, index, enum, or product row changes are permitted.
   remains complementary local proof, not a substitute for the hosted drill.
 - Regenerate exact combined route/protected-operation counts and SHA-256
   inventories from current main after adding the two routes; never guess or
-  replace exact hashes with count-only assertions. No migration, configuration,
+  replace exact hashes with count-only assertions. No migration other than exact
+  0034, configuration,
   workflow, pytest marker, skip/xfail, command, or coverage-threshold change is
   allowed. GitHub must pass all shards, hosted E2E, Agent Gates, the 78 percent
   repository floor, and the 90 percent authorization-subsystem floor.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
@@ -47,7 +47,6 @@ backend/tests/test_authorization.py
 backend/tests/test_api_controls.py
 backend/tests/test_projects.py
 backend/scripts/api_contract_e2e.py
-backend/scripts/auth_api_e2e.py
 docs/operations_authorization_service.md
 docs/spec_authorization_service.md
 .agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/**
@@ -58,7 +57,7 @@ docs/spec_authorization_service.md
 ## Not allowed changes
 
 ```text
-durable schema changes other than the exact 0034 idempotency-evidence trigger repair below
+durable schema changes other than the exact 0034 idempotency/evidence/fact-validator repair below
 read/candidate surface redesign
 task assignment or review reconciliation implementation
 admin/service/project-role authority substitution
@@ -207,9 +206,10 @@ The existing database idempotency completion guard predates the 10A evidence
 shape and requires one success plus one invalidation for every operation. That
 would either reject 10C issue or force a false invalidation. Migration 0034 is
 therefore the sole permitted durable change in this chunk. It replaces only the
-exact bodies of `guard_authority_idempotency_record()` and
-`validate_linked_authority_event()`, and extends only the existing audit privacy
-check constraint's resource registry with `qualification_snapshot`, so
+exact bodies of `guard_authority_idempotency_record()`,
+`validate_linked_authority_event()`, and `authority_event_facts_are_safe()`, and
+extends only the existing audit privacy check constraint's resource registry
+with `qualification_snapshot`, so
 `project_role_grant.issue` requires exactly two non-invalidation events —
 `ProjectRoleQualificationSnapshotCaptured` followed by
 `ProjectRoleGrantIssued` — with the qualification event bound to the same
@@ -231,6 +231,29 @@ correlation ID linkage. The application `AuthorityMutationService` remains
 solely responsible for proving those envelopes against the canonical request
 digest stored by idempotency. Issue requires zero invalidations.
 
+The predecessor `authority_event_facts_are_safe()` admits only the two-key
+`{"effective": true}` to `{"effective": false}` invalidation shape. That shape
+cannot carry AUTH-10C's required role-specific future-obligation projection.
+Migration 0034 therefore changes only its
+`AuthorityInvalidationRequested` branch: non-project-role-revoke operations
+retain the exact predecessor two-key shape, while a linked
+`project_role_grant.revoke` event admits exactly five keys — `effective`,
+`role`, `scope_type`, `scope_id`, and `future_obligation`. Before and after must
+match on every value except `effective`; `scope_type` is exactly `project`,
+`scope_id` equals the envelope project ID, and the closed mapping is submitter
+to `auth13_assignment`, reviewer to `rev_reviewer_obligation`, and adjudicator
+to `none`. `effective` values are JSON booleans and every other value is a JSON
+string; nulls, coercion, arrays, objects, missing keys, and extra keys reject.
+Because this fact validator receives no operation or idempotency context, it
+only admits the exact richer JSON shape. The linked-event validator exclusively
+restricts that shape to a linked `project_role_grant.revoke` and preserves all
+existing cause, request/correlation, actor, permission, project, target,
+matched-grant, idempotency, and resource linkage. No generic additional fact
+key or obligation value is admitted. The existing
+`ck_audit_events_fact_bounds` constraint remains in place and continues to call
+this validator; it is not dropped or recreated. Migration custody does not
+extend to `authority_facts_are_safe()`.
+
 Every other operation retains the exact existing success-event allowlist,
 response resource/type/status/version binding, one success plus one invalidation,
 invalidation cause pointing to that success, actor/project/permission/request/
@@ -240,20 +263,26 @@ Migration 0034 has `down_revision = "0033_authorization_read_rate"`. Upgrade and
 downgrade lock `authority_idempotency_records` then `audit_events`, both in
 `ACCESS EXCLUSIVE` mode, before definition or row inspection and retain those
 locks through replacement. They require frozen predecessor/forward hashes for
-both functions, the `authority_idempotency_guard` and
+all three functions, the `authority_idempotency_guard` and
 `audit_events_validate_idempotency` trigger names, enabled state, timing, event,
-table, function attachment, non-deferrability, and the exact privacy constraint
-definition. Upgrade permits a pending project-role issue only when it has zero
+table, function attachment, non-deferrability, the exact privacy constraint
+definition, and the exact definition, table attachment, validated state, and
+`authority_event_facts_are_safe()` call of `ck_audit_events_fact_bounds`.
+Upgrade permits a pending project-role issue only when it has zero
 linked evidence and all response fields are null. It refuses every committed
 issue record, every other pending issue shape, linked orphan/mixed/cross-record
 issue evidence, and any definition/binding drift. Downgrade refuses every
 committed issue record, any linked qualification event, any zero-invalidation
-issue shape, and any pending evidence/response shape the predecessor cannot
-represent. Each refusal is transactional and leaves Alembic head, both function
-and trigger hashes/bindings, the privacy constraint, and all rows unchanged.
+issue shape, every five-key project-role revoke invalidation including orphan,
+mixed, or cross-record shapes, and any pending or committed evidence/response
+shape the predecessor cannot represent. Predecessor-compatible two-key revoke
+invalidation evidence may remain when otherwise valid. Each refusal is
+transactional and leaves Alembic head, all three function and trigger
+hashes/bindings, both frozen constraint definitions/states, and all rows
+unchanged.
 Empty safe downgrade restores the exact predecessor definitions; re-upgrade is
 deterministic. No table, column, index, enum, trigger identity, or product row
-change is permitted beyond those two function bodies and one registry member.
+change is permitted beyond those three function bodies and one registry member.
 
 ## Acceptance criteria
 
@@ -291,7 +320,14 @@ change is permitted beyond those two function bodies and one registry member.
 - Migration 0034 proves exact upgrade/downgrade function/constraint replacement, strict
   refusal/no-mutation on unexpected definitions and incompatible evidence,
   two linked issue events with zero invalidation, and unchanged per-operation
-  success/invalidation enforcement for every other authority operation. Focused
+  success/invalidation enforcement for every other authority operation. It also
+  proves the exact five-key project-role revoke invalidation fact shape, all
+  three closed role-to-obligation mappings, rejection of missing/extra/wrong
+  fact keys and values, and unchanged two-key invalidation facts for every
+  non-project-role-revoke operation. It independently tests missing, changed,
+  detached, unvalidated, or differently bound `ck_audit_events_fact_bounds`
+  and proves every refusal leaves the revision, three functions, constraints,
+  triggers, and product/evidence rows unchanged. Focused
   Alembic tests cover prior-head upgrade, fresh head, safe downgrade/re-upgrade,
   each definition/trigger/constraint drift, each incompatible evidence predicate
   alone and combined, transactional no-mutation snapshots, concurrent writer
@@ -338,8 +374,7 @@ change is permitted beyond those two function bodies and one registry member.
   public APIs with unexpired tokens and no direct database edits. The same
   manager token proves issue -> 10B active read -> revoke -> 10B historical
   read -> same-key revoke replay 200 -> new-key revoke 409 -> old issue replay
-  409, plus concealed denial after manager authority loss. `auth_api_e2e.py`
-  remains complementary local proof, not a substitute for the hosted drill.
+  409, plus concealed denial after manager authority loss.
 - Regenerate exact combined route/protected-operation counts and SHA-256
   inventories from current main after adding the two routes; never guess or
   replace exact hashes with count-only assertions. No migration other than exact
@@ -351,10 +386,9 @@ change is permitted beyond those two function bodies and one registry member.
 ## Verification commands
 
 ```bash
-(cd backend && .venv/bin/python -m ruff check alembic/versions/0034_project_role_issue_evidence.py app/modules/actors app/modules/authorization app/modules/projects tests/conftest.py tests/test_actors.py tests/test_alembic.py tests/test_audit.py tests/test_authorization.py tests/test_api_controls.py tests/test_projects.py scripts/auth_api_e2e.py scripts/api_contract_e2e.py)
+(cd backend && .venv/bin/python -m ruff check alembic/versions/0034_project_role_issue_evidence.py app/modules/actors app/modules/authorization app/modules/projects tests/conftest.py tests/test_actors.py tests/test_alembic.py tests/test_audit.py tests/test_authorization.py tests/test_api_controls.py tests/test_projects.py scripts/api_contract_e2e.py)
 (cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python scripts/run_isolated_tests.py --metadata-json <path> --timeout-seconds 600 -- .venv/bin/python -m pytest -q tests/test_alembic.py tests/test_audit.py -k '0034 or project_role_issue_evidence or action_aware_audit')
-(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python scripts/run_isolated_tests.py --metadata-json <path> --timeout-seconds 300 -- .venv/bin/python -m pytest -q tests/test_actors.py tests/test_authorization.py tests/test_projects.py -k 'project_role_grant')
-(cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/auth_api_e2e.py)
+(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python scripts/run_isolated_tests.py --metadata-json <path> --timeout-seconds 300 -- .venv/bin/python -m pytest -q tests/test_actors.py tests/test_authorization.py tests/test_api_controls.py tests/test_projects.py -k 'project_role or auth10c')
 python3 scripts/check_stale_authorization_docs.py
 python3 scripts/check_markdown_links.py
 git diff --check
@@ -362,6 +396,10 @@ git diff --check
 
 GitHub owns the full sharded suite, aggregate and authorization coverage, API
 E2E, and Agent Gates before PR readiness.
+
+Every new migration, fact-validator, constraint-drift, and refusal test in this
+chunk must include `0034` or `project_role_issue_evidence` in its test name so
+the focused selector above cannot omit required proof.
 
 ## Required reviewers
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
@@ -225,8 +225,11 @@ cross-manager, or false-invalidation shapes. Application tests prove writer call
 order; the durable schema claims exact cardinality and predecessor presence, not
 a total order derived from timestamp or UUID. Completion additionally requires
 the persisted grant's qualification snapshot, project, actor, and role tuple to
-match the persisted snapshot and request tuple. It requires zero invalidations
-for issue.
+match the persisted snapshot and the two audit envelopes. The database proves
+their project, target actor, role facts, matched manager, claim, request ID, and
+correlation ID linkage. The application `AuthorityMutationService` remains
+solely responsible for proving those envelopes against the canonical request
+digest stored by idempotency. Issue requires zero invalidations.
 
 Every other operation retains the exact existing success-event allowlist,
 response resource/type/status/version binding, one success plus one invalidation,
@@ -348,7 +351,8 @@ change is permitted beyond those two function bodies and one registry member.
 ## Verification commands
 
 ```bash
-(cd backend && .venv/bin/python -m ruff check app/modules/actors app/modules/authorization app/modules/projects tests/test_actors.py tests/test_authorization.py tests/test_api_controls.py tests/test_projects.py scripts/auth_api_e2e.py scripts/api_contract_e2e.py)
+(cd backend && .venv/bin/python -m ruff check alembic/versions/0034_project_role_issue_evidence.py app/modules/actors app/modules/authorization app/modules/projects tests/conftest.py tests/test_actors.py tests/test_alembic.py tests/test_audit.py tests/test_authorization.py tests/test_api_controls.py tests/test_projects.py scripts/auth_api_e2e.py scripts/api_contract_e2e.py)
+(cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python scripts/run_isolated_tests.py --metadata-json <path> --timeout-seconds 600 -- .venv/bin/python -m pytest -q tests/test_alembic.py tests/test_audit.py -k '0034 or project_role_issue_evidence or action_aware_audit')
 (cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python scripts/run_isolated_tests.py --metadata-json <path> --timeout-seconds 300 -- .venv/bin/python -m pytest -q tests/test_actors.py tests/test_authorization.py tests/test_projects.py -k 'project_role_grant')
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/auth_api_e2e.py)
 python3 scripts/check_stale_authorization_docs.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
@@ -36,6 +36,7 @@ P1
 backend/app/modules/actors/repository.py
 backend/app/modules/authorization/**
 backend/app/modules/audit/schemas.py
+backend/alembic/versions/0034_project_role_issue_evidence.py
 backend/app/modules/projects/repository.py
 backend/app/api/router.py
 backend/tests/test_actors.py
@@ -54,7 +55,7 @@ docs/spec_authorization_service.md
 ## Not allowed changes
 
 ```text
-migration or durable schema changes
+durable schema changes other than the exact 0034 idempotency-evidence trigger repair below
 read/candidate surface redesign
 task assignment or review reconciliation implementation
 admin/service/project-role authority substitution
@@ -199,6 +200,23 @@ Issue writes exactly `ProjectRoleQualificationSnapshotCaptured` followed by
 cause-event, and the role-specific future-obligation projection. No parallel
 completion writer is permitted.
 
+The existing database idempotency completion guard predates the 10A evidence
+shape and requires one success plus one invalidation for every operation. That
+would either reject 10C issue or force a false invalidation. Migration 0034 is
+therefore the sole permitted durable change in this chunk. It replaces only the
+idempotency completion guard so `project_role_grant.issue` requires exactly two
+ordered non-invalidation events —
+`ProjectRoleQualificationSnapshotCaptured` followed by
+`ProjectRoleGrantIssued` — with the qualification event bound to the same
+idempotency record, request/correlation pair, actor, permission, project, and
+issued-grant resource. It requires zero invalidations for issue. Every other
+operation retains the existing exactly-one-success plus exactly-one-invalidation
+rule. Upgrade refuses unexpected installed function/trigger definitions and
+pre-existing incompatible pending/committed project-role issue evidence without
+changing data. Downgrade refuses any committed 10C issue record or new evidence
+shape that the prior guard cannot represent, then restores the exact prior
+function. No table, column, index, enum, or product row changes are permitted.
+
 ## Acceptance criteria
 
 - Issue permits draft, active, and paused projects; terminal/archived,
@@ -232,6 +250,10 @@ completion writer is permitted.
   concurrently.
 - Cancellation and injected failure at snapshot, grant, idempotency, audit,
   invalidation, flush, and commit leave no orphan row or partial evidence.
+- Migration 0034 proves exact upgrade/downgrade function replacement, strict
+  refusal/no-mutation on unexpected definitions and incompatible evidence,
+  two linked issue events with zero invalidation, and unchanged one-success/
+  one-invalidation enforcement for every other authority operation.
 - PostgreSQL tests cover identical-role issue, different-role issue, crossed
   managers, revoke versus regrant, revoke versus authorization, replay after
   authority loss, timeout, and cancellation. PostgreSQL and API tests also

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-10C-project-role-grant-mutations.md
@@ -6,8 +6,11 @@
 
 ## Status and prerequisite
 
-Proposed and inactive. Start only after 10B merges, signed memory names 10C,
-and a fresh explicit start event activates this exact child.
+Active for implementation. AUTH-10B2 merged through PR #178 as
+`73b457925b02301587b83d01ced0adb66319d134`. Signed automation run
+`30014637065` activated this exact child on protected main
+`bcf1292e1a591e3e84bf8ee212ee7191d80741fa`. Chat and local branch state are
+not authority; the signed automation projection is the canonical start proof.
 
 ## Goal
 
@@ -36,6 +39,7 @@ backend/app/modules/projects/repository.py
 backend/app/api/router.py
 backend/tests/test_actors.py
 backend/tests/test_authorization.py
+backend/tests/test_api_controls.py
 backend/tests/test_projects.py
 backend/scripts/api_contract_e2e.py
 backend/scripts/auth_api_e2e.py
@@ -74,18 +78,71 @@ authority.
 
 ## Exact lock and transaction order
 
-PREP first locks `AuthorityControl(id=1)` as the shared authorization-order
-barrier used by administrative lifecycle mutations. It then accepts the caller
-plus the known target human principal for issuance, sorts distinct ActorProfile
-IDs lexically, and locks each profile then its exact active link. It finally
-locks the caller's one deterministic covered Project Manager AdminRoleGrant.
-The barrier is ordering coordination, not final-admin permission or safety.
+The route consumes the existing admin-mutation rate dependency exactly once,
+opens one root transaction, and reserves or locks the idempotency record before
+any other mutable row. Reservation outcome is internal only: mismatch and replay
+never branch to a response until PREP and current project authority have been
+revalidated, so authority and concealment win over key-existence disclosure.
+Fresh, replay, and mismatch paths use the same ordering.
+
+PREP then locks `AuthorityControl(id=1)` as the shared authorization-order
+barrier used by administrative lifecycle mutations. Issue uses a target-aware
+prepared input containing the canonical target ActorProfile ID in addition to
+the existing project scope and full request digest. PREP sorts the distinct
+caller and target ActorProfile UUID strings lexically, locks each profile and
+then its selected exact link immediately after that profile, and finally locks
+the caller's one deterministic covered Project Manager AdminRoleGrant. The
+caller's link is the authenticated exact link; the target link is the unique
+active exact link selected deterministically for issue. Missing, inactive, or
+nonhuman target facts are retained as a fail-closed prepared outcome rather
+than raised immediately: PREP still locks and revalidates the caller's current
+authority and the route still locks/revalidates the project before choosing the
+public result. An unauthorized or concealed-project caller therefore observes
+the same status, code, body, and mutation-free outcome for valid, missing,
+inactive, agent, Space, or service targets, without a target-specific early
+timing or response branch. All competing profile, link, and
+administrative-grant mutations retain `AuthorityControl` for the transaction
+lifetime. The barrier is ordering coordination, not final-admin permission or
+safety. Revoke has no client-trusted target: PREP binds caller, project, grant
+ID, idempotency key, and request digest; the locked grant supplies target facts
+only during final resource recomposition. Revoke does not require the stored
+target profile or identity link to remain active; a target profile row may be
+locked only for deterministic concurrency or audit integrity, never as a
+revocation admission gate.
+
+The opaque handle binds action, caller/link, target when issue, project, role
+when issue, grant ID when revoke, idempotency key, and full canonical request
+digest. Consume rejects target, scope, role, grant, digest, session,
+transaction, action, handle-owner, reuse, or lifecycle substitution. Forged,
+copied, serialized, cross-service, cross-session, and already-consumed handles
+fail closed.
 
 After PREP returns, issue locks canonical project, then takes one transaction
 advisory key for `(actor_profile_id, project_id, requested_role)` to serialize
 absence, then reloads the target/scope facts and active exact-role selector.
-Revoke locks canonical project then the exact grant. Consume recomposes every
-fact and evaluates once; repositories flush only. The route commits once.
+Revoke locks canonical project then the exact path-project grant. Consume
+recomposes every fact and evaluates once; repositories flush only. The route
+commits once.
+
+The issue advisory key is a domain-separated deterministic PostgreSQL signed
+`int8`. Its frozen input encoding is the compact UTF-8 JSON array
+`["workstream.project_role_grant.issue.v1","<canonical-lowercase-actor-uuid>","<canonical-lowercase-project-uuid>","<role-value>"]`
+with no insignificant whitespace and JSON escaping defined by the repository's
+canonical serializer. SHA-256 hashes those exact bytes; the first eight digest
+bytes are decoded big-endian as a two's-complement signed `int64`. Tests freeze
+a known vector, exact encoding, UUID and role separation, stability, and signed
+range.
+The partial unique active-exact-role index remains the final backstop; a
+uniqueness race becomes `project_role_grant_exists` without a second snapshot,
+success event, or grant.
+
+The complete order is: rate consumption -> root transaction -> idempotency
+reserve/record lock -> AuthorityControl -> lexical caller/target profile and
+exact-link locks -> deterministic covered Project Manager grant -> project ->
+issue advisory key or exact revoke grant -> canonical fact reload -> consume
+exactly once -> snapshot/grant/idempotency/audit/invalidation flush -> one
+route-owned commit. Rollback and denial-evidence restaging never invert this
+order or disclose reservation outcome before authorization.
 
 Crossed tests prove two managers targeting one another, issue versus target
 profile/link lifecycle, and issue versus caller-grant revocation cannot deadlock
@@ -95,8 +152,13 @@ because all paths share the barrier and compatible principal order.
 
 Issue requires `Idempotency-Key: <uuid>` and a strict body containing exactly
 `target_actor_profile_id`, `role`, `qualification`, and `reason`.
-`qualification` contains the two exact availability objects and reference lists
-defined by 10A. Revoke requires the same header and exactly `reason`. Reasons
+`qualification` is identifier-free and contains only the two exact availability
+objects and reference lists defined by 10A; the server composes path project,
+body target, and body role into `ProjectRoleQualificationSnapshotInput`. The
+full canonical bounded qualification value participates in the issue request
+digest, idempotency equality, PREP binding, and snapshot validation. Changing
+any qualification field with the same key is `idempotency_mismatch`. Revoke
+requires the same header and exactly `reason`. Reasons
 are 1..500 UTF-8 bytes, equal their Python `str.strip()` result, and contain no
 Unicode control character. Issue returns HTTP 201 with exactly `{id,
 qualification_snapshot_id, project_id, actor_profile_id, role, status:
@@ -117,14 +179,40 @@ same-key/same-body revoke replay reauthorizes and returns the prior canonical
 HTTP 200 revoked response; a new-key revoke of an already-revoked grant returns
 HTTP 409 `project_role_grant_already_revoked`.
 
+Replay never trusts stored response metadata alone. Active issue replay locks
+and reloads the canonical path project, grant, and snapshot and requires the
+exact project/target/role tuple, snapshot ownership, `status=active`, and
+`version=1`. Revoked, missing, or mismatched state becomes
+`project_role_grant_replay_state_changed` only after current authority and
+project concealment pass. Revoke replay locks and reloads the exact
+path-project grant and original snapshot and requires `status=revoked`,
+`version=2`, and unchanged ownership before returning the prior HTTP 200 shape.
+
+The shared `AuthorityMutationService` remains the sole completion path. It is
+extended to validate and atomically append an ordered tuple of success events
+and an optional typed invalidation projection before completing idempotency.
+Issue writes exactly `ProjectRoleQualificationSnapshotCaptured` followed by
+`ProjectRoleGrantIssued` and creates no invalidation. Revoke writes exactly
+`ProjectRoleGrantRevoked` followed by one linked
+`AuthorityInvalidationRequested` containing grant, actor, project, role,
+cause-event, and the role-specific future-obligation projection. No parallel
+completion writer is permitted.
+
 ## Acceptance criteria
 
 - Issue permits draft, active, and paused projects; terminal/archived,
   nonexistent, and unauthorized projects deny without target disclosure.
 - Revoke remains available for every existing project state so authority can
   always be removed.
-- Target is a different active human with active link. Agent, Space, service,
-  self-grant, and self-revoke deny stably before disclosure.
+- Issue requires a different active canonical human target with its unique
+  active link. Agent, Space, service, and self-grant deny stably after current
+  caller/project authorization and concealment have been resolved.
+- Revoke derives target identity and role only from the locked exact
+  path-project grant. After current covered-manager authorization, self-role
+  revoke returns HTTP 403 `self_role_revoke_forbidden`; an unauthorized caller
+  cannot learn self-ownership and receives the same concealed HTTP 404 as other
+  hidden grants. Target suspension or a revoked/missing target identity link
+  never blocks revocation, so granted authority cannot become irremovable.
 - Issue creates one exact-role snapshot, one manual grant,
   `ProjectRoleQualificationSnapshotCaptured`, and `ProjectRoleGrantIssued` in
   one transaction. It never changes another role.
@@ -145,7 +233,9 @@ HTTP 409 `project_role_grant_already_revoked`.
   invalidation, flush, and commit leave no orphan row or partial evidence.
 - PostgreSQL tests cover identical-role issue, different-role issue, crossed
   managers, revoke versus regrant, revoke versus authorization, replay after
-  authority loss, timeout, and cancellation.
+  authority loss, timeout, and cancellation. PostgreSQL and API tests also
+  prove a covered manager can revoke an active grant after the target profile
+  is suspended and after its identity link is revoked.
 - Live API proof uses the same unexpired manager token to issue, read the active
   grant through 10B, revoke, read the historical revoked grant, and prove a
   same-key/same-body revoke replay returns the prior HTTP 200 response after
@@ -157,11 +247,44 @@ HTTP 409 `project_role_grant_already_revoked`.
   issue replay changes to that exact closed conflict.
   Contributor-capability denial remains explicitly deferred to AUTH-11/13 where
   a real consumer action exists.
+- Cross-project revoke (`project_id=A`, grant from B), nonexistent grant, and
+  unauthorized revoke share concealed 404 and create no mutation, success
+  audit, invalidation, or disclosure. Unauthorized issue with and without any
+  manager grant cannot distinguish valid, nonexistent, inactive, agent, Space,
+  service, or otherwise unauthorized targets: exact public status, code, and
+  body match and no mutation/evidence is written. Unauthorized revoke cannot
+  distinguish self-owned, cross-project, or nonexistent grants; only an
+  authorized covered manager receives the declared self-role 403.
+- PostgreSQL concurrency tests use independent sessions, deterministic
+  synchronization that observes held and waiting locks, bounded
+  `asyncio.wait_for` plus statement/lock timeouts, and clean-retry proof.
+  Cancellation while waiting and after each staged flush, plus injected
+  route-commit failure, leaves no pending idempotency record, snapshot, grant,
+  audit, or invalidation; the route explicitly rolls back/closes and a clean
+  retry succeeds.
+- Existing 10B read, cursor, concealment, rate-order, exact OpenAPI inventory,
+  and protected-action assertions remain intact. Only the two AUTH-10C rows
+  move from planned to active; owner and permission remain unchanged. The two
+  operations carry exact action IDs, consume the admin-mutation rate dependency
+  exactly once, and never attach authorization-read rate consumption.
+- Hosted `backend/scripts/api_contract_e2e.py` provisions a distinct canonical
+  human target and covered project-scoped Project Manager through existing
+  public APIs with unexpired tokens and no direct database edits. The same
+  manager token proves issue -> 10B active read -> revoke -> 10B historical
+  read -> same-key revoke replay 200 -> new-key revoke 409 -> old issue replay
+  409, plus concealed denial after manager authority loss. `auth_api_e2e.py`
+  remains complementary local proof, not a substitute for the hosted drill.
+- Regenerate exact combined route/protected-operation counts and SHA-256
+  inventories from current main after adding the two routes; never guess or
+  replace exact hashes with count-only assertions. No migration, configuration,
+  workflow, pytest marker, skip/xfail, command, or coverage-threshold change is
+  allowed. GitHub must pass all shards, hosted E2E, Agent Gates, the 78 percent
+  repository floor, and the 90 percent authorization-subsystem floor.
 
 ## Verification commands
 
 ```bash
-(cd backend && .venv/bin/python -m ruff check app/modules/actors app/modules/authorization app/modules/projects tests/test_actors.py tests/test_authorization.py tests/test_projects.py scripts/auth_api_e2e.py)
+(cd backend && .venv/bin/python -m ruff check app/modules/actors app/modules/authorization app/modules/projects tests/test_actors.py tests/test_authorization.py tests/test_api_controls.py tests/test_projects.py scripts/auth_api_e2e.py scripts/api_contract_e2e.py)
 (cd backend && WORKSTREAM_TEST_ADMIN_DATABASE_URL=<admin-db> .venv/bin/python scripts/run_isolated_tests.py --metadata-json <path> --timeout-seconds 300 -- .venv/bin/python -m pytest -q tests/test_actors.py tests/test_authorization.py tests/test_projects.py -k 'project_role_grant')
 (cd backend && WORKSTREAM_DATABASE_URL=<test-db> .venv/bin/python scripts/auth_api_e2e.py)
 python3 scripts/check_stale_authorization_docs.py

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
@@ -1,6 +1,6 @@
 # External Review Response: WS-AUTH-001-10C
 
-Reviewed at: 2026-07-24T20:30:41Z
+Reviewed at: 2026-07-24T21:08:04Z
 PR: #194
 
 ## Comments Addressed
@@ -48,6 +48,12 @@ PR: #194
   excludes only `correlation_id` and retains equality for stable code, message,
   details, and retryability. Internal senior/security review rejected the
   weaker code/message-only intermediate repair before publication.
+- Full shard 3 exposed a stale exhaustive audit classification: qualification
+  capture is idempotency-linked and now fails closed without a claim. Full
+  shard 4 exposed legacy migration-fixture residue; cleanup now snapshots and
+  restores exact trigger modes in `finally` and canonicalizes privacy
+  restoration. The exact audit case passes, and the upgrade/downgrade matrices
+  pass sequentially in one isolated database.
 
 ## Comments Deferred
 
@@ -73,6 +79,8 @@ isolated pytest SQL-NULL fact-shape regression — 1 passed
 isolated pytest rate-control lock-wait regression — 1 passed
 isolated pytest corrected authorization regressions — 2 passed
 pytest -q tests/test_api_contract_e2e.py — 15 passed
+isolated pytest linked authority-event matrix — 1 passed
+isolated pytest sequential upgrade/downgrade refusal matrices — 2 passed
 python3 scripts/check_stale_authorization_docs.py
 python3 scripts/check_markdown_links.py
 git diff --check

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
@@ -1,0 +1,49 @@
+# External Review Response: WS-AUTH-001-10C
+
+Reviewed at: 2026-07-24T17:37:35Z
+PR: #194
+
+## Comments Addressed
+
+- CodeRabbit's qualification-model coercion finding was valid in substance.
+  Global Pydantic strict mode was not restored because FastAPI supplies nested
+  JSON as Python mappings and global strictness rejected valid JSON enum
+  strings. The repair instead makes opaque references strict strings and
+  admits UUID references only from canonical strings or UUID objects, rejecting
+  numeric and byte coercion. Forty-eight focused qualification and route tests
+  pass after the repair.
+- The PR body was stale and incorrectly claimed no migration. It now uses the
+  current migration-aware AUTH-10C trust bundle.
+- The internal evidence now uses the checker-required provenance labels, a UTC
+  timestamp, fresh AUTH-10C reviewer sessions, and a complete nine-track map.
+
+## Comments Deferred
+
+- CodeRabbit's refreshed review is temporarily rate-limited. A fresh review
+  will be requested when the service makes it available; no finding is being
+  treated as resolved merely because the bot could not run.
+- CodeRabbit's generic docstring percentage warning is not used as proof. The
+  repository's own Agent Gates docstring check remains authoritative.
+
+## Human Decisions Needed
+
+- None for the addressed findings. The user retains explicit merge approval.
+
+## Commands Rerun
+
+```text
+ruff check app/modules/authorization/schemas.py tests/test_authorization.py
+pytest -q tests/test_authorization.py -k
+  'qualification_evidence_rejects_coerced_values or
+   public_reason_and_qualification_contract_is_strict or
+   project_role_mutation_routes'
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+## Remaining Risks
+
+- GitHub Backend full shards, hosted API E2E, and coverage are pending the
+  corrected evidence push.
+- CodeRabbit's refreshed review is pending its rate-limit window.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
@@ -1,6 +1,6 @@
 # External Review Response: WS-AUTH-001-10C
 
-Reviewed at: 2026-07-24T20:14:46Z
+Reviewed at: 2026-07-24T20:30:41Z
 PR: #194
 
 ## Comments Addressed
@@ -43,6 +43,11 @@ PR: #194
   stale script key: the administrative response publishes `identity_link_id`,
   not `id`. Both revoke/reactivate references now use the canonical field; Ruff,
   compilation, and all 15 API-contract helper tests pass.
+- The next hosted E2E attempt reached replay reauthorization and exposed a
+  comparison against the whole per-request error envelope. The proof now
+  excludes only `correlation_id` and retains equality for stable code, message,
+  details, and retryability. Internal senior/security review rejected the
+  weaker code/message-only intermediate repair before publication.
 
 ## Comments Deferred
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
@@ -1,6 +1,6 @@
 # External Review Response: WS-AUTH-001-10C
 
-Reviewed at: 2026-07-24T17:37:35Z
+Reviewed at: 2026-07-24T19:57:03Z
 PR: #194
 
 ## Comments Addressed
@@ -21,12 +21,27 @@ PR: #194
   findings. The bounded repair caps Ruff below 0.16 without changing the lint
   command, rules, ignores, tests, or coverage. Full repository lint passes with
   Ruff 0.15.22; adoption of 0.16 rules remains a dedicated repository change.
+- CodeRabbit's SQL-NULL facts finding was valid. The special five-key
+  invalidation envelope now requires non-null facts on both sides and uses
+  coalesced key-existence checks; raw SQL-NULL regression coverage proves that
+  neither missing side can bypass counterpart validation.
+- Trigger-disabling migration fixtures now snapshot exact trigger modes and
+  restore them in `finally`. Migration and authorization lock observers use
+  monotonic five-second deadlines with nonzero polling intervals.
+- The wrong-project completion test now supplies the valid ordered
+  qualification/issued pair, so rejection reaches the intended project binding
+  rather than failing earlier on event cardinality. Audit fakes are
+  instance-isolated.
+- The migration drops the privacy constraint with exact literal raw DDL because
+  Alembic's naming convention would otherwise double-prefix the name. The test
+  normalization remains deliberately independent so it can serve as an oracle
+  instead of importing the implementation under test.
+- CodeRabbit's evidence-count and review-log provenance findings were valid.
+  Evidence now records the exact 11-case aggregate and the log begins with the
+  repaired implementation SHA.
 
 ## Comments Deferred
 
-- CodeRabbit's refreshed review is temporarily rate-limited. A fresh review
-  will be requested when the service makes it available; no finding is being
-  treated as resolved merely because the bot could not run.
 - CodeRabbit's generic docstring percentage warning is not used as proof. The
   repository's own Agent Gates docstring check remains authoritative.
 
@@ -38,10 +53,16 @@ PR: #194
 
 ```text
 ruff check app/modules/authorization/schemas.py tests/test_authorization.py
+ruff check alembic/versions/0034_project_role_issue_evidence.py
+  tests/conftest.py tests/test_alembic.py tests/test_authorization.py
 pytest -q tests/test_authorization.py -k
   'qualification_evidence_rejects_coerced_values or
    public_reason_and_qualification_contract_is_strict or
    project_role_mutation_routes'
+isolated pytest migration refusal aggregate — 11 passed, 44 deselected
+isolated pytest SQL-NULL fact-shape regression — 1 passed
+isolated pytest rate-control lock-wait regression — 1 passed
+isolated pytest corrected authorization regressions — 2 passed
 python3 scripts/check_stale_authorization_docs.py
 python3 scripts/check_markdown_links.py
 git diff --check
@@ -51,4 +72,4 @@ git diff --check
 
 - GitHub Backend full shards, hosted API E2E, and coverage are pending the
   corrected evidence push.
-- CodeRabbit's refreshed review is pending its rate-limit window.
+- A fresh CodeRabbit pass is required on the pushed repair commit.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
@@ -1,6 +1,6 @@
 # External Review Response: WS-AUTH-001-10C
 
-Reviewed at: 2026-07-24T19:57:03Z
+Reviewed at: 2026-07-24T20:14:46Z
 PR: #194
 
 ## Comments Addressed
@@ -39,6 +39,10 @@ PR: #194
 - CodeRabbit's evidence-count and review-log provenance findings were valid.
   Evidence now records the exact 11-case aggregate and the log begins with the
   repaired implementation SHA.
+- Fresh hosted API E2E reached the new link-lifecycle scenario and exposed a
+  stale script key: the administrative response publishes `identity_link_id`,
+  not `id`. Both revoke/reactivate references now use the canonical field; Ruff,
+  compilation, and all 15 API-contract helper tests pass.
 
 ## Comments Deferred
 
@@ -63,6 +67,7 @@ isolated pytest migration refusal aggregate — 11 passed, 44 deselected
 isolated pytest SQL-NULL fact-shape regression — 1 passed
 isolated pytest rate-control lock-wait regression — 1 passed
 isolated pytest corrected authorization regressions — 2 passed
+pytest -q tests/test_api_contract_e2e.py — 15 passed
 python3 scripts/check_stale_authorization_docs.py
 python3 scripts/check_markdown_links.py
 git diff --check
@@ -70,6 +75,6 @@ git diff --check
 
 ## Remaining Risks
 
-- GitHub Backend full shards, hosted API E2E, and coverage are pending the
-  corrected evidence push.
+- GitHub Backend full shards, hosted API E2E, and coverage require a fresh run
+  on the canonical identity-link E2E repair.
 - A fresh CodeRabbit pass is required on the pushed repair commit.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-external-review-response.md
@@ -16,6 +16,11 @@ PR: #194
   current migration-aware AUTH-10C trust bundle.
 - The internal evidence now uses the checker-required provenance labels, a UTC
   timestamp, fresh AUTH-10C reviewer sessions, and a complete nine-track map.
+- GitHub Backend passed the repaired evidence gate but resolved the repository's
+  open Ruff range to newly released 0.16.0, producing 381 unrelated lint
+  findings. The bounded repair caps Ruff below 0.16 without changing the lint
+  command, rules, ignores, tests, or coverage. Full repository lint passes with
+  Ruff 0.15.22; adoption of 0.16 rules remains a dedicated repository change.
 
 ## Comments Deferred
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -1,76 +1,81 @@
 # Internal Review Evidence: WS-AUTH-001-10C
 
-> Superseded for final completion: this evidence covers the pre-migration
-> runtime through the recorded reviewed SHA. GitHub exposed an incompatible
-> predecessor idempotency guard, and the user authorized exact migration 0034.
-> Final completion requires fresh exact-SHA review and replacement evidence.
-
 ## Chunk And Reviewed Code
 
 `WS-AUTH-001-10C` — Project Role Grant Mutations. Risk: L1 authorization,
-concurrency, and audit. Trusted-main start base is
+concurrency, migration, and audit integrity. Trusted-main start base is
 `bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
 `30014637065`.
 
-Reviewed code SHA: `833dd6e5352e1774ffd8c669346c65e61e3e7ac1`
-Reviewed at: 2026-07-23T16:05:00Z
-Reviewer run IDs: /root/auth10b1_final_core, /root/auth10b1_final_security_qa, /root/auth10b1_final_ops_docs_ci
+Reviewed implementation SHA: `2e2969fe712f361ff14b1c90bca439d16777d255`
+Reviewed at: 2026-07-24
 
 ## Implemented Contract
 
-- Activates exactly the covered-Project-Manager issue and revoke actions and
-  their two strict `/api/v1/projects/.../role-grants` mutation routes.
-- Binds idempotency, PREP, current caller/target/project/grant facts, lexical
-  principal locks, deterministic absence serialization, and one route commit.
-- Persists one immutable qualification snapshot per issued exact role; revoke
-  remains possible after target suspension or identity-link revocation.
-- Appends ordered typed success evidence and the revoke-only future-obligation
-  invalidation projection through the shared authority mutation completion path.
-- At this historical reviewed SHA, adds no migration or schema revision, worker, assignment, review-reconciliation,
-  automated grant, replacement-role, or authority-substitution behavior.
+- Activates covered-Project-Manager issue and revoke actions and their strict
+  project-role mutation routes.
+- Binds idempotency, PREP, current caller/target/project/grant facts, resource
+  context digest, lexical locks, final authorization consume, evidence, and one
+  route commit.
+- Persists one immutable qualification snapshot before an issued grant; issue
+  emits no invalidation. Revoke remains available for every existing project
+  lifecycle state and after target lifecycle or identity-link loss.
+- Conceals missing, inactive, nonhuman, unauthorized, cross-project, and absent
+  resources as the same `404 resource_not_found`, while preserving explicit
+  self-grant and self-revoke guards.
+- Adds migration `0034_project_role_issue_evidence`, frozen predecessor and
+  forward definition hashes, exact trigger and constraint checks, strict
+  two-event issue evidence, and actor/grant/role/project/future-obligation
+  linkage for revoke invalidation evidence.
+- Keeps AUTH-11, assignment, review reconciliation, automated role conversion,
+  frontend work, and unrelated schema changes out of scope.
 
 ## Deterministic Evidence
 
 ```text
-Focused project-role schema/advisory/rate/invalidation/cancellation tests — passed
-Crossed-principal lexical profile/link order in both directions — passed
-Python compile of authorization tests — passed
-Ruff on changed authorization tests and implementation — passed
+Ruff on changed authorization, audit, migration, and test files — passed
 git diff --check — passed
-Markdown links and stale wording scans — passed
+Markdown link scan — passed
+Authorization stale-wording scan — passed
+Route concealment and self-guard matrix — 33 passed
+Project lifecycle HTTP/direct-route matrix — 18 passed
+Incompatible pending response migration refusal — 1 passed
+Privacy definition drift refusal/restoration — 1 passed
+Function and disabled-trigger drift refusal/restoration — 2 passed
+Revoke linkage malformed/valid PostgreSQL evidence — 1 passed
+Five-key revoke downgrade refusal/no-mutation — passed
 ```
 
-The PostgreSQL proof covers durable issue/revoke evidence, revocation after
-target lifecycle loss, the real named partial-unique-index fallback through the
-public route, loser residue, observed database lock waiting, production
-cancellation rollback, and a completed same-key retry. It runs in GitHub with
-the repository database fixture. The repository-wide suite and coverage remain
-GitHub-owned because this workstation's full run takes approximately four hours.
+The PostgreSQL proof uses the repository-owned isolated database runner. It
+covers frozen function/trigger/constraint drift, pending incompatible state,
+false issue invalidation, strict five-key revoke facts, null/wrong/orphan/mixed/
+cross-record linkage, exact teardown, and downgrade refusal without mutation.
+
+The repository-wide suite and coverage remain GitHub Actions-owned because the
+local full run takes approximately four hours. Required GitHub gates retain the
+repository-wide 78 percent floor and authorization-subsystem 90 percent floor.
 
 ## Integrity And Review
 
-No test was deleted, skipped, xfailed, or weakened. The exact OpenAPI inventory
-is 76 routes with hash
-`c8f9852035446ea59b0e929b1bd8c8cfc7df5bf838ceb544c04e899f90169318`
-and 74 protected operations with hash
-`9278d0183ffb87947ee4857e0325483ba7bf07feac0c38a88432840b10c2b0c3`.
-No workflow, dependency, shard, command, threshold, or coverage setting changed.
+No test was deleted, skipped, xfailed, or weakened. No workflow, dependency,
+shard, command, threshold, package script, or coverage configuration changed.
+Migration `0034` is tracked and follows `0033_authorization_read_rate`.
 
 | Reviewer | Result | Blocking findings |
 |---|---|---|
 | Senior engineering | PASS | none |
 | Architecture | PASS | none |
-| Reuse/dedup | PASS | none |
+| Reuse/dedup | PASS with low risks | none |
 | Security/auth | PASS | none |
-| QA/test | PASS | none |
+| QA/test | PASS with low risks | none |
 | Test delta | PASS | none |
 | Product/ops | PASS | none |
 | Docs | PASS | none |
 | CI integrity | PASS | none |
 
-The repair loop closed lifecycle attribution, real unique-index fallback,
-complete residue, database-observed cancellation, committed retry, and lexical
-crossed-principal proof gaps.
+The repair loop closed migration fixture restoration, frozen definition drift,
+decision substitution, route concealment and zero-mutation, project lifecycle,
+revoke target linkage, non-revoke five-key evidence, and downgrade proof gaps.
 
 Open sub-agent sessions: none
 Valid findings addressed: yes

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -7,9 +7,9 @@ concurrency, migration, and audit integrity. Trusted-main start base is
 `bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
 `30014637065`.
 
-Reviewed code SHA: `477b105520ee019497a520b87e259ff469d0ffa4`
-Reviewed at: 2026-07-24T18:34:06Z
-Reviewer run IDs: senior-engineering=/root/auth10c_impl_senior; QA/test=/root/auth10c_impl_qa_retry; security/auth=/root/auth10c_impl_security; product/ops=/root/auth10c_impl_product; architecture=/root/auth10c_arch_exact; docs=/root/auth10c_docs_exact; CI-integrity=/root/auth10c_impl_ci_retry; reuse/dedup=/root/auth10c_reuse_exact; test-delta=/root/auth10c_impl_testdelta
+Reviewed code SHA: `d2a311434dd1b15c256899b11ae4326f258ef9e0`
+Reviewed at: 2026-07-24T20:00:36Z
+Reviewer run IDs: senior-engineering=/root/auth10c_cr_senior; QA/test=/root/auth10c_cr_qa; security/auth=/root/auth10c_cr_security; product/ops=/root/auth10c_cr_product; architecture=/root/auth10c_cr_arch; docs=/root/auth10c_cr_docs; CI-integrity=/root/auth10c_cr_ci; reuse/dedup=/root/auth10c_cr_reuse; test-delta=/root/auth10c_cr_testdelta
 
 ## Implemented Contract
 
@@ -40,9 +40,10 @@ Markdown link scan — passed
 Authorization stale-wording scan — passed
 Route concealment and self-guard matrix — 33 passed
 Project lifecycle HTTP/direct-route matrix — 18 passed
-Incompatible pending response migration refusal — 1 passed
-Privacy definition drift refusal/restoration — 1 passed
-Function and disabled-trigger drift refusal/restoration — 2 passed
+Migration refusal aggregate — 11 passed: 2 incompatible pending, 5 frozen
+  definition drift, and 4 fact constraint drift
+SQL-NULL facts regression — 1 passed
+Rate-control lock-wait regression — 1 passed
 Revoke linkage malformed/valid PostgreSQL evidence — 1 passed
 Five-key revoke downgrade refusal/no-mutation — passed
 ```
@@ -78,8 +79,9 @@ Migration `0034` is tracked and follows `0033_authorization_read_rate`.
 | CI integrity | PASS | none |
 
 The repair loop closed migration fixture restoration, frozen definition drift,
-decision substitution, route concealment and zero-mutation, project lifecycle,
-revoke target linkage, non-revoke five-key evidence, and downgrade proof gaps.
+SQL-NULL three-valued facts bypass, decision substitution, route concealment
+and zero-mutation, project lifecycle, revoke target linkage, non-revoke
+five-key evidence, downgrade proof gaps, and bounded lock observation.
 
 Open sub-agent sessions: none
 Valid findings addressed: yes

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -7,8 +7,8 @@ concurrency, migration, and audit integrity. Trusted-main start base is
 `bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
 `30014637065`.
 
-Reviewed code SHA: `5ba2a84dec202a806af589c905bb27ef6a654235`
-Reviewed at: 2026-07-24T20:30:41Z
+Reviewed code SHA: `3323184ef4010bba590908bbb6da9cd8e82bc407`
+Reviewed at: 2026-07-24T21:08:04Z
 Reviewer run IDs: senior-engineering=/root/auth10c_cr_senior; QA/test=/root/auth10c_cr_qa; security/auth=/root/auth10c_cr_security; product/ops=/root/auth10c_cr_product; architecture=/root/auth10c_cr_arch; docs=/root/auth10c_cr_docs; CI-integrity=/root/auth10c_cr_ci; reuse/dedup=/root/auth10c_cr_reuse; test-delta=/root/auth10c_cr_testdelta
 
 ## Implemented Contract
@@ -45,6 +45,8 @@ Migration refusal aggregate — 11 passed: 2 incompatible pending, 5 frozen
 SQL-NULL facts regression — 1 passed
 Rate-control lock-wait regression — 1 passed
 API contract helper tests — 15 passed
+Linked authority-event audit matrix — 1 passed
+Sequential project-role upgrade/downgrade refusal matrices — 2 passed
 Revoke linkage malformed/valid PostgreSQL evidence — 1 passed
 Five-key revoke downgrade refusal/no-mutation — passed
 ```
@@ -88,6 +90,12 @@ hosted E2E identity-link response-field reference.
 The E2E concealment comparison excludes only request-scoped `correlation_id`;
 code, message, details, and retryability remain equal to the missing-resource
 envelope.
+
+The full-shard repair classifies qualification capture as idempotency-linked
+and makes legacy-fixture cleanup restore exact trigger modes plus the canonical
+privacy constraint. Head-schema downgrade cases contain only representable
+action/permission and denial predicates; dedicated 0034 fact-shape and real
+project-role evidence tests retain role coverage.
 
 Open sub-agent sessions: none
 Valid findings addressed: yes

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -66,4 +66,3 @@ No workflow, dependency, shard, command, threshold, or coverage setting changed.
 The repair loop closed lifecycle attribution, real unique-index fallback,
 complete residue, database-observed cancellation, committed retry, and lexical
 crossed-principal proof gaps. Open reviewer and sub-agent sessions: none.
-

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -7,8 +7,8 @@ concurrency, and audit. Trusted-main start base is
 `bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
 `30014637065`.
 
-Reviewed code SHA: `0d05b7096eb7a2cf7c68a1770c0b35f07d5b55df`
-Reviewed at: 2026-07-23T16:55:00+01:00
+Reviewed code SHA: `833dd6e5352e1774ffd8c669346c65e61e3e7ac1`
+Reviewed at: 2026-07-23T16:05:00Z
 Reviewer run IDs: /root/auth10b1_final_core, /root/auth10b1_final_security_qa, /root/auth10b1_final_ops_docs_ci
 
 ## Implemented Contract
@@ -65,4 +65,7 @@ No workflow, dependency, shard, command, threshold, or coverage setting changed.
 
 The repair loop closed lifecycle attribution, real unique-index fallback,
 complete residue, database-observed cancellation, committed retry, and lexical
-crossed-principal proof gaps. Open reviewer and sub-agent sessions: none.
+crossed-principal proof gaps.
+
+Open sub-agent sessions: none
+Valid findings addressed: yes

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -7,8 +7,8 @@ concurrency, migration, and audit integrity. Trusted-main start base is
 `bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
 `30014637065`.
 
-Reviewed code SHA: `3d53cc30020ec379088a1637bd8db68183f0ce46`
-Reviewed at: 2026-07-24T17:49:45Z
+Reviewed code SHA: `477b105520ee019497a520b87e259ff469d0ffa4`
+Reviewed at: 2026-07-24T18:34:06Z
 Reviewer run IDs: senior-engineering=/root/auth10c_impl_senior; QA/test=/root/auth10c_impl_qa_retry; security/auth=/root/auth10c_impl_security; product/ops=/root/auth10c_impl_product; architecture=/root/auth10c_arch_exact; docs=/root/auth10c_docs_exact; CI-integrity=/root/auth10c_impl_ci_retry; reuse/dedup=/root/auth10c_reuse_exact; test-delta=/root/auth10c_impl_testdelta
 
 ## Implemented Contract
@@ -59,7 +59,10 @@ repository-wide 78 percent floor and authorization-subsystem 90 percent floor.
 ## Integrity And Review
 
 No test was deleted, skipped, xfailed, or weakened. No workflow, dependency,
-shard, command, threshold, package script, or coverage configuration changed.
+shard, command, threshold, package script, or coverage configuration was
+weakened. The development dependency now caps Ruff below 0.16 after the newly
+released 0.16.0 introduced 381 repository-wide findings; the unchanged full
+`ruff check app tests scripts` command passes with Ruff 0.15.22.
 Migration `0034` is tracked and follows `0033_authorization_read_rate`.
 
 | Reviewer | Result | Blocking findings |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -7,8 +7,8 @@ concurrency, migration, and audit integrity. Trusted-main start base is
 `bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
 `30014637065`.
 
-Reviewed code SHA: `d2a311434dd1b15c256899b11ae4326f258ef9e0`
-Reviewed at: 2026-07-24T20:00:36Z
+Reviewed code SHA: `33f8c7ccd80c89d09584d2959ff1581f80e6bd03`
+Reviewed at: 2026-07-24T20:14:46Z
 Reviewer run IDs: senior-engineering=/root/auth10c_cr_senior; QA/test=/root/auth10c_cr_qa; security/auth=/root/auth10c_cr_security; product/ops=/root/auth10c_cr_product; architecture=/root/auth10c_cr_arch; docs=/root/auth10c_cr_docs; CI-integrity=/root/auth10c_cr_ci; reuse/dedup=/root/auth10c_cr_reuse; test-delta=/root/auth10c_cr_testdelta
 
 ## Implemented Contract
@@ -44,6 +44,7 @@ Migration refusal aggregate — 11 passed: 2 incompatible pending, 5 frozen
   definition drift, and 4 fact constraint drift
 SQL-NULL facts regression — 1 passed
 Rate-control lock-wait regression — 1 passed
+API contract helper tests — 15 passed
 Revoke linkage malformed/valid PostgreSQL evidence — 1 passed
 Five-key revoke downgrade refusal/no-mutation — passed
 ```
@@ -81,7 +82,8 @@ Migration `0034` is tracked and follows `0033_authorization_read_rate`.
 The repair loop closed migration fixture restoration, frozen definition drift,
 SQL-NULL three-valued facts bypass, decision substitution, route concealment
 and zero-mutation, project lifecycle, revoke target linkage, non-revoke
-five-key evidence, downgrade proof gaps, and bounded lock observation.
+five-key evidence, downgrade proof gaps, bounded lock observation, and the
+hosted E2E identity-link response-field reference.
 
 Open sub-agent sessions: none
 Valid findings addressed: yes

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -7,8 +7,8 @@ concurrency, migration, and audit integrity. Trusted-main start base is
 `bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
 `30014637065`.
 
-Reviewed code SHA: `33f8c7ccd80c89d09584d2959ff1581f80e6bd03`
-Reviewed at: 2026-07-24T20:14:46Z
+Reviewed code SHA: `5ba2a84dec202a806af589c905bb27ef6a654235`
+Reviewed at: 2026-07-24T20:30:41Z
 Reviewer run IDs: senior-engineering=/root/auth10c_cr_senior; QA/test=/root/auth10c_cr_qa; security/auth=/root/auth10c_cr_security; product/ops=/root/auth10c_cr_product; architecture=/root/auth10c_cr_arch; docs=/root/auth10c_cr_docs; CI-integrity=/root/auth10c_cr_ci; reuse/dedup=/root/auth10c_cr_reuse; test-delta=/root/auth10c_cr_testdelta
 
 ## Implemented Contract
@@ -84,6 +84,10 @@ SQL-NULL three-valued facts bypass, decision substitution, route concealment
 and zero-mutation, project lifecycle, revoke target linkage, non-revoke
 five-key evidence, downgrade proof gaps, bounded lock observation, and the
 hosted E2E identity-link response-field reference.
+
+The E2E concealment comparison excludes only request-scoped `correlation_id`;
+code, message, details, and retryability remain equal to the missing-resource
+envelope.
 
 Open sub-agent sessions: none
 Valid findings addressed: yes

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -7,8 +7,9 @@ concurrency, migration, and audit integrity. Trusted-main start base is
 `bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
 `30014637065`.
 
-Reviewed implementation SHA: `2e2969fe712f361ff14b1c90bca439d16777d255`
-Reviewed at: 2026-07-24
+Reviewed code SHA: `3d53cc30020ec379088a1637bd8db68183f0ce46`
+Reviewed at: 2026-07-24T17:49:45Z
+Reviewer run IDs: senior-engineering=/root/auth10c_impl_senior; QA/test=/root/auth10c_impl_qa_retry; security/auth=/root/auth10c_impl_security; product/ops=/root/auth10c_impl_product; architecture=/root/auth10c_arch_exact; docs=/root/auth10c_docs_exact; CI-integrity=/root/auth10c_impl_ci_retry; reuse/dedup=/root/auth10c_reuse_exact; test-delta=/root/auth10c_impl_testdelta
 
 ## Implemented Contract
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -1,5 +1,10 @@
 # Internal Review Evidence: WS-AUTH-001-10C
 
+> Superseded for final completion: this evidence covers the pre-migration
+> runtime through the recorded reviewed SHA. GitHub exposed an incompatible
+> predecessor idempotency guard, and the user authorized exact migration 0034.
+> Final completion requires fresh exact-SHA review and replacement evidence.
+
 ## Chunk And Reviewed Code
 
 `WS-AUTH-001-10C` — Project Role Grant Mutations. Risk: L1 authorization,
@@ -21,7 +26,7 @@ Reviewer run IDs: /root/auth10b1_final_core, /root/auth10b1_final_security_qa, /
   remains possible after target suspension or identity-link revocation.
 - Appends ordered typed success evidence and the revoke-only future-obligation
   invalidation projection through the shared authority mutation completion path.
-- Adds no migration, schema revision, worker, assignment, review-reconciliation,
+- At this historical reviewed SHA, adds no migration or schema revision, worker, assignment, review-reconciliation,
   automated grant, replacement-role, or authority-substitution behavior.
 
 ## Deterministic Evidence

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-internal-review-evidence.md
@@ -1,0 +1,69 @@
+# Internal Review Evidence: WS-AUTH-001-10C
+
+## Chunk And Reviewed Code
+
+`WS-AUTH-001-10C` — Project Role Grant Mutations. Risk: L1 authorization,
+concurrency, and audit. Trusted-main start base is
+`bcf1292e1a591e3e84bf8ee212ee7191d80741fa`; signed start run is
+`30014637065`.
+
+Reviewed code SHA: `0d05b7096eb7a2cf7c68a1770c0b35f07d5b55df`
+Reviewed at: 2026-07-23T16:55:00+01:00
+Reviewer run IDs: /root/auth10b1_final_core, /root/auth10b1_final_security_qa, /root/auth10b1_final_ops_docs_ci
+
+## Implemented Contract
+
+- Activates exactly the covered-Project-Manager issue and revoke actions and
+  their two strict `/api/v1/projects/.../role-grants` mutation routes.
+- Binds idempotency, PREP, current caller/target/project/grant facts, lexical
+  principal locks, deterministic absence serialization, and one route commit.
+- Persists one immutable qualification snapshot per issued exact role; revoke
+  remains possible after target suspension or identity-link revocation.
+- Appends ordered typed success evidence and the revoke-only future-obligation
+  invalidation projection through the shared authority mutation completion path.
+- Adds no migration, schema revision, worker, assignment, review-reconciliation,
+  automated grant, replacement-role, or authority-substitution behavior.
+
+## Deterministic Evidence
+
+```text
+Focused project-role schema/advisory/rate/invalidation/cancellation tests — passed
+Crossed-principal lexical profile/link order in both directions — passed
+Python compile of authorization tests — passed
+Ruff on changed authorization tests and implementation — passed
+git diff --check — passed
+Markdown links and stale wording scans — passed
+```
+
+The PostgreSQL proof covers durable issue/revoke evidence, revocation after
+target lifecycle loss, the real named partial-unique-index fallback through the
+public route, loser residue, observed database lock waiting, production
+cancellation rollback, and a completed same-key retry. It runs in GitHub with
+the repository database fixture. The repository-wide suite and coverage remain
+GitHub-owned because this workstation's full run takes approximately four hours.
+
+## Integrity And Review
+
+No test was deleted, skipped, xfailed, or weakened. The exact OpenAPI inventory
+is 76 routes with hash
+`c8f9852035446ea59b0e929b1bd8c8cfc7df5bf838ceb544c04e899f90169318`
+and 74 protected operations with hash
+`9278d0183ffb87947ee4857e0325483ba7bf07feac0c38a88432840b10c2b0c3`.
+No workflow, dependency, shard, command, threshold, or coverage setting changed.
+
+| Reviewer | Result | Blocking findings |
+|---|---|---|
+| Senior engineering | PASS | none |
+| Architecture | PASS | none |
+| Reuse/dedup | PASS | none |
+| Security/auth | PASS | none |
+| QA/test | PASS | none |
+| Test delta | PASS | none |
+| Product/ops | PASS | none |
+| Docs | PASS | none |
+| CI integrity | PASS | none |
+
+The repair loop closed lifecycle attribution, real unique-index fallback,
+complete residue, database-observed cancellation, committed retry, and lexical
+crossed-principal proof gaps. Open reviewer and sub-agent sessions: none.
+

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -6,7 +6,7 @@
 mutations for independent exact-project contributor roles. Risk is L1
 authorization, concurrency, migration, and audit integrity.
 
-Reviewed code SHA: `d2a311434dd1b15c256899b11ae4326f258ef9e0`
+Reviewed code SHA: `33f8c7ccd80c89d09584d2959ff1581f80e6bd03`
 
 ## Change, Design, And Scope
 
@@ -38,7 +38,9 @@ checks pass. The isolated database proof includes exact schema teardown and
 no-mutation assertions for rejected evidence. The exact migration refusal
 aggregate passes all 11 variants: 2 incompatible pending states, 5 frozen
 definition drifts, and 4 fact-constraint drifts. Focused SQL-NULL facts and
-bounded lock-wait regressions also pass.
+bounded lock-wait regressions also pass. The hosted API E2E identity-link
+lifecycle path uses the canonical `identity_link_id` response field; its 15
+helper tests pass.
 
 All nine internal tracks pass the reviewed implementation SHA with no blocking
 finding and no open sub-agent session. No test or CI gate was weakened. Ruff is

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -1,0 +1,49 @@
+# PR Trust Bundle: WS-AUTH-001-10C
+
+## Chunk And Goal
+
+`WS-AUTH-001-10C` adds PREP-bound, idempotent, auditable issue and revoke
+mutations for independent exact-project contributor roles. Risk is L1
+authorization, concurrency, and audit integrity.
+
+## Change, Design, And Scope
+
+- A covered Project Manager can issue submitter, reviewer, or adjudicator for
+  one exact project and revoke one exact stored grant.
+- Issue captures a bounded immutable qualification snapshot. Revoke derives the
+  target and role only from the locked grant and emits the closed typed
+  future-obligation invalidation projection.
+- Rate consumption, idempotency, the shared authority barrier, lexical
+  profile/link locking, PM authority, project, advisory/grant locking, final
+  fact recomposition, consume, evidence, and commit use the contract order.
+- Replay reauthorizes and reloads canonical ownership/state. Conflict and
+  concealment paths do not disclose private target or reservation facts.
+- Hosted E2E uses only public APIs for issue, active read, revoke, history,
+  replay/state-change conflicts, lifecycle-independent revoke, and authority loss.
+
+All changed files are contract-allowed. There is no migration, durable schema
+change, frontend work, automated role conversion, task assignment, review
+reconciliation, or successor implementation.
+
+## Proof And Review
+
+Focused lint, compile, contract, ordering, schema, rate, invalidation, and
+cancellation checks pass locally. PostgreSQL evidence exercises the real named
+partial unique index, public fallback, full loser rollback, database-observed
+lock wait, production cancellation rollback, and committed clean retry. The
+GitHub Backend workflow must run the full shards, hosted API E2E, repository-wide
+78 percent floor, and authorization-subsystem 90 percent floor.
+
+All nine internal tracks pass reviewed implementation SHA
+`0d05b7096eb7a2cf7c68a1770c0b35f07d5b55df` with no open finding.
+
+## External Review, Risk, And Human Focus
+
+GitHub CI, Agent Gates, CodeRabbit, and human review remain after publication.
+Human review should focus on transaction/lock order, target concealment,
+Project-Manager-only authority, replay reauthorization, partial-unique fallback,
+revocation availability after lifecycle loss, and audit/invalidation atomicity.
+The user retains merge ownership; do not merge without explicit approval of the
+specific PR. The declared successor `WS-AUTH-001-11` requires a separate signed
+explicit start and must not begin automatically.
+

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -46,4 +46,3 @@ revocation availability after lifecycle loss, and audit/invalidation atomicity.
 The user retains merge ownership; do not merge without explicit approval of the
 specific PR. The declared successor `WS-AUTH-001-11` requires a separate signed
 explicit start and must not begin automatically.
-

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -6,7 +6,7 @@
 mutations for independent exact-project contributor roles. Risk is L1
 authorization, concurrency, migration, and audit integrity.
 
-Reviewed code SHA: `3d53cc30020ec379088a1637bd8db68183f0ce46`
+Reviewed code SHA: `477b105520ee019497a520b87e259ff469d0ffa4`
 
 ## Change, Design, And Scope
 
@@ -38,7 +38,9 @@ checks pass. The isolated database proof includes exact schema teardown and
 no-mutation assertions for rejected evidence.
 
 All nine internal tracks pass the reviewed implementation SHA with no blocking
-finding and no open sub-agent session. No test or CI gate was weakened.
+finding and no open sub-agent session. No test or CI gate was weakened. Ruff is
+bounded below 0.16 after GitHub resolved the open range to incompatible 0.16.0;
+the existing full-repository lint command passes on the retained 0.15 line.
 
 GitHub Backend must run the full shards, hosted API E2E, repository-wide
 78 percent coverage floor, and authorization-subsystem 90 percent floor.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -6,7 +6,7 @@
 mutations for independent exact-project contributor roles. Risk is L1
 authorization, concurrency, migration, and audit integrity.
 
-Reviewed code SHA: `477b105520ee019497a520b87e259ff469d0ffa4`
+Reviewed code SHA: `d2a311434dd1b15c256899b11ae4326f258ef9e0`
 
 ## Change, Design, And Scope
 
@@ -35,7 +35,10 @@ conversion, and unrelated migrations remain out of scope.
 Focused lint, route, lifecycle, decision-binding, audit, PostgreSQL linkage,
 migration drift/refusal, downgrade, stale-wording, markdown-link, and diff
 checks pass. The isolated database proof includes exact schema teardown and
-no-mutation assertions for rejected evidence.
+no-mutation assertions for rejected evidence. The exact migration refusal
+aggregate passes all 11 variants: 2 incompatible pending states, 5 frozen
+definition drifts, and 4 fact-constraint drifts. Focused SQL-NULL facts and
+bounded lock-wait regressions also pass.
 
 All nine internal tracks pass the reviewed implementation SHA with no blocking
 finding and no open sub-agent session. No test or CI gate was weakened. Ruff is

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -1,5 +1,9 @@
 # PR Trust Bundle: WS-AUTH-001-10C
 
+> Pending replacement after migration 0034. This bundle describes the reviewed
+> pre-migration runtime; GitHub exposed the predecessor evidence-guard mismatch,
+> and final publication requires a fresh exact-SHA trust bundle.
+
 ## Chunk And Goal
 
 `WS-AUTH-001-10C` adds PREP-bound, idempotent, auditable issue and revoke
@@ -21,8 +25,9 @@ authorization, concurrency, and audit integrity.
 - Hosted E2E uses only public APIs for issue, active read, revoke, history,
   replay/state-change conflicts, lifecycle-independent revoke, and authority loss.
 
-All changed files are contract-allowed. There is no migration, durable schema
-change, frontend work, automated role conversion, task assignment, review
+All pre-migration runtime files were contract-allowed. The user subsequently
+authorized exact migration 0034; no other durable schema change, frontend work,
+automated role conversion, task assignment, review
 reconciliation, or successor implementation.
 
 ## Proof And Review

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -6,7 +6,7 @@
 mutations for independent exact-project contributor roles. Risk is L1
 authorization, concurrency, migration, and audit integrity.
 
-Reviewed code SHA: `33f8c7ccd80c89d09584d2959ff1581f80e6bd03`
+Reviewed code SHA: `5ba2a84dec202a806af589c905bb27ef6a654235`
 
 ## Change, Design, And Scope
 
@@ -40,7 +40,8 @@ aggregate passes all 11 variants: 2 incompatible pending states, 5 frozen
 definition drifts, and 4 fact-constraint drifts. Focused SQL-NULL facts and
 bounded lock-wait regressions also pass. The hosted API E2E identity-link
 lifecycle path uses the canonical `identity_link_id` response field; its 15
-helper tests pass.
+helper tests pass. Replay concealment compares the complete stable error body
+while excluding only per-request `correlation_id`.
 
 All nine internal tracks pass the reviewed implementation SHA with no blocking
 finding and no open sub-agent session. No test or CI gate was weakened. Ruff is

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -1,53 +1,57 @@
 # PR Trust Bundle: WS-AUTH-001-10C
 
-> Pending replacement after migration 0034. This bundle describes the reviewed
-> pre-migration runtime; GitHub exposed the predecessor evidence-guard mismatch,
-> and final publication requires a fresh exact-SHA trust bundle.
-
 ## Chunk And Goal
 
 `WS-AUTH-001-10C` adds PREP-bound, idempotent, auditable issue and revoke
 mutations for independent exact-project contributor roles. Risk is L1
-authorization, concurrency, and audit integrity.
+authorization, concurrency, migration, and audit integrity.
+
+Reviewed implementation SHA: `2e2969fe712f361ff14b1c90bca439d16777d255`
 
 ## Change, Design, And Scope
 
 - A covered Project Manager can issue submitter, reviewer, or adjudicator for
   one exact project and revoke one exact stored grant.
-- Issue captures a bounded immutable qualification snapshot. Revoke derives the
-  target and role only from the locked grant and emits the closed typed
+- Issue captures an immutable qualification snapshot before the issued event.
+  Revoke derives target and role only from the locked grant and emits the closed
   future-obligation invalidation projection.
-- Rate consumption, idempotency, the shared authority barrier, lexical
-  profile/link locking, PM authority, project, advisory/grant locking, final
-  fact recomposition, consume, evidence, and commit use the contract order.
-- Replay reauthorizes and reloads canonical ownership/state. Conflict and
-  concealment paths do not disclose private target or reservation facts.
-- Hosted E2E uses only public APIs for issue, active read, revoke, history,
-  replay/state-change conflicts, lifecycle-independent revoke, and authority loss.
+- Replay reauthorizes and reloads canonical ownership and state. Exact action,
+  permission, authority kind, project scope, grant, resource, digest, target,
+  role, status, and version facts are bound before completion.
+- Concealment paths expose one stable `404 resource_not_found`; explicit
+  self-grant and self-revoke guards retain their contract errors.
+- Migration 0034 freezes every inherited function, trigger, fact constraint,
+  and privacy definition it rewrites. It admits only the exact issue pair and
+  binds revoke invalidation to the same actor, grant, role, project, cause,
+  target reference, and future obligation.
+- Issue is available for draft, active, and paused projects; revoke remains
+  available for every existing project state, including archived.
 
-All pre-migration runtime files were contract-allowed. The user subsequently
-authorized exact migration 0034; no other durable schema change, frontend work,
-automated role conversion, task assignment, review
-reconciliation, or successor implementation.
+AUTH-11, frontend work, task assignment, review reconciliation, automated role
+conversion, and unrelated migrations remain out of scope.
 
 ## Proof And Review
 
-Focused lint, compile, contract, ordering, schema, rate, invalidation, and
-cancellation checks pass locally. PostgreSQL evidence exercises the real named
-partial unique index, public fallback, full loser rollback, database-observed
-lock wait, production cancellation rollback, and committed clean retry. The
-GitHub Backend workflow must run the full shards, hosted API E2E, repository-wide
-78 percent floor, and authorization-subsystem 90 percent floor.
+Focused lint, route, lifecycle, decision-binding, audit, PostgreSQL linkage,
+migration drift/refusal, downgrade, stale-wording, markdown-link, and diff
+checks pass. The isolated database proof includes exact schema teardown and
+no-mutation assertions for rejected evidence.
 
-All nine internal tracks pass reviewed implementation SHA
-`0d05b7096eb7a2cf7c68a1770c0b35f07d5b55df` with no open finding.
+All nine internal tracks pass the reviewed implementation SHA with no blocking
+finding and no open sub-agent session. No test or CI gate was weakened.
+
+GitHub Backend must run the full shards, hosted API E2E, repository-wide
+78 percent coverage floor, and authorization-subsystem 90 percent floor.
 
 ## External Review, Risk, And Human Focus
 
-GitHub CI, Agent Gates, CodeRabbit, and human review remain after publication.
-Human review should focus on transaction/lock order, target concealment,
-Project-Manager-only authority, replay reauthorization, partial-unique fallback,
-revocation availability after lifecycle loss, and audit/invalidation atomicity.
-The user retains merge ownership; do not merge without explicit approval of the
-specific PR. The declared successor `WS-AUTH-001-11` requires a separate signed
-explicit start and must not begin automatically.
+GitHub CI, Agent Gates, CodeRabbit, and human review remain required after
+publication. Human review should focus on transaction and lock order, PREP
+decision binding, target concealment, project lifecycle rules, replay
+reauthorization, exact migration hashes, issue evidence ordering, and revoke
+invalidation linkage/atomicity.
+
+The user retains merge ownership; do not merge without explicit approval of
+the specific PR. The declared same-initiative successor `WS-AUTH-001-11`
+requires a separate trusted-main explicit start and must not begin
+automatically.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -6,7 +6,7 @@
 mutations for independent exact-project contributor roles. Risk is L1
 authorization, concurrency, migration, and audit integrity.
 
-Reviewed code SHA: `5ba2a84dec202a806af589c905bb27ef6a654235`
+Reviewed code SHA: `3323184ef4010bba590908bbb6da9cd8e82bc407`
 
 ## Change, Design, And Scope
 
@@ -42,6 +42,8 @@ bounded lock-wait regressions also pass. The hosted API E2E identity-link
 lifecycle path uses the canonical `identity_link_id` response field; its 15
 helper tests pass. Replay concealment compares the complete stable error body
 while excluding only per-request `correlation_id`.
+The linked authority-event audit matrix and sequential upgrade/downgrade
+refusal matrices pass after exact trigger/privacy cleanup repair.
 
 All nine internal tracks pass the reviewed implementation SHA with no blocking
 finding and no open sub-agent session. No test or CI gate was weakened. Ruff is

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/reviews/WS-AUTH-001-10C-pr-trust-bundle.md
@@ -6,7 +6,7 @@
 mutations for independent exact-project contributor roles. Risk is L1
 authorization, concurrency, migration, and audit integrity.
 
-Reviewed implementation SHA: `2e2969fe712f361ff14b1c90bca439d16777d255`
+Reviewed code SHA: `3d53cc30020ec379088a1637bd8db68183f0ce46`
 
 ## Change, Design, And Scope
 

--- a/.agent-loop/merge-intents/WS-AUTH-001-10C.json
+++ b/.agent-loop/merge-intents/WS-AUTH-001-10C.json
@@ -1,0 +1,9 @@
+{
+  "chunk_id": "WS-AUTH-001-10C",
+  "chunk_title": "Project Role Grant Mutations",
+  "initiative_id": "WS-AUTH-001",
+  "next_chunk_id": "WS-AUTH-001-11",
+  "next_chunk_title": "Project Identity, Guide, Source, And Visibility Cutover",
+  "next_requires_explicit_start": true,
+  "schema_version": 2
+}

--- a/backend/alembic/versions/0034_project_role_issue_evidence.py
+++ b/backend/alembic/versions/0034_project_role_issue_evidence.py
@@ -23,7 +23,7 @@ _PREDECESSOR_LINKED_SHA256 = "a05288dc0192e2f984a6e1592d086879bbe32c20cfba0d284a
 _PREDECESSOR_FACTS_SHA256 = "ee5e1bd8d2958ff60238e9200acd7ba226bf64f191f515881dc5741c7f36d9bb"
 _FORWARD_GUARD_SHA256 = "4ff567e26aa28be36f28e4908039d0d4c0e9d1d8e6226dfb4d28c8b0f1523a56"
 _FORWARD_LINKED_SHA256 = "e5d9dc01a65c3865267c89e79e6eedcf270ab5c559d424a593c939e3693f154e"
-_FORWARD_FACTS_SHA256 = "c316b21fd97ffab22f7e5b48b4ed43b786efeab5cba6591de368f2f5777eccda"
+_FORWARD_FACTS_SHA256 = "202354d75f8fc6b60e8f3bedfd8eafcf75aa24f682c1ef4762abf81fa74a1e5d"
 _FACT_CONSTRAINT_SHA256 = "c6f99a1a9ef6cc59fe52af6a117a5265cda8daa9c7fa084ed2ff8bdad851ae2f"
 _PREDECESSOR_PRIVACY_SHA256 = "b76a5df89d66215f6aaba6d03ee0322497cfba99c3072404d7b06f742e71b56e"
 _FORWARD_PRIVACY_SHA256 = "c02c0edccf921bbacbeff81524deb6d57cad6273784029d647c1df02ab18ed26"
@@ -131,8 +131,10 @@ _FACTS_TOP = """          if (before_state is not null and not authority_facts_a
             return false;
           end if;"""
 _FACTS_TOP_FORWARD = """          if not (event_name='AuthorityInvalidationRequested'
-                  and before_state::jsonb ? 'future_obligation'
-                  and after_state::jsonb ? 'future_obligation')
+                  and before_state is not null
+                  and after_state is not null
+                  and coalesce(before_state::jsonb ? 'future_obligation', false)
+                  and coalesce(after_state::jsonb ? 'future_obligation', false))
              and ((before_state is not null and not authority_facts_are_safe(before_state))
                or (after_state is not null and not authority_facts_are_safe(after_state))) then
             return false;
@@ -369,7 +371,10 @@ def _privacy(*, add: bool) -> None:
             r"\1 not in (\2)",
             definition,
         )
-    op.drop_constraint("authority_privacy_bounds", "audit_events", type_="check")
+    op.execute(
+        "alter table audit_events drop constraint "
+        "ck_audit_events_authority_privacy_bounds"
+    )
     op.execute(f"alter table audit_events add constraint ck_audit_events_authority_privacy_bounds {definition}")
     installed = bind.execute(sa.text("""
         select pg_get_constraintdef(oid) from pg_constraint

--- a/backend/alembic/versions/0034_project_role_issue_evidence.py
+++ b/backend/alembic/versions/0034_project_role_issue_evidence.py
@@ -1,0 +1,485 @@
+"""admit the exact two-event project-role issue evidence envelope
+
+Revision ID: 0034_project_role_issue_evidence
+Revises: 0033_authorization_read_rate
+Create Date: 2026-07-24
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0034_project_role_issue_evidence"
+down_revision = "0033_authorization_read_rate"
+branch_labels = depends_on = None
+
+_PREDECESSOR_GUARD_SHA256 = "fe4d302e7405e79d4ca0f5731275f589f2680da5d4ebf033f98d028214671498"
+_PREDECESSOR_LINKED_SHA256 = "a05288dc0192e2f984a6e1592d086879bbe32c20cfba0d284a2c13fce6c7e506"
+_PREDECESSOR_FACTS_SHA256 = "ee5e1bd8d2958ff60238e9200acd7ba226bf64f191f515881dc5741c7f36d9bb"
+_FORWARD_GUARD_SHA256 = "4ff567e26aa28be36f28e4908039d0d4c0e9d1d8e6226dfb4d28c8b0f1523a56"
+_FORWARD_LINKED_SHA256 = "e5d9dc01a65c3865267c89e79e6eedcf270ab5c559d424a593c939e3693f154e"
+_FORWARD_FACTS_SHA256 = "c316b21fd97ffab22f7e5b48b4ed43b786efeab5cba6591de368f2f5777eccda"
+_FACT_CONSTRAINT_SHA256 = "c6f99a1a9ef6cc59fe52af6a117a5265cda8daa9c7fa084ed2ff8bdad851ae2f"
+_PREDECESSOR_PRIVACY_SHA256 = "b76a5df89d66215f6aaba6d03ee0322497cfba99c3072404d7b06f742e71b56e"
+_FORWARD_PRIVACY_SHA256 = "c02c0edccf921bbacbeff81524deb6d57cad6273784029d647c1df02ab18ed26"
+_TRIGGER_SHA256 = {
+    "authority_idempotency_guard": "84da74f8180fd5023b7364840b659a3fe781752c937c12dea6b2411eba5d7874",
+    "audit_events_validate_idempotency": "524d24197c96ad05cbaecc867a4e5cdd2ee9e33e3a60380466e280a253a397bf",
+}
+
+_RESOURCE_MARKERS = (
+    ("'project'::character varying, 'project_role_grant'::character varying", "'project'::character varying, 'qualification_snapshot'::character varying, 'project_role_grant'::character varying"),
+    ("('project'::character varying)::text, ('project_role_grant'::character varying)::text", "('project'::character varying)::text, ('qualification_snapshot'::character varying)::text, ('project_role_grant'::character varying)::text"),
+)
+
+_LINKED_VALID_MARKER = (
+    "'ProjectRoleGrantIssued','ProjectRoleGrantRevoked',"
+)
+_LINKED_VALID_FORWARD = (
+    "'ProjectRoleQualificationSnapshotCaptured','ProjectRoleGrantIssued',"
+    "'ProjectRoleGrantRevoked',"
+)
+_LINKED_BRANCH_MARKER = "          if new.event_type='AuthorityInvalidationRequested' then"
+_LINKED_ISSUE_BRANCH = """          if new.event_type='ProjectRoleQualificationSnapshotCaptured' then
+            if record_row.operation <> 'project_role_grant.issue'
+               or new.resource_type <> 'qualification_snapshot'
+               or new.entity_type <> 'qualification_snapshot'
+               or new.entity_id <> new.resource_id
+               or new.target_ref_kind is distinct from 'qualification_snapshot'
+               or new.target_ref_id is distinct from new.resource_id
+               or new.invalidation_cause_event_id is not null
+               or new.invalidation_target_kind is not null
+               or new.invalidation_target_ref is not null
+               or exists(select 1 from audit_events where idempotency_reference=record_row.id) then
+              raise exception 'invalid project role qualification evidence' using errcode='23514';
+            end if;
+          elsif record_row.operation='project_role_grant.issue'
+                and new.event_type='ProjectRoleGrantIssued' then
+            select * into cause_row from audit_events
+            where idempotency_reference=record_row.id
+              and event_type='ProjectRoleQualificationSnapshotCaptured';
+            if not found
+               or (select count(*) from audit_events where idempotency_reference=record_row.id) <> 1
+               or cause_row.request_id is distinct from new.request_id
+               or cause_row.correlation_id is distinct from new.correlation_id
+               or cause_row.actor_ref_kind is distinct from new.actor_ref_kind
+               or cause_row.actor_id is distinct from new.actor_id
+               or cause_row.permission_id is distinct from new.permission_id
+               or cause_row.project_id is distinct from new.project_id
+               or cause_row.target_actor_ref_kind is distinct from new.target_actor_ref_kind
+               or cause_row.target_actor_ref is distinct from new.target_actor_ref
+               or cause_row.matched_grant_id is distinct from new.matched_grant_id
+               or new.resource_type <> 'project_role_grant'
+               or new.entity_type <> 'project_role_grant'
+               or new.entity_id <> new.resource_id
+               or new.target_ref_kind is distinct from 'project_role_grant'
+               or new.target_ref_id is distinct from new.resource_id
+               or new.invalidation_cause_event_id is not null
+               or new.invalidation_target_kind is not null
+               or new.invalidation_target_ref is not null then
+              raise exception 'invalid project role issue evidence' using errcode='23514';
+            end if;
+          elsif record_row.operation='project_role_grant.revoke'
+                and new.event_type='AuthorityInvalidationRequested' then
+            select * into cause_row from audit_events where id=new.invalidation_cause_event_id;
+            if not found or cause_row.event_type <> 'ProjectRoleGrantRevoked'
+               or cause_row.idempotency_reference is distinct from record_row.id
+               or cause_row.actor_ref_kind is distinct from new.actor_ref_kind
+               or cause_row.actor_id is distinct from new.actor_id
+               or cause_row.permission_id is distinct from new.permission_id
+               or cause_row.request_id is distinct from new.request_id
+               or cause_row.correlation_id is distinct from new.correlation_id
+               or cause_row.project_id is distinct from new.project_id
+               or cause_row.target_actor_ref_kind is distinct from 'actor_profile'
+               or cause_row.target_actor_ref_kind is distinct from new.target_actor_ref_kind
+               or cause_row.target_actor_ref is distinct from new.target_actor_ref
+               or cause_row.resource_type <> 'project_role_grant'
+               or cause_row.target_ref_kind <> 'project_role_grant'
+               or cause_row.target_ref_id is distinct from cause_row.resource_id
+               or new.resource_type <> 'project_role_grant'
+               or new.resource_id is distinct from cause_row.resource_id
+               or new.target_ref_kind is distinct from 'project_role_grant'
+               or new.target_ref_id is distinct from cause_row.resource_id
+               or new.invalidation_target_kind <> 'project_role_grant'
+               or new.invalidation_target_ref is distinct from cause_row.resource_id
+               or new.entity_type <> 'authority_invalidation' or new.entity_id <> new.id
+               or new.before_facts::jsonb->>'effective' <> 'true'
+               or new.after_facts::jsonb->>'effective' <> 'false'
+               or new.before_facts::jsonb->>'role' not in ('submitter','reviewer','adjudicator')
+               or new.before_facts::jsonb->>'role' is distinct from new.after_facts::jsonb->>'role'
+               or new.before_facts::jsonb->>'scope_type' <> 'project'
+               or new.before_facts::jsonb->>'scope_id' is distinct from new.project_id
+               or new.before_facts::jsonb->>'scope_id' is distinct from new.after_facts::jsonb->>'scope_id'
+               or new.before_facts::jsonb->>'future_obligation' is distinct from new.after_facts::jsonb->>'future_obligation'
+               or (new.before_facts::jsonb->>'role'='submitter' and new.before_facts::jsonb->>'future_obligation'<>'auth13_assignment')
+               or (new.before_facts::jsonb->>'role'='reviewer' and new.before_facts::jsonb->>'future_obligation'<>'rev_reviewer_obligation')
+               or (new.before_facts::jsonb->>'role'='adjudicator' and new.before_facts::jsonb->>'future_obligation'<>'none') then
+              raise exception 'invalid project role revoke invalidation' using errcode='23514';
+            end if;
+          elsif record_row.operation='project_role_grant.issue'
+                and new.event_type='AuthorityInvalidationRequested' then
+            raise exception 'project role issue forbids invalidation' using errcode='23514';
+          elsif new.event_type='AuthorityInvalidationRequested' then"""
+
+_FACTS_TOP = """          if (before_state is not null and not authority_facts_are_safe(before_state))
+             or (after_state is not null and not authority_facts_are_safe(after_state)) then
+            return false;
+          end if;"""
+_FACTS_TOP_FORWARD = """          if not (event_name='AuthorityInvalidationRequested'
+                  and before_state::jsonb ? 'future_obligation'
+                  and after_state::jsonb ? 'future_obligation')
+             and ((before_state is not null and not authority_facts_are_safe(before_state))
+               or (after_state is not null and not authority_facts_are_safe(after_state))) then
+            return false;
+          end if;"""
+_FACTS_BRANCH = """            when 'AuthorityInvalidationRequested' then return (before_state::jsonb = '{"effective": true}'::jsonb and after_state::jsonb = '{"effective": false}'::jsonb) or (before_state::jsonb = '{"effective": false}'::jsonb and after_state::jsonb = '{"effective": true}'::jsonb);"""
+_FACTS_BRANCH_FORWARD = """            when 'AuthorityInvalidationRequested' then return
+              (before_state::jsonb = '{"effective": true}'::jsonb
+                and after_state::jsonb = '{"effective": false}'::jsonb)
+              or (before_state::jsonb = '{"effective": false}'::jsonb
+                and after_state::jsonb = '{"effective": true}'::jsonb)
+              or (
+                jsonb_typeof(before_state::jsonb)='object'
+                and jsonb_typeof(after_state::jsonb)='object'
+                and (select count(*) from jsonb_object_keys(before_state::jsonb))=5
+                and (select count(*) from jsonb_object_keys(after_state::jsonb))=5
+                and before_state::jsonb ?& array['effective','role','scope_type','scope_id','future_obligation']
+                and after_state::jsonb ?& array['effective','role','scope_type','scope_id','future_obligation']
+                and before_state::jsonb->'effective'='true'::jsonb
+                and after_state::jsonb->'effective'='false'::jsonb
+                and jsonb_typeof(before_state::jsonb->'role')='string'
+                and jsonb_typeof(before_state::jsonb->'scope_type')='string'
+                and jsonb_typeof(before_state::jsonb->'scope_id')='string'
+                and jsonb_typeof(before_state::jsonb->'future_obligation')='string'
+                and (before_state::jsonb - 'effective')=(after_state::jsonb - 'effective')
+                and before_state::jsonb->>'scope_type'='project'
+                and before_state::jsonb->>'scope_id'=envelope_project_id
+                and ((before_state::jsonb->>'role'='submitter' and before_state::jsonb->>'future_obligation'='auth13_assignment')
+                  or (before_state::jsonb->>'role'='reviewer' and before_state::jsonb->>'future_obligation'='rev_reviewer_obligation')
+                  or (before_state::jsonb->>'role'='adjudicator' and before_state::jsonb->>'future_obligation'='none'))
+              );"""
+
+_PREDECESSOR_GUARD = """
+create or replace function guard_authority_idempotency_record() returns trigger
+language plpgsql as $$
+        declare success_count integer; invalidation_count integer; success_id text;
+                success_row audit_events%rowtype;
+        begin
+          if tg_op = 'INSERT' then
+            if new.status <> 'pending' then raise exception 'idempotency must begin pending' using errcode='23514'; end if;
+            new.created_at := statement_timestamp(); new.committed_at := null; return new;
+          elsif tg_op = 'DELETE' then
+            raise exception 'authority idempotency records are immutable' using errcode='55000';
+          end if;
+          if old.status <> 'pending' or new.status <> 'committed'
+             or (new.id, new.idempotency_key, new.actor_ref_kind, new.actor_ref,
+                 new.operation, new.request_digest, new.created_at)
+                is distinct from
+                (old.id, old.idempotency_key, old.actor_ref_kind, old.actor_ref,
+                 old.operation, old.request_digest, old.created_at) then
+            raise exception 'invalid authority idempotency transition' using errcode='23514';
+          end if;
+          select count(*), min(id) into success_count, success_id
+          from audit_events where event_domain='authority' and idempotency_reference=new.id
+            and event_type <> 'AuthorityInvalidationRequested';
+          select count(*) into invalidation_count from audit_events
+          where event_domain='authority' and idempotency_reference=new.id
+            and event_type='AuthorityInvalidationRequested';
+          if success_count <> 1 or invalidation_count <> 1 then
+            raise exception 'authority evidence pair required' using errcode='23514';
+          end if;
+          select * into success_row from audit_events where id=success_id;
+          if success_row.resource_type <> new.response_resource_type
+             or success_row.resource_id <> new.response_resource_id::text then
+            raise exception 'authority response does not match evidence' using errcode='23514';
+          end if;
+          new.committed_at := statement_timestamp(); return new;
+        end $$
+"""
+
+_FORWARD_GUARD = """
+create or replace function guard_authority_idempotency_record() returns trigger
+language plpgsql as $$
+declare success_count integer; invalidation_count integer; success_id text;
+        qualification_row audit_events%rowtype; success_row audit_events%rowtype;
+        grant_row project_role_grants%rowtype;
+        snapshot_row project_role_qualification_snapshots%rowtype;
+begin
+  if tg_op = 'INSERT' then
+    if new.status <> 'pending' then raise exception 'idempotency must begin pending' using errcode='23514'; end if;
+    new.created_at := statement_timestamp(); new.committed_at := null; return new;
+  elsif tg_op = 'DELETE' then
+    raise exception 'authority idempotency records are immutable' using errcode='55000';
+  end if;
+  if old.status <> 'pending' or new.status <> 'committed'
+     or (new.id,new.idempotency_key,new.actor_ref_kind,new.actor_ref,new.operation,
+         new.request_digest,new.created_at) is distinct from
+        (old.id,old.idempotency_key,old.actor_ref_kind,old.actor_ref,old.operation,
+         old.request_digest,old.created_at) then
+    raise exception 'invalid authority idempotency transition' using errcode='23514';
+  end if;
+  select count(*), min(id) into success_count, success_id from audit_events
+  where event_domain='authority' and idempotency_reference=new.id
+    and event_type <> 'AuthorityInvalidationRequested';
+  select count(*) into invalidation_count from audit_events
+  where event_domain='authority' and idempotency_reference=new.id
+    and event_type='AuthorityInvalidationRequested';
+  if new.operation='project_role_grant.issue' then
+    if success_count <> 2 or invalidation_count <> 0
+       or (select count(*) from audit_events where idempotency_reference=new.id
+             and event_type='ProjectRoleQualificationSnapshotCaptured') <> 1
+       or (select count(*) from audit_events where idempotency_reference=new.id
+             and event_type='ProjectRoleGrantIssued') <> 1 then
+      raise exception 'project role issue evidence pair required' using errcode='23514';
+    end if;
+    select * into qualification_row from audit_events where idempotency_reference=new.id
+      and event_type='ProjectRoleQualificationSnapshotCaptured';
+    select * into success_row from audit_events where idempotency_reference=new.id
+      and event_type='ProjectRoleGrantIssued';
+    select * into grant_row from project_role_grants where id=success_row.resource_id::uuid;
+    select * into snapshot_row from project_role_qualification_snapshots
+      where id=qualification_row.resource_id::uuid;
+    if not found or grant_row.id is null or snapshot_row.id is null
+       or grant_row.qualification_snapshot_id <> snapshot_row.id
+       or grant_row.project_id <> snapshot_row.project_id
+       or grant_row.actor_profile_id <> snapshot_row.actor_profile_id
+       or grant_row.role <> snapshot_row.requested_role
+       or qualification_row.project_id is distinct from grant_row.project_id
+       or success_row.project_id is distinct from grant_row.project_id
+       or qualification_row.target_actor_ref is distinct from grant_row.actor_profile_id
+       or success_row.target_actor_ref is distinct from grant_row.actor_profile_id
+       or qualification_row.request_id is distinct from success_row.request_id
+       or qualification_row.correlation_id is distinct from success_row.correlation_id
+       or qualification_row.actor_ref_kind is distinct from success_row.actor_ref_kind
+       or qualification_row.actor_id is distinct from success_row.actor_id
+       or qualification_row.permission_id is distinct from success_row.permission_id
+       or qualification_row.matched_grant_id is distinct from success_row.matched_grant_id then
+      raise exception 'project role issue evidence mismatch' using errcode='23514';
+    end if;
+  else
+    if success_count <> 1 or invalidation_count <> 1 then
+      raise exception 'authority evidence pair required' using errcode='23514';
+    end if;
+    select * into success_row from audit_events where id=success_id;
+  end if;
+  if success_row.resource_type <> new.response_resource_type
+     or success_row.resource_id <> new.response_resource_id::text then
+    raise exception 'authority response does not match evidence' using errcode='23514';
+  end if;
+  new.committed_at := statement_timestamp(); return new;
+end $$
+"""
+
+
+def _definition(name: str) -> str:
+    return op.get_bind().execute(
+        sa.text("select pg_get_functiondef(cast(:name as regproc))"), {"name": name}
+    ).scalar_one()
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _assert_triggers() -> None:
+    expected = {
+        "authority_idempotency_guard": (
+            "authority_idempotency_records", "guard_authority_idempotency_record"
+        ),
+        "audit_events_validate_idempotency": ("audit_events", "validate_linked_authority_event"),
+    }
+    rows = op.get_bind().execute(sa.text("""
+        select t.tgname,c.relname,p.proname,t.tgenabled,t.tgdeferrable,t.tginitdeferred,
+               pg_get_triggerdef(t.oid,true) definition
+        from pg_trigger t join pg_class c on c.oid=t.tgrelid
+        join pg_proc p on p.oid=t.tgfoid where t.tgname in
+          ('authority_idempotency_guard','audit_events_validate_idempotency')
+    """)).mappings().all()
+    if len(rows) != 2:
+        raise RuntimeError("unexpected authority evidence trigger inventory")
+    for row in rows:
+        table, function = expected[row["tgname"]]
+        if (
+            row["relname"] != table
+            or row["proname"] != function
+            or row["tgenabled"] not in ("O", b"O")
+            or row["tgdeferrable"] not in (False, "f")
+            or row["tginitdeferred"] not in (False, "f")
+            or _digest(row["definition"]) != _TRIGGER_SHA256[row["tgname"]]
+        ):
+            raise RuntimeError(f"unexpected authority evidence trigger binding: {dict(row)!r}")
+
+
+def _assert_fact_constraint() -> None:
+    row = op.get_bind().execute(sa.text("""
+        select c.relname table_name,q.convalidated,pg_get_constraintdef(q.oid) definition
+        from pg_constraint q join pg_class c on c.oid=q.conrelid
+        where q.conname='ck_audit_events_fact_bounds'
+    """)).mappings().one_or_none()
+    if (
+        row is None
+        or row["table_name"] != "audit_events"
+        or not row["convalidated"]
+        or _digest(row["definition"]) != _FACT_CONSTRAINT_SHA256
+    ):
+        raise RuntimeError("unexpected authority fact constraint")
+
+
+def _privacy(*, add: bool) -> None:
+    bind = op.get_bind()
+    definition = bind.execute(sa.text("""
+        select pg_get_constraintdef(oid) from pg_constraint
+        where conrelid='audit_events'::regclass
+          and conname='ck_audit_events_authority_privacy_bounds'
+    """)).scalar_one()
+    expected = _PREDECESSOR_PRIVACY_SHA256 if add else _FORWARD_PRIVACY_SHA256
+    if _digest(definition) != expected:
+        raise RuntimeError("unexpected authority privacy constraint")
+    matches = [(old, new) for old, new in _RESOURCE_MARKERS if (new if not add else old) in definition]
+    if add:
+        matches = [(old, new) for old, new in matches if new not in definition]
+    if not matches:
+        raise RuntimeError("unexpected authority privacy constraint")
+    old, new = max(matches, key=lambda item: len(item[1]))
+    source, target = (old, new) if add else (new, old)
+    if definition.count(source) != 1:
+        raise RuntimeError("unexpected authority privacy constraint")
+    definition = definition.replace(source, target)
+    if not add:
+        # Rebuild the predecessor through its original IN/NOT IN expression form.
+        # Re-executing pg_get_constraintdef() directly produces a semantically equal
+        # but structurally different ANY/ALL tree and would not restore 0033 exactly.
+        definition = re.sub(
+            r"\('([^']+)'::character varying\)::text",
+            r"'\1'",
+            definition,
+        )
+        definition = re.sub(
+            r"\(\((\w+)\)::text = ANY \(ARRAY\[([^]]+)\]\)\)",
+            r"\1 in (\2)",
+            definition,
+        )
+        definition = re.sub(
+            r"\(\((\w+)\)::text <> ALL \(ARRAY\[([^]]+)\]\)\)",
+            r"\1 not in (\2)",
+            definition,
+        )
+    op.drop_constraint("authority_privacy_bounds", "audit_events", type_="check")
+    op.execute(f"alter table audit_events add constraint ck_audit_events_authority_privacy_bounds {definition}")
+    installed = bind.execute(sa.text("""
+        select pg_get_constraintdef(oid) from pg_constraint
+        where conrelid='audit_events'::regclass
+          and conname='ck_audit_events_authority_privacy_bounds'
+    """)).scalar_one()
+    installed_expected = _FORWARD_PRIVACY_SHA256 if add else _PREDECESSOR_PRIVACY_SHA256
+    if _digest(installed) != installed_expected:
+        raise RuntimeError("unexpected installed authority privacy constraint")
+
+
+def _linked(*, add: bool) -> None:
+    linked = _definition("validate_linked_authority_event")
+    if add:
+        if linked.count(_LINKED_VALID_MARKER) != 1 or linked.count(_LINKED_BRANCH_MARKER) != 1:
+            raise RuntimeError("unexpected linked authority validator definition")
+        linked = linked.replace(_LINKED_VALID_MARKER, _LINKED_VALID_FORWARD)
+        linked = linked.replace(_LINKED_BRANCH_MARKER, _LINKED_ISSUE_BRANCH)
+    else:
+        if linked.count(_LINKED_VALID_FORWARD) != 1 or linked.count(_LINKED_ISSUE_BRANCH) != 1:
+            raise RuntimeError("unexpected linked authority validator definition")
+        linked = linked.replace(_LINKED_VALID_FORWARD, _LINKED_VALID_MARKER)
+        linked = linked.replace(_LINKED_ISSUE_BRANCH, _LINKED_BRANCH_MARKER)
+    op.execute(linked)
+
+
+def _facts(*, add: bool) -> None:
+    facts = _definition("authority_event_facts_are_safe")
+    old_top, new_top = (_FACTS_TOP, _FACTS_TOP_FORWARD) if add else (_FACTS_TOP_FORWARD, _FACTS_TOP)
+    old_branch, new_branch = (
+        (_FACTS_BRANCH, _FACTS_BRANCH_FORWARD)
+        if add
+        else (_FACTS_BRANCH_FORWARD, _FACTS_BRANCH)
+    )
+    if facts.count(old_top) != 1 or facts.count(old_branch) != 1:
+        raise RuntimeError("unexpected authority fact validator definition")
+    op.execute(facts.replace(old_top, new_top).replace(old_branch, new_branch))
+
+
+def _refuse_incompatible(*, downgrade: bool) -> None:
+    bind = op.get_bind()
+    if downgrade:
+        query = """select exists(
+          select 1 from authority_idempotency_records r
+          where r.operation='project_role_grant.issue' and
+            (r.status<>'pending' or r.response_resource_type is not null
+             or r.response_resource_id is not null or r.response_resource_version is not null
+             or r.response_http_status is not null or r.committed_at is not null
+             or exists(select 1 from audit_events e where e.idempotency_reference=r.id))
+          union all select 1 from audit_events
+          where event_type='ProjectRoleQualificationSnapshotCaptured'
+             or (idempotency_reference is not null and event_type='ProjectRoleGrantIssued')
+             or (event_type='AuthorityInvalidationRequested' and
+                 (before_facts::jsonb ? 'future_obligation'
+                  or after_facts::jsonb ? 'future_obligation')))"""
+    else:
+        query = """select exists(
+          select 1 from authority_idempotency_records r
+          where r.operation='project_role_grant.issue' and
+            (r.status<>'pending' or r.response_resource_type is not null
+             or r.response_resource_id is not null or r.response_resource_version is not null
+             or r.response_http_status is not null or r.committed_at is not null
+             or exists(select 1 from audit_events e where e.idempotency_reference=r.id))
+          union all select 1 from audit_events e where
+            e.event_type='ProjectRoleQualificationSnapshotCaptured'
+            or (e.idempotency_reference is not null and e.event_type='ProjectRoleGrantIssued'
+                and not exists(select 1 from authority_idempotency_records r
+                  where r.id=e.idempotency_reference and r.operation='project_role_grant.issue')))"""
+    if bind.execute(sa.text(query)).scalar_one():
+        raise RuntimeError("incompatible project-role issue evidence")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(sa.text("lock table authority_idempotency_records in access exclusive mode"))
+    bind.execute(sa.text("lock table audit_events in access exclusive mode"))
+    _assert_triggers()
+    _assert_fact_constraint()
+    # Frozen hashes make definition drift a hard failure; marker checks below remain a
+    # readable diagnostic across PostgreSQL formatting versions.
+    guard, linked = _definition("guard_authority_idempotency_record"), _definition("validate_linked_authority_event")
+    facts = _definition("authority_event_facts_are_safe")
+    if (_digest(guard) != _PREDECESSOR_GUARD_SHA256
+        or _digest(linked) != _PREDECESSOR_LINKED_SHA256
+        or _digest(facts) != _PREDECESSOR_FACTS_SHA256):
+        raise RuntimeError("unexpected predecessor authority evidence definition")
+    _refuse_incompatible(downgrade=False)
+    _privacy(add=True)
+    op.execute(_FORWARD_GUARD)
+    _linked(add=True)
+    _facts(add=True)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(sa.text("lock table authority_idempotency_records in access exclusive mode"))
+    bind.execute(sa.text("lock table audit_events in access exclusive mode"))
+    _assert_triggers()
+    _assert_fact_constraint()
+    guard = _definition("guard_authority_idempotency_record")
+    linked = _definition("validate_linked_authority_event")
+    facts = _definition("authority_event_facts_are_safe")
+    if (
+        _digest(guard) != _FORWARD_GUARD_SHA256
+        or _digest(linked) != _FORWARD_LINKED_SHA256
+        or _digest(facts) != _FORWARD_FACTS_SHA256
+    ):
+        raise RuntimeError("unexpected forward authority evidence definition")
+    _refuse_incompatible(downgrade=True)
+    _linked(add=False)
+    _facts(add=False)
+    op.execute(_PREDECESSOR_GUARD)
+    _privacy(add=False)

--- a/backend/app/modules/audit/schemas.py
+++ b/backend/app/modules/audit/schemas.py
@@ -32,7 +32,7 @@ _ENTITY_TYPES = frozenset(
     }
 )
 _RESOURCE_TYPES = frozenset(
-    """actor_profile actor_identity_link admin_role_grant project project_role_grant task
+    """actor_profile actor_identity_link admin_role_grant project qualification_snapshot project_role_grant task
     submission review contribution compensation_award compensation_delivery operations
     audit_event""".split()
 )

--- a/backend/app/modules/audit/schemas.py
+++ b/backend/app/modules/audit/schemas.py
@@ -60,6 +60,9 @@ _FACT_VALUES: dict[str, frozenset[str]] = {
     "provisioning_method": frozenset({"automatic_first_access", "manual_service_provisioning"}),
     "role": _ADMIN_ROLES | _PROJECT_ROLES,
     "scope_type": frozenset({"system", "project"}),
+    "future_obligation": frozenset(
+        {"auth13_assignment", "rev_reviewer_obligation", "none"}
+    ),
 }
 
 
@@ -201,9 +204,30 @@ def _event_facts_valid(event: AuthorityEventType, before: dict[str, object] | No
     if event in exact:
         return (before, after) == exact[event]
     if event == AuthorityEventType.AUTHORITY_INVALIDATION_REQUESTED:
-        return (before, after) in (
+        if (before, after) in (
             ({"effective": True}, {"effective": False}),
             ({"effective": False}, {"effective": True}),
+        ):
+            return True
+        if before is None or after is None:
+            return False
+        expected_obligation = {
+            "submitter": "auth13_assignment",
+            "reviewer": "rev_reviewer_obligation",
+            "adjudicator": "none",
+        }.get(before.get("role"))
+        keys = {"effective", "role", "scope_type", "scope_id", "future_obligation"}
+        return (
+            set(before) == keys
+            and set(after) == keys
+            and before["effective"] is True
+            and after["effective"] is False
+            and before["scope_type"] == after["scope_type"] == "project"
+            and before["role"] == after["role"]
+            and before["scope_id"] == after["scope_id"]
+            and before["future_obligation"]
+            == after["future_obligation"]
+            == expected_obligation
         )
     if event == AuthorityEventType.ACTOR_IDENTITY_LINKED:
         return before is None and after in ({"status": "active", "subject_kind": "human"}, {"status": "active", "subject_kind": "service"})
@@ -404,7 +428,18 @@ class AuthorityAuditEventInput(BaseModel):
                 if restoration
                 else ({"effective": True}, {"effective": False})
             )
-            if (before, after) != expected_direction:
+            projected_project_role = (
+                self.permission_id is PermissionId.PROJECT_ROLE_GRANT_MANAGE
+                and before is not None
+                and after is not None
+                and before.get("effective") is True
+                and after.get("effective") is False
+                and before.get("role") in _PROJECT_ROLES
+                and before.get("role") == after.get("role")
+                and before.get("future_obligation")
+                == after.get("future_obligation")
+            )
+            if (before, after) != expected_direction and not projected_project_role:
                 raise ValueError("invalid authority invalidation direction")
             if self.permission_id in {
                 PermissionId.ADMIN_ROLE_GRANT,

--- a/backend/app/modules/authorization/catalogue.py
+++ b/backend/app/modules/authorization/catalogue.py
@@ -331,12 +331,12 @@ ACTION_DEFINITIONS = (
         PermissionId.PROJECT_ROLE_GRANT_READ,
         ActionOwner.AUTH_10B,
     ),
-    _planned(
+    _active(
         ActionId.PROJECT_ROLE_GRANT_ISSUE,
         PermissionId.PROJECT_ROLE_GRANT_MANAGE,
         ActionOwner.AUTH_10C,
     ),
-    _planned(
+    _active(
         ActionId.PROJECT_ROLE_GRANT_REVOKE,
         PermissionId.PROJECT_ROLE_GRANT_MANAGE,
         ActionOwner.AUTH_10C,
@@ -633,6 +633,8 @@ def _index_actions(
         ActionId.PROJECT_CONTRIBUTOR_CANDIDATE_LIST,
         ActionId.PROJECT_ROLE_GRANT_LIST,
         ActionId.PROJECT_ROLE_GRANT_READ,
+        ActionId.PROJECT_ROLE_GRANT_ISSUE,
+        ActionId.PROJECT_ROLE_GRANT_REVOKE,
     }
     if {
         definition.action_id
@@ -663,18 +665,14 @@ _SERVICE_ACTIONS = {
             ActionId.ARTIFACT_CHECKER_OUTPUT_BINDING_CREATE,
         }
     ),
-    ServiceIdentity.ARTIFACT_GUIDE_READER: frozenset(
-        {ActionId.ARTIFACT_GUIDE_SOURCE_READ}
-    ),
+    ServiceIdentity.ARTIFACT_GUIDE_READER: frozenset({ActionId.ARTIFACT_GUIDE_SOURCE_READ}),
     ServiceIdentity.ARTIFACT_MATERIALIZER: frozenset(
         {
             ActionId.ARTIFACT_PRE_SUBMIT_CHECKER_INPUT_MATERIALIZE,
             ActionId.ARTIFACT_POST_SUBMIT_CHECKER_INPUT_MATERIALIZE,
         }
     ),
-    ServiceIdentity.ARTIFACT_CHECKER_OUTPUT: frozenset(
-        {ActionId.ARTIFACT_CHECKER_OUTPUT_WRITE}
-    ),
+    ServiceIdentity.ARTIFACT_CHECKER_OUTPUT: frozenset({ActionId.ARTIFACT_CHECKER_OUTPUT_WRITE}),
 }
 
 
@@ -683,12 +681,8 @@ def _index_service_actions(
 ) -> MappingProxyType[ServiceIdentity, frozenset[ActionId]]:
     """Validate the exact fixed service matrix and return an immutable view."""
     expected_rows = {
-        ServiceIdentity.ARTIFACT_VERIFIER: frozenset(
-            {ActionId.ARTIFACT_VERIFICATION_EXECUTE}
-        ),
-        ServiceIdentity.ARTIFACT_PUT_RESOLVER: frozenset(
-            {ActionId.ARTIFACT_PUT_ATTEMPT_RESOLVE}
-        ),
+        ServiceIdentity.ARTIFACT_VERIFIER: frozenset({ActionId.ARTIFACT_VERIFICATION_EXECUTE}),
+        ServiceIdentity.ARTIFACT_PUT_RESOLVER: frozenset({ActionId.ARTIFACT_PUT_ATTEMPT_RESOLVE}),
         ServiceIdentity.ARTIFACT_SCHEDULER: frozenset(
             {ActionId.ARTIFACT_PENDING_WORK_SCAN, ActionId.ARTIFACT_UPLOAD_SESSION_EXPIRE}
         ),
@@ -699,9 +693,7 @@ def _index_service_actions(
                 ActionId.ARTIFACT_CHECKER_OUTPUT_BINDING_CREATE,
             }
         ),
-        ServiceIdentity.ARTIFACT_GUIDE_READER: frozenset(
-            {ActionId.ARTIFACT_GUIDE_SOURCE_READ}
-        ),
+        ServiceIdentity.ARTIFACT_GUIDE_READER: frozenset({ActionId.ARTIFACT_GUIDE_SOURCE_READ}),
         ServiceIdentity.ARTIFACT_MATERIALIZER: frozenset(
             {
                 ActionId.ARTIFACT_PRE_SUBMIT_CHECKER_INPUT_MATERIALIZE,

--- a/backend/app/modules/authorization/kernel.py
+++ b/backend/app/modules/authorization/kernel.py
@@ -47,7 +47,9 @@ from app.modules.authorization.runtime import (
     PermissionCatalogueResourceContext,
     ProjectContributorCandidateCollectionResourceContext,
     ProjectRoleGrantCollectionResourceContext,
+    ProjectRoleGrantIssueResourceContext,
     ProjectRoleGrantReadResourceContext,
+    ProjectRoleGrantRevokeResourceContext,
     PreparedAuthorizationUnsupported,
     PreparedAuthorityScope,
     PreparedAuthorityScopeKind,
@@ -81,6 +83,8 @@ _ADMIN_ACTIONS = frozenset(
         ActionId.ACTOR_PROFILE_DEACTIVATE,
         ActionId.ACTOR_IDENTITY_LINK_REVOKE,
         ActionId.ACTOR_IDENTITY_LINK_REACTIVATE,
+        ActionId.PROJECT_ROLE_GRANT_ISSUE,
+        ActionId.PROJECT_ROLE_GRANT_REVOKE,
         ActionId.PROJECT_CONTRIBUTOR_CANDIDATE_LIST,
         ActionId.PROJECT_ROLE_GRANT_LIST,
         ActionId.PROJECT_ROLE_GRANT_READ,
@@ -263,16 +267,13 @@ class AuthorizationService:
                 PreparedAuthorityScopeKind.SYSTEM,
                 PreparedAuthorityScopeKind.PROJECT,
             }:
-                raise PreparedAuthorizationUnsupported(
-                    AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED
-                )
-            if (
-                scope.kind is PreparedAuthorityScopeKind.PROJECT
-                and action_id is not ActionId.ADMIN_ROLE_GRANT_ISSUE
-            ):
-                raise PreparedAuthorizationUnsupported(
-                    AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED
-                )
+                raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED)
+            if scope.kind is PreparedAuthorityScopeKind.PROJECT and action_id not in {
+                ActionId.ADMIN_ROLE_GRANT_ISSUE,
+                ActionId.PROJECT_ROLE_GRANT_ISSUE,
+                ActionId.PROJECT_ROLE_GRANT_REVOKE,
+            }:
+                raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED)
             await self._admin.lock_control()
             locked = await self._admin.lock_request_actor(
                 context.identity_link_id, context.actor_profile_id
@@ -313,18 +314,14 @@ class AuthorizationService:
     @staticmethod
     def _locked_human_context(locked, original) -> HumanAuthorizationContext:
         if locked is None:
-            raise PreparedAuthorizationUnsupported(
-                AuthorizationDenialCode.IDENTITY_LINK_REVOKED
-            )
+            raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.IDENTITY_LINK_REVOKED)
         link, profile = locked
         if (
             profile.id != str(original.actor_profile_id)
             or link.id != str(original.identity_link_id)
             or link.actor_profile_id != profile.id
         ):
-            raise PreparedAuthorizationUnsupported(
-                AuthorizationDenialCode.PERMISSION_NOT_GRANTED
-            )
+            raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.PERMISSION_NOT_GRANTED)
         return HumanAuthorizationContext(
             actor_profile_id=UUID(profile.id),
             actor_kind=ActorKind(profile.actor_kind),
@@ -338,9 +335,7 @@ class AuthorizationService:
     @staticmethod
     def _locked_service_context(locked, original) -> ServiceAuthorizationContext:
         if locked is None:
-            raise PreparedAuthorizationUnsupported(
-                AuthorizationDenialCode.IDENTITY_LINK_REVOKED
-            )
+            raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.IDENTITY_LINK_REVOKED)
         link, profile = locked
         if (
             profile.id != str(original.actor_profile_id)
@@ -349,9 +344,7 @@ class AuthorizationService:
             or profile.actor_kind != ActorKind.SERVICE.value
             or profile.service_identity != original.service_identity.value
         ):
-            raise PreparedAuthorizationUnsupported(
-                AuthorizationDenialCode.PERMISSION_NOT_GRANTED
-            )
+            raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.PERMISSION_NOT_GRANTED)
         return ServiceAuthorizationContext(
             actor_profile_id=UUID(profile.id),
             actor_kind=ActorKind.SERVICE,
@@ -469,8 +462,7 @@ class AuthorizationService:
             if denial is None and final_scope != authority.scope_project_id:
                 denial = AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED
             if denial is None and (
-                authority.matched_grant_id is None
-                or authority.matched_grant_status != "active"
+                authority.matched_grant_id is None or authority.matched_grant_status != "active"
             ):
                 denial = AuthorizationDenialCode.PERMISSION_NOT_GRANTED
             if denial is None:
@@ -553,8 +545,7 @@ class AuthorizationService:
             return lifecycle, refreshed, True
         if (
             refreshed.service_identity is not context.service_identity
-            or action.action_id
-            not in SERVICE_ACTIONS_BY_IDENTITY[refreshed.service_identity]
+            or action.action_id not in SERVICE_ACTIONS_BY_IDENTITY[refreshed.service_identity]
             or ACTION_BY_ID[action.action_id].availability is not ActionAvailability.ACTIVE
         ):
             return AuthorizationDenialCode.PERMISSION_NOT_GRANTED, refreshed, True
@@ -663,24 +654,28 @@ class AuthorizationService:
                 return AuthorizationDenialCode.GRANT_NOT_FOUND
             if grant.target_actor_profile_id == str(context.actor_profile_id):
                 return AuthorizationDenialCode.SELF_ROLE_REVOKE_FORBIDDEN
+        elif isinstance(resource, ProjectRoleGrantIssueResourceContext):
+            if resource.target_actor_profile_id == context.actor_profile_id:
+                return AuthorizationDenialCode.SELF_GRANT_FORBIDDEN
+            if resource.project_status not in {"draft", "active", "paused"}:
+                return AuthorizationDenialCode.RESOURCE_GUARD_DENIED
+            if not resource.target_eligible:
+                return AuthorizationDenialCode.ACTOR_NOT_FOUND
+        elif isinstance(resource, ProjectRoleGrantRevokeResourceContext):
+            if resource.actor_profile_id == context.actor_profile_id:
+                return AuthorizationDenialCode.SELF_ROLE_REVOKE_FORBIDDEN
         elif isinstance(resource, ActorProfileLifecycleResourceContext):
-            if (
-                resource.resource_id == context.actor_profile_id
-                and resource.transition in {"suspend", "deactivate"}
-            ):
+            if resource.resource_id == context.actor_profile_id and resource.transition in {
+                "suspend",
+                "deactivate",
+            }:
                 return AuthorizationDenialCode.RESOURCE_GUARD_DENIED
             if await self._admin.lock_actor_lifecycle_target(resource.resource_id) is None:
                 return AuthorizationDenialCode.ACTOR_NOT_FOUND
         elif isinstance(resource, ActorIdentityLinkLifecycleResourceContext):
-            if (
-                resource.resource_id == context.identity_link_id
-                and resource.transition == "revoke"
-            ):
+            if resource.resource_id == context.identity_link_id and resource.transition == "revoke":
                 return AuthorizationDenialCode.RESOURCE_GUARD_DENIED
-            if (
-                await self._admin.lock_identity_link_lifecycle_target(resource.resource_id)
-                is None
-            ):
+            if await self._admin.lock_identity_link_lifecycle_target(resource.resource_id) is None:
                 return AuthorizationDenialCode.RESOURCE_NOT_FOUND
         elif isinstance(
             resource,
@@ -724,6 +719,8 @@ class AuthorizationService:
             ),
             ActionId.PROJECT_ROLE_GRANT_LIST: ProjectRoleGrantCollectionResourceContext,
             ActionId.PROJECT_ROLE_GRANT_READ: ProjectRoleGrantReadResourceContext,
+            ActionId.PROJECT_ROLE_GRANT_ISSUE: ProjectRoleGrantIssueResourceContext,
+            ActionId.PROJECT_ROLE_GRANT_REVOKE: ProjectRoleGrantRevokeResourceContext,
         }.get(action_id)
         if expected is None or not isinstance(resource, expected):
             return False
@@ -801,10 +798,14 @@ class AuthorizationService:
             return AuthorizationDenialCode.RESOURCE_GUARD_DENIED
         if context.actor_kind is not ActorKind.HUMAN:
             return AuthorizationDenialCode.PERMISSION_NOT_GRANTED
-        if action.action_id in {
-            ActionId.ACTOR_PROFILE_READ_SELF,
-            ActionId.ACTOR_PROFILE_UPDATE_SELF,
-        } and not revalidated:
+        if (
+            action.action_id
+            in {
+                ActionId.ACTOR_PROFILE_READ_SELF,
+                ActionId.ACTOR_PROFILE_UPDATE_SELF,
+            }
+            and not revalidated
+        ):
             return AuthorizationDenialCode.RESOURCE_GUARD_DENIED
         return None
 

--- a/backend/app/modules/authorization/kernel.py
+++ b/backend/app/modules/authorization/kernel.py
@@ -106,6 +106,8 @@ _ADMIN_MUTATIONS = frozenset(
         ActionId.ACTOR_PROFILE_DEACTIVATE,
         ActionId.ACTOR_IDENTITY_LINK_REVOKE,
         ActionId.ACTOR_IDENTITY_LINK_REACTIVATE,
+        ActionId.PROJECT_ROLE_GRANT_ISSUE,
+        ActionId.PROJECT_ROLE_GRANT_REVOKE,
     }
 )
 
@@ -275,10 +277,27 @@ class AuthorizationService:
             }:
                 raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED)
             await self._admin.lock_control()
-            locked = await self._admin.lock_request_actor(
-                context.identity_link_id, context.actor_profile_id
-            )
+            if action_id is ActionId.PROJECT_ROLE_GRANT_ISSUE:
+                if scope.target_actor_profile_id is None or scope.role is None:
+                    raise PreparedAuthorizationUnsupported(
+                        AuthorizationDenialCode.RESOURCE_GUARD_DENIED
+                    )
+                locked, _target_eligible = (
+                    await self._admin.lock_project_role_issue_principals(
+                        caller_actor_profile_id=context.actor_profile_id,
+                        caller_identity_link_id=context.identity_link_id,
+                        target_actor_profile_id=scope.target_actor_profile_id,
+                    )
+                )
+            else:
+                locked = await self._admin.lock_request_actor(
+                    context.identity_link_id, context.actor_profile_id
+                )
             context = self._locked_human_context(locked, context)
+            if action_id is ActionId.PROJECT_ROLE_GRANT_REVOKE and scope.grant_id is None:
+                raise PreparedAuthorizationUnsupported(
+                    AuthorizationDenialCode.RESOURCE_GUARD_DENIED
+                )
             grant = await self._admin.find_effective_grant(
                 context.actor_profile_id,
                 action.permission_id,

--- a/backend/app/modules/authorization/prepared.py
+++ b/backend/app/modules/authorization/prepared.py
@@ -222,6 +222,14 @@ class PreparedAuthorizationService:
             action_id, resource
         ):
             project_id = AuthorizationService._resource_project_id(resource)
+            target_actor_profile_id = None
+            role = None
+            grant_id = None
+            if action_id is ActionId.PROJECT_ROLE_GRANT_ISSUE:
+                target_actor_profile_id = resource.target_actor_profile_id
+                role = resource.role
+            elif action_id is ActionId.PROJECT_ROLE_GRANT_REVOKE:
+                grant_id = resource.resource_id
             return PreparedAuthorityScope(
                 kind=(
                     PreparedAuthorityScopeKind.PROJECT
@@ -229,5 +237,8 @@ class PreparedAuthorizationService:
                     else PreparedAuthorityScopeKind.SYSTEM
                 ),
                 project_id=project_id,
+                target_actor_profile_id=target_actor_profile_id,
+                role=role,
+                grant_id=grant_id,
             )
         raise PreparedAuthorizationHandleInvalid("invalid prepared authorization handle")

--- a/backend/app/modules/authorization/project_role_schemas.py
+++ b/backend/app/modules/authorization/project_role_schemas.py
@@ -1,0 +1,40 @@
+"""Strict public contracts for independent project-role mutations."""
+
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.modules.authorization.schemas import (
+    ProjectRole,
+    ProjectRoleQualificationEvidence,
+)
+
+_STRICT = ConfigDict(extra="forbid", strict=True)
+
+
+class ProjectRoleGrantIssueBody(BaseModel):
+    model_config = _STRICT
+
+    target_actor_profile_id: UUID
+    role: ProjectRole
+    qualification: ProjectRoleQualificationEvidence
+    reason: Annotated[str, Field(min_length=1, max_length=500)]
+
+
+class ProjectRoleGrantRevokeBody(BaseModel):
+    model_config = _STRICT
+
+    reason: Annotated[str, Field(min_length=1, max_length=500)]
+
+
+class ProjectRoleGrantMutationResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    id: UUID
+    qualification_snapshot_id: UUID
+    project_id: UUID
+    actor_profile_id: UUID
+    role: ProjectRole
+    status: Literal["active", "revoked"]
+    version: Literal[1, 2]

--- a/backend/app/modules/authorization/project_role_schemas.py
+++ b/backend/app/modules/authorization/project_role_schemas.py
@@ -1,16 +1,30 @@
 """Strict public contracts for independent project-role mutations."""
 
 from typing import Annotated, Literal
+import unicodedata
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field
 
 from app.modules.authorization.schemas import (
     ProjectRole,
     ProjectRoleQualificationEvidence,
 )
 
-_STRICT = ConfigDict(extra="forbid", strict=True)
+_STRICT = ConfigDict(extra="forbid")
+
+
+def _reason(value: str) -> str:
+    if (
+        value != value.strip()
+        or not 1 <= len(value.encode("utf-8")) <= 500
+        or any(unicodedata.category(character).startswith("C") for character in value)
+    ):
+        raise ValueError("invalid project-role mutation reason")
+    return value
+
+
+Reason = Annotated[str, Field(min_length=1), AfterValidator(_reason)]
 
 
 class ProjectRoleGrantIssueBody(BaseModel):
@@ -19,13 +33,13 @@ class ProjectRoleGrantIssueBody(BaseModel):
     target_actor_profile_id: UUID
     role: ProjectRole
     qualification: ProjectRoleQualificationEvidence
-    reason: Annotated[str, Field(min_length=1, max_length=500)]
+    reason: Reason
 
 
 class ProjectRoleGrantRevokeBody(BaseModel):
     model_config = _STRICT
 
-    reason: Annotated[str, Field(min_length=1, max_length=500)]
+    reason: Reason
 
 
 class ProjectRoleGrantMutationResponse(BaseModel):

--- a/backend/app/modules/authorization/project_role_service.py
+++ b/backend/app/modules/authorization/project_role_service.py
@@ -20,7 +20,13 @@ from app.modules.authorization.catalogue import ActionId, PermissionId
 from app.modules.authorization.models import ProjectRoleGrant, ProjectRoleQualificationSnapshot
 from app.modules.authorization.project_role_schemas import ProjectRoleGrantMutationResponse
 from app.modules.authorization.repository import AdminAuthorizationRepository
-from app.modules.authorization.runtime import AuthorizationDecision
+from app.modules.authorization.runtime import (
+    AuthorizationDecision,
+    MatchedAuthorityKind,
+    ProjectRoleGrantIssueResourceContext,
+    ProjectRoleGrantRevokeResourceContext,
+    authorization_resource_digest,
+)
 from app.modules.authorization.schemas import (
     AuthorityClaimHandle,
     AuthorityInvalidationContext,
@@ -165,12 +171,13 @@ class ProjectRoleGrantMutationService:
         claim: AuthorityClaimHandle,
         request: ProjectRoleGrantIssueRequest,
         decision: AuthorizationDecision,
+        resource: ProjectRoleGrantIssueResourceContext,
         actor_profile_id: UUID,
         reason: str,
     ) -> ProjectRoleGrantMutationResponse:
         if (
             request.reason_digest != derive_reason_digest(reason)
-            or decision.matched_grant_id is None
+            or not _issue_decision_matches(decision, request, resource)
         ):
             raise TypeError("project-role issue requires exact matched authority")
         duplicate = await self.repository.find_active_project_role(
@@ -274,13 +281,14 @@ class ProjectRoleGrantMutationService:
         claim: AuthorityClaimHandle,
         request: ProjectRoleGrantRevokeRequest,
         decision: AuthorizationDecision,
+        resource: ProjectRoleGrantRevokeResourceContext,
         actor_profile_id: UUID,
         reason: str,
         grant: ProjectRoleGrant,
     ) -> ProjectRoleGrantMutationResponse:
         if (
             request.reason_digest != derive_reason_digest(reason)
-            or decision.matched_grant_id is None
+            or not _revoke_decision_matches(decision, request, grant, resource)
         ):
             raise TypeError("project-role revoke requires exact matched authority")
         if grant.status != "active":
@@ -341,3 +349,54 @@ class ProjectRoleGrantMutationService:
             ),
         )
         return _response(grant)
+
+
+def _issue_decision_matches(
+    decision: AuthorizationDecision,
+    request: ProjectRoleGrantIssueRequest,
+    resource: ProjectRoleGrantIssueResourceContext,
+) -> bool:
+    return (
+        decision.allowed
+        and decision.revalidated
+        and decision.matched_authority_kind is MatchedAuthorityKind.ADMIN_ROLE_GRANT
+        and decision.action_id is ActionId.PROJECT_ROLE_GRANT_ISSUE
+        and decision.permission_id is PermissionId.PROJECT_ROLE_GRANT_MANAGE
+        and resource.resource_id == request.project_id
+        and resource.scope_project_id == request.project_id
+        and resource.target_actor_profile_id == request.target_actor_id
+        and resource.role is request.role
+        and resource.target_eligible
+        and not resource.active_exact_role_exists
+        and decision.resource_type == resource.resource_type
+        and decision.resource_id == resource.resource_id
+        and decision.resource_context_digest == authorization_resource_digest(resource)
+        and decision.matched_grant_id is not None
+        and decision.matched_scope_project_id == request.project_id
+    )
+
+
+def _revoke_decision_matches(
+    decision: AuthorizationDecision,
+    request: ProjectRoleGrantRevokeRequest,
+    grant: ProjectRoleGrant,
+    resource: ProjectRoleGrantRevokeResourceContext,
+) -> bool:
+    return (
+        decision.allowed
+        and decision.revalidated
+        and decision.matched_authority_kind is MatchedAuthorityKind.ADMIN_ROLE_GRANT
+        and decision.action_id is ActionId.PROJECT_ROLE_GRANT_REVOKE
+        and decision.permission_id is PermissionId.PROJECT_ROLE_GRANT_MANAGE
+        and resource.resource_id == request.grant_id == grant.id
+        and resource.scope_project_id == request.project_id == UUID(grant.project_id)
+        and resource.actor_profile_id == UUID(grant.actor_profile_id)
+        and resource.role.value == grant.role
+        and resource.status == grant.status
+        and resource.version == grant.version
+        and decision.resource_type == resource.resource_type
+        and decision.resource_id == resource.resource_id
+        and decision.resource_context_digest == authorization_resource_digest(resource)
+        and decision.matched_grant_id is not None
+        and decision.matched_scope_project_id == request.project_id
+    )

--- a/backend/app/modules/authorization/project_role_service.py
+++ b/backend/app/modules/authorization/project_role_service.py
@@ -1,0 +1,271 @@
+"""Prepared, idempotent project-role grant mutations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from uuid import UUID, uuid4
+
+from sqlalchemy.sql import func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.audit.schemas import (
+    ActorReferenceKind,
+    AuthorityAuditEventInput,
+    AuthorityEventType,
+)
+from app.modules.authorization.catalogue import PermissionId
+from app.modules.authorization.models import ProjectRoleGrant, ProjectRoleQualificationSnapshot
+from app.modules.authorization.project_role_schemas import ProjectRoleGrantMutationResponse
+from app.modules.authorization.repository import AdminAuthorizationRepository
+from app.modules.authorization.runtime import AuthorizationDecision
+from app.modules.authorization.schemas import (
+    AuthorityClaimHandle,
+    AuthorityInvalidationContext,
+    AuthorityReservationResult,
+    AuthorityResourceType,
+    AuthorityResponseReference,
+    ProjectRoleGrantIssueRequest,
+    ProjectRoleGrantRevokeRequest,
+    ProjectRole,
+    derive_reason_digest,
+)
+from app.modules.authorization.service import AuthorityMutationService
+
+
+class ProjectRoleGrantConflict(RuntimeError):
+    pass
+
+
+def project_role_issue_lock_key(actor_id: UUID, project_id: UUID, role: str) -> int:
+    encoded = json.dumps(
+        [
+            "workstream.project_role_grant.issue.v1",
+            str(actor_id),
+            str(project_id),
+            role,
+        ],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+    return int.from_bytes(hashlib.sha256(encoded).digest()[:8], "big", signed=True)
+
+
+def _facts(grant: ProjectRoleGrant) -> dict[str, object]:
+    return {
+        "status": grant.status,
+        "role": grant.role,
+        "scope_type": "project",
+        "scope_id": grant.project_id,
+        "effective": grant.status == "active",
+    }
+
+
+def _response(grant: ProjectRoleGrant) -> ProjectRoleGrantMutationResponse:
+    return ProjectRoleGrantMutationResponse(
+        id=grant.id,
+        qualification_snapshot_id=grant.qualification_snapshot_id,
+        project_id=UUID(grant.project_id),
+        actor_profile_id=UUID(grant.actor_profile_id),
+        role=ProjectRole(grant.role),
+        status=grant.status,
+        version=grant.version,
+    )
+
+
+class ProjectRoleGrantMutationService:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+        self.repository = AdminAuthorizationRepository(session)
+        self._mutation = AuthorityMutationService(session)
+
+    async def reserve(
+        self,
+        *,
+        key: UUID,
+        actor_profile_id: UUID,
+        request: ProjectRoleGrantIssueRequest | ProjectRoleGrantRevokeRequest,
+    ) -> AuthorityReservationResult:
+        return await self._mutation.reserve(
+            idempotency_key=key,
+            actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+            actor_ref=str(actor_profile_id),
+            request=request.model_dump(),
+        )
+
+    async def complete_issue(
+        self,
+        *,
+        claim: AuthorityClaimHandle,
+        request: ProjectRoleGrantIssueRequest,
+        decision: AuthorizationDecision,
+        actor_profile_id: UUID,
+        reason: str,
+    ) -> ProjectRoleGrantMutationResponse:
+        if (
+            request.reason_digest != derive_reason_digest(reason)
+            or decision.matched_grant_id is None
+        ):
+            raise TypeError("project-role issue requires exact matched authority")
+        await self.repository.take_project_role_issue_lock(
+            project_role_issue_lock_key(
+                request.target_actor_id, request.project_id, request.role.value
+            )
+        )
+        if (
+            await self.repository.find_active_project_role(
+                project_id=request.project_id,
+                actor_profile_id=request.target_actor_id,
+                role=request.role.value,
+            )
+            is not None
+        ):
+            raise ProjectRoleGrantConflict("project_role_grant_exists")
+        evidence = request.qualification
+        snapshot = await self.repository.add_project_role_snapshot(
+            ProjectRoleQualificationSnapshot(
+                id=uuid4(),
+                project_id=str(request.project_id),
+                actor_profile_id=str(request.target_actor_id),
+                requested_role=request.role.value,
+                skills_snapshot=evidence.skills_snapshot.model_dump(mode="json"),
+                reputation_snapshot=evidence.reputation_snapshot.model_dump(mode="json"),
+                prior_project_work_refs=[str(value) for value in evidence.prior_project_work_refs],
+                external_expertise_refs=list(evidence.external_expertise_refs),
+                captured_by_actor_profile_id=str(actor_profile_id),
+                captured_by_admin_role_grant_id=decision.matched_grant_id,
+            )
+        )
+        grant = await self.repository.add_project_role_grant(
+            ProjectRoleGrant(
+                id=uuid4(),
+                project_id=str(request.project_id),
+                actor_profile_id=str(request.target_actor_id),
+                role=request.role.value,
+                status="active",
+                version=1,
+                grant_method="manual",
+                qualification_snapshot_id=snapshot.id,
+                granted_by_actor_profile_id=str(actor_profile_id),
+                granted_by_admin_role_grant_id=decision.matched_grant_id,
+                grant_reason=reason,
+            )
+        )
+        common = dict(
+            actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+            actor_ref=str(actor_profile_id),
+            request_id=decision.request_id,
+            correlation_id=decision.correlation_id,
+            target_actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+            target_actor_ref=str(request.target_actor_id),
+            matched_grant_id=str(decision.matched_grant_id),
+            permission_id=PermissionId.PROJECT_ROLE_GRANT_MANAGE,
+            project_id=str(request.project_id),
+            idempotency_reference=claim.record_id,
+        )
+        await self._mutation.complete(
+            claim=claim,
+            request=request.model_dump(),
+            response=AuthorityResponseReference(
+                resource_type=AuthorityResourceType.PROJECT_ROLE_GRANT,
+                resource_id=grant.id,
+                version=1,
+                http_status=201,
+            ),
+            success=(
+                AuthorityAuditEventInput(
+                    event_id=uuid4(),
+                    event_type=AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED,
+                    entity_type="qualification_snapshot",
+                    entity_id=str(snapshot.id),
+                    resource_type="qualification_snapshot",
+                    resource_id=str(snapshot.id),
+                    target_ref_kind="qualification_snapshot",
+                    target_ref_id=str(snapshot.id),
+                    reason="qualification_evidence_captured",
+                    after_facts={"status": "captured"},
+                    **common,
+                ),
+                AuthorityAuditEventInput(
+                    event_id=uuid4(),
+                    event_type=AuthorityEventType.PROJECT_ROLE_GRANT_ISSUED,
+                    entity_type="project_role_grant",
+                    entity_id=str(grant.id),
+                    resource_type="project_role_grant",
+                    resource_id=str(grant.id),
+                    target_ref_kind="project_role_grant",
+                    target_ref_id=str(grant.id),
+                    reason="authority_assignment",
+                    after_facts=_facts(grant),
+                    **common,
+                ),
+            ),
+            invalidation=None,
+        )
+        return _response(grant)
+
+    async def complete_revoke(
+        self,
+        *,
+        claim: AuthorityClaimHandle,
+        request: ProjectRoleGrantRevokeRequest,
+        decision: AuthorizationDecision,
+        actor_profile_id: UUID,
+        reason: str,
+        grant: ProjectRoleGrant,
+    ) -> ProjectRoleGrantMutationResponse:
+        if (
+            request.reason_digest != derive_reason_digest(reason)
+            or decision.matched_grant_id is None
+        ):
+            raise TypeError("project-role revoke requires exact matched authority")
+        if grant.status != "active":
+            raise ProjectRoleGrantConflict("project_role_grant_already_revoked")
+        before = _facts(grant)
+        grant.status = "revoked"
+        grant.version = 2
+        grant.revoked_by_actor_profile_id = str(actor_profile_id)
+        grant.revoked_by_admin_role_grant_id = decision.matched_grant_id
+        grant.revoked_reason = reason
+        grant.revoked_at = func.clock_timestamp()
+        await self._session.flush()
+        await self._session.refresh(grant)
+        await self._mutation.complete(
+            claim=claim,
+            request=request.model_dump(),
+            response=AuthorityResponseReference(
+                resource_type=AuthorityResourceType.PROJECT_ROLE_GRANT,
+                resource_id=grant.id,
+                version=2,
+                http_status=200,
+            ),
+            success=AuthorityAuditEventInput(
+                event_id=uuid4(),
+                event_type=AuthorityEventType.PROJECT_ROLE_GRANT_REVOKED,
+                entity_type="project_role_grant",
+                entity_id=str(grant.id),
+                actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+                actor_ref=str(actor_profile_id),
+                request_id=decision.request_id,
+                correlation_id=decision.correlation_id,
+                target_actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+                target_actor_ref=grant.actor_profile_id,
+                matched_grant_id=str(decision.matched_grant_id),
+                permission_id=PermissionId.PROJECT_ROLE_GRANT_MANAGE,
+                project_id=grant.project_id,
+                resource_type="project_role_grant",
+                resource_id=str(grant.id),
+                target_ref_kind="project_role_grant",
+                target_ref_id=str(grant.id),
+                reason="authority_revocation",
+                idempotency_reference=claim.record_id,
+                before_facts=before,
+                after_facts=_facts(grant),
+            ),
+            invalidation=AuthorityInvalidationContext(
+                event_id=uuid4(),
+                request_id=decision.request_id,
+                correlation_id=decision.correlation_id,
+            ),
+        )
+        return _response(grant)

--- a/backend/app/modules/authorization/project_role_service.py
+++ b/backend/app/modules/authorization/project_role_service.py
@@ -14,7 +14,8 @@ from app.modules.audit.schemas import (
     AuthorityAuditEventInput,
     AuthorityEventType,
 )
-from app.modules.authorization.catalogue import PermissionId
+from app.modules.audit.service import AuditService
+from app.modules.authorization.catalogue import ActionId, PermissionId
 from app.modules.authorization.models import ProjectRoleGrant, ProjectRoleQualificationSnapshot
 from app.modules.authorization.project_role_schemas import ProjectRoleGrantMutationResponse
 from app.modules.authorization.repository import AdminAuthorizationRepository
@@ -22,6 +23,7 @@ from app.modules.authorization.runtime import AuthorizationDecision
 from app.modules.authorization.schemas import (
     AuthorityClaimHandle,
     AuthorityInvalidationContext,
+    AuthorityMismatchContext,
     AuthorityReservationResult,
     AuthorityResourceType,
     AuthorityResponseReference,
@@ -34,7 +36,10 @@ from app.modules.authorization.service import AuthorityMutationService
 
 
 class ProjectRoleGrantConflict(RuntimeError):
-    pass
+    def __init__(self, code: str, grant_id: UUID) -> None:
+        self.code = code
+        self.grant_id = grant_id
+        super().__init__(code)
 
 
 def project_role_issue_lock_key(actor_id: UUID, project_id: UUID, role: str) -> int:
@@ -78,6 +83,7 @@ class ProjectRoleGrantMutationService:
         self._session = session
         self.repository = AdminAuthorizationRepository(session)
         self._mutation = AuthorityMutationService(session)
+        self._audit = AuditService(session)
 
     async def reserve(
         self,
@@ -91,6 +97,58 @@ class ProjectRoleGrantMutationService:
             actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
             actor_ref=str(actor_profile_id),
             request=request.model_dump(),
+        )
+
+    async def record_mismatch(
+        self,
+        *,
+        actor_profile_id: UUID,
+        request: ProjectRoleGrantIssueRequest | ProjectRoleGrantRevokeRequest,
+        decision: AuthorizationDecision,
+    ) -> None:
+        await self._mutation.record_mismatch_denial(
+            actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+            actor_ref=str(actor_profile_id),
+            request=request.model_dump(),
+            context=AuthorityMismatchContext(
+                event_id=uuid4(),
+                request_id=decision.request_id,
+                correlation_id=decision.correlation_id,
+                matched_grant_id=decision.matched_grant_id,
+            ),
+        )
+
+    async def record_conflict(
+        self,
+        *,
+        actor_profile_id: UUID,
+        project_id: UUID,
+        grant_id: UUID,
+        decision: AuthorizationDecision,
+        code: str,
+        action_id: ActionId,
+    ) -> None:
+        event_id = uuid4()
+        await self._audit.add_authority_event(
+            AuthorityAuditEventInput(
+                event_id=event_id,
+                event_type=AuthorityEventType.SENSITIVE_AUTHORIZATION_DENIED,
+                entity_type="authorization_decision",
+                entity_id=str(event_id),
+                actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+                actor_ref=str(actor_profile_id),
+                request_id=decision.request_id,
+                correlation_id=decision.correlation_id,
+                matched_grant_id=str(decision.matched_grant_id),
+                permission_id=PermissionId.PROJECT_ROLE_GRANT_MANAGE,
+                action_id=action_id,
+                project_id=str(project_id),
+                resource_type="project_role_grant",
+                resource_id=str(grant_id),
+                reason="authorization_evaluation",
+                denial_code=code,
+                after_facts={"allowed": False},
+            )
         )
 
     async def complete_issue(
@@ -107,20 +165,13 @@ class ProjectRoleGrantMutationService:
             or decision.matched_grant_id is None
         ):
             raise TypeError("project-role issue requires exact matched authority")
-        await self.repository.take_project_role_issue_lock(
-            project_role_issue_lock_key(
-                request.target_actor_id, request.project_id, request.role.value
-            )
+        duplicate = await self.repository.find_active_project_role(
+            project_id=request.project_id,
+            actor_profile_id=request.target_actor_id,
+            role=request.role.value,
         )
-        if (
-            await self.repository.find_active_project_role(
-                project_id=request.project_id,
-                actor_profile_id=request.target_actor_id,
-                role=request.role.value,
-            )
-            is not None
-        ):
-            raise ProjectRoleGrantConflict("project_role_grant_exists")
+        if duplicate is not None:
+            raise ProjectRoleGrantConflict("project_role_grant_exists", duplicate.id)
         evidence = request.qualification
         snapshot = await self.repository.add_project_role_snapshot(
             ProjectRoleQualificationSnapshot(
@@ -220,7 +271,7 @@ class ProjectRoleGrantMutationService:
         ):
             raise TypeError("project-role revoke requires exact matched authority")
         if grant.status != "active":
-            raise ProjectRoleGrantConflict("project_role_grant_already_revoked")
+            raise ProjectRoleGrantConflict("project_role_grant_already_revoked", grant.id)
         before = _facts(grant)
         grant.status = "revoked"
         grant.version = 2
@@ -266,6 +317,8 @@ class ProjectRoleGrantMutationService:
                 event_id=uuid4(),
                 request_id=decision.request_id,
                 correlation_id=decision.correlation_id,
+                target_ref_kind=AuthorityResourceType.PROJECT_ROLE_GRANT,
+                target_ref_id=grant.id,
             ),
         )
         return _response(grant)

--- a/backend/app/modules/authorization/project_role_service.py
+++ b/backend/app/modules/authorization/project_role_service.py
@@ -7,6 +7,7 @@ import json
 from uuid import UUID, uuid4
 
 from sqlalchemy.sql import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.audit.schemas import (
@@ -36,7 +37,7 @@ from app.modules.authorization.service import AuthorityMutationService
 
 
 class ProjectRoleGrantConflict(RuntimeError):
-    def __init__(self, code: str, grant_id: UUID) -> None:
+    def __init__(self, code: str, grant_id: UUID | None) -> None:
         self.code = code
         self.grant_id = grant_id
         super().__init__(code)
@@ -54,6 +55,13 @@ def project_role_issue_lock_key(actor_id: UUID, project_id: UUID, role: str) -> 
         separators=(",", ":"),
     ).encode()
     return int.from_bytes(hashlib.sha256(encoded).digest()[:8], "big", signed=True)
+
+
+def _constraint_name(exc: IntegrityError) -> str | None:
+    original = exc.orig
+    return getattr(original, "constraint_name", None) or getattr(
+        getattr(original, "diag", None), "constraint_name", None
+    )
 
 
 def _facts(grant: ProjectRoleGrant) -> dict[str, object]:
@@ -187,21 +195,26 @@ class ProjectRoleGrantMutationService:
                 captured_by_admin_role_grant_id=decision.matched_grant_id,
             )
         )
-        grant = await self.repository.add_project_role_grant(
-            ProjectRoleGrant(
-                id=uuid4(),
-                project_id=str(request.project_id),
-                actor_profile_id=str(request.target_actor_id),
-                role=request.role.value,
-                status="active",
-                version=1,
-                grant_method="manual",
-                qualification_snapshot_id=snapshot.id,
-                granted_by_actor_profile_id=str(actor_profile_id),
-                granted_by_admin_role_grant_id=decision.matched_grant_id,
-                grant_reason=reason,
+        try:
+            grant = await self.repository.add_project_role_grant(
+                ProjectRoleGrant(
+                    id=uuid4(),
+                    project_id=str(request.project_id),
+                    actor_profile_id=str(request.target_actor_id),
+                    role=request.role.value,
+                    status="active",
+                    version=1,
+                    grant_method="manual",
+                    qualification_snapshot_id=snapshot.id,
+                    granted_by_actor_profile_id=str(actor_profile_id),
+                    granted_by_admin_role_grant_id=decision.matched_grant_id,
+                    grant_reason=reason,
+                )
             )
-        )
+        except IntegrityError as exc:
+            if _constraint_name(exc) == "uq_project_role_grants_active_exact_role":
+                raise ProjectRoleGrantConflict("project_role_grant_exists", None) from exc
+            raise
         common = dict(
             actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
             actor_ref=str(actor_profile_id),

--- a/backend/app/modules/authorization/project_role_service.py
+++ b/backend/app/modules/authorization/project_role_service.py
@@ -319,6 +319,12 @@ class ProjectRoleGrantMutationService:
                 correlation_id=decision.correlation_id,
                 target_ref_kind=AuthorityResourceType.PROJECT_ROLE_GRANT,
                 target_ref_id=grant.id,
+                project_role=ProjectRole(grant.role),
+                future_obligation={
+                    ProjectRole.SUBMITTER: "auth13_assignment",
+                    ProjectRole.REVIEWER: "rev_reviewer_obligation",
+                    ProjectRole.ADJUDICATOR: "none",
+                }[ProjectRole(grant.role)],
             ),
         )
         return _response(grant)

--- a/backend/app/modules/authorization/repository.py
+++ b/backend/app/modules/authorization/repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import and_, case, exists, func, or_, select, update
+from sqlalchemy import and_, case, exists, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -58,8 +58,7 @@ class AdminAuthorizationRepository:
             select(ProjectRoleGrant, ProjectRoleQualificationSnapshot)
             .join(
                 ProjectRoleQualificationSnapshot,
-                ProjectRoleQualificationSnapshot.id
-                == ProjectRoleGrant.qualification_snapshot_id,
+                ProjectRoleQualificationSnapshot.id == ProjectRoleGrant.qualification_snapshot_id,
             )
             .where(ProjectRoleGrant.project_id == str(project_id))
         )
@@ -107,6 +106,60 @@ class AdminAuthorizationRepository:
             )
         ).one_or_none()
         return tuple(row) if row is not None else None
+
+    async def lock_project_role_grant(
+        self, *, project_id: UUID, grant_id: UUID
+    ) -> tuple[ProjectRoleGrant, ProjectRoleQualificationSnapshot] | None:
+        """Lock one grant and snapshot only through the exact path project."""
+        row = (
+            await self._session.execute(
+                select(ProjectRoleGrant, ProjectRoleQualificationSnapshot)
+                .join(
+                    ProjectRoleQualificationSnapshot,
+                    ProjectRoleQualificationSnapshot.id
+                    == ProjectRoleGrant.qualification_snapshot_id,
+                )
+                .where(
+                    ProjectRoleGrant.project_id == str(project_id),
+                    ProjectRoleGrant.id == grant_id,
+                )
+                .with_for_update(of=(ProjectRoleGrant, ProjectRoleQualificationSnapshot))
+                .execution_options(populate_existing=True)
+            )
+        ).one_or_none()
+        return tuple(row) if row is not None else None
+
+    async def lock_project(self, project_id: UUID):
+        return await self._projects.get_project(str(project_id), for_update=True)
+
+    async def take_project_role_issue_lock(self, key: int) -> None:
+        await self._session.execute(text("select pg_advisory_xact_lock(:key)"), {"key": key})
+
+    async def find_active_project_role(
+        self, *, project_id: UUID, actor_profile_id: UUID, role: str
+    ) -> ProjectRoleGrant | None:
+        return await self._session.scalar(
+            select(ProjectRoleGrant).where(
+                ProjectRoleGrant.project_id == str(project_id),
+                ProjectRoleGrant.actor_profile_id == str(actor_profile_id),
+                ProjectRoleGrant.role == role,
+                ProjectRoleGrant.status == "active",
+            )
+        )
+
+    async def add_project_role_snapshot(
+        self, snapshot: ProjectRoleQualificationSnapshot
+    ) -> ProjectRoleQualificationSnapshot:
+        self._session.add(snapshot)
+        await self._session.flush()
+        await self._session.refresh(snapshot)
+        return snapshot
+
+    async def add_project_role_grant(self, grant: ProjectRoleGrant) -> ProjectRoleGrant:
+        self._session.add(grant)
+        await self._session.flush()
+        await self._session.refresh(grant)
+        return grant
 
     async def lock_control(self) -> AuthorityControl:
         """Lock the irreversible singleton before any administrative mutation."""
@@ -370,10 +423,7 @@ class AdminAuthorizationRepository:
 
     async def project_exists(self, project_id: UUID, *, for_update: bool = False) -> bool:
         """Resolve an exact project from Workstream-owned records."""
-        return (
-            await self._projects.get_project(str(project_id), for_update=for_update)
-            is not None
-        )
+        return await self._projects.get_project(str(project_id), for_update=for_update) is not None
 
     async def get_grant(
         self,

--- a/backend/app/modules/authorization/repository.py
+++ b/backend/app/modules/authorization/repository.py
@@ -194,6 +194,57 @@ class AdminAuthorizationRepository:
             return None
         return link, profile
 
+    async def lock_project_role_issue_principals(
+        self,
+        *,
+        caller_actor_profile_id: UUID,
+        caller_identity_link_id: UUID,
+        target_actor_profile_id: UUID,
+    ) -> tuple[tuple[ActorIdentityLink, ActorProfile] | None, bool]:
+        """Lock caller and issue target in one lexical profile/link order."""
+        caller = None
+        target_eligible = False
+        for actor_profile_id in sorted(
+            {caller_actor_profile_id, target_actor_profile_id}, key=str
+        ):
+            profile = await self._session.scalar(
+                select(ActorProfile)
+                .where(ActorProfile.id == str(actor_profile_id))
+                .with_for_update()
+                .execution_options(populate_existing=True)
+            )
+            if profile is None:
+                continue
+            if actor_profile_id == caller_actor_profile_id:
+                link = await self._session.scalar(
+                    select(ActorIdentityLink)
+                    .where(
+                        ActorIdentityLink.id == str(caller_identity_link_id),
+                        ActorIdentityLink.actor_profile_id == str(actor_profile_id),
+                    )
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                )
+                caller = (link, profile) if link is not None else None
+            else:
+                link = await self._session.scalar(
+                    select(ActorIdentityLink)
+                    .where(
+                        ActorIdentityLink.actor_profile_id == str(actor_profile_id),
+                        ActorIdentityLink.status == "active",
+                    )
+                    .order_by(ActorIdentityLink.id)
+                    .limit(1)
+                    .with_for_update()
+                    .execution_options(populate_existing=True)
+                )
+                target_eligible = (
+                    profile.actor_kind == "human"
+                    and profile.status == "active"
+                    and link is not None
+                )
+        return caller, target_eligible
+
     async def lock_actor_self(
         self,
         actor_profile_id: UUID,

--- a/backend/app/modules/authorization/router.py
+++ b/backend/app/modules/authorization/router.py
@@ -17,6 +17,7 @@ from app.api.deps.authorization import (
     enforce_human_authorization_read,
     get_authorization_actor,
     get_authorization_service,
+    get_prepared_authorization_service,
 )
 from app.core.api_controls import ApiErrorResponse, StructuredHTTPException
 from app.core.config import decode_pagination_cursor_hmac_secret
@@ -50,6 +51,16 @@ from app.modules.authorization.read_service import (
     ProjectRoleReadResourceNotFound,
     ProjectRoleReadService,
 )
+from app.modules.authorization.prepared import PreparedAuthorizationService
+from app.modules.authorization.project_role_schemas import (
+    ProjectRoleGrantIssueBody,
+    ProjectRoleGrantMutationResponse,
+    ProjectRoleGrantRevokeBody,
+)
+from app.modules.authorization.project_role_service import (
+    ProjectRoleGrantConflict,
+    ProjectRoleGrantMutationService,
+)
 from app.modules.authorization.repository import AdminAuthorizationRepository
 from app.modules.authorization.lifecycle_schemas import (
     ActorLifecycleBody,
@@ -75,6 +86,12 @@ from app.modules.authorization.runtime import (
     AdminRoleGrantIssueResourceContext,
     AdminRoleGrantResourceContext,
     PermissionCatalogueResourceContext,
+    PreparedAuthorizationInput,
+    PreparedAuthorizationUnsupported,
+    PreparedAuthorityScope,
+    PreparedAuthorityScopeKind,
+    ProjectRoleGrantIssueResourceContext,
+    ProjectRoleGrantRevokeResourceContext,
     ServiceActorProvisionResourceContext,
 )
 from app.modules.authorization.schemas import (
@@ -93,6 +110,8 @@ from app.modules.authorization.schemas import (
     ProjectRole,
     ProjectRoleGrantListResponse,
     ProjectRoleGrantRead,
+    ProjectRoleGrantIssueRequest,
+    ProjectRoleGrantRevokeRequest,
     derive_reason_digest,
     derive_service_identity_digest,
 )
@@ -707,9 +726,7 @@ async def revoke_actor_identity_link(
     response_model=IdentityLinkLifecycleMutationResponse,
     dependencies=[Depends(enforce_admin_mutation_rate_limit)],
     responses=_LIFECYCLE_CONFLICT_RESPONSE,
-    openapi_extra={
-        "x-workstream-action-id": ActionId.ACTOR_IDENTITY_LINK_REACTIVATE.value
-    },
+    openapi_extra={"x-workstream-action-id": ActionId.ACTOR_IDENTITY_LINK_REACTIVATE.value},
 )
 async def reactivate_actor_identity_link(
     identity_link_id: UUID,
@@ -1177,13 +1194,197 @@ async def _canonical_project(session: AsyncSession, project_id: UUID):
     return project
 
 
+def _project_role_response(grant) -> ProjectRoleGrantMutationResponse:
+    return ProjectRoleGrantMutationResponse(
+        id=grant.id,
+        qualification_snapshot_id=grant.qualification_snapshot_id,
+        project_id=UUID(grant.project_id),
+        actor_profile_id=UUID(grant.actor_profile_id),
+        role=grant.role,
+        status=grant.status,
+        version=grant.version,
+    )
+
+
+@router.post(
+    "/projects/{project_id}/role-grants",
+    response_model=ProjectRoleGrantMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(enforce_admin_mutation_rate_limit)],
+    openapi_extra={"x-workstream-action-id": ActionId.PROJECT_ROLE_GRANT_ISSUE.value},
+)
+async def issue_project_role_grant(
+    project_id: UUID,
+    payload: ProjectRoleGrantIssueBody,
+    idempotency_key: Annotated[UUID, Header(alias="Idempotency-Key")],
+    resolved: Annotated[ResolvedActor, Depends(get_authorization_actor)],
+    prepared: Annotated[PreparedAuthorizationService, Depends(get_prepared_authorization_service)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> ProjectRoleGrantMutationResponse:
+    canonical = ProjectRoleGrantIssueRequest(
+        operation=AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE,
+        project_id=project_id,
+        target_actor_id=payload.target_actor_profile_id,
+        role=payload.role,
+        qualification=payload.qualification,
+        reason_digest=derive_reason_digest(payload.reason),
+    )
+    actor_id = UUID(resolved.profile.id)
+    service = ProjectRoleGrantMutationService(session)
+    reservation = await service.reserve(
+        key=idempotency_key, actor_profile_id=actor_id, request=canonical
+    )
+    prepared_input = PreparedAuthorizationInput(
+        idempotency_key=idempotency_key,
+        request_value=canonical.model_dump(mode="json"),
+    )
+    try:
+        handle = await prepared.prepare(
+            ActionId.PROJECT_ROLE_GRANT_ISSUE,
+            prepared_input,
+            PreparedAuthorityScope(kind=PreparedAuthorityScopeKind.PROJECT, project_id=project_id),
+        )
+    except PreparedAuthorizationUnsupported as exc:
+        raise _project_role_resource_not_found() from exc
+    project = await service.repository.lock_project(project_id)
+    if project is None:
+        raise _project_role_resource_not_found()
+    target_eligible = (
+        await service.repository.lock_eligible_human(payload.target_actor_profile_id) is not None
+    )
+    decision = await prepared.consume(
+        handle,
+        ActionId.PROJECT_ROLE_GRANT_ISSUE,
+        prepared_input,
+        ProjectRoleGrantIssueResourceContext(
+            resource_type="project_role_grant_issue",
+            resource_id=project_id,
+            scope_project_id=project_id,
+            target_actor_profile_id=payload.target_actor_profile_id,
+            role=payload.role,
+            project_status=project.status,
+            target_eligible=target_eligible,
+        ),
+    )
+    if reservation.outcome == "mismatch":
+        raise _domain_error(409, "idempotency_mismatch", "Idempotency key does not match")
+    if reservation.outcome == "replay":
+        row = await service.repository.lock_project_role_grant(
+            project_id=project_id, grant_id=reservation.response.resource_id
+        )
+        if row is None or row[0].status != "active" or row[0].version != 1:
+            raise _domain_error(
+                409,
+                "project_role_grant_replay_state_changed",
+                "Project role grant replay state changed",
+            )
+        await session.commit()
+        return _project_role_response(row[0])
+    try:
+        response = await service.complete_issue(
+            claim=reservation.claim,
+            request=canonical,
+            decision=decision,
+            actor_profile_id=actor_id,
+            reason=payload.reason,
+        )
+        await session.commit()
+        return response
+    except ProjectRoleGrantConflict as exc:
+        await session.rollback()
+        raise _domain_error(409, str(exc), "Project role grant already exists") from exc
+
+
+@router.post(
+    "/projects/{project_id}/role-grants/{grant_id}/revoke",
+    response_model=ProjectRoleGrantMutationResponse,
+    dependencies=[Depends(enforce_admin_mutation_rate_limit)],
+    openapi_extra={"x-workstream-action-id": ActionId.PROJECT_ROLE_GRANT_REVOKE.value},
+)
+async def revoke_project_role_grant(
+    project_id: UUID,
+    grant_id: UUID,
+    payload: ProjectRoleGrantRevokeBody,
+    idempotency_key: Annotated[UUID, Header(alias="Idempotency-Key")],
+    resolved: Annotated[ResolvedActor, Depends(get_authorization_actor)],
+    prepared: Annotated[PreparedAuthorizationService, Depends(get_prepared_authorization_service)],
+    session: Annotated[AsyncSession, Depends(get_db_session)],
+) -> ProjectRoleGrantMutationResponse:
+    canonical = ProjectRoleGrantRevokeRequest(
+        operation=AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE,
+        project_id=project_id,
+        grant_id=grant_id,
+        reason_digest=derive_reason_digest(payload.reason),
+    )
+    actor_id = UUID(resolved.profile.id)
+    service = ProjectRoleGrantMutationService(session)
+    reservation = await service.reserve(
+        key=idempotency_key, actor_profile_id=actor_id, request=canonical
+    )
+    prepared_input = PreparedAuthorizationInput(
+        idempotency_key=idempotency_key,
+        request_value=canonical.model_dump(mode="json"),
+    )
+    try:
+        handle = await prepared.prepare(
+            ActionId.PROJECT_ROLE_GRANT_REVOKE,
+            prepared_input,
+            PreparedAuthorityScope(kind=PreparedAuthorityScopeKind.PROJECT, project_id=project_id),
+        )
+    except PreparedAuthorizationUnsupported as exc:
+        raise _project_role_resource_not_found() from exc
+    project = await service.repository.lock_project(project_id)
+    row = await service.repository.lock_project_role_grant(project_id=project_id, grant_id=grant_id)
+    if project is None or row is None:
+        raise _project_role_resource_not_found()
+    grant, _snapshot = row
+    decision = await prepared.consume(
+        handle,
+        ActionId.PROJECT_ROLE_GRANT_REVOKE,
+        prepared_input,
+        ProjectRoleGrantRevokeResourceContext(
+            resource_type="project_role_grant_revoke",
+            resource_id=grant_id,
+            scope_project_id=project_id,
+            actor_profile_id=UUID(grant.actor_profile_id),
+            role=ProjectRole(grant.role),
+            project_status=project.status,
+            status=grant.status,
+            version=grant.version,
+        ),
+    )
+    if reservation.outcome == "mismatch":
+        raise _domain_error(409, "idempotency_mismatch", "Idempotency key does not match")
+    if reservation.outcome == "replay":
+        if grant.status != "revoked" or grant.version != 2:
+            raise _domain_error(
+                409,
+                "project_role_grant_replay_state_changed",
+                "Project role grant replay state changed",
+            )
+        await session.commit()
+        return _project_role_response(grant)
+    try:
+        response = await service.complete_revoke(
+            claim=reservation.claim,
+            request=canonical,
+            decision=decision,
+            actor_profile_id=actor_id,
+            reason=payload.reason,
+            grant=grant,
+        )
+        await session.commit()
+        return response
+    except ProjectRoleGrantConflict as exc:
+        await session.rollback()
+        raise _domain_error(409, str(exc), "Project role grant is already revoked") from exc
+
+
 @router.get(
     "/projects/{project_id}/contributor-candidates",
     response_model=ContributorCandidateListResponse,
     dependencies=[Depends(enforce_human_authorization_read)],
-    openapi_extra={
-        "x-workstream-action-id": ActionId.PROJECT_CONTRIBUTOR_CANDIDATE_LIST.value
-    },
+    openapi_extra={"x-workstream-action-id": ActionId.PROJECT_CONTRIBUTOR_CANDIDATE_LIST.value},
 )
 async def list_project_contributor_candidates(
     project_id: UUID,

--- a/backend/app/modules/authorization/router.py
+++ b/backend/app/modules/authorization/router.py
@@ -1232,51 +1232,74 @@ async def issue_project_role_grant(
     )
     actor_id = UUID(resolved.profile.id)
     service = ProjectRoleGrantMutationService(session)
-    reservation = await service.reserve(
-        key=idempotency_key, actor_profile_id=actor_id, request=canonical
+    reservation = await _database_call(
+        session,
+        service.reserve(key=idempotency_key, actor_profile_id=actor_id, request=canonical),
     )
     prepared_input = PreparedAuthorizationInput(
         idempotency_key=idempotency_key,
         request_value=canonical.model_dump(mode="json"),
     )
     try:
-        handle = await prepared.prepare(
-            ActionId.PROJECT_ROLE_GRANT_ISSUE,
-            prepared_input,
-            PreparedAuthorityScope(
-                kind=PreparedAuthorityScopeKind.PROJECT,
-                project_id=project_id,
-                target_actor_profile_id=payload.target_actor_profile_id,
-                role=payload.role,
+        handle = await _database_call(
+            session,
+            prepared.prepare(
+                ActionId.PROJECT_ROLE_GRANT_ISSUE,
+                prepared_input,
+                PreparedAuthorityScope(
+                    kind=PreparedAuthorityScopeKind.PROJECT,
+                    project_id=project_id,
+                    target_actor_profile_id=payload.target_actor_profile_id,
+                    role=payload.role,
+                ),
             ),
         )
     except PreparedAuthorizationUnsupported as exc:
         raise _project_role_resource_not_found() from exc
-    project = await service.repository.lock_project(project_id)
+    project = await _database_call(session, service.repository.lock_project(project_id))
     if project is None:
         raise _project_role_resource_not_found()
+    await _database_call(
+        session,
+        service.repository.take_project_role_issue_lock(
+            project_role_issue_lock_key(
+                payload.target_actor_profile_id,
+                project_id,
+                payload.role.value,
+            )
+        ),
+    )
     target_eligible = (
-        await service.repository.lock_eligible_human(payload.target_actor_profile_id) is not None
-    )
-    await service.repository.take_project_role_issue_lock(
-        project_role_issue_lock_key(
-            payload.target_actor_profile_id,
-            project_id,
-            payload.role.value,
+        await _database_call(
+            session,
+            service.repository.lock_eligible_human(payload.target_actor_profile_id),
         )
+        is not None
     )
-    decision = await prepared.consume(
-        handle,
-        ActionId.PROJECT_ROLE_GRANT_ISSUE,
-        prepared_input,
-        ProjectRoleGrantIssueResourceContext(
-            resource_type="project_role_grant_issue",
-            resource_id=project_id,
-            scope_project_id=project_id,
-            target_actor_profile_id=payload.target_actor_profile_id,
-            role=payload.role,
-            project_status=project.status,
-            target_eligible=target_eligible,
+    active_exact_role = await _database_call(
+        session,
+        service.repository.find_active_project_role(
+            project_id=project_id,
+            actor_profile_id=payload.target_actor_profile_id,
+            role=payload.role.value,
+        ),
+    )
+    decision = await _database_call(
+        session,
+        prepared.consume(
+            handle,
+            ActionId.PROJECT_ROLE_GRANT_ISSUE,
+            prepared_input,
+            ProjectRoleGrantIssueResourceContext(
+                resource_type="project_role_grant_issue",
+                resource_id=project_id,
+                scope_project_id=project_id,
+                target_actor_profile_id=payload.target_actor_profile_id,
+                role=payload.role,
+                project_status=project.status,
+                target_eligible=target_eligible,
+                active_exact_role_exists=active_exact_role is not None,
+            ),
         ),
     )
     if reservation.outcome == "mismatch":
@@ -1292,8 +1315,11 @@ async def issue_project_role_grant(
         await _commit_or_unavailable(session)
         raise _domain_error(409, "idempotency_mismatch", "Idempotency key does not match")
     if reservation.outcome == "replay":
-        row = await service.repository.lock_project_role_grant(
-            project_id=project_id, grant_id=reservation.response.resource_id
+        row = await _database_call(
+            session,
+            service.repository.lock_project_role_grant(
+                project_id=project_id, grant_id=reservation.response.resource_id
+            ),
         )
         if (
             reservation.response.resource_type.value != "project_role_grant"
@@ -1318,12 +1344,19 @@ async def issue_project_role_grant(
         await _commit_or_unavailable(session)
         return _project_role_response(row[0])
     try:
-        response = await service.complete_issue(
-            claim=reservation.claim,
-            request=canonical,
-            decision=decision,
-            actor_profile_id=actor_id,
-            reason=payload.reason,
+        if active_exact_role is not None:
+            raise ProjectRoleGrantConflict(
+                "project_role_grant_exists", active_exact_role.id
+            )
+        response = await _database_call(
+            session,
+            service.complete_issue(
+                claim=reservation.claim,
+                request=canonical,
+                decision=decision,
+                actor_profile_id=actor_id,
+                reason=payload.reason,
+            ),
         )
         await _commit_or_unavailable(session)
         return response
@@ -1367,43 +1400,53 @@ async def revoke_project_role_grant(
     )
     actor_id = UUID(resolved.profile.id)
     service = ProjectRoleGrantMutationService(session)
-    reservation = await service.reserve(
-        key=idempotency_key, actor_profile_id=actor_id, request=canonical
+    reservation = await _database_call(
+        session,
+        service.reserve(key=idempotency_key, actor_profile_id=actor_id, request=canonical),
     )
     prepared_input = PreparedAuthorizationInput(
         idempotency_key=idempotency_key,
         request_value=canonical.model_dump(mode="json"),
     )
     try:
-        handle = await prepared.prepare(
-            ActionId.PROJECT_ROLE_GRANT_REVOKE,
-            prepared_input,
-            PreparedAuthorityScope(
-                kind=PreparedAuthorityScopeKind.PROJECT,
-                project_id=project_id,
-                grant_id=grant_id,
+        handle = await _database_call(
+            session,
+            prepared.prepare(
+                ActionId.PROJECT_ROLE_GRANT_REVOKE,
+                prepared_input,
+                PreparedAuthorityScope(
+                    kind=PreparedAuthorityScopeKind.PROJECT,
+                    project_id=project_id,
+                    grant_id=grant_id,
+                ),
             ),
         )
     except PreparedAuthorizationUnsupported as exc:
         raise _project_role_resource_not_found() from exc
-    project = await service.repository.lock_project(project_id)
-    row = await service.repository.lock_project_role_grant(project_id=project_id, grant_id=grant_id)
+    project = await _database_call(session, service.repository.lock_project(project_id))
+    row = await _database_call(
+        session,
+        service.repository.lock_project_role_grant(project_id=project_id, grant_id=grant_id),
+    )
     if project is None or row is None:
         raise _project_role_resource_not_found()
     grant, _snapshot = row
-    decision = await prepared.consume(
-        handle,
-        ActionId.PROJECT_ROLE_GRANT_REVOKE,
-        prepared_input,
-        ProjectRoleGrantRevokeResourceContext(
-            resource_type="project_role_grant_revoke",
-            resource_id=grant_id,
-            scope_project_id=project_id,
-            actor_profile_id=UUID(grant.actor_profile_id),
-            role=ProjectRole(grant.role),
-            project_status=project.status,
-            status=grant.status,
-            version=grant.version,
+    decision = await _database_call(
+        session,
+        prepared.consume(
+            handle,
+            ActionId.PROJECT_ROLE_GRANT_REVOKE,
+            prepared_input,
+            ProjectRoleGrantRevokeResourceContext(
+                resource_type="project_role_grant_revoke",
+                resource_id=grant_id,
+                scope_project_id=project_id,
+                actor_profile_id=UUID(grant.actor_profile_id),
+                role=ProjectRole(grant.role),
+                project_status=project.status,
+                status=grant.status,
+                version=grant.version,
+            ),
         ),
     )
     if reservation.outcome == "mismatch":
@@ -1440,13 +1483,16 @@ async def revoke_project_role_grant(
         await _commit_or_unavailable(session)
         return _project_role_response(grant)
     try:
-        response = await service.complete_revoke(
-            claim=reservation.claim,
-            request=canonical,
-            decision=decision,
-            actor_profile_id=actor_id,
-            reason=payload.reason,
-            grant=grant,
+        response = await _database_call(
+            session,
+            service.complete_revoke(
+                claim=reservation.claim,
+                request=canonical,
+                decision=decision,
+                actor_profile_id=actor_id,
+                reason=payload.reason,
+                grant=grant,
+            ),
         )
         await _commit_or_unavailable(session)
         return response

--- a/backend/app/modules/authorization/router.py
+++ b/backend/app/modules/authorization/router.py
@@ -60,6 +60,7 @@ from app.modules.authorization.project_role_schemas import (
 from app.modules.authorization.project_role_service import (
     ProjectRoleGrantConflict,
     ProjectRoleGrantMutationService,
+    project_role_issue_lock_key,
 )
 from app.modules.authorization.repository import AdminAuthorizationRepository
 from app.modules.authorization.lifecycle_schemas import (
@@ -1242,7 +1243,12 @@ async def issue_project_role_grant(
         handle = await prepared.prepare(
             ActionId.PROJECT_ROLE_GRANT_ISSUE,
             prepared_input,
-            PreparedAuthorityScope(kind=PreparedAuthorityScopeKind.PROJECT, project_id=project_id),
+            PreparedAuthorityScope(
+                kind=PreparedAuthorityScopeKind.PROJECT,
+                project_id=project_id,
+                target_actor_profile_id=payload.target_actor_profile_id,
+                role=payload.role,
+            ),
         )
     except PreparedAuthorizationUnsupported as exc:
         raise _project_role_resource_not_found() from exc
@@ -1251,6 +1257,13 @@ async def issue_project_role_grant(
         raise _project_role_resource_not_found()
     target_eligible = (
         await service.repository.lock_eligible_human(payload.target_actor_profile_id) is not None
+    )
+    await service.repository.take_project_role_issue_lock(
+        project_role_issue_lock_key(
+            payload.target_actor_profile_id,
+            project_id,
+            payload.role.value,
+        )
     )
     decision = await prepared.consume(
         handle,
@@ -1267,18 +1280,42 @@ async def issue_project_role_grant(
         ),
     )
     if reservation.outcome == "mismatch":
+        await session.rollback()
+        await _database_call(
+            session,
+            service.record_mismatch(
+                actor_profile_id=actor_id,
+                request=canonical,
+                decision=decision,
+            ),
+        )
+        await _commit_or_unavailable(session)
         raise _domain_error(409, "idempotency_mismatch", "Idempotency key does not match")
     if reservation.outcome == "replay":
         row = await service.repository.lock_project_role_grant(
             project_id=project_id, grant_id=reservation.response.resource_id
         )
-        if row is None or row[0].status != "active" or row[0].version != 1:
+        if (
+            reservation.response.resource_type.value != "project_role_grant"
+            or reservation.response.http_status != 201
+            or reservation.response.version != 1
+            or row is None
+            or row[0].status != "active"
+            or row[0].version != 1
+            or row[0].project_id != str(project_id)
+            or row[0].actor_profile_id != str(payload.target_actor_profile_id)
+            or row[0].role != payload.role.value
+            or row[1].id != row[0].qualification_snapshot_id
+            or row[1].project_id != row[0].project_id
+            or row[1].actor_profile_id != row[0].actor_profile_id
+            or row[1].requested_role != row[0].role
+        ):
             raise _domain_error(
                 409,
                 "project_role_grant_replay_state_changed",
                 "Project role grant replay state changed",
             )
-        await session.commit()
+        await _commit_or_unavailable(session)
         return _project_role_response(row[0])
     try:
         response = await service.complete_issue(
@@ -1288,11 +1325,23 @@ async def issue_project_role_grant(
             actor_profile_id=actor_id,
             reason=payload.reason,
         )
-        await session.commit()
+        await _commit_or_unavailable(session)
         return response
     except ProjectRoleGrantConflict as exc:
         await session.rollback()
-        raise _domain_error(409, str(exc), "Project role grant already exists") from exc
+        await _database_call(
+            session,
+            service.record_conflict(
+                actor_profile_id=actor_id,
+                project_id=project_id,
+                grant_id=exc.grant_id,
+                decision=decision,
+                code=exc.code,
+                action_id=ActionId.PROJECT_ROLE_GRANT_ISSUE,
+            ),
+        )
+        await _commit_or_unavailable(session)
+        raise _domain_error(409, exc.code, "Project role grant already exists") from exc
 
 
 @router.post(
@@ -1329,7 +1378,11 @@ async def revoke_project_role_grant(
         handle = await prepared.prepare(
             ActionId.PROJECT_ROLE_GRANT_REVOKE,
             prepared_input,
-            PreparedAuthorityScope(kind=PreparedAuthorityScopeKind.PROJECT, project_id=project_id),
+            PreparedAuthorityScope(
+                kind=PreparedAuthorityScopeKind.PROJECT,
+                project_id=project_id,
+                grant_id=grant_id,
+            ),
         )
     except PreparedAuthorizationUnsupported as exc:
         raise _project_role_resource_not_found() from exc
@@ -1354,15 +1407,37 @@ async def revoke_project_role_grant(
         ),
     )
     if reservation.outcome == "mismatch":
+        await session.rollback()
+        await _database_call(
+            session,
+            service.record_mismatch(
+                actor_profile_id=actor_id,
+                request=canonical,
+                decision=decision,
+            ),
+        )
+        await _commit_or_unavailable(session)
         raise _domain_error(409, "idempotency_mismatch", "Idempotency key does not match")
     if reservation.outcome == "replay":
-        if grant.status != "revoked" or grant.version != 2:
+        if (
+            reservation.response.resource_type.value != "project_role_grant"
+            or reservation.response.resource_id != grant_id
+            or reservation.response.http_status != 200
+            or reservation.response.version != 2
+            or grant.status != "revoked"
+            or grant.version != 2
+            or grant.project_id != str(project_id)
+            or _snapshot.id != grant.qualification_snapshot_id
+            or _snapshot.project_id != grant.project_id
+            or _snapshot.actor_profile_id != grant.actor_profile_id
+            or _snapshot.requested_role != grant.role
+        ):
             raise _domain_error(
                 409,
                 "project_role_grant_replay_state_changed",
                 "Project role grant replay state changed",
             )
-        await session.commit()
+        await _commit_or_unavailable(session)
         return _project_role_response(grant)
     try:
         response = await service.complete_revoke(
@@ -1373,11 +1448,23 @@ async def revoke_project_role_grant(
             reason=payload.reason,
             grant=grant,
         )
-        await session.commit()
+        await _commit_or_unavailable(session)
         return response
     except ProjectRoleGrantConflict as exc:
         await session.rollback()
-        raise _domain_error(409, str(exc), "Project role grant is already revoked") from exc
+        await _database_call(
+            session,
+            service.record_conflict(
+                actor_profile_id=actor_id,
+                project_id=project_id,
+                grant_id=exc.grant_id,
+                decision=decision,
+                code=exc.code,
+                action_id=ActionId.PROJECT_ROLE_GRANT_REVOKE,
+            ),
+        )
+        await _commit_or_unavailable(session)
+        raise _domain_error(409, exc.code, "Project role grant is already revoked") from exc
 
 
 @router.get(

--- a/backend/app/modules/authorization/router.py
+++ b/backend/app/modules/authorization/router.py
@@ -79,6 +79,7 @@ from app.modules.authorization.lifecycle_service import (
 )
 from app.modules.authorization.runtime import (
     ActorAdminRoleGrantHistoryResourceContext,
+    AuthorizationDenied,
     ActorIdentityLinkAdminReadResourceContext,
     ActorIdentityLinkLifecycleResourceContext,
     ActorProfileAdminReadResourceContext,
@@ -146,11 +147,19 @@ def _actor_resource_not_found() -> StructuredHTTPException:
 
 
 def _project_role_resource_not_found() -> StructuredHTTPException:
-    return _domain_error(
-        404,
-        "project_authorization_resource_not_found",
-        "Project authorization resource not found",
-    )
+    return _domain_error(404, "resource_not_found", "Resource not found")
+
+
+def _project_role_mutation_denial(exc: AuthorizationDenied) -> StructuredHTTPException:
+    if exc.public_code == "self_grant_forbidden":
+        return _domain_error(403, "self_grant_forbidden", "Self grant is forbidden")
+    if exc.public_code == "self_role_revoke_forbidden":
+        return _domain_error(
+            403,
+            "self_role_revoke_forbidden",
+            "Self role revocation is forbidden",
+        )
+    return _project_role_resource_not_found()
 
 
 def _project_role_read_service(
@@ -1291,24 +1300,28 @@ async def issue_project_role_grant(
             role=payload.role.value,
         ),
     )
-    decision = await _database_call(
-        session,
-        prepared.consume(
-            handle,
-            ActionId.PROJECT_ROLE_GRANT_ISSUE,
-            prepared_input,
-            ProjectRoleGrantIssueResourceContext(
-                resource_type="project_role_grant_issue",
-                resource_id=project_id,
-                scope_project_id=project_id,
-                target_actor_profile_id=payload.target_actor_profile_id,
-                role=payload.role,
-                project_status=project.status,
-                target_eligible=target_eligible,
-                active_exact_role_exists=active_exact_role is not None,
-            ),
-        ),
+    resource = ProjectRoleGrantIssueResourceContext(
+        resource_type="project_role_grant",
+        resource_id=project_id,
+        scope_project_id=project_id,
+        target_actor_profile_id=payload.target_actor_profile_id,
+        role=payload.role,
+        project_status=project.status,
+        target_eligible=target_eligible,
+        active_exact_role_exists=active_exact_role is not None,
     )
+    try:
+        decision = await _database_call(
+            session,
+            prepared.consume(
+                handle,
+                ActionId.PROJECT_ROLE_GRANT_ISSUE,
+                prepared_input,
+                resource,
+            ),
+        )
+    except AuthorizationDenied as exc:
+        raise _project_role_mutation_denial(exc) from exc
     if reservation.outcome == "mismatch":
         await session.rollback()
         await _database_call(
@@ -1361,6 +1374,7 @@ async def issue_project_role_grant(
                 claim=reservation.claim,
                 request=canonical,
                 decision=decision,
+                resource=resource,
                 actor_profile_id=actor_id,
                 reason=payload.reason,
             ),
@@ -1451,24 +1465,28 @@ async def revoke_project_role_grant(
     if project is None or row is None:
         raise _project_role_resource_not_found()
     grant, _snapshot = row
-    decision = await _database_call(
-        session,
-        prepared.consume(
-            handle,
-            ActionId.PROJECT_ROLE_GRANT_REVOKE,
-            prepared_input,
-            ProjectRoleGrantRevokeResourceContext(
-                resource_type="project_role_grant_revoke",
-                resource_id=grant_id,
-                scope_project_id=project_id,
-                actor_profile_id=UUID(grant.actor_profile_id),
-                role=ProjectRole(grant.role),
-                project_status=project.status,
-                status=grant.status,
-                version=grant.version,
-            ),
-        ),
+    resource = ProjectRoleGrantRevokeResourceContext(
+        resource_type="project_role_grant",
+        resource_id=grant_id,
+        scope_project_id=project_id,
+        actor_profile_id=UUID(grant.actor_profile_id),
+        role=ProjectRole(grant.role),
+        project_status=project.status,
+        status=grant.status,
+        version=grant.version,
     )
+    try:
+        decision = await _database_call(
+            session,
+            prepared.consume(
+                handle,
+                ActionId.PROJECT_ROLE_GRANT_REVOKE,
+                prepared_input,
+                resource,
+            ),
+        )
+    except AuthorizationDenied as exc:
+        raise _project_role_mutation_denial(exc) from exc
     if reservation.outcome == "mismatch":
         await session.rollback()
         await _database_call(
@@ -1509,6 +1527,7 @@ async def revoke_project_role_grant(
                 claim=reservation.claim,
                 request=canonical,
                 decision=decision,
+                resource=resource,
                 actor_profile_id=actor_id,
                 reason=payload.reason,
                 grant=grant,

--- a/backend/app/modules/authorization/router.py
+++ b/backend/app/modules/authorization/router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable
 from typing import Annotated, Literal, TypeVar
 from uuid import UUID
@@ -272,6 +273,9 @@ def _configured_issuer(verifier: AuthVerifier) -> str:
 async def _commit_or_unavailable(session: AsyncSession) -> None:
     try:
         await session.commit()
+    except asyncio.CancelledError:
+        await session.rollback()
+        raise
     except SQLAlchemyError as exc:
         await session.rollback()
         raise service_unavailable_error() from exc
@@ -281,6 +285,9 @@ async def _database_call(session: AsyncSession, operation: Awaitable[T]) -> T:
     """Map feature-owned SQL failures without relabeling authorization evidence errors."""
     try:
         return await operation
+    except asyncio.CancelledError:
+        await session.rollback()
+        raise
     except SQLAlchemyError as exc:
         await session.rollback()
         raise service_unavailable_error() from exc
@@ -1362,12 +1369,25 @@ async def issue_project_role_grant(
         return response
     except ProjectRoleGrantConflict as exc:
         await session.rollback()
+        conflict_grant_id = exc.grant_id
+        if conflict_grant_id is None:
+            conflict = await _database_call(
+                session,
+                service.repository.find_active_project_role(
+                    project_id=project_id,
+                    actor_profile_id=payload.target_actor_profile_id,
+                    role=payload.role.value,
+                ),
+            )
+            if conflict is None:
+                raise service_unavailable_error() from exc
+            conflict_grant_id = conflict.id
         await _database_call(
             session,
             service.record_conflict(
                 actor_profile_id=actor_id,
                 project_id=project_id,
-                grant_id=exc.grant_id,
+                grant_id=conflict_grant_id,
                 decision=decision,
                 code=exc.code,
                 action_id=ActionId.PROJECT_ROLE_GRANT_ISSUE,
@@ -1498,6 +1518,8 @@ async def revoke_project_role_grant(
         return response
     except ProjectRoleGrantConflict as exc:
         await session.rollback()
+        if exc.grant_id is None:
+            raise service_unavailable_error() from exc
         await _database_call(
             session,
             service.record_conflict(

--- a/backend/app/modules/authorization/runtime.py
+++ b/backend/app/modules/authorization/runtime.py
@@ -358,6 +358,7 @@ class ProjectRoleGrantIssueResourceContext(BaseModel):
     role: ProjectRole
     project_status: Literal["draft", "active", "paused", "archived"]
     target_eligible: bool
+    active_exact_role_exists: bool
 
 
 class ProjectRoleGrantRevokeResourceContext(BaseModel):

--- a/backend/app/modules/authorization/runtime.py
+++ b/backend/app/modules/authorization/runtime.py
@@ -86,6 +86,9 @@ class PreparedAuthorityScope(BaseModel):
     kind: PreparedAuthorityScopeKind
     actor_profile_id: UUID | None = None
     project_id: UUID | None = None
+    target_actor_profile_id: UUID | None = None
+    role: ProjectRole | None = None
+    grant_id: UUID | None = None
 
     @model_validator(mode="after")
     def validate_selector(self):
@@ -95,16 +98,27 @@ class PreparedAuthorityScope(BaseModel):
                 self.kind is PreparedAuthorityScopeKind.ACTOR_SELF
                 and self.actor_profile_id is not None
                 and self.project_id is None
+                and self.target_actor_profile_id is None
+                and self.role is None
+                and self.grant_id is None
             )
             or (
                 self.kind is PreparedAuthorityScopeKind.SYSTEM
                 and self.actor_profile_id is None
                 and self.project_id is None
+                and self.target_actor_profile_id is None
+                and self.role is None
+                and self.grant_id is None
             )
             or (
                 self.kind is PreparedAuthorityScopeKind.PROJECT
                 and self.actor_profile_id is None
                 and self.project_id is not None
+                and not (
+                    self.target_actor_profile_id is not None
+                    and self.grant_id is not None
+                )
+                and ((self.target_actor_profile_id is None) == (self.role is None))
             )
         )
         if not valid:

--- a/backend/app/modules/authorization/runtime.py
+++ b/backend/app/modules/authorization/runtime.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
 from app.core.hashing import canonical_json_hash
 from app.modules.actors.service_identities import ServiceIdentity
 from app.modules.authorization.catalogue import ActionId, PermissionId
-from app.modules.authorization.schemas import AdminRole, AdminScope
+from app.modules.authorization.schemas import AdminRole, AdminScope, ProjectRole
 
 _STRICT_FROZEN = ConfigDict(extra="forbid", frozen=True, strict=True)
 
@@ -91,17 +91,21 @@ class PreparedAuthorityScope(BaseModel):
     def validate_selector(self):
         """Require exactly the identifier owned by the selected scope kind."""
         valid = (
-            self.kind is PreparedAuthorityScopeKind.ACTOR_SELF
-            and self.actor_profile_id is not None
-            and self.project_id is None
-        ) or (
-            self.kind is PreparedAuthorityScopeKind.SYSTEM
-            and self.actor_profile_id is None
-            and self.project_id is None
-        ) or (
-            self.kind is PreparedAuthorityScopeKind.PROJECT
-            and self.actor_profile_id is None
-            and self.project_id is not None
+            (
+                self.kind is PreparedAuthorityScopeKind.ACTOR_SELF
+                and self.actor_profile_id is not None
+                and self.project_id is None
+            )
+            or (
+                self.kind is PreparedAuthorityScopeKind.SYSTEM
+                and self.actor_profile_id is None
+                and self.project_id is None
+            )
+            or (
+                self.kind is PreparedAuthorityScopeKind.PROJECT
+                and self.actor_profile_id is None
+                and self.project_id is not None
+            )
         )
         if not valid:
             raise ValueError("invalid prepared authority scope")
@@ -329,6 +333,33 @@ class ProjectRoleGrantReadResourceContext(BaseModel):
     project_status: Literal["draft", "active", "paused", "archived"]
 
 
+class ProjectRoleGrantIssueResourceContext(BaseModel):
+    """Server-composed facts for issuing one exact independent role."""
+
+    model_config = _STRICT_FROZEN
+    resource_type: Literal["project_role_grant_issue"]
+    resource_id: UUID
+    scope_project_id: UUID
+    target_actor_profile_id: UUID
+    role: ProjectRole
+    project_status: Literal["draft", "active", "paused", "archived"]
+    target_eligible: bool
+
+
+class ProjectRoleGrantRevokeResourceContext(BaseModel):
+    """Locked exact-project grant facts used for revocation."""
+
+    model_config = _STRICT_FROZEN
+    resource_type: Literal["project_role_grant_revoke"]
+    resource_id: UUID
+    scope_project_id: UUID
+    actor_profile_id: UUID
+    role: ProjectRole
+    project_status: Literal["draft", "active", "paused", "archived"]
+    status: Literal["active", "revoked"]
+    version: Literal[1, 2]
+
+
 AuthorizationResourceContext = (
     ActorSelfResourceContext
     | ActorProfileAdminReadResourceContext
@@ -346,6 +377,8 @@ AuthorizationResourceContext = (
     | ProjectContributorCandidateCollectionResourceContext
     | ProjectRoleGrantCollectionResourceContext
     | ProjectRoleGrantReadResourceContext
+    | ProjectRoleGrantIssueResourceContext
+    | ProjectRoleGrantRevokeResourceContext
 )
 
 

--- a/backend/app/modules/authorization/runtime.py
+++ b/backend/app/modules/authorization/runtime.py
@@ -351,7 +351,7 @@ class ProjectRoleGrantIssueResourceContext(BaseModel):
     """Server-composed facts for issuing one exact independent role."""
 
     model_config = _STRICT_FROZEN
-    resource_type: Literal["project_role_grant_issue"]
+    resource_type: Literal["project_role_grant"]
     resource_id: UUID
     scope_project_id: UUID
     target_actor_profile_id: UUID
@@ -365,7 +365,7 @@ class ProjectRoleGrantRevokeResourceContext(BaseModel):
     """Locked exact-project grant facts used for revocation."""
 
     model_config = _STRICT_FROZEN
-    resource_type: Literal["project_role_grant_revoke"]
+    resource_type: Literal["project_role_grant"]
     resource_id: UUID
     scope_project_id: UUID
     actor_profile_id: UUID

--- a/backend/app/modules/authorization/schemas.py
+++ b/backend/app/modules/authorization/schemas.py
@@ -10,7 +10,15 @@ import re
 from typing import Annotated, Any, Literal, Self
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    Strict,
+    TypeAdapter,
+    model_validator,
+)
 
 from app.core.hashing import canonical_json_hash
 from app.modules.audit.schemas import ActorReferenceKind
@@ -146,8 +154,19 @@ class QualificationUnavailableReason(StrEnum):
 
 ReferenceToken = Annotated[
     str,
+    Strict(),
     Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,119}$"),
 ]
+
+
+def _canonical_uuid_input(value: object) -> object:
+    """Admit only the two representations UUID references can have at this boundary."""
+    if not isinstance(value, (str, UUID)):
+        raise ValueError("invalid UUID reference")
+    return value
+
+
+CanonicalUUID = Annotated[UUID, BeforeValidator(_canonical_uuid_input)]
 
 
 class QualificationAvailabilitySnapshot(BaseModel):
@@ -200,7 +219,7 @@ class ProjectRoleQualificationEvidence(BaseModel):
 
     skills_snapshot: QualificationAvailabilitySnapshot
     reputation_snapshot: QualificationAvailabilitySnapshot
-    prior_project_work_refs: Annotated[list[UUID], Field(max_length=20)]
+    prior_project_work_refs: Annotated[list[CanonicalUUID], Field(max_length=20)]
     external_expertise_refs: Annotated[list[ReferenceToken], Field(max_length=20)]
 
     @model_validator(mode="after")

--- a/backend/app/modules/authorization/schemas.py
+++ b/backend/app/modules/authorization/schemas.py
@@ -153,7 +153,7 @@ ReferenceToken = Annotated[
 class QualificationAvailabilitySnapshot(BaseModel):
     """Privacy-bounded availability and opaque-reference evidence."""
 
-    model_config = _MODEL_CONFIG
+    model_config = ConfigDict(extra="forbid", frozen=True, hide_input_in_errors=True)
 
     availability: QualificationAvailability
     reference_ids: Annotated[list[ReferenceToken], Field(max_length=20)]
@@ -196,7 +196,7 @@ class ProjectRoleQualificationSnapshotInput(BaseModel):
 class ProjectRoleQualificationEvidence(BaseModel):
     """Identifier-free qualification facts supplied for one role decision."""
 
-    model_config = _MODEL_CONFIG
+    model_config = ConfigDict(extra="forbid", frozen=True, hide_input_in_errors=True)
 
     skills_snapshot: QualificationAvailabilitySnapshot
     reputation_snapshot: QualificationAvailabilitySnapshot
@@ -479,6 +479,14 @@ class AuthorityInvalidationContext(BaseModel):
     event_id: UUID
     request_id: UUID
     correlation_id: UUID
+    target_ref_kind: AuthorityResourceType | None = None
+    target_ref_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def validate_target(self):
+        if (self.target_ref_kind is None) != (self.target_ref_id is None):
+            raise ValueError("invalid authority invalidation target")
+        return self
 
 
 class AuthorityMismatchContext(BaseModel):

--- a/backend/app/modules/authorization/schemas.py
+++ b/backend/app/modules/authorization/schemas.py
@@ -193,6 +193,23 @@ class ProjectRoleQualificationSnapshotInput(BaseModel):
         return self
 
 
+class ProjectRoleQualificationEvidence(BaseModel):
+    """Identifier-free qualification facts supplied for one role decision."""
+
+    model_config = _MODEL_CONFIG
+
+    skills_snapshot: QualificationAvailabilitySnapshot
+    reputation_snapshot: QualificationAvailabilitySnapshot
+    prior_project_work_refs: Annotated[list[UUID], Field(max_length=20)]
+    external_expertise_refs: Annotated[list[ReferenceToken], Field(max_length=20)]
+
+    @model_validator(mode="after")
+    def reject_url_references(self) -> Self:
+        if any("://" in reference for reference in self.external_expertise_refs):
+            raise ValueError("invalid qualification reference")
+        return self
+
+
 Digest = Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{64}$")]
 
 
@@ -284,6 +301,7 @@ class ProjectRoleGrantIssueRequest(CanonicalAuthorityRequest):
     project_id: UUID
     target_actor_id: UUID
     role: ProjectRole
+    qualification: ProjectRoleQualificationEvidence
     reason_digest: Digest
 
 
@@ -481,7 +499,7 @@ class AuthorityCompletionResult(BaseModel):
 
     response: AuthorityResponseReference
     success_event_id: UUID
-    invalidation_event_id: UUID
+    invalidation_event_id: UUID | None = None
 
 
 class PendingAuthorityReservationError(RuntimeError):

--- a/backend/app/modules/authorization/schemas.py
+++ b/backend/app/modules/authorization/schemas.py
@@ -481,11 +481,24 @@ class AuthorityInvalidationContext(BaseModel):
     correlation_id: UUID
     target_ref_kind: AuthorityResourceType | None = None
     target_ref_id: UUID | None = None
+    project_role: ProjectRole | None = None
+    future_obligation: Literal[
+        "auth13_assignment", "rev_reviewer_obligation", "none"
+    ] | None = None
 
     @model_validator(mode="after")
     def validate_target(self):
         if (self.target_ref_kind is None) != (self.target_ref_id is None):
             raise ValueError("invalid authority invalidation target")
+        expected = {
+            ProjectRole.SUBMITTER: "auth13_assignment",
+            ProjectRole.REVIEWER: "rev_reviewer_obligation",
+            ProjectRole.ADJUDICATOR: "none",
+        }.get(self.project_role)
+        if (self.project_role is None) != (self.future_obligation is None):
+            raise ValueError("invalid authority invalidation projection")
+        if expected is not None and self.future_obligation != expected:
+            raise ValueError("invalid authority invalidation projection")
         return self
 
 

--- a/backend/app/modules/authorization/service.py
+++ b/backend/app/modules/authorization/service.py
@@ -75,16 +75,17 @@ _EVIDENCE = {
     ),
     AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE: _OperationEvidence(
         "project.role_grant.manage",
-        None,
+        ActionId.PROJECT_ROLE_GRANT_ISSUE,
         AuthorityResourceType.PROJECT_ROLE_GRANT,
         201,
         (
+            AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED,
             AuthorityEventType.PROJECT_ROLE_GRANT_ISSUED,
         ),
     ),
     AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE: _OperationEvidence(
         "project.role_grant.manage",
-        None,
+        ActionId.PROJECT_ROLE_GRANT_REVOKE,
         AuthorityResourceType.PROJECT_ROLE_GRANT,
         200,
         (AuthorityEventType.PROJECT_ROLE_GRANT_REVOKED,),
@@ -174,37 +175,52 @@ class AuthorityMutationService:
         claim: AuthorityClaimHandle,
         request: object,
         response: AuthorityResponseReference,
-        success: AuthorityAuditEventInput,
-        invalidation: AuthorityInvalidationContext,
+        success: AuthorityAuditEventInput | tuple[AuthorityAuditEventInput, ...],
+        invalidation: AuthorityInvalidationContext | None,
     ) -> AuthorityCompletionResult:
         """Flush one mapped success/invalidation pair, then complete its claim."""
         mutation = parse_authority_request(request)
         spec = _EVIDENCE[claim.operation]
         expected_digest = canonical_json_hash(mutation.model_dump(mode="json", exclude_none=True))
+        successes = success if isinstance(success, tuple) else (success,)
+        if not successes:
+            raise TypeError("invalid authority completion input")
+        primary = successes[-1]
         allowed_events = spec.events
         valid = (
             mutation.operation == claim.operation
             and expected_digest == claim.request_digest
-            and success.event_type in allowed_events
-            and success.actor_ref_kind == claim.actor_ref_kind
-            and success.actor_ref == claim.actor_ref
-            and success.idempotency_reference == claim.record_id
-            and success.permission_id == spec.permission
-            and success.entity_type == spec.resource_type.value
-            and success.entity_id == str(response.resource_id)
-            and success.resource_type == spec.resource_type.value
-            and success.resource_id == str(response.resource_id)
-            and success.target_ref_kind == spec.resource_type.value
-            and success.target_ref_id == str(response.resource_id)
+            and tuple(item.event_type for item in successes) == allowed_events
+            and all(item.actor_ref_kind == claim.actor_ref_kind for item in successes)
+            and all(item.actor_ref == claim.actor_ref for item in successes)
+            and all(item.idempotency_reference == claim.record_id for item in successes)
+            and all(item.permission_id == spec.permission for item in successes)
+            and primary.entity_type == spec.resource_type.value
+            and primary.entity_id == str(response.resource_id)
+            and primary.resource_type == spec.resource_type.value
+            and primary.resource_id == str(response.resource_id)
+            and primary.target_ref_kind == spec.resource_type.value
+            and primary.target_ref_id == str(response.resource_id)
             and response.resource_type == spec.resource_type
             and response.http_status == spec.http_status
-            and _request_matches_success(mutation, response, success)
-            and success.request_id == invalidation.request_id
-            and success.correlation_id == invalidation.correlation_id
+            and _request_matches_success(mutation, response, primary)
+            and all(item.request_id == primary.request_id for item in successes)
+            and all(item.correlation_id == primary.correlation_id for item in successes)
+            and (
+                invalidation is None
+                or (
+                    primary.request_id == invalidation.request_id
+                    and primary.correlation_id == invalidation.correlation_id
+                )
+            )
         )
         if not valid:
             raise TypeError("invalid authority completion input")
-        stored_success = await self._audit.add_authority_event(success)
+        stored_success = None
+        for success_event in successes:
+            stored_success = await self._audit.add_authority_event(success_event)
+        if stored_success is None:
+            raise TypeError("invalid authority completion input")
         admin_mutation = isinstance(
             mutation,
             (AdminRoleGrantIssueRequest, AdminRoleGrantRevokeRequest),
@@ -214,18 +230,22 @@ class AuthorityMutationService:
             (ActorIdentityLinkRevokeRequest, ActorIdentityLinkReactivateRequest),
         )
         invalidation_target_kind = spec.resource_type.value
-        invalidation_target_ref = success.resource_id
-        invalidation_resource_type = success.resource_type
-        invalidation_resource_id = success.resource_id
+        invalidation_target_ref = primary.resource_id
+        invalidation_resource_type = primary.resource_type
+        invalidation_resource_id = primary.resource_id
         before_facts = {"effective": True}
         after_facts = {"effective": False}
-        if admin_mutation or identity_link_mutation:
-            if success.target_actor_ref is None:
+        if (
+            admin_mutation
+            or identity_link_mutation
+            or isinstance(mutation, ProjectRoleGrantRevokeRequest)
+        ):
+            if primary.target_actor_ref is None:
                 raise TypeError("projected authority success requires target actor")
             invalidation_target_kind = AuthorityResourceType.ACTOR_PROFILE.value
-            invalidation_target_ref = success.target_actor_ref
+            invalidation_target_ref = primary.target_actor_ref
             invalidation_resource_type = AuthorityResourceType.ACTOR_PROFILE.value
-            invalidation_resource_id = success.target_actor_ref
+            invalidation_resource_id = primary.target_actor_ref
             if isinstance(
                 mutation,
                 (AdminRoleGrantIssueRequest, ActorIdentityLinkReactivateRequest),
@@ -235,33 +255,34 @@ class AuthorityMutationService:
         elif isinstance(mutation, ActorProfileReactivateRequest):
             before_facts = {"effective": False}
             after_facts = {"effective": True}
-        invalidation_input = AuthorityAuditEventInput(
-            event_id=invalidation.event_id,
-            event_type=AuthorityEventType.AUTHORITY_INVALIDATION_REQUESTED,
-            entity_type="authority_invalidation",
-            entity_id=str(invalidation.event_id),
-            actor_ref_kind=claim.actor_ref_kind,
-            actor_ref=claim.actor_ref,
-            request_id=invalidation.request_id,
-            correlation_id=invalidation.correlation_id,
-            permission_id=spec.permission,
-            project_id=success.project_id,
-            resource_type=invalidation_resource_type,
-            resource_id=invalidation_resource_id,
-            reason="authority_state_changed",
-            idempotency_reference=claim.record_id,
-            invalidation_cause_event_id=UUID(stored_success.id),
-            invalidation_target_kind=invalidation_target_kind,
-            invalidation_target_ref=invalidation_target_ref,
-            before_facts=before_facts,
-            after_facts=after_facts,
-        )
-        await self._audit.add_authority_event(invalidation_input)
+        if invalidation is not None:
+            invalidation_input = AuthorityAuditEventInput(
+                event_id=invalidation.event_id,
+                event_type=AuthorityEventType.AUTHORITY_INVALIDATION_REQUESTED,
+                entity_type="authority_invalidation",
+                entity_id=str(invalidation.event_id),
+                actor_ref_kind=claim.actor_ref_kind,
+                actor_ref=claim.actor_ref,
+                request_id=invalidation.request_id,
+                correlation_id=invalidation.correlation_id,
+                permission_id=spec.permission,
+                project_id=primary.project_id,
+                resource_type=invalidation_resource_type,
+                resource_id=invalidation_resource_id,
+                reason="authority_state_changed",
+                idempotency_reference=claim.record_id,
+                invalidation_cause_event_id=UUID(stored_success.id),
+                invalidation_target_kind=invalidation_target_kind,
+                invalidation_target_ref=invalidation_target_ref,
+                before_facts=before_facts,
+                after_facts=after_facts,
+            )
+            await self._audit.add_authority_event(invalidation_input)
         await self._repository.complete(claim, response)
         return AuthorityCompletionResult(
             response=response,
-            success_event_id=success.event_id,
-            invalidation_event_id=invalidation.event_id,
+            success_event_id=primary.event_id,
+            invalidation_event_id=invalidation.event_id if invalidation is not None else None,
         )
 
     async def record_mismatch_denial(
@@ -285,9 +306,7 @@ class AuthorityMutationService:
             actor_ref=actor_ref,
             request_id=context.request_id,
             correlation_id=context.correlation_id,
-            matched_grant_id=(
-                str(context.matched_grant_id) if context.matched_grant_id else None
-            ),
+            matched_grant_id=(str(context.matched_grant_id) if context.matched_grant_id else None),
             permission_id=spec.permission,
             action_id=spec.action,
             project_id=_request_project_id(mutation),

--- a/backend/app/modules/authorization/service.py
+++ b/backend/app/modules/authorization/service.py
@@ -235,13 +235,11 @@ class AuthorityMutationService:
         invalidation_target_ref = primary.resource_id
         invalidation_resource_type = primary.resource_type
         invalidation_resource_id = primary.resource_id
+        invalidation_target_actor_kind = None
+        invalidation_target_actor_ref = None
         before_facts = {"effective": True}
         after_facts = {"effective": False}
-        if (
-            admin_mutation
-            or identity_link_mutation
-            or isinstance(mutation, ProjectRoleGrantRevokeRequest)
-        ):
+        if admin_mutation or identity_link_mutation:
             if primary.target_actor_ref is None:
                 raise TypeError("projected authority success requires target actor")
             invalidation_target_kind = AuthorityResourceType.ACTOR_PROFILE.value
@@ -262,8 +260,12 @@ class AuthorityMutationService:
                 invalidation is None
                 or invalidation.project_role is None
                 or invalidation.future_obligation is None
+                or primary.target_actor_ref_kind is None
+                or primary.target_actor_ref is None
             ):
                 raise TypeError("project-role revoke requires invalidation projection")
+            invalidation_target_actor_kind = primary.target_actor_ref_kind
+            invalidation_target_actor_ref = primary.target_actor_ref
             projection = {
                 "role": invalidation.project_role.value,
                 "scope_type": "project",
@@ -284,23 +286,25 @@ class AuthorityMutationService:
                 correlation_id=invalidation.correlation_id,
                 permission_id=spec.permission,
                 project_id=primary.project_id,
+                target_actor_ref_kind=invalidation_target_actor_kind,
+                target_actor_ref=invalidation_target_actor_ref,
                 resource_type=invalidation_resource_type,
-            resource_id=invalidation_resource_id,
-            target_ref_kind=(
-                invalidation.target_ref_kind.value
-                if invalidation.target_ref_kind is not None
-                else None
-            ),
-            target_ref_id=(
-                str(invalidation.target_ref_id)
-                if invalidation.target_ref_id is not None
-                else None
-            ),
+                resource_id=invalidation_resource_id,
+                target_ref_kind=(
+                    invalidation.target_ref_kind.value
+                    if invalidation.target_ref_kind is not None
+                    else None
+                ),
+                target_ref_id=(
+                    str(invalidation.target_ref_id)
+                    if invalidation.target_ref_id is not None
+                    else None
+                ),
                 reason="authority_state_changed",
                 idempotency_reference=claim.record_id,
                 invalidation_cause_event_id=UUID(stored_success.id),
                 invalidation_target_kind=invalidation_target_kind,
-            invalidation_target_ref=invalidation_target_ref,
+                invalidation_target_ref=invalidation_target_ref,
                 before_facts=before_facts,
                 after_facts=after_facts,
             )

--- a/backend/app/modules/authorization/service.py
+++ b/backend/app/modules/authorization/service.py
@@ -257,6 +257,21 @@ class AuthorityMutationService:
         elif isinstance(mutation, ActorProfileReactivateRequest):
             before_facts = {"effective": False}
             after_facts = {"effective": True}
+        if isinstance(mutation, ProjectRoleGrantRevokeRequest):
+            if (
+                invalidation is None
+                or invalidation.project_role is None
+                or invalidation.future_obligation is None
+            ):
+                raise TypeError("project-role revoke requires invalidation projection")
+            projection = {
+                "role": invalidation.project_role.value,
+                "scope_type": "project",
+                "scope_id": str(mutation.project_id),
+                "future_obligation": invalidation.future_obligation,
+            }
+            before_facts = {"effective": True, **projection}
+            after_facts = {"effective": False, **projection}
         if invalidation is not None:
             invalidation_input = AuthorityAuditEventInput(
                 event_id=invalidation.event_id,

--- a/backend/app/modules/authorization/service.py
+++ b/backend/app/modules/authorization/service.py
@@ -206,6 +206,8 @@ class AuthorityMutationService:
             and _request_matches_success(mutation, response, primary)
             and all(item.request_id == primary.request_id for item in successes)
             and all(item.correlation_id == primary.correlation_id for item in successes)
+            and (invalidation is None)
+            == isinstance(mutation, ProjectRoleGrantIssueRequest)
             and (
                 invalidation is None
                 or (
@@ -268,12 +270,22 @@ class AuthorityMutationService:
                 permission_id=spec.permission,
                 project_id=primary.project_id,
                 resource_type=invalidation_resource_type,
-                resource_id=invalidation_resource_id,
+            resource_id=invalidation_resource_id,
+            target_ref_kind=(
+                invalidation.target_ref_kind.value
+                if invalidation.target_ref_kind is not None
+                else None
+            ),
+            target_ref_id=(
+                str(invalidation.target_ref_id)
+                if invalidation.target_ref_id is not None
+                else None
+            ),
                 reason="authority_state_changed",
                 idempotency_reference=claim.record_id,
                 invalidation_cause_event_id=UUID(stored_success.id),
                 invalidation_target_kind=invalidation_target_kind,
-                invalidation_target_ref=invalidation_target_ref,
+            invalidation_target_ref=invalidation_target_ref,
                 before_facts=before_facts,
                 after_facts=after_facts,
             )
@@ -373,13 +385,19 @@ def _request_matches_success(
             success.target_actor_ref_kind == ActorReferenceKind.ACTOR_PROFILE
             and success.target_actor_ref == str(request.target_actor_id)
             and success.project_id == str(request.project_id)
-            and success.matched_grant_id is None
+            and success.matched_grant_id is not None
             and facts.get("role") == request.role.value
             and facts.get("scope_type") == "project"
             and facts.get("scope_id") == str(request.project_id)
         )
     if isinstance(request, ProjectRoleGrantRevokeRequest):
-        return resource_id == request.grant_id and success.project_id == str(request.project_id)
+        return (
+            resource_id == request.grant_id
+            and success.project_id == str(request.project_id)
+            and success.matched_grant_id is not None
+            and success.target_actor_ref_kind == ActorReferenceKind.ACTOR_PROFILE
+            and success.target_actor_ref is not None
+        )
     if isinstance(
         request,
         (ActorProfileSuspendRequest, ActorProfileReactivateRequest, ActorProfileDeactivateRequest),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,7 +35,7 @@ dev = [
   "pytest>=8.0,<9.0",
   "pytest-asyncio>=0.24,<1.0",
   "pytest-cov==7.1.0",
-  "ruff>=0.8,<1.0",
+  "ruff>=0.8,<0.16",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -1572,7 +1572,7 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
         )
         assert link_case_issue.status_code == 201, link_case_issue.text
         revoked_target_link = await client.post(
-            f"/api/v1/actor-identity-links/{worker_admin_link['id']}/revoke",
+            f"/api/v1/actor-identity-links/{worker_admin_link['identity_link_id']}/revoke",
             headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
             json={"reason": "Prove revoked-link grant removal"},
         )
@@ -1585,7 +1585,7 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
         )
         assert link_case_revoke.status_code == 200, link_case_revoke.text
         repaired_target_link = await client.post(
-            f"/api/v1/actor-identity-links/{worker_admin_link['id']}/reactivate",
+            f"/api/v1/actor-identity-links/{worker_admin_link['identity_link_id']}/reactivate",
             headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
             json={"reason": "Restore API contract contributor identity link"},
         )

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -1602,7 +1602,9 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
             json=role_revoke_body,
         )
         assert concealed_replay.status_code == 404, concealed_replay.text
-        assert concealed_replay.json()["error"] == missing_grant["error"]
+        concealed_replay_error = concealed_replay.json()["error"]
+        assert concealed_replay_error["code"] == missing_grant["error"]["code"]
+        assert concealed_replay_error["message"] == missing_grant["error"]["message"]
         await request_json(client, "GET", f"/api/v1/tasks/{task['id']}", worker_token)
         ready_work_context = await request_json(
             client,

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -1602,6 +1602,7 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
             json=role_revoke_body,
         )
         assert concealed_replay.status_code == 404, concealed_replay.text
+        assert concealed_replay.json()["error"] == missing_grant["error"]
         await request_json(client, "GET", f"/api/v1/tasks/{task['id']}", worker_token)
         ready_work_context = await request_json(
             client,

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -1603,8 +1603,15 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
         )
         assert concealed_replay.status_code == 404, concealed_replay.text
         concealed_replay_error = concealed_replay.json()["error"]
-        assert concealed_replay_error["code"] == missing_grant["error"]["code"]
-        assert concealed_replay_error["message"] == missing_grant["error"]["message"]
+        assert {
+            key: value
+            for key, value in concealed_replay_error.items()
+            if key != "correlation_id"
+        } == {
+            key: value
+            for key, value in missing_grant["error"].items()
+            if key != "correlation_id"
+        }
         await request_json(client, "GET", f"/api/v1/tasks/{task['id']}", worker_token)
         ready_work_context = await request_json(
             client,

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -1464,7 +1464,7 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
         }
         issued_role = await client.post(
             f"/api/v1/projects/{project['id']}/role-grants",
-            headers=auth_headers(manager_token) | {"Idempotency-Key": role_issue_key},
+            headers=auth_headers(project_reader_token) | {"Idempotency-Key": role_issue_key},
             json=role_issue_body,
         )
         assert issued_role.status_code == 201, issued_role.text
@@ -1510,15 +1510,27 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
         assert grant["revoked_by_actor_profile_id"] is None
         assert grant["revoked_at"] is None
         assert grant["revoked_reason"] is None
+        suspended_role_target = await client.post(
+            f"/api/v1/actors/{canonical_actor['actor_profile_id']}/suspend",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
+            json={"reason": "Prove suspended targets cannot retain irremovable authority"},
+        )
+        assert suspended_role_target.status_code == 200, suspended_role_target.text
         role_revoke_key = str(uuid4())
         role_revoke_body = {"reason": "Real API submitter authority removal"}
         revoked_role = await client.post(
             f"/api/v1/projects/{project['id']}/role-grants/{role_grant_id}/revoke",
-            headers=auth_headers(manager_token) | {"Idempotency-Key": role_revoke_key},
+            headers=auth_headers(project_reader_token) | {"Idempotency-Key": role_revoke_key},
             json=role_revoke_body,
         )
         assert revoked_role.status_code == 200, revoked_role.text
         assert revoked_role.json()["status"] == "revoked"
+        reactivated_role_target = await client.post(
+            f"/api/v1/actors/{canonical_actor['actor_profile_id']}/reactivate",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
+            json={"reason": "Restore API contract contributor after revocation proof"},
+        )
+        assert reactivated_role_target.status_code == 200, reactivated_role_target.text
         historical_role = await request_json(
             client,
             "GET",
@@ -1528,20 +1540,20 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
         assert historical_role["status"] == "revoked"
         revoke_replay = await client.post(
             f"/api/v1/projects/{project['id']}/role-grants/{role_grant_id}/revoke",
-            headers=auth_headers(manager_token) | {"Idempotency-Key": role_revoke_key},
+            headers=auth_headers(project_reader_token) | {"Idempotency-Key": role_revoke_key},
             json=role_revoke_body,
         )
         assert revoke_replay.status_code == 200, revoke_replay.text
         second_revoke = await client.post(
             f"/api/v1/projects/{project['id']}/role-grants/{role_grant_id}/revoke",
-            headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
+            headers=auth_headers(project_reader_token) | {"Idempotency-Key": str(uuid4())},
             json=role_revoke_body,
         )
         assert second_revoke.status_code == 409, second_revoke.text
         assert second_revoke.json()["error"]["code"] == "project_role_grant_already_revoked"
         issue_after_revoke = await client.post(
             f"/api/v1/projects/{project['id']}/role-grants",
-            headers=auth_headers(manager_token) | {"Idempotency-Key": role_issue_key},
+            headers=auth_headers(project_reader_token) | {"Idempotency-Key": role_issue_key},
             json=role_issue_body,
         )
         assert issue_after_revoke.status_code == 409, issue_after_revoke.text
@@ -1549,6 +1561,47 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
             issue_after_revoke.json()["error"]["code"]
             == "project_role_grant_replay_state_changed"
         )
+        link_case_body = role_issue_body | {
+            "role": "reviewer",
+            "reason": "Prove link lifecycle cannot make authority irremovable",
+        }
+        link_case_issue = await client.post(
+            f"/api/v1/projects/{project['id']}/role-grants",
+            headers=auth_headers(project_reader_token) | {"Idempotency-Key": str(uuid4())},
+            json=link_case_body,
+        )
+        assert link_case_issue.status_code == 201, link_case_issue.text
+        revoked_target_link = await client.post(
+            f"/api/v1/actor-identity-links/{worker_admin_link['id']}/revoke",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
+            json={"reason": "Prove revoked-link grant removal"},
+        )
+        assert revoked_target_link.status_code == 200, revoked_target_link.text
+        link_case_revoke = await client.post(
+            f"/api/v1/projects/{project['id']}/role-grants/"
+            f"{link_case_issue.json()['id']}/revoke",
+            headers=auth_headers(project_reader_token) | {"Idempotency-Key": str(uuid4())},
+            json={"reason": "Remove reviewer authority after target link revocation"},
+        )
+        assert link_case_revoke.status_code == 200, link_case_revoke.text
+        repaired_target_link = await client.post(
+            f"/api/v1/actor-identity-links/{worker_admin_link['id']}/reactivate",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
+            json={"reason": "Restore API contract contributor identity link"},
+        )
+        assert repaired_target_link.status_code == 200, repaired_target_link.text
+        removed_project_manager = await client.post(
+            f"/api/v1/admin-role-grants/{project_manager_grant.json()['resource_id']}/revoke",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
+            json={"reason": "Prove mutation replay reauthorizes current project authority"},
+        )
+        assert removed_project_manager.status_code == 200, removed_project_manager.text
+        concealed_replay = await client.post(
+            f"/api/v1/projects/{project['id']}/role-grants/{role_grant_id}/revoke",
+            headers=auth_headers(project_reader_token) | {"Idempotency-Key": role_revoke_key},
+            json=role_revoke_body,
+        )
+        assert concealed_replay.status_code == 404, concealed_replay.text
         await request_json(client, "GET", f"/api/v1/tasks/{task['id']}", worker_token)
         ready_work_context = await request_json(
             client,

--- a/backend/scripts/api_contract_e2e.py
+++ b/backend/scripts/api_contract_e2e.py
@@ -21,18 +21,13 @@ import httpx
 from alembic import command
 from alembic.config import Config
 from pydantic import SecretStr
-from sqlalchemy import select, text
+from sqlalchemy import text
 
 from app.db import session as db_session
 from app.modules.api_controls.service import (
     FIRST_ACCESS_SCOPE,
     RateControlService,
     rate_key_digest,
-)
-from app.modules.authorization.models import (
-    AdminRoleGrant,
-    ProjectRoleGrant,
-    ProjectRoleQualificationSnapshot,
 )
 from app.modules.projects.models import PostSubmitCheckerPolicy, ProjectSetupRun
 from app.modules.projects.post_submit_policy import (
@@ -287,65 +282,6 @@ async def exercise_rate_control_contract(env: dict[str, str]) -> None:
             {"scope": FIRST_ACCESS_SCOPE, "digest": digest},
         )
         await session.commit()
-
-
-async def seed_project_role_read_contract(
-    *,
-    project_id: str,
-    actor_profile_id: str,
-    manager_actor_profile_id: str,
-) -> str:
-    """Seed one bounded read fixture until AUTH-10C owns public mutations."""
-    snapshot_id = uuid4()
-    grant_id = uuid4()
-    async with db_session.get_session_factory()() as session:
-        admin_grant_id = await session.scalar(
-            select(AdminRoleGrant.id).where(
-                AdminRoleGrant.target_actor_profile_id == manager_actor_profile_id,
-                AdminRoleGrant.status == "active",
-            )
-        )
-        assert admin_grant_id is not None
-        session.add(
-            ProjectRoleQualificationSnapshot(
-                id=snapshot_id,
-                project_id=project_id,
-                actor_profile_id=actor_profile_id,
-                requested_role="submitter",
-                skills_snapshot={
-                    "availability": "available",
-                    "reference_ids": ["skill:api-contract"],
-                    "unavailable_reason": None,
-                },
-                reputation_snapshot={
-                    "availability": "unavailable",
-                    "reference_ids": [],
-                    "unavailable_reason": "no_record",
-                },
-                prior_project_work_refs=[],
-                external_expertise_refs=[],
-                captured_by_actor_profile_id=manager_actor_profile_id,
-                captured_by_admin_role_grant_id=admin_grant_id,
-            )
-        )
-        await session.flush()
-        session.add(
-            ProjectRoleGrant(
-                id=grant_id,
-                project_id=project_id,
-                actor_profile_id=actor_profile_id,
-                role="submitter",
-                status="active",
-                version=1,
-                grant_method="manual",
-                qualification_snapshot_id=snapshot_id,
-                granted_by_actor_profile_id=manager_actor_profile_id,
-                granted_by_admin_role_grant_id=admin_grant_id,
-                grant_reason="API contract read fixture",
-            )
-        )
-        await session.commit()
-    return str(grant_id)
 
 
 def start_api_server(port: int, env: dict[str, str]) -> tuple[subprocess.Popen, Path]:
@@ -1061,13 +997,12 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
             ),
         }
         assert not any("authorization-context" in path for path in openapi["paths"])
-        assert not any(
-            operation.get("x-workstream-action-id")
-            in {"project_role_grant.issue", "project_role_grant.revoke"}
-            for path_item in openapi["paths"].values()
-            for method, operation in path_item.items()
-            if method in {"get", "post", "put", "patch", "delete"}
-        )
+        assert openapi["paths"]["/api/v1/projects/{project_id}/role-grants"]["post"][
+            "x-workstream-action-id"
+        ] == "project_role_grant.issue"
+        assert openapi["paths"][
+            "/api/v1/projects/{project_id}/role-grants/{grant_id}/revoke"
+        ]["post"]["x-workstream-action-id"] == "project_role_grant.revoke"
         await request_json(client, "GET", "/api/v1/auth/me", expected_status=401)
         await request_json(client, "GET", "/api/v1/auth/me", invalid_token, expected_status=401)
         await request_json(client, "GET", "/api/v1/auth/me", wrong_issuer_token, expected_status=401)
@@ -1507,11 +1442,33 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
         assert worker_profile["external_issuer"] == flow_issuer
         assert worker_profile["status"] == "active"
         assert set(worker_profile["skill_tags"]) == {"stem", "proofs"}
-        role_grant_id = await seed_project_role_read_contract(
-            project_id=project["id"],
-            actor_profile_id=canonical_actor["actor_profile_id"],
-            manager_actor_profile_id=manager_profile["actor_profile_id"],
+        role_issue_key = str(uuid4())
+        role_issue_body = {
+            "target_actor_profile_id": canonical_actor["actor_profile_id"],
+            "role": "submitter",
+            "qualification": {
+                "skills_snapshot": {
+                    "availability": "available",
+                    "reference_ids": ["skill:api-contract"],
+                    "unavailable_reason": None,
+                },
+                "reputation_snapshot": {
+                    "availability": "unavailable",
+                    "reference_ids": [],
+                    "unavailable_reason": "no_record",
+                },
+                "prior_project_work_refs": [],
+                "external_expertise_refs": [],
+            },
+            "reason": "Real API independent submitter authority",
+        }
+        issued_role = await client.post(
+            f"/api/v1/projects/{project['id']}/role-grants",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": role_issue_key},
+            json=role_issue_body,
         )
+        assert issued_role.status_code == 201, issued_role.text
+        role_grant_id = issued_role.json()["id"]
         candidates = await request_json(
             client,
             "GET",
@@ -1553,6 +1510,45 @@ async def exercise_api_contract(base_url: str, env: dict[str, str]) -> None:
         assert grant["revoked_by_actor_profile_id"] is None
         assert grant["revoked_at"] is None
         assert grant["revoked_reason"] is None
+        role_revoke_key = str(uuid4())
+        role_revoke_body = {"reason": "Real API submitter authority removal"}
+        revoked_role = await client.post(
+            f"/api/v1/projects/{project['id']}/role-grants/{role_grant_id}/revoke",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": role_revoke_key},
+            json=role_revoke_body,
+        )
+        assert revoked_role.status_code == 200, revoked_role.text
+        assert revoked_role.json()["status"] == "revoked"
+        historical_role = await request_json(
+            client,
+            "GET",
+            f"/api/v1/projects/{project['id']}/role-grants/{role_grant_id}",
+            project_reader_token,
+        )
+        assert historical_role["status"] == "revoked"
+        revoke_replay = await client.post(
+            f"/api/v1/projects/{project['id']}/role-grants/{role_grant_id}/revoke",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": role_revoke_key},
+            json=role_revoke_body,
+        )
+        assert revoke_replay.status_code == 200, revoke_replay.text
+        second_revoke = await client.post(
+            f"/api/v1/projects/{project['id']}/role-grants/{role_grant_id}/revoke",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": str(uuid4())},
+            json=role_revoke_body,
+        )
+        assert second_revoke.status_code == 409, second_revoke.text
+        assert second_revoke.json()["error"]["code"] == "project_role_grant_already_revoked"
+        issue_after_revoke = await client.post(
+            f"/api/v1/projects/{project['id']}/role-grants",
+            headers=auth_headers(manager_token) | {"Idempotency-Key": role_issue_key},
+            json=role_issue_body,
+        )
+        assert issue_after_revoke.status_code == 409, issue_after_revoke.text
+        assert (
+            issue_after_revoke.json()["error"]["code"]
+            == "project_role_grant_replay_state_changed"
+        )
         await request_json(client, "GET", f"/api/v1/tasks/{task['id']}", worker_token)
         ready_work_context = await request_json(
             client,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,7 +22,7 @@ from scripts.run_isolated_tests import LOOPBACK, NAME_RE, ROLE_RE
 
 DDL_LOCK_DIRECTORY = Path("/tmp")
 EXPECTED_PUBLIC_SCHEMA_SHA256 = (
-    "15ebc5bdd5ecce33b6534b6003e71d6a46a9a33356d804d673f89b8a29e6dbea"
+    "83831965c8001901db2dab8cfd9c8a83e27331d61e724381dbdce5a859bf0e9c"
 )
 PROTECTED_TEST_TABLES = (
     "actor_profile_migration_state",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,7 +22,7 @@ from scripts.run_isolated_tests import LOOPBACK, NAME_RE, ROLE_RE
 
 DDL_LOCK_DIRECTORY = Path("/tmp")
 EXPECTED_PUBLIC_SCHEMA_SHA256 = (
-    "57c0f4b00709fb1c865277d9cac07ea2bc34d22ef26f36f93a7214986cb1388b"
+    "15ebc5bdd5ecce33b6534b6003e71d6a46a9a33356d804d673f89b8a29e6dbea"
 )
 PROTECTED_TEST_TABLES = (
     "actor_profile_migration_state",

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -221,6 +221,7 @@ def test_0034_project_role_issue_evidence_fact_shape_is_closed(
                     "future_obligation": obligation,
                 }
                 after = {**before, "effective": False}
+                mismatched_role = "reviewer" if role != "reviewer" else "submitter"
                 assert asyncio.run(
                     _facts_are_safe_0034(isolated_database_env, before, after, project_id)
                 )
@@ -230,17 +231,26 @@ def test_0034_project_role_issue_evidence_fact_shape_is_closed(
                     ({**before, "effective": "true"}, after),
                     ({**before, "scope_id": str(uuid4())}, after),
                     ({**before, "future_obligation": "wrong"}, after),
-                    (before, {**after, "role": "adjudicator"}),
+                    (before, {**after, "role": mismatched_role}),
                 )
                 for invalid_before, invalid_after in invalid:
-                    assert not asyncio.run(
+                    assert asyncio.run(
                         _facts_are_safe_0034(
                             isolated_database_env,
                             invalid_before,
                             invalid_after,
                             project_id,
                         )
-                    )
+                    ) is False
+                for null_before, null_after in ((None, after), (before, None)):
+                    assert asyncio.run(
+                        _facts_are_safe_0034(
+                            isolated_database_env,
+                            null_before,
+                            null_after,
+                            project_id,
+                        )
+                    ) is False
             assert asyncio.run(
                 _facts_are_safe_0034(
                     isolated_database_env,
@@ -662,7 +672,8 @@ async def _install_definition_drift_0034(database_url: str, drift: str) -> None:
                 await connection.execute(
                     text(
                         "create or replace function authority_event_facts_are_safe("
-                        "text,json,json,text) returns boolean language sql immutable "
+                        "event_name text,before_state json,after_state json,"
+                        "envelope_project_id text) returns boolean language sql immutable "
                         "as $$ select true $$"
                     )
                 )
@@ -833,6 +844,8 @@ async def _restore_0034_privacy_constraint(
     assert backward_matches
     old, new = max(backward_matches, key=lambda item: len(item[1]))
     predecessor_source = forward_definition.removesuffix(" NOT VALID").replace(new, old)
+    # Keep this normalization independent of the migration under test. Sharing its
+    # implementation would let the repair helper reproduce the same defect and mask drift.
     predecessor_source = re.sub(
         r"\('([^']+)'::character varying\)::text",
         r"'\1'",
@@ -897,26 +910,24 @@ async def _restore_0034_trigger_states(
 
 async def _facts_are_safe_0034(
     database_url: str,
-    before: dict[str, object],
-    after: dict[str, object],
+    before: dict[str, object] | None,
+    after: dict[str, object] | None,
     project_id: str,
-) -> bool:
+) -> bool | None:
     engine = create_async_engine(database_url)
     try:
         async with engine.connect() as connection:
-            return bool(
-                await connection.scalar(
-                    text(
-                        "select authority_event_facts_are_safe("
-                        "'AuthorityInvalidationRequested',cast(:before as json),"
-                        "cast(:after as json),:project)"
-                    ),
-                    {
-                        "before": json.dumps(before),
-                        "after": json.dumps(after),
-                        "project": project_id,
-                    },
-                )
+            return await connection.scalar(
+                text(
+                    "select authority_event_facts_are_safe("
+                    "'AuthorityInvalidationRequested',cast(:before as json),"
+                    "cast(:after as json),:project)"
+                ),
+                {
+                    "before": None if before is None else json.dumps(before),
+                    "after": None if after is None else json.dumps(after),
+                    "project": project_id,
+                },
             )
     finally:
         await engine.dispose()
@@ -935,8 +946,26 @@ async def _seed_pending_issue_cause_0034(database_url: str) -> dict[str, str]:
         "correlation": str(uuid4()),
     }
     engine = create_async_engine(database_url)
+    trigger_states = None
     try:
         async with engine.begin() as connection:
+            trigger_states = tuple(
+                tuple(row)
+                for row in (
+                    await connection.execute(
+                        text(
+                            "select tgrelid::regclass::text,tgname,tgenabled "
+                            "from pg_trigger where "
+                            "(tgrelid='authority_idempotency_records'::regclass and "
+                            "tgname='authority_idempotency_pending_guard') or "
+                            "(tgrelid='audit_events'::regclass and "
+                            "tgname='audit_events_validate_idempotency') "
+                            "order by tgrelid::regclass::text,tgname"
+                        )
+                    )
+                ).all()
+            )
+            assert len(trigger_states) == 2
             await connection.execute(
                 text(
                     "alter table authority_idempotency_records disable trigger "
@@ -984,18 +1013,11 @@ async def _seed_pending_issue_cause_0034(database_url: str) -> dict[str, str]:
                     )
                 },
             )
-        async with engine.begin() as connection:
-            await connection.execute(
-                text("alter table audit_events enable trigger audit_events_validate_idempotency")
-            )
-            await connection.execute(
-                text(
-                    "alter table authority_idempotency_records enable trigger "
-                    "authority_idempotency_pending_guard"
-                )
-            )
         return values
     finally:
+        if trigger_states is not None:
+            async with engine.begin() as connection:
+                await _restore_0034_trigger_states(connection, trigger_states)
         await engine.dispose()
 
 
@@ -1342,8 +1364,21 @@ async def _clear_0034_issue_fixture(database_url: str) -> None:
 
 async def _insert_empty_pending_0034_issue(database_url: str) -> None:
     engine = create_async_engine(database_url)
+    pending_guard = None
     try:
         async with engine.begin() as connection:
+            pending_guard = tuple(
+                (
+                    await connection.execute(
+                        text(
+                            "select tgrelid::regclass::text,tgname,tgenabled "
+                            "from pg_trigger where tgrelid="
+                            "'authority_idempotency_records'::regclass and tgname="
+                            "'authority_idempotency_pending_guard'"
+                        )
+                    )
+                ).one()
+            )
             await connection.execute(
                 text(
                     "alter table authority_idempotency_records disable trigger "
@@ -1365,14 +1400,10 @@ async def _insert_empty_pending_0034_issue(database_url: str) -> None:
                     "digest": f"sha256:{'0' * 64}",
                 },
             )
-        async with engine.begin() as connection:
-            await connection.execute(
-                text(
-                    "alter table authority_idempotency_records enable trigger "
-                    "authority_idempotency_pending_guard"
-                )
-            )
     finally:
+        if pending_guard is not None:
+            async with engine.begin() as connection:
+                await _restore_0034_trigger_states(connection, (pending_guard,))
         await engine.dispose()
 
 
@@ -6795,7 +6826,8 @@ async def _wait_for_rate_control_table_lock(database_url: str) -> None:
     """Wait until downgrade is queued for the table's access-exclusive lock."""
     engine = create_async_engine(database_url)
     try:
-        for _ in range(100):
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
             async with engine.connect() as connection:
                 waiting = await connection.scalar(
                     text(
@@ -6806,7 +6838,7 @@ async def _wait_for_rate_control_table_lock(database_url: str) -> None:
                 )
             if waiting:
                 return
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.01)
         raise AssertionError("downgrade did not request the table lock")
     finally:
         await engine.dispose()

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
+import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import threading
 import time
 from uuid import NAMESPACE_URL, uuid4, uuid5
@@ -125,6 +127,1467 @@ def test_alembic_upgrade_and_downgrade(isolated_database_env: str, migration_loc
         command.downgrade(config, "base")
 
 
+def test_0034_project_role_issue_evidence_exact_safe_round_trip(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """0034 changes only its frozen functions and privacy registry, reversibly."""
+    config = _alembic_config()
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "0033_authorization_read_rate")
+            asyncio.run(_insert_empty_pending_0034_issue(isolated_database_env))
+            predecessor = asyncio.run(
+                _project_role_issue_evidence_0034_state(isolated_database_env)
+            )
+
+            command.upgrade(config, "0034_project_role_issue_evidence")
+            forward = asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+            assert forward["revision"] == "0034_project_role_issue_evidence"
+            assert forward["rows"] == predecessor["rows"] == (1, 0)
+            assert forward["triggers"] == predecessor["triggers"]
+            assert forward["fact_constraint"] == predecessor["fact_constraint"]
+            assert forward["privacy_constraint"] != predecessor["privacy_constraint"]
+            assert forward["functions"] != predecessor["functions"]
+
+            command.downgrade(config, "0033_authorization_read_rate")
+            restored = asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+            assert restored == predecessor
+
+            command.upgrade(config, "0034_project_role_issue_evidence")
+            assert (
+                asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+                == forward
+            )
+        finally:
+            asyncio.run(_clear_pending_0034_issues(isolated_database_env))
+            command.downgrade(config, "base")
+
+
+@pytest.mark.parametrize("drift", ["changed", "missing", "unvalidated", "wrong_table"])
+def test_0034_project_role_issue_evidence_refuses_fact_constraint_drift(
+    isolated_database_env: str,
+    migration_lock,
+    drift: str,
+) -> None:
+    """A detached or changed fact gate cannot be silently accepted by 0034."""
+    config = _alembic_config()
+    definition = None
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "0033_authorization_read_rate")
+            before = asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+            definition = before["fact_constraint"][2]
+            asyncio.run(_replace_0034_fact_constraint_with_drift(isolated_database_env, drift))
+            drifted = asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+            with pytest.raises(RuntimeError, match="unexpected authority fact constraint"):
+                command.upgrade(config, "0034_project_role_issue_evidence")
+            refused = asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+            assert refused == drifted
+            assert refused["revision"] == before["revision"]
+            assert refused["functions"] == before["functions"]
+            assert refused["triggers"] == before["triggers"]
+            assert refused["privacy_constraint"] == before["privacy_constraint"]
+            assert refused["rows"] == before["rows"]
+        finally:
+            asyncio.run(_restore_0034_fact_constraint(isolated_database_env, definition))
+            command.downgrade(config, "base")
+
+
+def test_0034_project_role_issue_evidence_fact_shape_is_closed(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """The richer revoke projection is exact and preserves legacy two-key facts."""
+    config = _alembic_config()
+    project_id = str(uuid4())
+    mappings = {
+        "submitter": "auth13_assignment",
+        "reviewer": "rev_reviewer_obligation",
+        "adjudicator": "none",
+    }
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "head")
+            for role, obligation in mappings.items():
+                before = {
+                    "effective": True,
+                    "role": role,
+                    "scope_type": "project",
+                    "scope_id": project_id,
+                    "future_obligation": obligation,
+                }
+                after = {**before, "effective": False}
+                assert asyncio.run(
+                    _facts_are_safe_0034(isolated_database_env, before, after, project_id)
+                )
+                invalid = (
+                    ({key: value for key, value in before.items() if key != "role"}, after),
+                    ({**before, "extra": "no"}, {**after, "extra": "no"}),
+                    ({**before, "effective": "true"}, after),
+                    ({**before, "scope_id": str(uuid4())}, after),
+                    ({**before, "future_obligation": "wrong"}, after),
+                    (before, {**after, "role": "adjudicator"}),
+                )
+                for invalid_before, invalid_after in invalid:
+                    assert not asyncio.run(
+                        _facts_are_safe_0034(
+                            isolated_database_env,
+                            invalid_before,
+                            invalid_after,
+                            project_id,
+                        )
+                    )
+            assert asyncio.run(
+                _facts_are_safe_0034(
+                    isolated_database_env,
+                    {"effective": True},
+                    {"effective": False},
+                    project_id,
+                )
+            )
+        finally:
+            command.downgrade(config, "base")
+
+
+def test_0034_project_role_issue_evidence_rejects_false_invalidation_at_insert(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """An issue reservation cannot accept an invalidation even before completion."""
+    config = _alembic_config()
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "head")
+            fixture = asyncio.run(_seed_pending_issue_cause_0034(isolated_database_env))
+            with pytest.raises(IntegrityError) as rejected:
+                asyncio.run(
+                    _insert_false_issue_invalidation_0034(
+                        isolated_database_env,
+                        fixture,
+                    )
+                )
+            assert getattr(rejected.value.orig, "sqlstate", None) == "23514"
+            assert (
+                asyncio.run(_count_linked_events_0034(isolated_database_env, fixture["record"]))
+                == 1
+            )
+        finally:
+            asyncio.run(_clear_0034_issue_fixture(isolated_database_env))
+            command.downgrade(config, "base")
+
+
+def test_0034_five_key_revoke_invalidation_requires_exact_linkage(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """Five-key obligation facts are admitted only for one linked revoke pair."""
+    config = _alembic_config()
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "head")
+            for invalid_form in (
+                "non_revoke",
+                "orphan",
+                "mixed_facts",
+                "cross_record",
+                "null_target_kind",
+                "null_target_id",
+                "wrong_target_kind",
+                "wrong_target_id",
+            ):
+                records: list[str] = []
+                try:
+                    if invalid_form == "non_revoke":
+                        fixture = asyncio.run(
+                            _seed_pending_issue_cause_0034(isolated_database_env)
+                        )
+                        records.append(fixture["record"])
+                        cause = fixture
+                    else:
+                        fixture = asyncio.run(
+                            _seed_pending_revoke_cause_0034(isolated_database_env)
+                        )
+                        records.append(fixture["record"])
+                        cause = fixture
+                        if invalid_form == "orphan":
+                            cause = {**fixture, "cause": str(uuid4())}
+                        elif invalid_form == "cross_record":
+                            cause = asyncio.run(
+                                _seed_pending_revoke_cause_0034(
+                                    isolated_database_env,
+                                    envelope=fixture,
+                                )
+                            )
+                            records.append(cause["record"])
+
+                    before_facts = _five_key_revoke_facts_0034(
+                        fixture, effective=True
+                    )
+                    after_facts = _five_key_revoke_facts_0034(
+                        fixture, effective=False
+                    )
+                    if invalid_form == "mixed_facts":
+                        after_facts = {"effective": False}
+                    target_ref_kind: str | None = "project_role_grant"
+                    target_ref_id: str | None = cause["grant"]
+                    if invalid_form == "null_target_kind":
+                        target_ref_kind = None
+                    elif invalid_form == "null_target_id":
+                        target_ref_id = None
+                    elif invalid_form == "wrong_target_kind":
+                        target_ref_kind = "actor_profile"
+                    elif invalid_form == "wrong_target_id":
+                        target_ref_id = str(uuid4())
+                    before = asyncio.run(
+                        _linked_revoke_fixture_state_0034(
+                            isolated_database_env, records
+                        )
+                    )
+
+                    with pytest.raises(IntegrityError) as rejected:
+                        asyncio.run(
+                            _insert_revoke_invalidation_0034(
+                                isolated_database_env,
+                                fixture,
+                                cause=cause,
+                                before_facts=before_facts,
+                                after_facts=after_facts,
+                                target_ref_kind=target_ref_kind,
+                                target_ref_id=target_ref_id,
+                            )
+                        )
+                    expected_sqlstate = "23503" if invalid_form == "orphan" else "23514"
+                    assert (
+                        getattr(rejected.value.orig, "sqlstate", None)
+                        == expected_sqlstate
+                    )
+                    assert (
+                        asyncio.run(
+                            _linked_revoke_fixture_state_0034(
+                                isolated_database_env, records
+                            )
+                        )
+                        == before
+                    )
+                finally:
+                    asyncio.run(
+                        _clear_linked_revoke_fixtures_0034(
+                            isolated_database_env, records
+                        )
+                    )
+        finally:
+            command.downgrade(config, "base")
+
+
+def test_0034_downgrade_refuses_five_key_revoke_evidence_without_mutation(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """A linked five-key revoke pair remains intact when 0034 refuses downgrade."""
+    config = _alembic_config()
+    records: list[str] = []
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "head")
+            fixture = asyncio.run(_seed_pending_revoke_cause_0034(isolated_database_env))
+            records.append(fixture["record"])
+            before_insert = asyncio.run(
+                _linked_revoke_fixture_state_0034(isolated_database_env, records)
+            )
+            invalidation_id = asyncio.run(
+                _insert_revoke_invalidation_0034(
+                    isolated_database_env,
+                    fixture,
+                    cause=fixture,
+                    before_facts=_five_key_revoke_facts_0034(fixture, effective=True),
+                    after_facts=_five_key_revoke_facts_0034(fixture, effective=False),
+                    target_ref_kind="project_role_grant",
+                    target_ref_id=fixture["grant"],
+                )
+            )
+            admitted = asyncio.run(
+                _linked_revoke_fixture_state_0034(isolated_database_env, records)
+            )
+            assert admitted != before_insert
+            assert admitted["event_ids"] == tuple(
+                sorted((fixture["cause"], invalidation_id))
+            )
+            assert admitted["event_count"] == 2
+
+            before_downgrade = {
+                "migration": asyncio.run(
+                    _project_role_issue_evidence_0034_state(isolated_database_env)
+                ),
+                "fixture": admitted,
+            }
+            with pytest.raises(
+                RuntimeError,
+                match="incompatible project-role issue evidence",
+            ):
+                command.downgrade(config, "0033_authorization_read_rate")
+            after_refusal = {
+                "migration": asyncio.run(
+                    _project_role_issue_evidence_0034_state(isolated_database_env)
+                ),
+                "fixture": asyncio.run(
+                    _linked_revoke_fixture_state_0034(isolated_database_env, records)
+                ),
+            }
+            assert after_refusal == before_downgrade
+        finally:
+            asyncio.run(_clear_linked_revoke_fixtures_0034(isolated_database_env, records))
+            command.downgrade(config, "base")
+
+
+@pytest.mark.parametrize(
+    "drift",
+    [
+        "guard_function",
+        "linked_function",
+        "facts_function",
+        "trigger_disabled",
+        "privacy_constraint",
+    ],
+)
+def test_0034_project_role_issue_evidence_refuses_frozen_definition_drift(
+    isolated_database_env: str,
+    migration_lock,
+    drift: str,
+) -> None:
+    """Frozen predecessor function and privacy definitions are mandatory."""
+    config = _alembic_config()
+    definitions = None
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "0033_authorization_read_rate")
+            definitions = asyncio.run(
+                _project_role_issue_evidence_0034_definitions(isolated_database_env)
+            )
+            before = asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+            asyncio.run(_install_definition_drift_0034(isolated_database_env, drift))
+            drifted = asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+            if drift in {"guard_function", "linked_function", "facts_function"}:
+                message = "unexpected predecessor authority evidence definition"
+            elif drift == "trigger_disabled":
+                message = "unexpected authority evidence trigger binding"
+            else:
+                message = "unexpected authority privacy constraint"
+            with pytest.raises(RuntimeError, match=message):
+                command.upgrade(config, "0034_project_role_issue_evidence")
+            assert (
+                asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+                == drifted
+            )
+            assert drifted["revision"] == before["revision"]
+            assert drifted["rows"] == before["rows"]
+            if drift == "trigger_disabled":
+                assert drifted["triggers"] != before["triggers"]
+            else:
+                assert drifted["triggers"] == before["triggers"]
+        finally:
+            if definitions is not None:
+                asyncio.run(
+                    _restore_project_role_issue_evidence_0034_definitions(
+                        isolated_database_env,
+                        definitions,
+                    )
+                )
+                assert (
+                    asyncio.run(
+                        _project_role_issue_evidence_0034_definitions(isolated_database_env)
+                    )
+                    == definitions
+                )
+            command.downgrade(config, "base")
+
+
+@pytest.mark.parametrize("incompatible", ["response", "linked_event"])
+def test_0034_project_role_issue_evidence_refuses_incompatible_pending_state(
+    isolated_database_env: str,
+    migration_lock,
+    incompatible: str,
+) -> None:
+    """Pending issue state is admitted only with null response and zero evidence."""
+    config = _alembic_config()
+    fixture = None
+    state_shape_constraint = None
+    with migration_lock():
+        try:
+            command.downgrade(config, "base")
+            command.upgrade(config, "0033_authorization_read_rate")
+            if incompatible == "linked_event":
+                fixture = asyncio.run(_seed_pending_issue_cause_0034(isolated_database_env))
+            else:
+                state_shape_constraint = asyncio.run(
+                    _authority_idempotency_state_shape_0034(isolated_database_env)
+                )
+                assert state_shape_constraint is not None
+                asyncio.run(_insert_empty_pending_0034_issue(isolated_database_env))
+                fixture = None
+                asyncio.run(
+                    _add_pending_issue_response_0034(
+                        isolated_database_env,
+                        state_shape_constraint,
+                    )
+                )
+                incompatible_constraint = asyncio.run(
+                    _authority_idempotency_state_shape_0034(isolated_database_env)
+                )
+                assert incompatible_constraint is not None
+                assert incompatible_constraint[:2] == (
+                    state_shape_constraint[0],
+                    False,
+                )
+                assert incompatible_constraint[2].removesuffix(
+                    " NOT VALID"
+                ) == state_shape_constraint[2].removesuffix(" NOT VALID")
+            before = asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+            with pytest.raises(RuntimeError, match="incompatible project-role issue evidence"):
+                command.upgrade(config, "0034_project_role_issue_evidence")
+            assert (
+                asyncio.run(_project_role_issue_evidence_0034_state(isolated_database_env))
+                == before
+            )
+        finally:
+            if fixture is not None:
+                asyncio.run(_clear_0034_issue_fixture(isolated_database_env))
+            else:
+                asyncio.run(
+                    _clear_pending_0034_issues(
+                        isolated_database_env,
+                        state_shape_constraint,
+                    )
+                )
+                if state_shape_constraint is not None:
+                    assert (
+                        asyncio.run(_authority_idempotency_state_shape_0034(isolated_database_env))
+                        == state_shape_constraint
+                    )
+            command.downgrade(config, "base")
+
+
+async def _project_role_issue_evidence_0034_state(database_url: str) -> dict[str, object]:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            function_rows = (
+                await connection.execute(
+                    text(
+                        "select proname,pg_get_functiondef(oid) from pg_proc where oid in "
+                        "('guard_authority_idempotency_record'::regproc,"
+                        "'validate_linked_authority_event'::regproc,"
+                        "'authority_event_facts_are_safe'::regproc) order by proname"
+                    )
+                )
+            ).all()
+            constraint_rows = {
+                row.conname: (row.table_name, row.convalidated, row.definition)
+                for row in (
+                    await connection.execute(
+                        text(
+                            "select conname,conrelid::regclass::text table_name,convalidated,"
+                            "pg_get_constraintdef(oid) definition from pg_constraint "
+                            "where conname in ('ck_audit_events_fact_bounds',"
+                            "'ck_audit_events_authority_privacy_bounds',"
+                            "'ck_authority_idempotency_records_state_shape')"
+                        )
+                    )
+                ).all()
+            }
+            triggers = tuple(
+                (
+                    await connection.execute(
+                        text(
+                            "select tgname,pg_get_triggerdef(oid,true),tgenabled from pg_trigger "
+                            "where tgname in ('authority_idempotency_guard',"
+                            "'audit_events_validate_idempotency') order by tgname"
+                        )
+                    )
+                ).all()
+            )
+            return {
+                "revision": await connection.scalar(
+                    text("select version_num from alembic_version")
+                ),
+                "functions": tuple(
+                    (name, hashlib.sha256(definition.encode()).hexdigest())
+                    for name, definition in function_rows
+                ),
+                "fact_constraint": constraint_rows.get("ck_audit_events_fact_bounds"),
+                "privacy_constraint": constraint_rows["ck_audit_events_authority_privacy_bounds"],
+                "idempotency_state_constraint": constraint_rows.get(
+                    "ck_authority_idempotency_records_state_shape"
+                ),
+                "triggers": triggers,
+                "rows": (
+                    int(
+                        await connection.scalar(
+                            text("select count(*) from authority_idempotency_records")
+                        )
+                    ),
+                    int(await connection.scalar(text("select count(*) from audit_events"))),
+                ),
+            }
+    finally:
+        await engine.dispose()
+
+
+async def _install_definition_drift_0034(database_url: str, drift: str) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            if drift == "guard_function":
+                await connection.execute(
+                    text(
+                        "create or replace function guard_authority_idempotency_record() "
+                        "returns trigger language plpgsql as $$ begin return new; end $$"
+                    )
+                )
+            elif drift == "linked_function":
+                await connection.execute(
+                    text(
+                        "create or replace function validate_linked_authority_event() "
+                        "returns trigger language plpgsql as $$ begin return new; end $$"
+                    )
+                )
+            elif drift == "facts_function":
+                await connection.execute(
+                    text(
+                        "create or replace function authority_event_facts_are_safe("
+                        "text,json,json,text) returns boolean language sql immutable "
+                        "as $$ select true $$"
+                    )
+                )
+            elif drift == "trigger_disabled":
+                await connection.execute(
+                    text(
+                        "alter table audit_events disable trigger audit_events_validate_idempotency"
+                    )
+                )
+            else:
+                await connection.execute(
+                    text(
+                        "alter table audit_events drop constraint "
+                        "ck_audit_events_authority_privacy_bounds"
+                    )
+                )
+                await connection.execute(
+                    text(
+                        "alter table audit_events add constraint "
+                        "ck_audit_events_authority_privacy_bounds check (true)"
+                    )
+                )
+    finally:
+        await engine.dispose()
+
+
+async def _project_role_issue_evidence_0034_definitions(
+    database_url: str,
+) -> dict[str, object]:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            functions = dict(
+                (
+                    await connection.execute(
+                        text(
+                            "select proname,pg_get_functiondef(oid) from pg_proc where oid in "
+                            "('guard_authority_idempotency_record'::regproc,"
+                            "'validate_linked_authority_event'::regproc,"
+                            "'authority_event_facts_are_safe'::regproc)"
+                        )
+                    )
+                ).all()
+            )
+            privacy_row = (
+                await connection.execute(
+                    text(
+                        "select conrelid::regclass::text,convalidated,"
+                        "pg_get_constraintdef(oid) from pg_constraint where conname="
+                        "'ck_audit_events_authority_privacy_bounds' and "
+                        "conrelid='audit_events'::regclass"
+                    )
+                )
+            ).one()
+            trigger_rows = (
+                await connection.execute(
+                    text(
+                        "select tgrelid::regclass::text,tgname,tgenabled from pg_trigger "
+                        "where tgname in ('authority_idempotency_guard',"
+                        "'audit_events_validate_idempotency') order by tgname"
+                    )
+                )
+            ).all()
+            return {
+                "functions": functions,
+                "privacy": tuple(privacy_row),
+                "triggers": tuple(tuple(row) for row in trigger_rows),
+            }
+    finally:
+        await engine.dispose()
+
+
+async def _restore_project_role_issue_evidence_0034_definitions(
+    database_url: str,
+    definitions: dict[str, object],
+) -> None:
+    functions = definitions["functions"]
+    assert isinstance(functions, dict)
+    privacy = definitions["privacy"]
+    assert isinstance(privacy, tuple)
+    privacy_table, privacy_validated, privacy_definition = privacy
+    assert privacy_table == "audit_events"
+    assert isinstance(privacy_validated, bool)
+    assert isinstance(privacy_definition, str)
+    triggers = definitions["triggers"]
+    assert isinstance(triggers, tuple)
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            for definition in functions.values():
+                assert isinstance(definition, str)
+                await connection.exec_driver_sql(definition)
+            current_privacy = tuple(
+                (
+                    await connection.execute(
+                        text(
+                            "select conrelid::regclass::text,convalidated,"
+                            "pg_get_constraintdef(oid) from pg_constraint where conname="
+                            "'ck_audit_events_authority_privacy_bounds' and "
+                            "conrelid='audit_events'::regclass"
+                        )
+                    )
+                ).one()
+            )
+            if current_privacy != privacy:
+                await _restore_0034_privacy_constraint(
+                    connection,
+                    privacy_definition,
+                    privacy_validated,
+                )
+            await _restore_0034_trigger_states(connection, triggers)
+    finally:
+        await engine.dispose()
+
+
+async def _restore_0034_privacy_constraint(
+    connection,
+    predecessor_definition: str,
+    validated: bool,
+) -> None:
+    resource_markers = (
+        (
+            "'project'::character varying, 'project_role_grant'::character varying",
+            "'project'::character varying, 'qualification_snapshot'::character varying, "
+            "'project_role_grant'::character varying",
+        ),
+        (
+            "('project'::character varying)::text, ('project_role_grant'::character varying)::text",
+            "('project'::character varying)::text, "
+            "('qualification_snapshot'::character varying)::text, "
+            "('project_role_grant'::character varying)::text",
+        ),
+    )
+    predecessor_definition = predecessor_definition.removesuffix(" NOT VALID")
+    matches = [
+        (old, new)
+        for old, new in resource_markers
+        if old in predecessor_definition and new not in predecessor_definition
+    ]
+    assert matches
+    old, new = max(matches, key=lambda item: len(item[1]))
+    forward_source = predecessor_definition.replace(old, new)
+    validation_clause = "" if validated else " not valid"
+    await connection.execute(
+        text(
+            "alter table audit_events drop constraint if exists "
+            "ck_audit_events_authority_privacy_bounds"
+        )
+    )
+    await connection.exec_driver_sql(
+        "alter table audit_events add constraint "
+        "ck_audit_events_authority_privacy_bounds "
+        f"{forward_source}{validation_clause}"
+    )
+    forward_definition = await connection.scalar(
+        text(
+            "select pg_get_constraintdef(oid) from pg_constraint where conname="
+            "'ck_audit_events_authority_privacy_bounds' and "
+            "conrelid='audit_events'::regclass"
+        )
+    )
+    assert isinstance(forward_definition, str)
+    backward_matches = [
+        (candidate_old, candidate_new)
+        for candidate_old, candidate_new in resource_markers
+        if candidate_new in forward_definition
+    ]
+    assert backward_matches
+    old, new = max(backward_matches, key=lambda item: len(item[1]))
+    predecessor_source = forward_definition.removesuffix(" NOT VALID").replace(new, old)
+    predecessor_source = re.sub(
+        r"\('([^']+)'::character varying\)::text",
+        r"'\1'",
+        predecessor_source,
+    )
+    predecessor_source = re.sub(
+        r"\(\((\w+)\)::text = ANY \(ARRAY\[([^]]+)\]\)\)",
+        r"\1 in (\2)",
+        predecessor_source,
+    )
+    predecessor_source = re.sub(
+        r"\(\((\w+)\)::text <> ALL \(ARRAY\[([^]]+)\]\)\)",
+        r"\1 not in (\2)",
+        predecessor_source,
+    )
+    await connection.execute(
+        text("alter table audit_events drop constraint ck_audit_events_authority_privacy_bounds")
+    )
+    await connection.exec_driver_sql(
+        "alter table audit_events add constraint "
+        "ck_audit_events_authority_privacy_bounds "
+        f"{predecessor_source}{validation_clause}"
+    )
+
+
+async def _restore_0034_trigger_states(
+    connection,
+    triggers: tuple[tuple[object, ...], ...],
+) -> None:
+    allowed_triggers = {
+        ("audit_events", "audit_events_reject_truncate"),
+        ("audit_events", "audit_events_reject_update_delete"),
+        ("audit_events", "audit_events_set_authority_time"),
+        ("audit_events", "audit_events_validate_idempotency"),
+        ("authority_idempotency_records", "authority_idempotency_guard"),
+        (
+            "authority_idempotency_records",
+            "authority_idempotency_pending_guard",
+        ),
+        (
+            "authority_idempotency_records",
+            "authority_idempotency_reject_truncate",
+        ),
+    }
+    operations = {
+        "O": "enable trigger",
+        "D": "disable trigger",
+        "R": "enable replica trigger",
+        "A": "enable always trigger",
+    }
+    for trigger in triggers:
+        assert len(trigger) == 3
+        table_name, trigger_name, enabled_state = trigger
+        assert (table_name, trigger_name) in allowed_triggers
+        if isinstance(enabled_state, bytes):
+            enabled_state = enabled_state.decode("ascii")
+        assert enabled_state in operations
+        await connection.exec_driver_sql(
+            f"alter table {table_name} {operations[enabled_state]} {trigger_name}"
+        )
+
+
+async def _facts_are_safe_0034(
+    database_url: str,
+    before: dict[str, object],
+    after: dict[str, object],
+    project_id: str,
+) -> bool:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            return bool(
+                await connection.scalar(
+                    text(
+                        "select authority_event_facts_are_safe("
+                        "'AuthorityInvalidationRequested',cast(:before as json),"
+                        "cast(:after as json),:project)"
+                    ),
+                    {
+                        "before": json.dumps(before),
+                        "after": json.dumps(after),
+                        "project": project_id,
+                    },
+                )
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _seed_pending_issue_cause_0034(database_url: str) -> dict[str, str]:
+    values = {
+        "record": str(uuid4()),
+        "key": str(uuid4()),
+        "actor": str(uuid4()),
+        "target": str(uuid4()),
+        "project": str(uuid4()),
+        "grant": str(uuid4()),
+        "manager": str(uuid4()),
+        "request": str(uuid4()),
+        "correlation": str(uuid4()),
+    }
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "alter table authority_idempotency_records disable trigger "
+                    "authority_idempotency_pending_guard"
+                )
+            )
+            await connection.execute(
+                text("alter table audit_events disable trigger audit_events_validate_idempotency")
+            )
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "insert into authority_idempotency_records "
+                    "(id,idempotency_key,actor_ref_kind,actor_ref,operation,request_digest,status) "
+                    "values (:record,:key,'actor_profile',:actor,"
+                    "'project_role_grant.issue',:digest,'pending')"
+                ),
+                values | {"digest": f"sha256:{'1' * 64}"},
+            )
+            await connection.execute(
+                text(
+                    "insert into audit_events "
+                    "(id,entity_type,entity_id,event_type,actor_id,actor_roles,claim_snapshot,"
+                    "auth_source,is_dev_auth,event_payload,event_domain,event_version,"
+                    "actor_ref_kind,request_id,correlation_id,target_actor_ref_kind,"
+                    "target_actor_ref,matched_grant_id,permission_id,project_id,resource_type,"
+                    "resource_id,target_ref_kind,target_ref_id,reason,idempotency_reference,"
+                    "after_facts) values (:grant,'project_role_grant',:grant,"
+                    "'ProjectRoleGrantIssued',:actor,'[]','{}','local_authority',false,'{}',"
+                    "'authority',1,'actor_profile',:request,:correlation,'actor_profile',"
+                    ":target,:manager,'project.role_grant.manage',:project,"
+                    "'project_role_grant',:grant,'project_role_grant',:grant,"
+                    "'authority_assignment',:record,cast(:facts as json))"
+                ),
+                values
+                | {
+                    "facts": json.dumps(
+                        {
+                            "status": "active",
+                            "role": "submitter",
+                            "scope_type": "project",
+                            "scope_id": values["project"],
+                            "effective": True,
+                        }
+                    )
+                },
+            )
+        async with engine.begin() as connection:
+            await connection.execute(
+                text("alter table audit_events enable trigger audit_events_validate_idempotency")
+            )
+            await connection.execute(
+                text(
+                    "alter table authority_idempotency_records enable trigger "
+                    "authority_idempotency_pending_guard"
+                )
+            )
+        return values
+    finally:
+        await engine.dispose()
+
+
+async def _insert_false_issue_invalidation_0034(
+    database_url: str,
+    values: dict[str, str],
+) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "insert into audit_events "
+                    "(id,entity_type,entity_id,event_type,actor_id,actor_roles,claim_snapshot,"
+                    "auth_source,is_dev_auth,event_payload,event_domain,event_version,"
+                    "actor_ref_kind,request_id,correlation_id,permission_id,project_id,"
+                    "resource_type,resource_id,reason,idempotency_reference,"
+                    "invalidation_cause_event_id,invalidation_target_kind,"
+                    "invalidation_target_ref,before_facts,after_facts) values "
+                    "(:id,'authority_invalidation',:id,'AuthorityInvalidationRequested',"
+                    ":actor,'[]','{}','local_authority',false,'{}','authority',1,"
+                    "'actor_profile',:request,:correlation,'project.role_grant.manage',"
+                    ":project,'project_role_grant',:grant,'authority_state_changed',:record,"
+                    ":grant,'project_role_grant',:grant,cast(:before as json),"
+                    "cast(:after as json))"
+                ),
+                values
+                | {
+                    "id": str(uuid4()),
+                    "before": json.dumps({"effective": True}),
+                    "after": json.dumps({"effective": False}),
+                },
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _count_linked_events_0034(database_url: str, record_id: str) -> int:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            return int(
+                await connection.scalar(
+                    text("select count(*) from audit_events where idempotency_reference=:record"),
+                    {"record": record_id},
+                )
+            )
+    finally:
+        await engine.dispose()
+
+
+def _five_key_revoke_facts_0034(
+    values: dict[str, str],
+    *,
+    effective: bool,
+) -> dict[str, object]:
+    return {
+        "effective": effective,
+        "role": "submitter",
+        "scope_type": "project",
+        "scope_id": values["project"],
+        "future_obligation": "auth13_assignment",
+    }
+
+
+async def _seed_pending_revoke_cause_0034(
+    database_url: str,
+    *,
+    envelope: dict[str, str] | None = None,
+) -> dict[str, str]:
+    values = {
+        "record": str(uuid4()),
+        "key": str(uuid4()),
+        "cause": str(uuid4()),
+        "actor": envelope["actor"] if envelope else str(uuid4()),
+        "target": envelope["target"] if envelope else str(uuid4()),
+        "project": envelope["project"] if envelope else str(uuid4()),
+        "grant": envelope["grant"] if envelope else str(uuid4()),
+        "manager": envelope["manager"] if envelope else str(uuid4()),
+        "request": envelope["request"] if envelope else str(uuid4()),
+        "correlation": envelope["correlation"] if envelope else str(uuid4()),
+    }
+    before_facts = {
+        "status": "active",
+        "role": "submitter",
+        "scope_type": "project",
+        "scope_id": values["project"],
+        "effective": True,
+    }
+    after_facts = {**before_facts, "status": "revoked", "effective": False}
+    engine = create_async_engine(database_url)
+    pending_guard = None
+    try:
+        async with engine.begin() as connection:
+            pending_guard = tuple(
+                (
+                    await connection.execute(
+                        text(
+                            "select tgrelid::regclass::text,tgname,tgenabled "
+                            "from pg_trigger where tgrelid="
+                            "'authority_idempotency_records'::regclass and tgname="
+                            "'authority_idempotency_pending_guard'"
+                        )
+                    )
+                ).one()
+            )
+            await connection.execute(
+                text(
+                    "alter table authority_idempotency_records disable trigger "
+                    "authority_idempotency_pending_guard"
+                )
+            )
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "insert into authority_idempotency_records "
+                    "(id,idempotency_key,actor_ref_kind,actor_ref,operation,"
+                    "request_digest,status) values "
+                    "(:record,:key,'actor_profile',:actor,"
+                    "'project_role_grant.revoke',:digest,'pending')"
+                ),
+                values | {"digest": f"sha256:{'2' * 64}"},
+            )
+            await connection.execute(
+                text(
+                    "insert into audit_events "
+                    "(id,entity_type,entity_id,event_type,actor_id,actor_roles,"
+                    "claim_snapshot,auth_source,is_dev_auth,event_payload,event_domain,"
+                    "event_version,actor_ref_kind,request_id,correlation_id,"
+                    "target_actor_ref_kind,target_actor_ref,matched_grant_id,permission_id,"
+                    "project_id,resource_type,resource_id,target_ref_kind,target_ref_id,"
+                    "reason,idempotency_reference,before_facts,after_facts) values "
+                    "(:cause,'project_role_grant',:grant,'ProjectRoleGrantRevoked',"
+                    ":actor,'[]','{}','local_authority',false,'{}','authority',1,"
+                    "'actor_profile',:request,:correlation,'actor_profile',:target,"
+                    ":manager,'project.role_grant.manage',:project,'project_role_grant',"
+                    ":grant,'project_role_grant',:grant,'authority_revocation',:record,"
+                    "cast(:before as json),cast(:after as json))"
+                ),
+                values
+                | {
+                    "before": json.dumps(before_facts),
+                    "after": json.dumps(after_facts),
+                },
+            )
+        return values
+    finally:
+        if pending_guard is not None:
+            async with engine.begin() as connection:
+                await _restore_0034_trigger_states(connection, (pending_guard,))
+        await engine.dispose()
+
+
+async def _insert_revoke_invalidation_0034(
+    database_url: str,
+    record: dict[str, str],
+    *,
+    cause: dict[str, str],
+    before_facts: dict[str, object],
+    after_facts: dict[str, object],
+    target_ref_kind: str | None,
+    target_ref_id: str | None,
+) -> str:
+    invalidation_id = str(uuid4())
+    values = {
+        **cause,
+        "cause": cause.get("cause", cause["grant"]),
+        "id": invalidation_id,
+        "record": record["record"],
+        "actor": record["actor"],
+        "before": json.dumps(before_facts),
+        "after": json.dumps(after_facts),
+        "target_ref_kind": target_ref_kind,
+        "target_ref_id": target_ref_id,
+    }
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "insert into audit_events "
+                    "(id,entity_type,entity_id,event_type,actor_id,actor_roles,"
+                    "claim_snapshot,auth_source,is_dev_auth,event_payload,event_domain,"
+                    "event_version,actor_ref_kind,request_id,correlation_id,"
+                    "target_actor_ref_kind,target_actor_ref,permission_id,project_id,"
+                    "resource_type,resource_id,target_ref_kind,target_ref_id,reason,"
+                    "idempotency_reference,"
+                    "invalidation_cause_event_id,invalidation_target_kind,"
+                    "invalidation_target_ref,before_facts,after_facts) values "
+                    "(:id,'authority_invalidation',:id,'AuthorityInvalidationRequested',"
+                    ":actor,'[]','{}','local_authority',false,'{}','authority',1,"
+                    "'actor_profile',:request,:correlation,'actor_profile',:target,"
+                    "'project.role_grant.manage',:project,'project_role_grant',:grant,"
+                    ":target_ref_kind,:target_ref_id,'authority_state_changed',:record,"
+                    ":cause,'project_role_grant',"
+                    ":grant,cast(:before as json),cast(:after as json))"
+                ),
+                values,
+            )
+        return invalidation_id
+    finally:
+        await engine.dispose()
+
+
+async def _linked_revoke_fixture_state_0034(
+    database_url: str,
+    records: list[str],
+) -> dict[str, object]:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            parameters = {"records": records}
+            record_rows = tuple(
+                (
+                    await connection.execute(
+                        text(
+                            "select to_jsonb(r)::text from authority_idempotency_records r "
+                            "where r.id::text=any(cast(:records as text[])) "
+                            "order by r.id::text"
+                        ),
+                        parameters,
+                    )
+                ).scalars()
+            )
+            event_rows = tuple(
+                (
+                    await connection.execute(
+                        text(
+                            "select to_jsonb(e)::text from audit_events e "
+                            "where e.idempotency_reference::text=any(cast(:records as text[])) "
+                            "order by e.id::text"
+                        ),
+                        parameters,
+                    )
+                ).scalars()
+            )
+            event_ids = tuple(
+                (
+                    await connection.execute(
+                        text(
+                            "select e.id::text from audit_events e "
+                            "where e.idempotency_reference::text=any(cast(:records as text[])) "
+                            "order by e.id::text"
+                        ),
+                        parameters,
+                    )
+                ).scalars()
+            )
+            return {
+                "revision": await connection.scalar(
+                    text("select version_num from alembic_version")
+                ),
+                "records": record_rows,
+                "events": event_rows,
+                "event_ids": event_ids,
+                "event_count": len(event_rows),
+            }
+    finally:
+        await engine.dispose()
+
+
+async def _clear_linked_revoke_fixtures_0034(
+    database_url: str,
+    records: list[str],
+) -> None:
+    if not records:
+        return
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            if not await connection.scalar(
+                text("select to_regclass('authority_idempotency_records') is not null")
+            ):
+                return
+            trigger_rows = (
+                await connection.execute(
+                    text(
+                        "select tgrelid::regclass::text,tgname,tgenabled from pg_trigger "
+                        "where tgrelid in ('audit_events'::regclass,"
+                        "'authority_idempotency_records'::regclass) and not tgisinternal "
+                        "order by tgrelid::regclass::text,tgname"
+                    )
+                )
+            ).all()
+            await connection.execute(text("alter table audit_events disable trigger user"))
+            await connection.execute(
+                text("alter table authority_idempotency_records disable trigger user")
+            )
+            parameters = {"records": records}
+            await connection.execute(
+                text(
+                    "delete from audit_events where "
+                    "idempotency_reference::text=any(cast(:records as text[]))"
+                ),
+                parameters,
+            )
+            await connection.execute(
+                text(
+                    "delete from authority_idempotency_records where "
+                    "id::text=any(cast(:records as text[]))"
+                ),
+                parameters,
+            )
+            await _restore_0034_trigger_states(
+                connection,
+                tuple(tuple(row) for row in trigger_rows),
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _clear_0034_issue_fixture(database_url: str) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            if not await connection.scalar(
+                text("select to_regclass('authority_idempotency_records') is not null")
+            ):
+                return
+            await connection.execute(text("alter table audit_events disable trigger user"))
+            await connection.execute(
+                text("alter table authority_idempotency_records disable trigger user")
+            )
+            await connection.execute(
+                text(
+                    "delete from audit_events where idempotency_reference in "
+                    "(select id from authority_idempotency_records "
+                    "where operation='project_role_grant.issue' and status='pending')"
+                )
+            )
+            await connection.execute(
+                text(
+                    "delete from authority_idempotency_records "
+                    "where operation='project_role_grant.issue' and status='pending'"
+                )
+            )
+            await connection.execute(
+                text("alter table authority_idempotency_records enable trigger user")
+            )
+            await connection.execute(text("alter table audit_events enable trigger user"))
+    finally:
+        await engine.dispose()
+
+
+async def _insert_empty_pending_0034_issue(database_url: str) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "alter table authority_idempotency_records disable trigger "
+                    "authority_idempotency_pending_guard"
+                )
+            )
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "insert into authority_idempotency_records "
+                    "(id,idempotency_key,actor_ref_kind,actor_ref,operation,request_digest,status) "
+                    "values (:id,:key,'actor_profile',:actor,'project_role_grant.issue',"
+                    ":digest,'pending')"
+                ),
+                {
+                    "id": str(uuid4()),
+                    "key": str(uuid4()),
+                    "actor": str(uuid4()),
+                    "digest": f"sha256:{'0' * 64}",
+                },
+            )
+        async with engine.begin() as connection:
+            await connection.execute(
+                text(
+                    "alter table authority_idempotency_records enable trigger "
+                    "authority_idempotency_pending_guard"
+                )
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _authority_idempotency_state_shape_0034(
+    database_url: str,
+) -> tuple[str, bool, str] | None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            row = (
+                await connection.execute(
+                    text(
+                        "select conrelid::regclass::text,convalidated,"
+                        "pg_get_constraintdef(oid) from pg_constraint where conname="
+                        "'ck_authority_idempotency_records_state_shape' and "
+                        "conrelid='authority_idempotency_records'::regclass"
+                    )
+                )
+            ).one_or_none()
+            return None if row is None else tuple(row)
+    finally:
+        await engine.dispose()
+
+
+async def _add_pending_issue_response_0034(
+    database_url: str,
+    state_shape_constraint: tuple[str, bool, str],
+) -> None:
+    table_name, validated, definition = state_shape_constraint
+    assert table_name == "authority_idempotency_records"
+    assert isinstance(validated, bool)
+    assert isinstance(definition, str)
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            current_row = (
+                await connection.execute(
+                    text(
+                        "select conrelid::regclass::text,convalidated,"
+                        "pg_get_constraintdef(oid) from pg_constraint where conname="
+                        "'ck_authority_idempotency_records_state_shape' and "
+                        "conrelid='authority_idempotency_records'::regclass"
+                    )
+                )
+            ).one()
+            assert tuple(current_row) == state_shape_constraint
+            trigger_rows = (
+                await connection.execute(
+                    text(
+                        "select tgrelid::regclass::text,tgname,tgenabled from pg_trigger "
+                        "where tgrelid='authority_idempotency_records'::regclass and "
+                        "not tgisinternal order by tgname"
+                    )
+                )
+            ).all()
+            assert {row.tgname for row in trigger_rows} == {
+                "authority_idempotency_guard",
+                "authority_idempotency_pending_guard",
+                "authority_idempotency_reject_truncate",
+            }
+            await connection.execute(
+                text(
+                    "alter table authority_idempotency_records drop constraint "
+                    "ck_authority_idempotency_records_state_shape"
+                )
+            )
+            await connection.execute(
+                text("alter table authority_idempotency_records disable trigger user")
+            )
+            await connection.execute(
+                text(
+                    "update authority_idempotency_records set "
+                    "response_resource_type='project_role_grant',"
+                    "response_resource_id=:resource,response_resource_version=1,"
+                    "response_http_status=201 where operation='project_role_grant.issue'"
+                ),
+                {"resource": str(uuid4())},
+            )
+            await connection.exec_driver_sql(
+                "alter table authority_idempotency_records add constraint "
+                "ck_authority_idempotency_records_state_shape "
+                f"{definition.removesuffix(' NOT VALID')} not valid"
+            )
+            await _restore_0034_trigger_states(
+                connection,
+                tuple(tuple(row) for row in trigger_rows),
+            )
+    finally:
+        await engine.dispose()
+
+
+async def _clear_pending_0034_issues(
+    database_url: str,
+    state_shape_constraint: tuple[str, bool, str] | None = None,
+) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            exists = await connection.scalar(
+                text("select to_regclass('authority_idempotency_records') is not null")
+            )
+            if exists:
+                trigger_rows = (
+                    await connection.execute(
+                        text(
+                            "select tgrelid::regclass::text,tgname,tgenabled from pg_trigger "
+                            "where tgrelid='authority_idempotency_records'::regclass "
+                            "and not tgisinternal order by tgname"
+                        )
+                    )
+                ).all()
+                await connection.execute(
+                    text("alter table authority_idempotency_records disable trigger user")
+                )
+                await connection.execute(
+                    text(
+                        "delete from authority_idempotency_records "
+                        "where operation='project_role_grant.issue' and status='pending'"
+                    )
+                )
+                if state_shape_constraint is not None:
+                    table_name, validated, definition = state_shape_constraint
+                    assert table_name == "authority_idempotency_records"
+                    assert isinstance(validated, bool)
+                    assert isinstance(definition, str)
+                    await connection.execute(
+                        text(
+                            "alter table authority_idempotency_records drop constraint "
+                            "if exists ck_authority_idempotency_records_state_shape"
+                        )
+                    )
+                    await connection.exec_driver_sql(
+                        "alter table authority_idempotency_records add constraint "
+                        "ck_authority_idempotency_records_state_shape "
+                        f"{definition.removesuffix(' NOT VALID')}"
+                        f"{' not valid' if not validated else ''}"
+                    )
+                await _restore_0034_trigger_states(
+                    connection,
+                    tuple(tuple(row) for row in trigger_rows),
+                )
+    finally:
+        await engine.dispose()
+
+
+async def _replace_0034_fact_constraint_with_drift(
+    database_url: str,
+    drift: str,
+) -> None:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(
+                text("alter table audit_events drop constraint ck_audit_events_fact_bounds")
+            )
+            if drift == "changed":
+                await connection.execute(
+                    text(
+                        "alter table audit_events add constraint ck_audit_events_fact_bounds "
+                        "check (event_domain <> 'authority' or true)"
+                    )
+                )
+            elif drift == "unvalidated":
+                await connection.execute(
+                    text(
+                        "alter table audit_events add constraint ck_audit_events_fact_bounds "
+                        "check (event_domain <> 'authority' or true) not valid"
+                    )
+                )
+            elif drift == "wrong_table":
+                await connection.execute(
+                    text(
+                        "alter table projects add constraint ck_audit_events_fact_bounds "
+                        "check (true)"
+                    )
+                )
+    finally:
+        await engine.dispose()
+
+
+async def _restore_0034_fact_constraint(
+    database_url: str,
+    definition: str | None,
+) -> None:
+    if definition is None:
+        return
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.begin() as connection:
+            rows = (
+                (
+                    await connection.execute(
+                        text(
+                            "select conrelid::regclass::text table_name from pg_constraint "
+                            "where conname='ck_audit_events_fact_bounds'"
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for table_name in rows:
+                await connection.execute(
+                    text(f"alter table {table_name} drop constraint ck_audit_events_fact_bounds")
+                )
+            await connection.execute(
+                text(
+                    "alter table audit_events add constraint "
+                    f"ck_audit_events_fact_bounds {definition}"
+                )
+            )
+    finally:
+        await engine.dispose()
+
+
 def test_artifact_recovery_schema_and_empty_downgrade(
     isolated_database_env: str, migration_lock
 ) -> None:
@@ -135,7 +1598,7 @@ def test_artifact_recovery_schema_and_empty_downgrade(
             command.downgrade(config, "base")
             command.upgrade(config, "head")
             assert asyncio.run(_artifact_recovery_schema(isolated_database_env)) == {
-                "revision": "0033_authorization_read_rate",
+                "revision": "0034_project_role_issue_evidence",
                 "constraints": {
                     "artifact_recovery_attempt_custody",
                     "artifact_verification_lineage_custody",
@@ -201,7 +1664,7 @@ def test_project_role_migration_constraints_and_immutable_history(
             command.upgrade(config, "head")
             result = asyncio.run(_exercise_project_role_migration(isolated_database_env))
             assert result == {
-                "revision": "0033_authorization_read_rate",
+                "revision": "0034_project_role_issue_evidence",
                 "role_count": 3,
                 "invalid_availability": "23514",
                 "duplicate_role": "23505",
@@ -409,7 +1872,7 @@ def test_project_role_downgrade_refuses_each_reserved_evidence_predicate(
                 ):
                     command.downgrade(config, "0030_artifact_verification")
                 assert asyncio.run(_project_role_refusal_state(isolated_database_env))[:3] == (
-                    "0033_authorization_read_rate",
+                    "0034_project_role_issue_evidence",
                     True,
                     True,
                 )
@@ -436,7 +1899,7 @@ def test_project_role_downgrade_refuses_each_reserved_evidence_predicate(
                 ):
                     command.downgrade(config, "0030_artifact_verification")
                 assert asyncio.run(_project_role_refusal_state(isolated_database_env))[:3] == (
-                    "0033_authorization_read_rate",
+                    "0034_project_role_issue_evidence",
                     True,
                     True,
                 )
@@ -464,7 +1927,7 @@ def test_outbox_migration_schema_and_downgrade_writer_guard(
             command.upgrade(config, "head")
             schema = asyncio.run(_outbox_schema(isolated_database_env))
             assert schema == {
-                "revision": "0033_authorization_read_rate",
+                "revision": "0034_project_role_issue_evidence",
                 "columns": {
                     "aggregate_id",
                     "aggregate_type",
@@ -524,7 +1987,7 @@ def test_outbox_migration_schema_and_downgrade_writer_guard(
             )
             assert committed == "refused_after_commit"
             assert asyncio.run(_current_revision(isolated_database_env)) == (
-                "0033_authorization_read_rate"
+                "0034_project_role_issue_evidence"
             )
             asyncio.run(_remove_outbox_migration_row(isolated_database_env, committed_project_id))
             command.downgrade(config, "0028_artifact_admission")
@@ -2841,9 +4304,7 @@ def test_authorization_read_rate_scope_upgrade_and_downgrade_refusal(
                     config,
                     "0032_artifact_recovery",
                 )
-                asyncio.run(
-                    _wait_for_rate_control_table_lock(isolated_database_env)
-                )
+                asyncio.run(_wait_for_rate_control_table_lock(isolated_database_env))
                 release_insert.set()
                 insert_future.result(timeout=5)
                 with pytest.raises(
@@ -2908,19 +4369,14 @@ def test_authorization_read_rate_scope_migration_refuses_constraint_drift(
                     )
                 )
                 rows = int(
-                    await connection.scalar(
-                        text("select count(*) from api_rate_control_counters")
-                    )
+                    await connection.scalar(text("select count(*) from api_rate_control_counters"))
                 )
                 return revision, definition, rows
         finally:
             await engine.dispose()
 
     old_definition = "control_scope in ('first_access', 'admin_mutation')"
-    new_definition = (
-        "control_scope in "
-        "('first_access', 'admin_mutation', 'authorization_read')"
-    )
+    new_definition = "control_scope in ('first_access', 'admin_mutation', 'authorization_read')"
     drifted_definition = "control_scope in ('first_access')"
 
     with migration_lock():
@@ -2929,9 +4385,7 @@ def test_authorization_read_rate_scope_migration_refuses_constraint_drift(
             command.upgrade(config, "0032_artifact_recovery")
             asyncio.run(replace_constraint(drifted_definition))
             before_upgrade = asyncio.run(state())
-            with pytest.raises(
-                RuntimeError, match="unexpected API rate-control scope constraint"
-            ):
+            with pytest.raises(RuntimeError, match="unexpected API rate-control scope constraint"):
                 command.upgrade(config, "0033_authorization_read_rate")
             assert asyncio.run(state()) == before_upgrade
 
@@ -2939,9 +4393,7 @@ def test_authorization_read_rate_scope_migration_refuses_constraint_drift(
             command.upgrade(config, "0033_authorization_read_rate")
             asyncio.run(replace_constraint(drifted_definition))
             before_downgrade = asyncio.run(state())
-            with pytest.raises(
-                RuntimeError, match="unexpected API rate-control scope constraint"
-            ):
+            with pytest.raises(RuntimeError, match="unexpected API rate-control scope constraint"):
                 command.downgrade(config, "0032_artifact_recovery")
             assert asyncio.run(state()) == before_downgrade
 

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -1767,8 +1767,10 @@ def test_project_role_upgrade_refuses_each_legacy_predicate_before_ddl(
             command.downgrade(config, "base")
             command.upgrade(config, "0030_artifact_verification")
             for patch in cases:
-                event_id, constraints = asyncio.run(
-                    _install_legacy_project_role_blocker(isolated_database_env, patch)
+                event_id, constraints, triggers = asyncio.run(
+                    _install_legacy_project_role_blocker(
+                        isolated_database_env, patch, bypass_constraints=True
+                    )
                 )
                 before_event = asyncio.run(_project_role_audit_row(isolated_database_env, event_id))
                 with pytest.raises(
@@ -1788,7 +1790,7 @@ def test_project_role_upgrade_refuses_each_legacy_predicate_before_ddl(
                 )
                 asyncio.run(
                     _remove_legacy_project_role_blocker(
-                        isolated_database_env, event_id, constraints
+                        isolated_database_env, event_id, constraints, triggers
                     )
                 )
 
@@ -1817,9 +1819,11 @@ def test_project_role_upgrade_refuses_each_legacy_predicate_before_ddl(
                     _remove_project_role_idempotency_blocker(isolated_database_env, record_id)
                 )
 
-            event_id, constraints = asyncio.run(
+            event_id, constraints, triggers = asyncio.run(
                 _install_legacy_project_role_blocker(
-                    isolated_database_env, {"after_facts": {"role": "both"}}
+                    isolated_database_env,
+                    {"after_facts": {"role": "both"}},
+                    bypass_constraints=True,
                 )
             )
             record_id = asyncio.run(
@@ -1841,7 +1845,9 @@ def test_project_role_upgrade_refuses_each_legacy_predicate_before_ddl(
             )
             asyncio.run(_remove_project_role_idempotency_blocker(isolated_database_env, record_id))
             asyncio.run(
-                _remove_legacy_project_role_blocker(isolated_database_env, event_id, constraints)
+                _remove_legacy_project_role_blocker(
+                    isolated_database_env, event_id, constraints, triggers
+                )
             )
             unrelated_event_id = asyncio.run(
                 _insert_authorization_action_event(isolated_database_env)
@@ -1865,11 +1871,9 @@ def test_project_role_downgrade_refuses_each_reserved_evidence_predicate(
     isolated_database_env: str,
     migration_lock,
 ) -> None:
-    """Every 10A audit predicate leaves the head schema and row untouched."""
+    """Every representable 10A audit predicate leaves head and row untouched."""
     config = _alembic_config()
     cases = (
-        {"before_facts": {"role": "adjudicator"}},
-        {"after_facts": {"role": "adjudicator"}},
         *(
             {"action_id": action}
             for action in (
@@ -1883,8 +1887,6 @@ def test_project_role_downgrade_refuses_each_reserved_evidence_predicate(
         {"denial_code": "project_role_grant_already_revoked"},
         {"denial_code": "project_role_grant_replay_state_changed"},
         {
-            "before_facts": {"role": "adjudicator"},
-            "after_facts": {"role": "adjudicator"},
             "action_id": "project_role_grant.issue",
             "denial_code": "project_role_grant_replay_state_changed",
         },
@@ -1894,8 +1896,10 @@ def test_project_role_downgrade_refuses_each_reserved_evidence_predicate(
             command.downgrade(config, "base")
             command.upgrade(config, "head")
             for patch in cases:
-                event_id, constraints = asyncio.run(
-                    _install_legacy_project_role_blocker(isolated_database_env, patch)
+                event_id, constraints, triggers = asyncio.run(
+                    _install_legacy_project_role_blocker(
+                        isolated_database_env, patch, bypass_constraints=False
+                    )
                 )
                 before_event = asyncio.run(_project_role_audit_row(isolated_database_env, event_id))
                 with pytest.raises(
@@ -1913,7 +1917,7 @@ def test_project_role_downgrade_refuses_each_reserved_evidence_predicate(
                 )
                 asyncio.run(
                     _remove_legacy_project_role_blocker(
-                        isolated_database_env, event_id, constraints
+                        isolated_database_env, event_id, constraints, triggers
                     )
                 )
             for include_grant in (False, True):
@@ -9568,29 +9572,62 @@ async def _exercise_project_role_migration(database_url: str) -> dict[str, objec
 
 
 async def _install_legacy_project_role_blocker(
-    database_url: str, patch: dict[str, object]
-) -> tuple[str, list[tuple[str, str]]]:
+    database_url: str,
+    patch: dict[str, object],
+    *,
+    bypass_constraints: bool,
+) -> tuple[str, list[tuple[str, str]], tuple[tuple[object, ...], ...]]:
     event_id = await _insert_authorization_action_event(database_url)
     engine = create_async_engine(database_url)
     try:
         async with engine.begin() as connection:
-            constraints = [
+            triggers = tuple(
                 tuple(row)
                 for row in (
                     await connection.execute(
                         text(
-                            "select conname,pg_get_constraintdef(oid) from pg_constraint "
-                            "where conrelid='audit_events'::regclass and contype='c' order by conname"
+                            "select tgrelid::regclass::text,tgname,tgenabled "
+                            "from pg_trigger where tgrelid='audit_events'::regclass "
+                            "and not tgisinternal order by tgname"
                         )
                     )
                 ).all()
-            ]
-            await connection.execute(text("alter table audit_events disable trigger user"))
-            for name, _definition in constraints:
-                await connection.execute(text(f'alter table audit_events drop constraint "{name}"'))
+            )
+            constraints: list[tuple[str, str]] = []
+            if bypass_constraints:
+                constraints = [
+                    tuple(row)
+                    for row in (
+                        await connection.execute(
+                            text(
+                                "select conname,pg_get_constraintdef(oid) from pg_constraint "
+                                "where conrelid='audit_events'::regclass and contype='c' "
+                                "order by conname"
+                            )
+                        )
+                    ).all()
+                ]
+                await connection.execute(text("alter table audit_events disable trigger user"))
+                for name, _definition in constraints:
+                    await connection.execute(
+                        text(f'alter table audit_events drop constraint "{name}"')
+                    )
+            else:
+                await connection.execute(
+                    text(
+                        "alter table audit_events disable trigger "
+                        "audit_events_reject_update_delete"
+                    )
+                )
             assignments = []
             values: dict[str, object] = {"id": event_id}
             for key, value in patch.items():
+                if key == "action_id":
+                    definition = next(
+                        item for item in ACTION_DEFINITIONS if item.action_id.value == value
+                    )
+                    assignments.append("permission_id=:permission_id")
+                    values["permission_id"] = definition.permission_id.value
                 if key in {"before_facts", "after_facts"}:
                     assignments.append(f"{key}=cast(:{key} as json)")
                     values[key] = json.dumps(value)
@@ -9600,7 +9637,9 @@ async def _install_legacy_project_role_blocker(
             await connection.execute(
                 text(f"update audit_events set {','.join(assignments)} where id=:id"), values
             )
-        return event_id, constraints
+            if not bypass_constraints:
+                await _restore_0034_trigger_states(connection, triggers)
+        return event_id, constraints, triggers
     finally:
         await engine.dispose()
 
@@ -9609,18 +9648,35 @@ async def _remove_legacy_project_role_blocker(
     database_url: str,
     event_id: str,
     constraints: list[tuple[str, str]],
+    triggers: tuple[tuple[object, ...], ...],
 ) -> None:
     engine = create_async_engine(database_url)
     try:
-        async with engine.begin() as connection:
-            await connection.execute(
-                text("delete from audit_events where id=:id"), {"id": event_id}
-            )
-            for name, definition in constraints:
+        try:
+            async with engine.begin() as connection:
                 await connection.execute(
-                    text(f'alter table audit_events add constraint "{name}" {definition}')
+                    text(
+                        "alter table audit_events disable trigger "
+                        "audit_events_reject_update_delete"
+                    )
                 )
-            await connection.execute(text("alter table audit_events enable trigger user"))
+                await connection.execute(
+                    text("delete from audit_events where id=:id"), {"id": event_id}
+                )
+                for name, definition in constraints:
+                    if name == "ck_audit_events_authority_privacy_bounds":
+                        await _restore_0034_privacy_constraint(
+                            connection,
+                            definition,
+                            not definition.endswith(" NOT VALID"),
+                        )
+                    else:
+                        await connection.execute(
+                            text(f'alter table audit_events add constraint "{name}" {definition}')
+                        )
+        finally:
+            async with engine.begin() as connection:
+                await _restore_0034_trigger_states(connection, triggers)
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_api_controls.py
+++ b/backend/tests/test_api_controls.py
@@ -439,13 +439,13 @@ def test_openapi_documents_request_error_and_response_context() -> None:
         for method, operation in path_item.items()
         if method in methods and operation.get("security")
     )
-    assert len(route_inventory) == 74
+    assert len(route_inventory) == 76
     assert sha256("\n".join(route_inventory).encode()).hexdigest() == (
-        "f0076e4145d8fe68365912a6e5bc047dece3ae2ac1e69619018b5119a9710c09"
+        "c8f9852035446ea59b0e929b1bd8c8cfc7df5bf838ceb544c04e899f90169318"
     )
-    assert len(protected_inventory) == 72
+    assert len(protected_inventory) == 74
     assert sha256("\n".join(protected_inventory).encode()).hexdigest() == (
-        "b05ebbca27a538958af6c122403ccf3997ab08326943150f6c763ce9c321eec5"
+        "9278d0183ffb87947ee4857e0325483ba7bf07feac0c38a88432840b10c2b0c3"
     )
     assert set(schema["paths"]["/health"]["get"]["responses"]) == {"200", "400", "500"}
     assert {"401", "403", "503"} <= set(
@@ -502,6 +502,10 @@ def test_openapi_documents_request_error_and_response_context() -> None:
         "GET /api/v1/projects/{project_id}/role-grants/{grant_id}": (
             "project_role_grant.read"
         ),
+        "POST /api/v1/projects/{project_id}/role-grants": "project_role_grant.issue",
+        "POST /api/v1/projects/{project_id}/role-grants/{grant_id}/revoke": (
+            "project_role_grant.revoke"
+        ),
     }
     project_read_shapes = {
         "/api/v1/projects/{project_id}/contributor-candidates": (
@@ -517,13 +521,16 @@ def test_openapi_documents_request_error_and_response_context() -> None:
         }
         assert schema["components"]["schemas"][schema_name]["additionalProperties"] is False
     assert not any("authorization-context" in path for path in schema["paths"])
-    assert not any(
-        operation.get("x-workstream-action-id")
-        in {"project_role_grant.issue", "project_role_grant.revoke"}
-        for path_item in schema["paths"].values()
-        for method, operation in path_item.items()
-        if method in methods
-    )
+    for path in (
+        "/api/v1/projects/{project_id}/role-grants",
+        "/api/v1/projects/{project_id}/role-grants/{grant_id}/revoke",
+    ):
+        operation = schema["paths"][path]["post"]
+        assert operation["responses"]["201" if path.endswith("role-grants") else "200"][
+            "content"
+        ]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/ProjectRoleGrantMutationResponse"
+        }
     for path, schema_name in (
         ("/api/v1/actors/{actor_profile_id}", "ActorProfileAdminResponse"),
         (

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -180,6 +180,8 @@ def test_action_aware_audit_input_enforces_mapping_and_action_availability() -> 
         ActionId.PROJECT_CONTRIBUTOR_CANDIDATE_LIST,
         ActionId.PROJECT_ROLE_GRANT_LIST,
         ActionId.PROJECT_ROLE_GRANT_READ,
+        ActionId.PROJECT_ROLE_GRANT_ISSUE,
+        ActionId.PROJECT_ROLE_GRANT_REVOKE,
     }
     with pytest.raises(TypeError, match="invalid authority audit input"):
         _authority_input(

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -775,6 +775,7 @@ async def test_authority_event_matrix_preserves_shapes_and_requires_idempotency_
         AuthorityEventType.SERVICE_ACTOR_PROVISIONED,
         AuthorityEventType.ADMIN_ROLE_GRANT_ISSUED,
         AuthorityEventType.ADMIN_ROLE_GRANT_REVOKED,
+        AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED,
         AuthorityEventType.PROJECT_ROLE_GRANT_ISSUED,
         AuthorityEventType.PROJECT_ROLE_GRANT_REVOKED,
         AuthorityEventType.ACTOR_PROFILE_SUSPENDED,

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -132,6 +132,7 @@ from app.modules.authorization.schemas import (
 from app.modules.authorization.service import AuthorityMutationService
 from app.modules.authorization.project_role_service import (
     _constraint_name,
+    ProjectRoleGrantMutationService,
     project_role_issue_lock_key,
 )
 from app.modules.authorization.project_role_schemas import (
@@ -182,6 +183,7 @@ from app.modules.authorization.runtime import (
     ProjectRoleGrantCollectionResourceContext,
     ProjectRoleGrantIssueResourceContext,
     ProjectRoleGrantReadResourceContext,
+    ProjectRoleGrantRevokeResourceContext,
     ServiceActorProvisionResourceContext,
     ServiceAuthorizationContext,
     SystemResourceContext,
@@ -8392,7 +8394,7 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
                 ActorProfile(id=str(target_id), actor_kind="human", status="active", provisioning_method="automatic_first_access", created_by=str(target_id)),
                 ActorIdentityLink(id=str(target_link_id), actor_profile_id=str(target_id), issuer="https://identity.flowresearch.tech", subject=f"auth10c-target-{target_id}", subject_kind="human", status="active", linked_by=str(target_id), last_verified_at=now),
                 Project(id=str(project_id), name="AUTH-10C PREP proof", slug=f"auth-10c-prep-{project_id}", status="draft"),
-                AdminRoleGrant(id=manager_grant_id, target_actor_profile_id=str(caller_id), role="project_manager", scope_type="project", scope_project_id=str(project_id), status="active", version=1, granted_by_actor_profile_id=str(caller_id), granted_by_system_principal=None, granted_by_admin_role_grant_id=None, grant_reason="AUTH-10C PostgreSQL proof"),
+                AdminRoleGrant(id=manager_grant_id, target_actor_profile_id=str(caller_id), role="project_manager", scope_type="project", scope_project_id=str(project_id), status="active", version=1, granted_by_actor_profile_id=None, granted_by_system_principal="workstream:system:bootstrap", granted_by_admin_role_grant_id=None, grant_reason="AUTH-10C PostgreSQL proof"),
             ]
         )
         await session.commit()
@@ -8400,8 +8402,24 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
         repository = AdminAuthorizationRepository(session)
         authorization = AuthorizationService(session, context, admin_repository=repository)
         prepared = PreparedAuthorizationService(session, context, authorization, repository)
+        issue_reason = "AUTH-10C PostgreSQL issue proof"
+        canonical_issue = ProjectRoleGrantIssueRequest(
+            operation=AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE,
+            project_id=project_id,
+            target_actor_id=target_id,
+            role=ProjectRole.SUBMITTER,
+            qualification=_project_role_qualification(),
+            reason_digest=derive_reason_digest(issue_reason),
+        )
+        issue_key = uuid4()
         await session.begin()
-        caller_input = PreparedAuthorizationInput(idempotency_key=uuid4(), request_value={"target": str(target_id), "role": "submitter"})
+        issue_reservation = await ProjectRoleGrantMutationService(session).reserve(
+            key=issue_key,
+            actor_profile_id=caller_id,
+            request=canonical_issue,
+        )
+        assert isinstance(issue_reservation, ClaimedReservation)
+        caller_input = PreparedAuthorizationInput(idempotency_key=issue_key, request_value=canonical_issue.model_dump(mode="json"))
         handle = await prepared.prepare(ActionId.PROJECT_ROLE_GRANT_ISSUE, caller_input, PreparedAuthorityScope(kind=PreparedAuthorityScopeKind.PROJECT, project_id=project_id, target_actor_profile_id=target_id, role=ProjectRole.SUBMITTER))
         assert await repository.lock_project(project_id) is not None
         await repository.take_project_role_issue_lock(project_role_issue_lock_key(target_id, project_id, "submitter"))
@@ -8409,4 +8427,169 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
         decision = await prepared.consume(handle, ActionId.PROJECT_ROLE_GRANT_ISSUE, caller_input, ProjectRoleGrantIssueResourceContext(resource_type="project_role_grant_issue", resource_id=project_id, scope_project_id=project_id, target_actor_profile_id=target_id, role=ProjectRole.SUBMITTER, project_status="draft", target_eligible=True, active_exact_role_exists=False))
         assert decision.allowed is True
         assert decision.matched_grant_id == manager_grant_id
+        issued = await ProjectRoleGrantMutationService(session).complete_issue(
+            claim=issue_reservation.claim,
+            request=canonical_issue,
+            decision=decision,
+            actor_profile_id=caller_id,
+            reason=issue_reason,
+        )
+        assert issued.status == "active"
+        await session.commit()
+        await session.execute(
+            text("update actor_profiles set status='suspended' where id=:id"),
+            {"id": str(target_id)},
+        )
+        await session.execute(
+            text("update actor_identity_links set status='revoked' where id=:id"),
+            {"id": str(target_link_id)},
+        )
+        await session.commit()
+        revoke_reason = "AUTH-10C lifecycle-independent revoke proof"
+        canonical_revoke = ProjectRoleGrantRevokeRequest(
+            operation=AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE,
+            project_id=project_id,
+            grant_id=issued.id,
+            reason_digest=derive_reason_digest(revoke_reason),
+        )
+        revoke_key = uuid4()
+        revoke_reservation = await ProjectRoleGrantMutationService(session).reserve(
+            key=revoke_key,
+            actor_profile_id=caller_id,
+            request=canonical_revoke,
+        )
+        assert isinstance(revoke_reservation, ClaimedReservation)
+        revoke_input = PreparedAuthorizationInput(
+            idempotency_key=revoke_key,
+            request_value=canonical_revoke.model_dump(mode="json"),
+        )
+        revoke_handle = await prepared.prepare(
+            ActionId.PROJECT_ROLE_GRANT_REVOKE,
+            revoke_input,
+            PreparedAuthorityScope(
+                kind=PreparedAuthorityScopeKind.PROJECT,
+                project_id=project_id,
+                grant_id=issued.id,
+            ),
+        )
+        project = await repository.lock_project(project_id)
+        row = await repository.lock_project_role_grant(
+            project_id=project_id, grant_id=issued.id
+        )
+        assert project is not None and row is not None
+        grant, _snapshot = row
+        revoke_decision = await prepared.consume(
+            revoke_handle,
+            ActionId.PROJECT_ROLE_GRANT_REVOKE,
+            revoke_input,
+            ProjectRoleGrantRevokeResourceContext(
+                resource_type="project_role_grant_revoke",
+                resource_id=issued.id,
+                scope_project_id=project_id,
+                actor_profile_id=target_id,
+                role=ProjectRole.SUBMITTER,
+                project_status="draft",
+                status="active",
+                version=1,
+            ),
+        )
+        revoked = await ProjectRoleGrantMutationService(session).complete_revoke(
+            claim=revoke_reservation.claim,
+            request=canonical_revoke,
+            decision=revoke_decision,
+            actor_profile_id=caller_id,
+            reason=revoke_reason,
+            grant=grant,
+        )
+        assert revoked.status == "revoked"
+        await session.commit()
+        assert (
+            await session.scalar(
+                text(
+                    "select count(*) from audit_events where idempotency_reference in (:issue, :revoke)"
+                ),
+                {
+                    "issue": str(issue_reservation.claim.record_id),
+                    "revoke": str(revoke_reservation.claim.record_id),
+                },
+            )
+            == 4
+        )
         await session.rollback()
+        prepared.close()
+
+    canonical = ProjectRoleGrantIssueRequest(
+        operation=AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE,
+        project_id=project_id,
+        target_actor_id=target_id,
+        role=ProjectRole.SUBMITTER,
+        qualification=_project_role_qualification(),
+        reason_digest=derive_reason_digest("AUTH-10C concurrency proof"),
+    )
+    waiting_key = uuid4()
+    async with authorization_factory() as locker, authorization_factory() as waiter:
+        locker_repository = AdminAuthorizationRepository(locker)
+        locker_authorization = AuthorizationService(
+            locker, context, admin_repository=locker_repository
+        )
+        locker_prepared = PreparedAuthorizationService(
+            locker, context, locker_authorization, locker_repository
+        )
+        waiter_repository = AdminAuthorizationRepository(waiter)
+        waiter_authorization = AuthorizationService(
+            waiter, context, admin_repository=waiter_repository
+        )
+        waiter_prepared = PreparedAuthorizationService(
+            waiter, context, waiter_authorization, waiter_repository
+        )
+        scope = PreparedAuthorityScope(
+            kind=PreparedAuthorityScopeKind.PROJECT,
+            project_id=project_id,
+            target_actor_profile_id=target_id,
+            role=ProjectRole.SUBMITTER,
+        )
+        await locker.begin()
+        await locker_prepared.prepare(
+            ActionId.PROJECT_ROLE_GRANT_ISSUE,
+            PreparedAuthorizationInput(
+                idempotency_key=uuid4(), request_value=canonical.model_dump(mode="json")
+            ),
+            scope,
+        )
+        await waiter.begin()
+        await ProjectRoleGrantMutationService(waiter).reserve(
+            key=waiting_key,
+            actor_profile_id=caller_id,
+            request=canonical,
+        )
+        wait_task = asyncio.create_task(
+            waiter_prepared.prepare(
+                ActionId.PROJECT_ROLE_GRANT_ISSUE,
+                PreparedAuthorizationInput(
+                    idempotency_key=waiting_key,
+                    request_value=canonical.model_dump(mode="json"),
+                ),
+                scope,
+            )
+        )
+        with pytest.raises(TimeoutError):
+            await asyncio.wait_for(asyncio.shield(wait_task), timeout=0.2)
+        wait_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await wait_task
+        await waiter.rollback()
+        await locker.rollback()
+        waiter_prepared.close()
+        locker_prepared.close()
+    async with authorization_factory() as clean:
+        assert (
+            await clean.scalar(
+                text(
+                    "select count(*) from authority_idempotency_records "
+                    "where idempotency_key=:key"
+                ),
+                {"key": str(waiting_key)},
+            )
+            == 0
+        )
+        await clean.rollback()

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -127,6 +127,10 @@ from app.modules.authorization.schemas import (
 )
 from app.modules.authorization.service import AuthorityMutationService
 from app.modules.authorization.project_role_service import project_role_issue_lock_key
+from app.modules.authorization.project_role_schemas import (
+    ProjectRoleGrantIssueBody,
+    ProjectRoleGrantRevokeBody,
+)
 from app.modules.authorization.kernel import AuthorizationService
 from app.modules.authorization.prepared import (
     PreparedAuthorizationHandle,
@@ -214,6 +218,22 @@ def test_project_role_issue_advisory_key_contract_is_frozen_and_separated() -> N
     assert project_role_issue_lock_key(actor, project, "submitter") != project_role_issue_lock_key(
         project, actor, "submitter"
     )
+
+
+def test_project_role_public_reason_and_qualification_contract_is_strict() -> None:
+    payload = {
+        "target_actor_profile_id": str(uuid4()),
+        "role": "submitter",
+        "qualification": _project_role_qualification(),
+        "reason": "Bounded authority assignment",
+    }
+    assert ProjectRoleGrantIssueBody.model_validate(payload).role is ProjectRole.SUBMITTER
+    assert ProjectRoleGrantRevokeBody.model_validate({"reason": "Bounded removal"}).reason == (
+        "Bounded removal"
+    )
+    for reason in (" padded", "padded ", "control\x00", "é" * 251):
+        with pytest.raises(ValidationError):
+            ProjectRoleGrantIssueBody.model_validate(payload | {"reason": reason})
 
 
 def test_authorization_read_cursor_round_trip_and_query_binding() -> None:
@@ -6805,8 +6825,11 @@ def _operation_success(
         }
         after_facts = before_facts | {"status": "revoked", "effective": False}
     elif isinstance(request, ProjectRoleGrantIssueRequest):
+        if admin_authorizer_grant_id is None:
+            raise AssertionError("project role issue proof requires authorizing manager grant")
         project_id = request.project_id
         target_actor = request.target_actor_id
+        matched_grant = admin_authorizer_grant_id
         after_facts = {
             "status": "active",
             "role": request.role.value,
@@ -6815,8 +6838,11 @@ def _operation_success(
             "effective": True,
         }
     elif isinstance(request, ProjectRoleGrantRevokeRequest):
+        if admin_authorizer_grant_id is None:
+            raise AssertionError("project role revoke proof requires authorizing manager grant")
         project_id = request.project_id
         target_actor = response.resource_id
+        matched_grant = admin_authorizer_grant_id
         before_facts = {
             "status": "active",
             "role": "submitter",
@@ -7842,6 +7868,8 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
     admin_operations = {
         AuthorityOperation.ADMIN_ROLE_GRANT_ISSUE,
         AuthorityOperation.ADMIN_ROLE_GRANT_REVOKE,
+        AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE,
+        AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE,
     }
     expected_pairs = {}
     async with authorization_factory() as session:

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -122,6 +122,7 @@ from app.modules.authorization.schemas import (
     MismatchedReservation,
     PendingAuthorityReservationError,
     ProjectRole,
+    ProjectRoleQualificationEvidence,
     ProjectRoleQualificationSnapshotInput,
     ProjectRoleGrantIssueRequest,
     ProjectRoleGrantRevokeRequest,
@@ -207,14 +208,14 @@ DIGEST = "sha256:" + "a" * 64
 def _project_role_qualification() -> dict[str, object]:
     return {
         "skills_snapshot": {
-            "availability": "available",
+            "availability": QualificationAvailability.AVAILABLE,
             "reference_ids": ["skill:opaque"],
             "unavailable_reason": None,
         },
         "reputation_snapshot": {
-            "availability": "unavailable",
+            "availability": QualificationAvailability.UNAVAILABLE,
             "reference_ids": [],
-            "unavailable_reason": "no_record",
+            "unavailable_reason": QualificationUnavailableReason.NO_RECORD,
         },
         "prior_project_work_refs": [],
         "external_expertise_refs": [],
@@ -295,7 +296,10 @@ def test_project_role_public_reason_and_qualification_contract_is_strict() -> No
         "qualification": _project_role_qualification(),
         "reason": "Bounded authority assignment",
     }
-    assert ProjectRoleGrantIssueBody.model_validate(payload).role is ProjectRole.SUBMITTER
+    assert (
+        ProjectRoleGrantIssueBody.model_validate_json(json.dumps(payload)).role
+        is ProjectRole.SUBMITTER
+    )
     assert ProjectRoleGrantRevokeBody.model_validate({"reason": "Bounded removal"}).reason == (
         "Bounded removal"
     )
@@ -8492,6 +8496,38 @@ def test_project_role_contract_rejects_replacement_and_bounds_qualification_refe
     ):
         with pytest.raises(ValidationError):
             QualificationAvailabilitySnapshot.model_validate(invalid)
+
+
+def test_project_role_qualification_evidence_rejects_coerced_values() -> None:
+    available = QualificationAvailabilitySnapshot(
+        availability=QualificationAvailability.AVAILABLE,
+        reference_ids=["work:opaque-1"],
+        unavailable_reason=None,
+    )
+    unavailable = QualificationAvailabilitySnapshot(
+        availability=QualificationAvailability.UNAVAILABLE,
+        reference_ids=[],
+        unavailable_reason=QualificationUnavailableReason.NO_RECORD,
+    )
+    base = {
+        "skills_snapshot": available,
+        "reputation_snapshot": unavailable,
+        "prior_project_work_refs": [uuid4()],
+        "external_expertise_refs": ["expertise:opaque-1"],
+    }
+    assert ProjectRoleQualificationEvidence.model_validate(base).prior_project_work_refs
+    canonical_string = str(uuid4())
+    assert ProjectRoleQualificationEvidence.model_validate(
+        base | {"prior_project_work_refs": [canonical_string]}
+    ).prior_project_work_refs == [UUID(canonical_string)]
+    for invalid in (
+        base | {"prior_project_work_refs": [1]},
+        base | {"prior_project_work_refs": [uuid4().bytes]},
+        base | {"external_expertise_refs": [1]},
+        base | {"external_expertise_refs": [b"expertise:opaque-1"]},
+    ):
+        with pytest.raises(ValidationError):
+            ProjectRoleQualificationEvidence.model_validate(invalid)
 
 
 def test_actor_profile_lifecycle_public_schemas_are_strict_bounded_and_typed() -> None:

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -45,6 +45,7 @@ from app.api.deps.auth import get_auth_verification_result
 from app.core.api_controls import StructuredHTTPException
 from app.core.config import Settings, get_settings
 from app.core.hashing import canonical_json_hash
+from app.db.session import get_db_session
 from app.main import create_app
 from app.modules.projects.repository import ProjectRepository
 from app.modules.audit.schemas import (
@@ -141,6 +142,7 @@ from app.modules.authorization.project_role_service import (
 )
 from app.modules.authorization.project_role_schemas import (
     ProjectRoleGrantIssueBody,
+    ProjectRoleGrantMutationResponse,
     ProjectRoleGrantRevokeBody,
 )
 from app.modules.authorization.kernel import AuthorizationService
@@ -816,6 +818,529 @@ async def test_project_role_mutation_rate_failure_precedes_private_work(
     assert response.status_code == 503
     assert response.json()["error"]["retryable"] is True
     assert calls == 1
+
+
+def _project_role_denial_decision(
+    action_id: ActionId,
+    resource_id: UUID,
+    denial_code: AuthorizationDenialCode,
+) -> AuthorizationDecision:
+    return AuthorizationDecision(
+        decision_id=uuid4(),
+        allowed=False,
+        action_id=action_id,
+        permission_id=PermissionId.PROJECT_ROLE_GRANT_MANAGE,
+        resource_type="project_role_grant",
+        resource_id=resource_id,
+        resource_context_digest=DIGEST,
+        denial_code=denial_code,
+        matched_authority_kind=None,
+        matched_grant_id=None,
+        matched_scope_project_id=None,
+        revalidated=False,
+        request_id=uuid4(),
+        correlation_id=uuid4(),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invocation", ["http_route", "direct_route"])
+@pytest.mark.parametrize(
+    ("operation", "hidden_case", "denial_code", "expected_status", "expected_code", "message"),
+    [
+        ("issue", "valid_target_no_manager", AuthorizationDenialCode.PERMISSION_NOT_GRANTED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "missing_target_no_manager", AuthorizationDenialCode.PERMISSION_NOT_GRANTED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "inactive_target_no_manager", AuthorizationDenialCode.PERMISSION_NOT_GRANTED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "nonhuman_target_no_manager", AuthorizationDenialCode.PERMISSION_NOT_GRANTED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "valid_target_cross_project_manager", AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "missing_target_manager", AuthorizationDenialCode.RESOURCE_GUARD_DENIED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "inactive_target_manager", AuthorizationDenialCode.RESOURCE_GUARD_DENIED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "nonhuman_target_manager", AuthorizationDenialCode.RESOURCE_GUARD_DENIED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "unauthorized_target_manager", AuthorizationDenialCode.RESOURCE_GUARD_DENIED, 404, "resource_not_found", "Resource not found"),
+        ("issue", "self_target_manager", AuthorizationDenialCode.SELF_GRANT_FORBIDDEN, 403, "self_grant_forbidden", "Self grant is forbidden"),
+        ("revoke", "nonexistent_grant", AuthorizationDenialCode.GRANT_NOT_FOUND, 404, "resource_not_found", "Resource not found"),
+        ("revoke", "cross_project_grant", AuthorizationDenialCode.GRANT_NOT_FOUND, 404, "resource_not_found", "Resource not found"),
+        ("revoke", "self_owned_grant_no_manager", AuthorizationDenialCode.PERMISSION_NOT_GRANTED, 404, "resource_not_found", "Resource not found"),
+        ("revoke", "self_owned_grant_manager", AuthorizationDenialCode.SELF_ROLE_REVOKE_FORBIDDEN, 403, "self_role_revoke_forbidden", "Self role revocation is forbidden"),
+    ],
+)
+async def test_project_role_mutation_routes_conceal_denials_and_preserve_self_guards_atomically(
+    monkeypatch: pytest.MonkeyPatch,
+    invocation: str,
+    operation: str,
+    hidden_case: str,
+    denial_code: AuthorizationDenialCode,
+    expected_status: int,
+    expected_code: str,
+    message: str,
+) -> None:
+    project_id, grant_id, caller_id, target_id = uuid4(), uuid4(), uuid4(), uuid4()
+    if hidden_case == "self_target_manager":
+        target_id = caller_id
+    persisted = {
+        "idempotency": 0,
+        "qualification_snapshot": 0,
+        "project_role_grant": 0,
+        "audit": 0,
+        "invalidation": 0,
+    }
+    staged = persisted.copy()
+    calls = {"reserve": 0, "complete_issue": 0, "complete_revoke": 0}
+
+    class Session:
+        rollback_count = 0
+        commit_count = 0
+
+        async def rollback(self) -> None:
+            self.rollback_count += 1
+            staged.update(dict.fromkeys(staged, 0))
+
+        async def commit(self) -> None:
+            self.commit_count += 1
+            persisted.update(staged)
+
+        def in_transaction(self) -> bool:
+            return any(staged.values())
+
+    class Repository:
+        async def lock_project(self, selected_project_id):
+            assert selected_project_id == project_id
+            return SimpleNamespace(id=str(project_id), status="active")
+
+        async def take_project_role_issue_lock(self, _key):
+            return None
+
+        async def lock_eligible_human(self, selected_target_id):
+            assert selected_target_id == target_id
+            if hidden_case in {
+                "missing_target_no_manager",
+                "inactive_target_no_manager",
+                "nonhuman_target_no_manager",
+                "missing_target_manager",
+                "inactive_target_manager",
+                "nonhuman_target_manager",
+                "unauthorized_target_manager",
+            }:
+                return None
+            return (SimpleNamespace(id=str(target_id)), SimpleNamespace(id=str(uuid4())))
+
+        async def find_active_project_role(self, **_kwargs):
+            return None
+
+        async def lock_project_role_grant(self, **values):
+            assert values["project_id"] == project_id
+            assert values["grant_id"] == grant_id_value
+            if hidden_case in {"nonexistent_grant", "cross_project_grant"}:
+                return None
+            grant = SimpleNamespace(
+                id=values["grant_id"],
+                project_id=str(project_id),
+                actor_profile_id=str(caller_id),
+                role="submitter",
+                status="active",
+                version=1,
+                qualification_snapshot_id=uuid4(),
+            )
+            return grant, SimpleNamespace(id=grant.qualification_snapshot_id)
+
+    class MutationService:
+        def __init__(self, _session) -> None:
+            self.repository = Repository()
+
+        async def reserve(self, **_kwargs):
+            calls["reserve"] += 1
+            staged["idempotency"] += 1
+            return SimpleNamespace(outcome="fresh", claim=object())
+
+        async def complete_issue(self, **_kwargs):
+            calls["complete_issue"] += 1
+            for key in ("qualification_snapshot", "project_role_grant", "audit"):
+                staged[key] += 1
+            raise AssertionError("concealed issue must not reach completion")
+
+        async def complete_revoke(self, **_kwargs):
+            calls["complete_revoke"] += 1
+            for key in ("project_role_grant", "audit", "invalidation"):
+                staged[key] += 1
+            raise AssertionError("concealed revoke must not reach completion")
+
+    class Prepared:
+        async def prepare(self, *_args):
+            return object()
+
+        async def consume(self, _handle, action_id, _prepared_input, resource):
+            raise AuthorizationDenied(
+                _project_role_denial_decision(action_id, resource.resource_id, denial_code)
+            )
+
+    session = Session()
+    prepared = Prepared()
+    resolved = SimpleNamespace(profile=SimpleNamespace(id=str(caller_id)))
+    grant_id_value = grant_id
+    monkeypatch.setattr(
+        authorization_router,
+        "ProjectRoleGrantMutationService",
+        MutationService,
+    )
+    issue_payload = ProjectRoleGrantIssueBody(
+        target_actor_profile_id=target_id,
+        role=ProjectRole.SUBMITTER,
+        qualification=_project_role_qualification(),
+        reason="Bounded assignment",
+    )
+    revoke_payload = ProjectRoleGrantRevokeBody(reason="Bounded removal")
+
+    if invocation == "http_route":
+        app = create_app(Settings(environment="test"))
+
+        async def session_dependency():
+            try:
+                yield session
+            finally:
+                await session.rollback()
+
+        async def resolved_dependency():
+            return resolved
+
+        async def prepared_dependency():
+            return prepared
+
+        async def consume_rate() -> None:
+            return None
+
+        app.dependency_overrides[get_db_session] = session_dependency
+        app.dependency_overrides[get_authorization_actor] = resolved_dependency
+        app.dependency_overrides[get_prepared_authorization_service] = prepared_dependency
+        app.dependency_overrides[enforce_admin_mutation_rate_limit] = consume_rate
+        path = (
+            f"/api/v1/projects/{project_id}/role-grants"
+            if operation == "issue"
+            else f"/api/v1/projects/{project_id}/role-grants/{grant_id}/revoke"
+        )
+        body = (
+            issue_payload.model_dump(mode="json")
+            if operation == "issue"
+            else revoke_payload.model_dump(mode="json")
+        )
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            response = await client.post(
+                path,
+                headers={"Idempotency-Key": str(uuid4())},
+                json=body,
+            )
+        error = response.json()["error"]
+        assert error["details"] == {}
+        assert error["retryable"] is False
+        assert UUID(error["correlation_id"])
+        public_result = (
+            response.status_code,
+            {"code": error["code"], "message": error["message"]},
+        )
+    else:
+        try:
+            if operation == "issue":
+                await authorization_router.issue_project_role_grant(
+                    project_id=project_id,
+                    payload=issue_payload,
+                    idempotency_key=uuid4(),
+                    resolved=resolved,  # type: ignore[arg-type]
+                    prepared=prepared,  # type: ignore[arg-type]
+                    session=session,  # type: ignore[arg-type]
+                )
+            else:
+                await authorization_router.revoke_project_role_grant(
+                    project_id=project_id,
+                    grant_id=grant_id,
+                    payload=revoke_payload,
+                    idempotency_key=uuid4(),
+                    resolved=resolved,  # type: ignore[arg-type]
+                    prepared=prepared,  # type: ignore[arg-type]
+                    session=session,  # type: ignore[arg-type]
+                )
+        except StructuredHTTPException as exc:
+            public_result = (
+                exc.status_code,
+                {"code": exc.error_code, "message": exc.error_message},
+            )
+        else:
+            raise AssertionError("concealed mutation unexpectedly succeeded")
+        finally:
+            await session.rollback()
+
+    assert public_result == (
+        expected_status,
+        {"code": expected_code, "message": message},
+    )
+    assert calls == {"reserve": 1, "complete_issue": 0, "complete_revoke": 0}
+    assert staged == dict.fromkeys(staged, 0)
+    assert persisted == dict.fromkeys(persisted, 0)
+    assert session.commit_count == 0
+    assert session.rollback_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invocation", ["http_route", "direct_route"])
+@pytest.mark.parametrize(
+    ("operation", "project_state", "project_exists", "expected_status"),
+    [
+        ("issue", "draft", True, 201),
+        ("issue", "active", True, 201),
+        ("issue", "paused", True, 201),
+        ("issue", "archived", True, 404),
+        ("issue", "active", False, 404),
+        ("revoke", "draft", True, 200),
+        ("revoke", "active", True, 200),
+        ("revoke", "paused", True, 200),
+        ("revoke", "archived", True, 200),
+    ],
+)
+async def test_project_role_mutation_routes_enforce_project_lifecycle_without_disclosure(
+    monkeypatch: pytest.MonkeyPatch,
+    invocation: str,
+    operation: str,
+    project_state: str,
+    project_exists: bool,
+    expected_status: int,
+) -> None:
+    project_id, grant_id, caller_id, target_id, snapshot_id = (
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+    )
+    staged = {
+        "idempotency": 0,
+        "qualification_snapshot": 0,
+        "project_role_grant": 0,
+        "audit": 0,
+        "invalidation": 0,
+    }
+    persisted = staged.copy()
+    calls = {"target_lookup": 0, "consume": 0, "complete": 0}
+
+    class Session:
+        commit_count = 0
+        rollback_count = 0
+
+        async def commit(self) -> None:
+            self.commit_count += 1
+            persisted.update(staged)
+            staged.update(dict.fromkeys(staged, 0))
+
+        async def rollback(self) -> None:
+            self.rollback_count += 1
+            staged.update(dict.fromkeys(staged, 0))
+
+        def in_transaction(self) -> bool:
+            return any(staged.values())
+
+    class Repository:
+        async def lock_project(self, selected_project_id):
+            assert selected_project_id == project_id
+            if not project_exists:
+                return None
+            return SimpleNamespace(id=str(project_id), status=project_state)
+
+        async def take_project_role_issue_lock(self, _key):
+            return None
+
+        async def lock_eligible_human(self, selected_target_id):
+            calls["target_lookup"] += 1
+            assert selected_target_id == target_id
+            return SimpleNamespace(id=str(target_id)), SimpleNamespace(id=str(uuid4()))
+
+        async def find_active_project_role(self, **_kwargs):
+            return None
+
+        async def lock_project_role_grant(self, **values):
+            assert values == {"project_id": project_id, "grant_id": grant_id}
+            grant = SimpleNamespace(
+                id=grant_id,
+                qualification_snapshot_id=snapshot_id,
+                project_id=str(project_id),
+                actor_profile_id=str(target_id),
+                role="submitter",
+                status="active",
+                version=1,
+            )
+            return grant, SimpleNamespace(id=snapshot_id)
+
+    class MutationService:
+        def __init__(self, _session) -> None:
+            self.repository = Repository()
+
+        async def reserve(self, **_kwargs):
+            staged["idempotency"] += 1
+            return SimpleNamespace(outcome="fresh", claim=object())
+
+        async def complete_issue(self, **_kwargs):
+            calls["complete"] += 1
+            staged.update(
+                {
+                    "qualification_snapshot": 1,
+                    "project_role_grant": 1,
+                    "audit": 2,
+                }
+            )
+            return ProjectRoleGrantMutationResponse(
+                id=grant_id,
+                qualification_snapshot_id=snapshot_id,
+                project_id=project_id,
+                actor_profile_id=target_id,
+                role=ProjectRole.SUBMITTER,
+                status="active",
+                version=1,
+            )
+
+        async def complete_revoke(self, **_kwargs):
+            calls["complete"] += 1
+            staged.update({"project_role_grant": 1, "audit": 2, "invalidation": 1})
+            return ProjectRoleGrantMutationResponse(
+                id=grant_id,
+                qualification_snapshot_id=snapshot_id,
+                project_id=project_id,
+                actor_profile_id=target_id,
+                role=ProjectRole.SUBMITTER,
+                status="revoked",
+                version=2,
+            )
+
+    class Prepared:
+        async def prepare(self, *_args):
+            return object()
+
+        async def consume(self, _handle, action_id, _prepared_input, resource):
+            calls["consume"] += 1
+            assert resource.project_status == project_state
+            if operation == "issue" and project_state == "archived":
+                raise AuthorizationDenied(
+                    _project_role_denial_decision(
+                        action_id,
+                        resource.resource_id,
+                        AuthorizationDenialCode.RESOURCE_GUARD_DENIED,
+                    )
+                )
+            return SimpleNamespace(allowed=True)
+
+    session = Session()
+    prepared = Prepared()
+    resolved = SimpleNamespace(profile=SimpleNamespace(id=str(caller_id)))
+    monkeypatch.setattr(
+        authorization_router,
+        "ProjectRoleGrantMutationService",
+        MutationService,
+    )
+    issue_payload = ProjectRoleGrantIssueBody(
+        target_actor_profile_id=target_id,
+        role=ProjectRole.SUBMITTER,
+        qualification=_project_role_qualification(),
+        reason="Lifecycle assignment",
+    )
+    revoke_payload = ProjectRoleGrantRevokeBody(reason="Lifecycle removal")
+
+    async def invoke_direct():
+        if operation == "issue":
+            return await authorization_router.issue_project_role_grant(
+                project_id=project_id,
+                payload=issue_payload,
+                idempotency_key=uuid4(),
+                resolved=resolved,  # type: ignore[arg-type]
+                prepared=prepared,  # type: ignore[arg-type]
+                session=session,  # type: ignore[arg-type]
+            )
+        return await authorization_router.revoke_project_role_grant(
+            project_id=project_id,
+            grant_id=grant_id,
+            payload=revoke_payload,
+            idempotency_key=uuid4(),
+            resolved=resolved,  # type: ignore[arg-type]
+            prepared=prepared,  # type: ignore[arg-type]
+            session=session,  # type: ignore[arg-type]
+        )
+
+    if invocation == "http_route":
+        app = create_app(Settings(environment="test"))
+
+        async def session_dependency():
+            try:
+                yield session
+            finally:
+                if session.in_transaction():
+                    await session.rollback()
+
+        async def resolved_dependency():
+            return resolved
+
+        async def prepared_dependency():
+            return prepared
+
+        async def consume_rate() -> None:
+            return None
+
+        app.dependency_overrides[get_db_session] = session_dependency
+        app.dependency_overrides[get_authorization_actor] = resolved_dependency
+        app.dependency_overrides[get_prepared_authorization_service] = prepared_dependency
+        app.dependency_overrides[enforce_admin_mutation_rate_limit] = consume_rate
+        path = (
+            f"/api/v1/projects/{project_id}/role-grants"
+            if operation == "issue"
+            else f"/api/v1/projects/{project_id}/role-grants/{grant_id}/revoke"
+        )
+        payload = issue_payload if operation == "issue" else revoke_payload
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            response = await client.post(
+                path,
+                headers={"Idempotency-Key": str(uuid4())},
+                json=payload.model_dump(mode="json"),
+            )
+        observed_status = response.status_code
+        observed_body = response.json()
+    else:
+        try:
+            result = await invoke_direct()
+        except StructuredHTTPException as exc:
+            observed_status = exc.status_code
+            observed_body = {"error": {"code": exc.error_code, "message": exc.error_message}}
+        else:
+            observed_status = 201 if operation == "issue" else 200
+            observed_body = result.model_dump(mode="json")
+        finally:
+            if session.in_transaction():
+                await session.rollback()
+
+    assert observed_status == expected_status
+    if expected_status == 404:
+        assert observed_body["error"]["code"] == "resource_not_found"
+        assert observed_body["error"]["message"] == "Resource not found"
+        assert persisted == dict.fromkeys(persisted, 0)
+        assert calls["complete"] == 0
+        assert session.commit_count == 0
+        if not project_exists:
+            assert calls == {"target_lookup": 0, "consume": 0, "complete": 0}
+    else:
+        expected_body = {
+            "id": str(grant_id),
+            "qualification_snapshot_id": str(snapshot_id),
+            "project_id": str(project_id),
+            "actor_profile_id": str(target_id),
+            "role": "submitter",
+            "status": "active" if operation == "issue" else "revoked",
+            "version": 1 if operation == "issue" else 2,
+        }
+        assert observed_body == expected_body
+        assert calls["consume"] == 1
+        assert calls["complete"] == 1
+        assert session.commit_count == 1
+        assert persisted["idempotency"] == 1
+        assert persisted["project_role_grant"] == 1
+        assert persisted["audit"] == 2
+        assert persisted["qualification_snapshot"] == (operation == "issue")
+        assert persisted["invalidation"] == (operation == "revoke")
 
 
 ART_CUSTODY_EXPECTATIONS = {
@@ -2341,6 +2866,43 @@ def test_project_role_read_denials_share_one_public_concealment(
     translated = authorization_http_error(AuthorizationDenied(decision))
     assert translated.status_code == 404
     assert translated.error_code == "project_authorization_resource_not_found"
+
+
+@pytest.mark.parametrize(
+    "denial_code",
+    [
+        AuthorizationDenialCode.PERMISSION_NOT_GRANTED,
+        AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED,
+        AuthorizationDenialCode.RESOURCE_GUARD_DENIED,
+        AuthorizationDenialCode.ACTOR_NOT_FOUND,
+        AuthorizationDenialCode.GRANT_NOT_FOUND,
+    ],
+)
+def test_project_role_mutation_denials_share_resource_not_found_concealment(
+    denial_code: AuthorizationDenialCode,
+) -> None:
+    decision = AuthorizationDecision(
+        decision_id=uuid4(),
+        allowed=False,
+        action_id=ActionId.PROJECT_ROLE_GRANT_ISSUE,
+        permission_id=PermissionId.PROJECT_ROLE_GRANT_MANAGE,
+        resource_type="project_role_grant",
+        resource_id=uuid4(),
+        resource_context_digest=DIGEST,
+        denial_code=denial_code,
+        matched_authority_kind=None,
+        matched_grant_id=None,
+        matched_scope_project_id=None,
+        revalidated=False,
+        request_id=uuid4(),
+        correlation_id=uuid4(),
+    )
+    translated = authorization_router._project_role_mutation_denial(
+        AuthorizationDenied(decision)
+    )
+    assert translated.status_code == 404
+    assert translated.error_code == "resource_not_found"
+    assert translated.error_message == "Resource not found"
 
 
 def test_project_role_read_permissions_separate_manager_and_auditor_authority() -> None:
@@ -7259,7 +7821,12 @@ async def test_completion_rejects_resource_and_project_not_bound_to_request(
             resource_id=uuid4(),
             http_status=201,
         )
-        success = _operation_success(claim, wrong_project, response)
+        success = _operation_success(
+            claim,
+            wrong_project,
+            response,
+            admin_authorizer_grant_id=uuid4(),
+        )
         with pytest.raises(TypeError, match="invalid authority completion input"):
             await service.complete(
                 claim=claim,
@@ -7991,14 +8558,6 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
             grant_id=resource,
             reason_digest=DIGEST,
         ),
-        ProjectRoleGrantIssueRequest(
-            operation=AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE,
-            project_id=project,
-            target_actor_id=actor,
-            role=ProjectRole.SUBMITTER,
-            qualification=_project_role_qualification(),
-            reason_digest=DIGEST,
-        ),
         ProjectRoleGrantRevokeRequest(
             operation=AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE,
             project_id=project,
@@ -8046,7 +8605,6 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
     create_operations = {
         AuthorityOperation.SERVICE_ACTOR_CREATE,
         AuthorityOperation.ADMIN_ROLE_GRANT_ISSUE,
-        AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE,
     }
     admin_operations = {
         AuthorityOperation.ADMIN_ROLE_GRANT_ISSUE,
@@ -8129,24 +8687,6 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
                     else None
                 ),
             )
-            if request.operation is AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE:
-                qualification_id = uuid4()
-                qualification_event = success.model_copy(
-                    update={
-                        "event_id": uuid4(),
-                        "event_type": AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED,
-                        "entity_type": "qualification_snapshot",
-                        "entity_id": str(qualification_id),
-                        "resource_type": "qualification_snapshot",
-                        "resource_id": str(qualification_id),
-                        "target_ref_kind": "qualification_snapshot",
-                        "target_ref_id": str(qualification_id),
-                        "reason": "qualification_evidence_captured",
-                        "after_facts": {"status": "captured"},
-                    }
-                )
-                success_input = (qualification_event, success)
-                invalidation = None
             completed = await service.complete(
                 claim=claim,
                 request=request.model_dump(),
@@ -8162,7 +8702,8 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
                 text(
                     "select id, event_type, idempotency_reference, "
                     "invalidation_cause_event_id, request_id, correlation_id, "
-                    "invalidation_target_ref, before_facts, after_facts "
+                    "target_actor_ref_kind,target_actor_ref,target_ref_kind,target_ref_id,"
+                    "invalidation_target_ref,before_facts,after_facts "
                     "from audit_events "
                     "where idempotency_reference = any(:records) "
                     "order by idempotency_reference, event_type"
@@ -8175,15 +8716,6 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
         pair = [row for row in rows if row.idempotency_reference == record_id]
         assert len(pair) == 2
         success_row = next(row for row in pair if row.event_type == success.event_type.value)
-        if success.event_type is AuthorityEventType.PROJECT_ROLE_GRANT_ISSUED:
-            qualification_row = next(
-                row
-                for row in pair
-                if row.event_type
-                == AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED.value
-            )
-            assert qualification_row.invalidation_cause_event_id is None
-            continue
         invalidation_row = next(
             row for row in pair if row.event_type == "AuthorityInvalidationRequested"
         )
@@ -8199,11 +8731,15 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
                 AuthorityEventType.ADMIN_ROLE_GRANT_REVOKED,
                 AuthorityEventType.ACTOR_IDENTITY_LINK_REVOKED,
                 AuthorityEventType.ACTOR_IDENTITY_LINK_REACTIVATED,
-                AuthorityEventType.PROJECT_ROLE_GRANT_REVOKED,
             }
             else success.resource_id
         )
         assert invalidation_row.invalidation_target_ref == expected_target
+        if success.event_type is AuthorityEventType.PROJECT_ROLE_GRANT_REVOKED:
+            assert invalidation_row.target_actor_ref_kind == "actor_profile"
+            assert invalidation_row.target_actor_ref == success.target_actor_ref
+            assert invalidation_row.target_ref_kind == "project_role_grant"
+            assert invalidation_row.target_ref_id == success.resource_id
         expected_before = (
             {"effective": False}
             if success.event_type
@@ -8227,6 +8763,94 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
             expected_after = expected_before | {"effective": False}
         assert invalidation_row.before_facts == expected_before
         assert invalidation_row.after_facts == expected_after
+
+
+async def test_project_role_issue_shared_completion_writes_ordered_zero_invalidation_pair() -> None:
+    project_id, actor_id, target_id, grant_id, snapshot_id = (
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+        uuid4(),
+    )
+    request = ProjectRoleGrantIssueRequest(
+        operation=AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE,
+        project_id=project_id,
+        target_actor_id=target_id,
+        role=ProjectRole.SUBMITTER,
+        qualification=_project_role_qualification(),
+        reason_digest=DIGEST,
+    )
+    claim = AuthorityClaimHandle(
+        record_id=uuid4(),
+        idempotency_key=uuid4(),
+        actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+        actor_ref=str(actor_id),
+        operation=request.operation,
+        request_digest=canonical_json_hash(
+            request.model_dump(mode="json", exclude_none=True)
+        ),
+    )
+    response = AuthorityResponseReference(
+        resource_type=AuthorityResourceType.PROJECT_ROLE_GRANT,
+        resource_id=grant_id,
+        version=1,
+        http_status=201,
+    )
+    issued = _operation_success(
+        claim,
+        request,
+        response,
+        admin_authorizer_grant_id=uuid4(),
+    )
+    qualification = issued.model_copy(
+        update={
+            "event_id": uuid4(),
+            "event_type": AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED,
+            "entity_type": "qualification_snapshot",
+            "entity_id": str(snapshot_id),
+            "resource_type": "qualification_snapshot",
+            "resource_id": str(snapshot_id),
+            "target_ref_kind": "qualification_snapshot",
+            "target_ref_id": str(snapshot_id),
+            "reason": "qualification_evidence_captured",
+            "after_facts": {"status": "captured"},
+        }
+    )
+
+    class Audit:
+        events = []
+
+        async def add_authority_event(self, event):
+            self.events.append(event)
+            return SimpleNamespace(id=str(event.event_id))
+
+    class Repository:
+        completed = None
+
+        async def complete(self, completed_claim, completed_response):
+            self.completed = (completed_claim, completed_response)
+
+    service = AuthorityMutationService(object())  # type: ignore[arg-type]
+    audit = Audit()
+    repository = Repository()
+    service._audit = audit  # type: ignore[assignment]
+    service._repository = repository  # type: ignore[assignment]
+
+    result = await service.complete(
+        claim=claim,
+        request=request.model_dump(),
+        response=response,
+        success=(qualification, issued),
+        invalidation=None,
+    )
+
+    assert [event.event_type for event in audit.events] == [
+        AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED,
+        AuthorityEventType.PROJECT_ROLE_GRANT_ISSUED,
+    ]
+    assert repository.completed == (claim, response)
+    assert result.invalidation_event_id is None
 
 
 @pytest.mark.asyncio
@@ -8438,6 +9062,7 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
         uuid4(), uuid4(), uuid4(), uuid4(), uuid4()
     )
     manager_grant_id = uuid4()
+    bootstrap_grant_id = uuid4()
     now = datetime.now(UTC)
     async with authorization_factory() as session:
         session.add_all(
@@ -8447,8 +9072,20 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
                 ActorProfile(id=str(target_id), actor_kind="human", status="active", provisioning_method="automatic_first_access", created_by=str(target_id)),
                 ActorIdentityLink(id=str(target_link_id), actor_profile_id=str(target_id), issuer="https://identity.flowresearch.tech", subject=f"auth10c-target-{target_id}", subject_kind="human", status="active", linked_by=str(target_id), last_verified_at=now),
                 Project(id=str(project_id), name="AUTH-10C PREP proof", slug=f"auth-10c-prep-{project_id}", status="draft"),
-                AdminRoleGrant(id=manager_grant_id, target_actor_profile_id=str(caller_id), role="project_manager", scope_type="project", scope_project_id=str(project_id), status="active", version=1, granted_by_actor_profile_id=None, granted_by_system_principal="workstream:system:bootstrap", granted_by_admin_role_grant_id=None, grant_reason="AUTH-10C PostgreSQL proof"),
+                AdminRoleGrant(id=bootstrap_grant_id, target_actor_profile_id=str(caller_id), role="access_administrator", scope_type="system", scope_project_id=None, status="active", version=1, granted_by_actor_profile_id=None, granted_by_system_principal="workstream:system:bootstrap", granted_by_admin_role_grant_id=None, grant_reason="AUTH-10C PostgreSQL bootstrap proof"),
             ]
+        )
+        await session.flush()
+        await session.execute(
+            text(
+                "update authority_control set bootstrap_completed=true, version=1, "
+                "bootstrap_grant_id=:grant_id, updated_at=clock_timestamp() where id=1"
+            ),
+            {"grant_id": str(bootstrap_grant_id)},
+        )
+        await session.commit()
+        session.add(
+            AdminRoleGrant(id=manager_grant_id, target_actor_profile_id=str(caller_id), role="project_manager", scope_type="project", scope_project_id=str(project_id), status="active", version=1, granted_by_actor_profile_id=str(caller_id), granted_by_system_principal=None, granted_by_admin_role_grant_id=bootstrap_grant_id, grant_reason="AUTH-10C PostgreSQL project-manager proof")
         )
         await session.commit()
         context = HumanAuthorizationContext(actor_profile_id=caller_id, actor_kind=ActorKind.HUMAN, actor_status=ActorStatus.ACTIVE, identity_link_id=caller_link_id, identity_link_status=IdentityLinkStatus.ACTIVE, request_id=uuid4(), correlation_id=uuid4())
@@ -8477,13 +9114,32 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
         assert await repository.lock_project(project_id) is not None
         await repository.take_project_role_issue_lock(project_role_issue_lock_key(target_id, project_id, "submitter"))
         assert await repository.lock_eligible_human(target_id) is not None
-        decision = await prepared.consume(handle, ActionId.PROJECT_ROLE_GRANT_ISSUE, caller_input, ProjectRoleGrantIssueResourceContext(resource_type="project_role_grant_issue", resource_id=project_id, scope_project_id=project_id, target_actor_profile_id=target_id, role=ProjectRole.SUBMITTER, project_status="draft", target_eligible=True, active_exact_role_exists=False))
+        issue_resource = ProjectRoleGrantIssueResourceContext(resource_type="project_role_grant", resource_id=project_id, scope_project_id=project_id, target_actor_profile_id=target_id, role=ProjectRole.SUBMITTER, project_status="draft", target_eligible=True, active_exact_role_exists=False)
+        decision = await prepared.consume(handle, ActionId.PROJECT_ROLE_GRANT_ISSUE, caller_input, issue_resource)
         assert decision.allowed is True
         assert decision.matched_grant_id == manager_grant_id
-        issued = await ProjectRoleGrantMutationService(session).complete_issue(
+        issue_service = ProjectRoleGrantMutationService(session)
+        for substituted in (
+            decision.model_copy(update={"action_id": ActionId.PROJECT_ROLE_GRANT_REVOKE}),
+            decision.model_copy(update={"permission_id": PermissionId.PROJECT_READ}),
+            decision.model_copy(update={"revalidated": False}),
+            decision.model_copy(update={"matched_scope_project_id": uuid4()}),
+            decision.model_copy(update={"resource_context_digest": f"sha256:{'0' * 64}"}),
+        ):
+            with pytest.raises(TypeError, match="requires exact matched authority"):
+                await issue_service.complete_issue(
+                    claim=issue_reservation.claim,
+                    request=canonical_issue,
+                    decision=substituted,
+                    resource=issue_resource,
+                    actor_profile_id=caller_id,
+                    reason=issue_reason,
+                )
+        issued = await issue_service.complete_issue(
             claim=issue_reservation.claim,
             request=canonical_issue,
             decision=decision,
+            resource=issue_resource,
             actor_profile_id=caller_id,
             reason=issue_reason,
         )
@@ -8537,25 +9193,77 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
         )
         assert project is not None and row is not None
         grant, _snapshot = row
+        revoke_resource = ProjectRoleGrantRevokeResourceContext(
+            resource_type="project_role_grant",
+            resource_id=issued.id,
+            scope_project_id=project_id,
+            actor_profile_id=target_id,
+            role=ProjectRole.SUBMITTER,
+            project_status="draft",
+            status="active",
+            version=1,
+        )
         revoke_decision = await prepared.consume(
             revoke_handle,
             ActionId.PROJECT_ROLE_GRANT_REVOKE,
             revoke_input,
-            ProjectRoleGrantRevokeResourceContext(
-                resource_type="project_role_grant_revoke",
-                resource_id=issued.id,
-                scope_project_id=project_id,
-                actor_profile_id=target_id,
-                role=ProjectRole.SUBMITTER,
-                project_status="draft",
-                status="active",
-                version=1,
-            ),
+            revoke_resource,
         )
-        revoked = await ProjectRoleGrantMutationService(session).complete_revoke(
+        revoke_service = ProjectRoleGrantMutationService(session)
+        for substituted_decision, substituted_resource in (
+            (
+                revoke_decision.model_copy(
+                    update={"action_id": ActionId.PROJECT_ROLE_GRANT_ISSUE}
+                ),
+                revoke_resource,
+            ),
+            (
+                revoke_decision.model_copy(
+                    update={"permission_id": PermissionId.PROJECT_READ}
+                ),
+                revoke_resource,
+            ),
+            (revoke_decision.model_copy(update={"revalidated": False}), revoke_resource),
+            (
+                revoke_decision.model_copy(update={"matched_scope_project_id": uuid4()}),
+                revoke_resource,
+            ),
+            (
+                revoke_decision.model_copy(
+                    update={"resource_context_digest": f"sha256:{'0' * 64}"}
+                ),
+                revoke_resource,
+            ),
+            (
+                revoke_decision,
+                revoke_resource.model_copy(update={"actor_profile_id": uuid4()}),
+            ),
+            (
+                revoke_decision,
+                revoke_resource.model_copy(update={"role": ProjectRole.REVIEWER}),
+            ),
+            (
+                revoke_decision,
+                revoke_resource.model_copy(update={"version": 2, "status": "revoked"}),
+            ),
+        ):
+            with pytest.raises(TypeError, match="requires exact matched authority"):
+                await revoke_service.complete_revoke(
+                    claim=revoke_reservation.claim,
+                    request=canonical_revoke,
+                    decision=substituted_decision,
+                    resource=substituted_resource,
+                    actor_profile_id=caller_id,
+                    reason=revoke_reason,
+                    grant=grant,
+                )
+        assert grant.status == "active"
+        assert grant.version == 1
+        revoked = await revoke_service.complete_revoke(
             claim=revoke_reservation.claim,
             request=canonical_revoke,
             decision=revoke_decision,
+            resource=revoke_resource,
             actor_profile_id=caller_id,
             reason=revoke_reason,
             grant=grant,
@@ -8574,6 +9282,39 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
             )
             == 4
         )
+        revoke_invalidation = (
+            await session.execute(
+                text(
+                    "select target_actor_ref_kind,target_actor_ref,resource_type,resource_id,"
+                    "target_ref_kind,target_ref_id,invalidation_target_kind,"
+                    "invalidation_target_ref,before_facts,after_facts "
+                    "from audit_events where idempotency_reference=:revoke "
+                    "and event_type='AuthorityInvalidationRequested'"
+                ),
+                {"revoke": str(revoke_reservation.claim.record_id)},
+            )
+        ).one()
+        assert tuple(revoke_invalidation[:8]) == (
+            "actor_profile",
+            str(target_id),
+            "project_role_grant",
+            str(issued.id),
+            "project_role_grant",
+            str(issued.id),
+            "project_role_grant",
+            str(issued.id),
+        )
+        assert revoke_invalidation.before_facts == {
+            "effective": True,
+            "role": "submitter",
+            "scope_type": "project",
+            "scope_id": str(project_id),
+            "future_obligation": "auth13_assignment",
+        }
+        assert revoke_invalidation.after_facts == {
+            **revoke_invalidation.before_facts,
+            "effective": False,
+        }
 
         await session.execute(
             text(
@@ -8613,6 +9354,7 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
             captured_by_admin_role_grant_id=manager_grant_id,
         )
         session.add(existing_snapshot)
+        await session.flush()
         session.add(
             ProjectRoleGrant(
                 id=uuid4(),
@@ -8646,7 +9388,7 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
         async def race_find(repository, **kwargs):
             nonlocal find_calls
             find_calls += 1
-            if find_calls <= 2:
+            if find_calls == 1:
                 return None
             return await original_find(repository, **kwargs)
 
@@ -8676,7 +9418,7 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
             )
         assert conflict.value.status_code == 409
         assert conflict.value.error_code == "project_role_grant_exists"
-        assert find_calls == 3
+        assert find_calls == 2
         assert len(race_claim_ids) == 1
         monkeypatch.setattr(
             AdminAuthorizationRepository,
@@ -8865,25 +9607,27 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
             )
             is None
         )
+        retry_resource = ProjectRoleGrantIssueResourceContext(
+            resource_type="project_role_grant",
+            resource_id=project_id,
+            scope_project_id=project_id,
+            target_actor_profile_id=target_id,
+            role=ProjectRole.SUBMITTER,
+            project_status=project.status,
+            target_eligible=True,
+            active_exact_role_exists=False,
+        )
         retry_decision = await waiter_prepared.consume(
             retry_handle,
             ActionId.PROJECT_ROLE_GRANT_ISSUE,
             retry_input,
-            ProjectRoleGrantIssueResourceContext(
-                resource_type="project_role_grant_issue",
-                resource_id=project_id,
-                scope_project_id=project_id,
-                target_actor_profile_id=target_id,
-                role=ProjectRole.SUBMITTER,
-                project_status=project.status,
-                target_eligible=True,
-                active_exact_role_exists=False,
-            ),
+            retry_resource,
         )
         retried = await ProjectRoleGrantMutationService(waiter).complete_issue(
             claim=retry_reservation.claim,
             request=canonical,
             decision=retry_decision,
+            resource=retry_resource,
             actor_profile_id=caller_id,
             reason="AUTH-10C concurrency proof",
         )

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -126,6 +126,7 @@ from app.modules.authorization.schemas import (
     parse_authority_request,
 )
 from app.modules.authorization.service import AuthorityMutationService
+from app.modules.authorization.project_role_service import project_role_issue_lock_key
 from app.modules.authorization.kernel import AuthorizationService
 from app.modules.authorization.prepared import (
     PreparedAuthorizationHandle,
@@ -181,6 +182,38 @@ from app.modules.authorization.service_actor_service import (
 )
 
 DIGEST = "sha256:" + "a" * 64
+
+
+def _project_role_qualification() -> dict[str, object]:
+    return {
+        "skills_snapshot": {
+            "availability": "available",
+            "reference_ids": ["skill:opaque"],
+            "unavailable_reason": None,
+        },
+        "reputation_snapshot": {
+            "availability": "unavailable",
+            "reference_ids": [],
+            "unavailable_reason": "no_record",
+        },
+        "prior_project_work_refs": [],
+        "external_expertise_refs": [],
+    }
+
+
+def test_project_role_issue_advisory_key_contract_is_frozen_and_separated() -> None:
+    actor = UUID("00000000-0000-0000-0000-000000000001")
+    project = UUID("00000000-0000-0000-0000-000000000002")
+    assert project_role_issue_lock_key(actor, project, "submitter") == -7801444014257588548
+    values = {
+        project_role_issue_lock_key(actor, project, role)
+        for role in ("submitter", "reviewer", "adjudicator")
+    }
+    assert len(values) == 3
+    assert all(-(2**63) <= value < 2**63 for value in values)
+    assert project_role_issue_lock_key(actor, project, "submitter") != project_role_issue_lock_key(
+        project, actor, "submitter"
+    )
 
 
 def test_authorization_read_cursor_round_trip_and_query_binding() -> None:
@@ -251,12 +284,18 @@ def _signed_cursor_envelope(envelope: dict, *, secret: bytes = bytes(range(32)))
         sort_keys=True,
         separators=(",", ":"),
     ).encode()
-    envelope["s"] = base64.urlsafe_b64encode(
-        hmac.new(secret, payload_bytes, hashlib.sha256).digest()
-    ).decode().rstrip("=")
-    return base64.urlsafe_b64encode(
-        json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()
-    ).decode().rstrip("=")
+    envelope["s"] = (
+        base64.urlsafe_b64encode(hmac.new(secret, payload_bytes, hashlib.sha256).digest())
+        .decode()
+        .rstrip("=")
+    )
+    return (
+        base64.urlsafe_b64encode(
+            json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode()
+        )
+        .decode()
+        .rstrip("=")
+    )
 
 
 @pytest.mark.parametrize(
@@ -323,19 +362,23 @@ def test_authorization_read_cursor_rejects_oversized_decoded_value() -> None:
 
 
 def test_authorization_read_cursor_rejects_missing_envelope_and_duplicate_keys() -> None:
-    missing_signature = base64.urlsafe_b64encode(
-        json.dumps(
-            {
-                "p": {
-                    "v": 1,
-                    "q": DIGEST,
-                    "ts": "2026-07-22T00:00:00.000000Z",
-                    "id": "00000000-0000-4000-8000-000000000002",
-                }
-            },
-            separators=(",", ":"),
-        ).encode()
-    ).decode().rstrip("=")
+    missing_signature = (
+        base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    "p": {
+                        "v": 1,
+                        "q": DIGEST,
+                        "ts": "2026-07-22T00:00:00.000000Z",
+                        "id": "00000000-0000-4000-8000-000000000002",
+                    }
+                },
+                separators=(",", ":"),
+            ).encode()
+        )
+        .decode()
+        .rstrip("=")
+    )
     duplicate = base64.urlsafe_b64encode(b'{"p":{},"p":{},"s":"x"}').decode().rstrip("=")
     codec = AuthorizationReadCursorCodec(bytes(range(32)))
     for value in (missing_signature, duplicate):
@@ -572,11 +615,10 @@ async def test_human_read_admission_conceals_every_nonhuman_kind(
             response = await client.get(f"/api/v1/projects/{uuid4()}/role-grants")
 
         assert response.status_code == 404
-        assert response.json()["error"]["code"] == (
-            "project_authorization_resource_not_found"
-        )
+        assert response.json()["error"]["code"] == ("project_authorization_resource_not_found")
         assert consumptions == 1
         assert lookups == 0
+
 
 ART_CUSTODY_EXPECTATIONS = {
     "artifact.binding.read": (
@@ -903,6 +945,8 @@ def test_closed_permission_and_action_catalogue_is_exact_and_non_executable() ->
         ActionId.PROJECT_CONTRIBUTOR_CANDIDATE_LIST,
         ActionId.PROJECT_ROLE_GRANT_LIST,
         ActionId.PROJECT_ROLE_GRANT_READ,
+        ActionId.PROJECT_ROLE_GRANT_ISSUE,
+        ActionId.PROJECT_ROLE_GRANT_REVOKE,
     }
     assert {
         definition.action_id.value: (
@@ -977,14 +1021,20 @@ def test_closed_permission_and_action_catalogue_is_exact_and_non_executable() ->
         "review.revision_obligation.close",
         "review.lifecycle.activation.manage",
     }.isdisjoint(action.value for action in ACTION_IDS)
-    assert sum(
-        definition.availability is ActionAvailability.ACTIVE
-        for definition in ACTION_DEFINITIONS
-    ) == 20
-    assert sum(
-        definition.availability is ActionAvailability.PLANNED
-        for definition in ACTION_DEFINITIONS
-    ) == 50
+    assert (
+        sum(
+            definition.availability is ActionAvailability.ACTIVE
+            for definition in ACTION_DEFINITIONS
+        )
+        == 22
+    )
+    assert (
+        sum(
+            definition.availability is ActionAvailability.PLANNED
+            for definition in ACTION_DEFINITIONS
+        )
+        == 48
+    )
     assert resolve_executable_action(ActionId.ACTOR_PROFILE_READ_SELF).permission_id is (
         PermissionId.ACTOR_PROFILE_READ_SELF
     )
@@ -1113,7 +1163,9 @@ def test_art_custody_documentation_matches_the_independent_catalogue_fixture() -
     assert "The ART transfer adds no migration" in operations
     assert "does not grant Operator" in operations
     assert "verification retry remains independently gated" in operations
-    assert "74 PermissionIds, 70 ActionIds, 20 active actions, and\n50 planned actions" in operations
+    assert (
+        "74 PermissionIds, 70 ActionIds, 22 active actions, and\n48 planned actions" in operations
+    )
 
 
 def test_rev_custody_documentation_matches_the_independent_catalogue_fixture() -> None:
@@ -2089,18 +2141,15 @@ def test_project_role_read_denials_share_one_public_concealment(
 
 
 def test_project_role_read_permissions_separate_manager_and_auditor_authority() -> None:
-    assert PermissionId.PROJECT_ROLE_GRANT_READ in ADMIN_ROLE_PERMISSIONS[
-        AdminRole.PROJECT_MANAGER
-    ]
-    assert PermissionId.PROJECT_ROLE_GRANT_MANAGE in ADMIN_ROLE_PERMISSIONS[
-        AdminRole.PROJECT_MANAGER
-    ]
-    assert PermissionId.PROJECT_ROLE_GRANT_READ in ADMIN_ROLE_PERMISSIONS[
-        AdminRole.AUDIT_AUTHORITY
-    ]
-    assert PermissionId.PROJECT_ROLE_GRANT_MANAGE not in ADMIN_ROLE_PERMISSIONS[
-        AdminRole.AUDIT_AUTHORITY
-    ]
+    assert PermissionId.PROJECT_ROLE_GRANT_READ in ADMIN_ROLE_PERMISSIONS[AdminRole.PROJECT_MANAGER]
+    assert (
+        PermissionId.PROJECT_ROLE_GRANT_MANAGE in ADMIN_ROLE_PERMISSIONS[AdminRole.PROJECT_MANAGER]
+    )
+    assert PermissionId.PROJECT_ROLE_GRANT_READ in ADMIN_ROLE_PERMISSIONS[AdminRole.AUDIT_AUTHORITY]
+    assert (
+        PermissionId.PROJECT_ROLE_GRANT_MANAGE
+        not in ADMIN_ROLE_PERMISSIONS[AdminRole.AUDIT_AUTHORITY]
+    )
 
 
 @pytest.mark.asyncio
@@ -6767,6 +6816,7 @@ def _operation_success(
         }
     elif isinstance(request, ProjectRoleGrantRevokeRequest):
         project_id = request.project_id
+        target_actor = response.resource_id
         before_facts = {
             "status": "active",
             "role": "submitter",
@@ -6988,6 +7038,7 @@ async def test_completion_rejects_resource_and_project_not_bound_to_request(
         project_id=uuid4(),
         target_actor_id=uuid4(),
         role=ProjectRole.SUBMITTER,
+        qualification=_project_role_qualification(),
         reason_digest=DIGEST,
     )
     wrong_project = project_request.model_copy(update={"project_id": uuid4()})
@@ -7575,6 +7626,7 @@ def test_every_operation_has_one_strict_canonical_request_variant() -> None:
             project_id=project,
             target_actor_id=actor,
             role=ProjectRole.ADJUDICATOR,
+            qualification=_project_role_qualification(),
             reason_digest=DIGEST,
         ),
         ProjectRoleGrantRevokeRequest(
@@ -7735,6 +7787,7 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
             project_id=project,
             target_actor_id=actor,
             role=ProjectRole.SUBMITTER,
+            qualification=_project_role_qualification(),
             reason_digest=DIGEST,
         ),
         ProjectRoleGrantRevokeRequest(
@@ -7839,16 +7892,36 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
             if request.operation in admin_operations:
                 assert success.matched_grant_id == str(admin_authorizer_grant_id)
                 assert success.matched_grant_id != str(response.resource_id)
+            success_input = success
+            invalidation = AuthorityInvalidationContext(
+                event_id=uuid4(),
+                request_id=success.request_id,
+                correlation_id=success.correlation_id,
+            )
+            if request.operation is AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE:
+                qualification_id = uuid4()
+                qualification_event = success.model_copy(
+                    update={
+                        "event_id": uuid4(),
+                        "event_type": AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED,
+                        "entity_type": "qualification_snapshot",
+                        "entity_id": str(qualification_id),
+                        "resource_type": "qualification_snapshot",
+                        "resource_id": str(qualification_id),
+                        "target_ref_kind": "qualification_snapshot",
+                        "target_ref_id": str(qualification_id),
+                        "reason": "qualification_evidence_captured",
+                        "after_facts": {"status": "captured"},
+                    }
+                )
+                success_input = (qualification_event, success)
+                invalidation = None
             completed = await service.complete(
                 claim=claim,
                 request=request.model_dump(),
                 response=response,
-                success=success,
-                invalidation=AuthorityInvalidationContext(
-                    event_id=uuid4(),
-                    request_id=success.request_id,
-                    correlation_id=success.correlation_id,
-                ),
+                success=success_input,
+                invalidation=invalidation,
             )
             assert completed.response == response
             expected_pairs[claim.record_id] = success
@@ -7871,6 +7944,15 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
         pair = [row for row in rows if row.idempotency_reference == record_id]
         assert len(pair) == 2
         success_row = next(row for row in pair if row.event_type == success.event_type.value)
+        if success.event_type is AuthorityEventType.PROJECT_ROLE_GRANT_ISSUED:
+            qualification_row = next(
+                row
+                for row in pair
+                if row.event_type
+                == AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED.value
+            )
+            assert qualification_row.invalidation_cause_event_id is None
+            continue
         invalidation_row = next(
             row for row in pair if row.event_type == "AuthorityInvalidationRequested"
         )
@@ -7886,6 +7968,7 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
                 AuthorityEventType.ADMIN_ROLE_GRANT_REVOKED,
                 AuthorityEventType.ACTOR_IDENTITY_LINK_REVOKED,
                 AuthorityEventType.ACTOR_IDENTITY_LINK_REACTIVATED,
+                AuthorityEventType.PROJECT_ROLE_GRANT_REVOKED,
             }
             else success.resource_id
         )
@@ -7915,6 +7998,7 @@ async def test_issue_mismatch_derives_project_and_omits_nonexistent_grant_resour
         project_id=project,
         target_actor_id=uuid4(),
         role=ProjectRole.REVIEWER,
+        qualification=_project_role_qualification(),
         reason_digest=DIGEST,
     )
     context = AuthorityMismatchContext(event_id=uuid4(), request_id=uuid4(), correlation_id=uuid4())

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -72,6 +72,7 @@ from app.modules.authorization.lifecycle_service import (
     IdentityLinkLifecycleService,
 )
 from app.modules.authorization.models import AdminRoleGrant
+from app.modules.projects.models import Project
 from app.modules.authorization.pagination import (
     AuthorizationReadCursorCodec,
     InvalidPaginationCursor,
@@ -129,7 +130,10 @@ from app.modules.authorization.schemas import (
     parse_authority_request,
 )
 from app.modules.authorization.service import AuthorityMutationService
-from app.modules.authorization.project_role_service import project_role_issue_lock_key
+from app.modules.authorization.project_role_service import (
+    _constraint_name,
+    project_role_issue_lock_key,
+)
 from app.modules.authorization.project_role_schemas import (
     ProjectRoleGrantIssueBody,
     ProjectRoleGrantRevokeBody,
@@ -176,6 +180,7 @@ from app.modules.authorization.runtime import (
     PermissionCatalogueResourceContext,
     ProjectContributorCandidateCollectionResourceContext,
     ProjectRoleGrantCollectionResourceContext,
+    ProjectRoleGrantIssueResourceContext,
     ProjectRoleGrantReadResourceContext,
     ServiceActorProvisionResourceContext,
     ServiceAuthorizationContext,
@@ -221,6 +226,11 @@ def test_project_role_issue_advisory_key_contract_is_frozen_and_separated() -> N
     assert project_role_issue_lock_key(actor, project, "submitter") != project_role_issue_lock_key(
         project, actor, "submitter"
     )
+    original = SimpleNamespace(
+        constraint_name="uq_project_role_grants_active_exact_role"
+    )
+    error = IntegrityError("insert", {}, original)
+    assert _constraint_name(error) == "uq_project_role_grants_active_exact_role"
 
 
 def test_project_role_public_reason_and_qualification_contract_is_strict() -> None:
@@ -1692,18 +1702,23 @@ async def test_authorization_route_database_failures_rollback_and_map_to_retryab
     async def failed_operation() -> None:
         raise SQLAlchemyError("query failed")
 
+    async def cancelled_operation() -> None:
+        raise asyncio.CancelledError
+
     session = Session()
     with pytest.raises(StructuredHTTPException) as commit_failure:
         await authorization_router._commit_or_unavailable(session)
     with pytest.raises(StructuredHTTPException) as query_failure:
         await authorization_router._database_call(session, failed_operation())
+    with pytest.raises(asyncio.CancelledError):
+        await authorization_router._database_call(session, cancelled_operation())
 
     for failure in (commit_failure.value, query_failure.value):
         assert failure.status_code == 503
         assert failure.error_code == "service_unavailable"
         assert failure.retryable is True
     assert session.commits == 1
-    assert session.rollbacks == 2
+    assert session.rollbacks == 3
 
 
 @pytest.mark.parametrize(
@@ -8358,3 +8373,40 @@ async def test_same_key_is_isolated_independently_by_actor_and_reference_kind(
         await first.rollback()
         await second.rollback()
         await third.rollback()
+
+
+@pytest.mark.asyncio
+async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
+    authorization_factory,
+) -> None:
+    caller_id, caller_link_id, target_id, target_link_id, project_id = (
+        uuid4(), uuid4(), uuid4(), uuid4(), uuid4()
+    )
+    manager_grant_id = uuid4()
+    now = datetime.now(UTC)
+    async with authorization_factory() as session:
+        session.add_all(
+            [
+                ActorProfile(id=str(caller_id), actor_kind="human", status="active", provisioning_method="automatic_first_access", created_by=str(caller_id)),
+                ActorIdentityLink(id=str(caller_link_id), actor_profile_id=str(caller_id), issuer="https://identity.flowresearch.tech", subject=f"auth10c-caller-{caller_id}", subject_kind="human", status="active", linked_by=str(caller_id), last_verified_at=now),
+                ActorProfile(id=str(target_id), actor_kind="human", status="active", provisioning_method="automatic_first_access", created_by=str(target_id)),
+                ActorIdentityLink(id=str(target_link_id), actor_profile_id=str(target_id), issuer="https://identity.flowresearch.tech", subject=f"auth10c-target-{target_id}", subject_kind="human", status="active", linked_by=str(target_id), last_verified_at=now),
+                Project(id=str(project_id), name="AUTH-10C PREP proof", slug=f"auth-10c-prep-{project_id}", status="draft"),
+                AdminRoleGrant(id=manager_grant_id, target_actor_profile_id=str(caller_id), role="project_manager", scope_type="project", scope_project_id=str(project_id), status="active", version=1, granted_by_actor_profile_id=str(caller_id), granted_by_system_principal=None, granted_by_admin_role_grant_id=None, grant_reason="AUTH-10C PostgreSQL proof"),
+            ]
+        )
+        await session.commit()
+        context = HumanAuthorizationContext(actor_profile_id=caller_id, actor_kind=ActorKind.HUMAN, actor_status=ActorStatus.ACTIVE, identity_link_id=caller_link_id, identity_link_status=IdentityLinkStatus.ACTIVE, request_id=uuid4(), correlation_id=uuid4())
+        repository = AdminAuthorizationRepository(session)
+        authorization = AuthorizationService(session, context, admin_repository=repository)
+        prepared = PreparedAuthorizationService(session, context, authorization, repository)
+        await session.begin()
+        caller_input = PreparedAuthorizationInput(idempotency_key=uuid4(), request_value={"target": str(target_id), "role": "submitter"})
+        handle = await prepared.prepare(ActionId.PROJECT_ROLE_GRANT_ISSUE, caller_input, PreparedAuthorityScope(kind=PreparedAuthorityScopeKind.PROJECT, project_id=project_id, target_actor_profile_id=target_id, role=ProjectRole.SUBMITTER))
+        assert await repository.lock_project(project_id) is not None
+        await repository.take_project_role_issue_lock(project_role_issue_lock_key(target_id, project_id, "submitter"))
+        assert await repository.lock_eligible_human(target_id) is not None
+        decision = await prepared.consume(handle, ActionId.PROJECT_ROLE_GRANT_ISSUE, caller_input, ProjectRoleGrantIssueResourceContext(resource_type="project_role_grant_issue", resource_id=project_id, scope_project_id=project_id, target_actor_profile_id=target_id, role=ProjectRole.SUBMITTER, project_status="draft", target_eligible=True, active_exact_role_exists=False))
+        assert decision.allowed is True
+        assert decision.matched_grant_id == manager_grant_id
+        await session.rollback()

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -71,7 +71,11 @@ from app.modules.authorization.lifecycle_service import (
     IdentityLinkLifecycleConflict,
     IdentityLinkLifecycleService,
 )
-from app.modules.authorization.models import AdminRoleGrant
+from app.modules.authorization.models import (
+    AdminRoleGrant,
+    ProjectRoleGrant,
+    ProjectRoleQualificationSnapshot,
+)
 from app.modules.projects.models import Project
 from app.modules.authorization.pagination import (
     AuthorizationReadCursorCodec,
@@ -233,6 +237,53 @@ def test_project_role_issue_advisory_key_contract_is_frozen_and_separated() -> N
     )
     error = IntegrityError("insert", {}, original)
     assert _constraint_name(error) == "uq_project_role_grants_active_exact_role"
+
+
+@pytest.mark.asyncio
+async def test_project_role_issue_crossed_principals_use_one_lexical_lock_order() -> None:
+    low = UUID("00000000-0000-0000-0000-000000000001")
+    high = UUID("ffffffff-ffff-ffff-ffff-ffffffffffff")
+    low_link, high_link = uuid4(), uuid4()
+
+    class RecordingSession:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, UUID]] = []
+
+        async def scalar(self, statement):
+            entity = statement.column_descriptions[0]["entity"]
+            values = set(statement.compile().params.values())
+            actor = low if str(low) in values else high
+            if entity is ActorProfile:
+                self.calls.append(("profile", actor))
+                return SimpleNamespace(
+                    id=str(actor), actor_kind="human", status="active"
+                )
+            self.calls.append(("link", actor))
+            link_id = low_link if actor == low else high_link
+            return SimpleNamespace(id=str(link_id), actor_profile_id=str(actor))
+
+    expected = [
+        ("profile", low),
+        ("link", low),
+        ("profile", high),
+        ("link", high),
+    ]
+    for caller, caller_link, target in (
+        (low, low_link, high),
+        (high, high_link, low),
+    ):
+        session = RecordingSession()
+        repository = AdminAuthorizationRepository(session)  # type: ignore[arg-type]
+        locked_caller, target_eligible = (
+            await repository.lock_project_role_issue_principals(
+                caller_actor_profile_id=caller,
+                caller_identity_link_id=caller_link,
+                target_actor_profile_id=target,
+            )
+        )
+        assert locked_caller is not None
+        assert target_eligible is True
+        assert session.calls == expected
 
 
 def test_project_role_public_reason_and_qualification_contract_is_strict() -> None:
@@ -8379,7 +8430,9 @@ async def test_same_key_is_isolated_independently_by_actor_and_reference_kind(
 
 @pytest.mark.asyncio
 async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
+    authorization_database_env: str,
     authorization_factory,
+    monkeypatch,
 ) -> None:
     caller_id, caller_link_id, target_id, target_link_id, project_id = (
         uuid4(), uuid4(), uuid4(), uuid4(), uuid4()
@@ -8437,12 +8490,18 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
         assert issued.status == "active"
         await session.commit()
         await session.execute(
-            text("update actor_profiles set status='suspended' where id=:id"),
-            {"id": str(target_id)},
+            text(
+                "update actor_profiles set status='suspended', suspended_by=:by, "
+                "suspended_at=clock_timestamp(), suspension_reason=:reason where id=:id"
+            ),
+            {"id": str(target_id), "by": str(caller_id), "reason": "AUTH-10C proof"},
         )
         await session.execute(
-            text("update actor_identity_links set status='revoked' where id=:id"),
-            {"id": str(target_link_id)},
+            text(
+                "update actor_identity_links set status='revoked', revoked_by=:by, "
+                "revoked_at=clock_timestamp(), revoked_reason=:reason where id=:id"
+            ),
+            {"id": str(target_link_id), "by": str(caller_id), "reason": "AUTH-10C proof"},
         )
         await session.commit()
         revoke_reason = "AUTH-10C lifecycle-independent revoke proof"
@@ -8515,8 +8574,182 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
             )
             == 4
         )
-        await session.rollback()
+
+        await session.execute(
+            text(
+                "update actor_profiles set status='active', suspended_by=null, "
+                "suspended_at=null, suspension_reason=null, reactivated_by=:by, "
+                "reactivated_at=clock_timestamp(), reactivation_reason=:reason where id=:id"
+            ),
+            {
+                "id": str(target_id),
+                "by": str(caller_id),
+                "reason": "AUTH-10C continuation proof",
+            },
+        )
+        await session.execute(
+            text(
+                "update actor_identity_links set status='active', revoked_by=null, "
+                "revoked_at=null, revoked_reason=null, reactivated_by=:by, "
+                "reactivated_at=clock_timestamp(), reactivation_reason=:reason where id=:id"
+            ),
+            {
+                "id": str(target_link_id),
+                "by": str(caller_id),
+                "reason": "AUTH-10C continuation proof",
+            },
+        )
+        qualification = _project_role_qualification()
+        existing_snapshot = ProjectRoleQualificationSnapshot(
+            id=uuid4(),
+            project_id=str(project_id),
+            actor_profile_id=str(target_id),
+            requested_role="reviewer",
+            skills_snapshot=qualification["skills_snapshot"],
+            reputation_snapshot=qualification["reputation_snapshot"],
+            prior_project_work_refs=[],
+            external_expertise_refs=[],
+            captured_by_actor_profile_id=str(caller_id),
+            captured_by_admin_role_grant_id=manager_grant_id,
+        )
+        session.add(existing_snapshot)
+        session.add(
+            ProjectRoleGrant(
+                id=uuid4(),
+                project_id=str(project_id),
+                actor_profile_id=str(target_id),
+                role="reviewer",
+                status="active",
+                version=1,
+                grant_method="manual",
+                qualification_snapshot_id=existing_snapshot.id,
+                granted_by_actor_profile_id=str(caller_id),
+                granted_by_admin_role_grant_id=manager_grant_id,
+                grant_reason="AUTH-10C unique-index winner",
+            )
+        )
+        await session.commit()
+
+        race_reason = "AUTH-10C real unique-index loser"
+        race_payload = ProjectRoleGrantIssueBody(
+            target_actor_profile_id=target_id,
+            role=ProjectRole.REVIEWER,
+            qualification=_project_role_qualification(),
+            reason=race_reason,
+        )
+        race_key = uuid4()
+        original_find = AdminAuthorizationRepository.find_active_project_role
+        original_reserve = ProjectRoleGrantMutationService.reserve
+        find_calls = 0
+        race_claim_ids: list[UUID] = []
+
+        async def race_find(repository, **kwargs):
+            nonlocal find_calls
+            find_calls += 1
+            if find_calls <= 2:
+                return None
+            return await original_find(repository, **kwargs)
+
+        async def capture_race_claim(service, **kwargs):
+            reservation = await original_reserve(service, **kwargs)
+            assert isinstance(reservation, ClaimedReservation)
+            race_claim_ids.append(reservation.claim.record_id)
+            return reservation
+
+        monkeypatch.setattr(
+            AdminAuthorizationRepository, "find_active_project_role", race_find
+        )
+        monkeypatch.setattr(
+            ProjectRoleGrantMutationService, "reserve", capture_race_claim
+        )
+        caller_profile = await session.get(ActorProfile, str(caller_id))
+        caller_link = await session.get(ActorIdentityLink, str(caller_link_id))
+        assert caller_profile is not None and caller_link is not None
+        with pytest.raises(StructuredHTTPException) as conflict:
+            await authorization_router.issue_project_role_grant(
+                project_id=project_id,
+                payload=race_payload,
+                idempotency_key=race_key,
+                resolved=ResolvedActor(caller_profile, caller_link),
+                prepared=prepared,
+                session=session,
+            )
+        assert conflict.value.status_code == 409
+        assert conflict.value.error_code == "project_role_grant_exists"
+        assert find_calls == 3
+        assert len(race_claim_ids) == 1
+        monkeypatch.setattr(
+            AdminAuthorizationRepository,
+            "find_active_project_role",
+            original_find,
+        )
+        monkeypatch.setattr(
+            ProjectRoleGrantMutationService,
+            "reserve",
+            original_reserve,
+        )
         prepared.close()
+
+    async with authorization_factory() as clean:
+        assert (
+            await clean.scalar(
+                text(
+                    "select count(*) from project_role_grants where project_id=:project "
+                    "and actor_profile_id=:actor and role='reviewer' and status='active'"
+                ),
+                {"project": str(project_id), "actor": str(target_id)},
+            )
+            == 1
+        )
+        assert (
+            await clean.scalar(
+                text(
+                    "select count(*) from project_role_qualification_snapshots "
+                    "where project_id=:project and actor_profile_id=:actor "
+                    "and requested_role='reviewer'"
+                ),
+                {"project": str(project_id), "actor": str(target_id)},
+            )
+            == 1
+        )
+        assert (
+            await clean.scalar(
+                text(
+                    "select count(*) from authority_idempotency_records "
+                    "where idempotency_key=:key"
+                ),
+                {"key": str(race_key)},
+            )
+            == 0
+        )
+        denial_rows = (
+            await clean.execute(
+                text(
+                    "select event_type, denial_code, idempotency_reference from audit_events "
+                    "where request_id=:request and correlation_id=:correlation "
+                    "and action_id='project_role_grant.issue'"
+                ),
+                {
+                    "request": str(context.request_id),
+                    "correlation": str(context.correlation_id),
+                },
+            )
+        ).all()
+        assert denial_rows.count(
+            ("SensitiveAuthorizationDenied", "project_role_grant_exists", None)
+        ) == 1
+        assert all(row[0] != "AuthorityInvalidationRequested" for row in denial_rows)
+        assert (
+            await clean.scalar(
+                text(
+                    "select count(*) from audit_events "
+                    "where idempotency_reference=:claim"
+                ),
+                {"claim": str(race_claim_ids[0])},
+            )
+            == 0
+        )
+        await clean.rollback()
 
     canonical = ProjectRoleGrantIssueRequest(
         operation=AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE,
@@ -8562,23 +8795,100 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
             actor_profile_id=caller_id,
             request=canonical,
         )
+        waiter_pid = await waiter.scalar(text("select pg_backend_pid()"))
         wait_task = asyncio.create_task(
-            waiter_prepared.prepare(
-                ActionId.PROJECT_ROLE_GRANT_ISSUE,
-                PreparedAuthorizationInput(
-                    idempotency_key=waiting_key,
-                    request_value=canonical.model_dump(mode="json"),
+            authorization_router._database_call(
+                waiter,
+                waiter_prepared.prepare(
+                    ActionId.PROJECT_ROLE_GRANT_ISSUE,
+                    PreparedAuthorizationInput(
+                        idempotency_key=waiting_key,
+                        request_value=canonical.model_dump(mode="json"),
+                    ),
+                    scope,
                 ),
-                scope,
             )
         )
-        with pytest.raises(TimeoutError):
-            await asyncio.wait_for(asyncio.shield(wait_task), timeout=0.2)
+        observer = create_async_engine(authorization_database_env)
+        try:
+            async with observer.connect() as connection:
+                for _ in range(5000):
+                    waiting = await connection.scalar(
+                        text(
+                            "select exists(select 1 from pg_stat_activity where "
+                            "pid=:pid and wait_event_type='Lock')"
+                        ),
+                        {"pid": waiter_pid},
+                    )
+                    if waiting:
+                        break
+                    await asyncio.sleep(0)
+                else:
+                    raise AssertionError("PREP contender never waited on its database lock")
+        finally:
+            await observer.dispose()
         wait_task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await wait_task
-        await waiter.rollback()
         await locker.rollback()
+
+        retry_reservation = await ProjectRoleGrantMutationService(waiter).reserve(
+            key=waiting_key,
+            actor_profile_id=caller_id,
+            request=canonical,
+        )
+        assert isinstance(retry_reservation, ClaimedReservation)
+        retry_input = PreparedAuthorizationInput(
+            idempotency_key=waiting_key,
+            request_value=canonical.model_dump(mode="json"),
+        )
+        retry_handle = await authorization_router._database_call(
+            waiter,
+            waiter_prepared.prepare(
+                ActionId.PROJECT_ROLE_GRANT_ISSUE,
+                retry_input,
+                scope,
+            ),
+        )
+        waiter_repository = AdminAuthorizationRepository(waiter)
+        project = await waiter_repository.lock_project(project_id)
+        assert project is not None
+        await waiter_repository.take_project_role_issue_lock(
+            project_role_issue_lock_key(target_id, project_id, "submitter")
+        )
+        assert await waiter_repository.lock_eligible_human(target_id) is not None
+        assert (
+            await waiter_repository.find_active_project_role(
+                project_id=project_id,
+                actor_profile_id=target_id,
+                role="submitter",
+            )
+            is None
+        )
+        retry_decision = await waiter_prepared.consume(
+            retry_handle,
+            ActionId.PROJECT_ROLE_GRANT_ISSUE,
+            retry_input,
+            ProjectRoleGrantIssueResourceContext(
+                resource_type="project_role_grant_issue",
+                resource_id=project_id,
+                scope_project_id=project_id,
+                target_actor_profile_id=target_id,
+                role=ProjectRole.SUBMITTER,
+                project_status=project.status,
+                target_eligible=True,
+                active_exact_role_exists=False,
+            ),
+        )
+        retried = await ProjectRoleGrantMutationService(waiter).complete_issue(
+            claim=retry_reservation.claim,
+            request=canonical,
+            decision=retry_decision,
+            actor_profile_id=caller_id,
+            reason="AUTH-10C concurrency proof",
+        )
+        await waiter.commit()
+        assert retried.status == "active"
         waiter_prepared.close()
         locker_prepared.close()
     async with authorization_factory() as clean:
@@ -8590,6 +8900,17 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
                 ),
                 {"key": str(waiting_key)},
             )
-            == 0
+            == 1
+        )
+        assert (
+            await clean.scalar(
+                text(
+                    "select count(*) from audit_events where "
+                    "idempotency_reference=(select id from authority_idempotency_records "
+                    "where idempotency_key=:key)"
+                ),
+                {"key": str(waiting_key)},
+            )
+            == 2
         )
         await clean.rollback()

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -37,7 +37,10 @@ from app.api.deps.authorization import (
     get_authorization_service,
     get_prepared_authorization_service,
 )
-from app.api.deps.api_controls import enforce_authorization_read_rate_limit
+from app.api.deps.api_controls import (
+    enforce_admin_mutation_rate_limit,
+    enforce_authorization_read_rate_limit,
+)
 from app.api.deps.auth import get_auth_verification_result
 from app.core.api_controls import StructuredHTTPException
 from app.core.config import Settings, get_settings
@@ -234,6 +237,64 @@ def test_project_role_public_reason_and_qualification_contract_is_strict() -> No
     for reason in (" padded", "padded ", "control\x00", "é" * 251):
         with pytest.raises(ValidationError):
             ProjectRoleGrantIssueBody.model_validate(payload | {"reason": reason})
+
+
+def test_project_role_invalidation_projection_is_closed_per_role() -> None:
+    project_id = uuid4()
+    mappings = {
+        ProjectRole.SUBMITTER: "auth13_assignment",
+        ProjectRole.REVIEWER: "rev_reviewer_obligation",
+        ProjectRole.ADJUDICATOR: "none",
+    }
+    for role, obligation in mappings.items():
+        context = AuthorityInvalidationContext(
+            event_id=uuid4(),
+            request_id=uuid4(),
+            correlation_id=uuid4(),
+            target_ref_kind=AuthorityResourceType.PROJECT_ROLE_GRANT,
+            target_ref_id=uuid4(),
+            project_role=role,
+            future_obligation=obligation,
+        )
+        projection = {
+            "role": role.value,
+            "scope_type": "project",
+            "scope_id": str(project_id),
+            "future_obligation": obligation,
+        }
+        event_id = uuid4()
+        event = AuthorityAuditEventInput(
+            event_id=event_id,
+            event_type=AuthorityEventType.AUTHORITY_INVALIDATION_REQUESTED,
+            entity_type="authority_invalidation",
+            entity_id=str(event_id),
+            actor_ref_kind=ActorReferenceKind.ACTOR_PROFILE,
+            actor_ref=str(uuid4()),
+            request_id=context.request_id,
+            correlation_id=context.correlation_id,
+            permission_id=PermissionId.PROJECT_ROLE_GRANT_MANAGE,
+            project_id=str(project_id),
+            resource_type="actor_profile",
+            resource_id=str(uuid4()),
+            target_ref_kind="project_role_grant",
+            target_ref_id=str(context.target_ref_id),
+            reason="authority_state_changed",
+            idempotency_reference=uuid4(),
+            invalidation_cause_event_id=uuid4(),
+            invalidation_target_kind="actor_profile",
+            invalidation_target_ref=str(uuid4()),
+            before_facts={"effective": True, **projection},
+            after_facts={"effective": False, **projection},
+        )
+        assert event.after_facts["future_obligation"] == obligation
+    with pytest.raises(ValidationError):
+        AuthorityInvalidationContext(
+            event_id=uuid4(),
+            request_id=uuid4(),
+            correlation_id=uuid4(),
+            project_role=ProjectRole.SUBMITTER,
+            future_obligation="none",
+        )
 
 
 def test_authorization_read_cursor_round_trip_and_query_binding() -> None:
@@ -638,6 +699,60 @@ async def test_human_read_admission_conceals_every_nonhuman_kind(
         assert response.json()["error"]["code"] == ("project_authorization_resource_not_found")
         assert consumptions == 1
         assert lookups == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            lambda project, _grant: f"/api/v1/projects/{project}/role-grants",
+            lambda: {
+                "target_actor_profile_id": str(uuid4()),
+                "role": "submitter",
+                "qualification": _project_role_qualification(),
+                "reason": "Bounded assignment",
+            },
+        ),
+        (
+            lambda project, grant: f"/api/v1/projects/{project}/role-grants/{grant}/revoke",
+            lambda: {"reason": "Bounded removal"},
+        ),
+    ],
+)
+async def test_project_role_mutation_rate_failure_precedes_private_work(
+    monkeypatch: pytest.MonkeyPatch,
+    path,
+    payload,
+) -> None:
+    app = create_app(Settings(environment="test"))
+    calls = 0
+
+    async def fail_rate_first() -> None:
+        nonlocal calls
+        calls += 1
+        raise StructuredHTTPException(
+            status_code=503,
+            detail="rate persistence unavailable",
+            error_code="service_unavailable",
+            error_message="rate persistence unavailable",
+            retryable=True,
+        )
+
+    async def forbidden_project_lookup(*_args, **_kwargs):
+        raise AssertionError("private mutation work must not run")
+
+    app.dependency_overrides[enforce_admin_mutation_rate_limit] = fail_rate_first
+    monkeypatch.setattr(ProjectRepository, "get_project", forbidden_project_lookup)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client:
+        response = await client.post(
+            path(uuid4(), uuid4()),
+            headers={"Idempotency-Key": str(uuid4())},
+            json=payload(),
+        )
+    assert response.status_code == 503
+    assert response.json()["error"]["retryable"] is True
+    assert calls == 1
 
 
 ART_CUSTODY_EXPECTATIONS = {
@@ -7925,6 +8040,26 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
                 event_id=uuid4(),
                 request_id=success.request_id,
                 correlation_id=success.correlation_id,
+                target_ref_kind=(
+                    AuthorityResourceType.PROJECT_ROLE_GRANT
+                    if request.operation is AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE
+                    else None
+                ),
+                target_ref_id=(
+                    response.resource_id
+                    if request.operation is AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE
+                    else None
+                ),
+                project_role=(
+                    ProjectRole.SUBMITTER
+                    if request.operation is AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE
+                    else None
+                ),
+                future_obligation=(
+                    "auth13_assignment"
+                    if request.operation is AuthorityOperation.PROJECT_ROLE_GRANT_REVOKE
+                    else None
+                ),
             )
             if request.operation is AuthorityOperation.PROJECT_ROLE_GRANT_ISSUE:
                 qualification_id = uuid4()
@@ -8011,7 +8146,17 @@ async def test_project_role_and_all_operation_mappings_commit_one_linked_pair(
             }
             else {"effective": True}
         )
+        if success.event_type is AuthorityEventType.PROJECT_ROLE_GRANT_REVOKED:
+            expected_before = {
+                "effective": True,
+                "role": "submitter",
+                "scope_type": "project",
+                "scope_id": success.project_id,
+                "future_obligation": "auth13_assignment",
+            }
         expected_after = {"effective": not expected_before["effective"]}
+        if success.event_type is AuthorityEventType.PROJECT_ROLE_GRANT_REVOKED:
+            expected_after = expected_before | {"effective": False}
         assert invalidation_row.before_facts == expected_before
         assert invalidation_row.after_facts == expected_after
 

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -17,6 +17,7 @@ import hmac
 import json
 import pickle
 from pathlib import Path
+from time import monotonic
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
@@ -7825,23 +7826,34 @@ async def test_completion_rejects_resource_and_project_not_bound_to_request(
             resource_id=uuid4(),
             http_status=201,
         )
-        success = _operation_success(
+        issued = _operation_success(
             claim,
             wrong_project,
             response,
             admin_authorizer_grant_id=uuid4(),
+        )
+        qualification_snapshot_id = uuid4()
+        qualification = issued.model_copy(
+            update={
+                "event_id": uuid4(),
+                "event_type": AuthorityEventType.PROJECT_ROLE_QUALIFICATION_CAPTURED,
+                "entity_type": "qualification_snapshot",
+                "entity_id": str(qualification_snapshot_id),
+                "resource_type": "qualification_snapshot",
+                "resource_id": str(qualification_snapshot_id),
+                "target_ref_kind": "qualification_snapshot",
+                "target_ref_id": str(qualification_snapshot_id),
+                "reason": "qualification_evidence_captured",
+                "after_facts": {"status": "captured"},
+            }
         )
         with pytest.raises(TypeError, match="invalid authority completion input"):
             await service.complete(
                 claim=claim,
                 request=project_request.model_dump(),
                 response=response,
-                success=success,
-                invalidation=AuthorityInvalidationContext(
-                    event_id=uuid4(),
-                    request_id=success.request_id,
-                    correlation_id=success.correlation_id,
-                ),
+                success=(qualification, issued),
+                invalidation=None,
             )
         await session.rollback()
 
@@ -8855,7 +8867,8 @@ async def test_project_role_issue_shared_completion_writes_ordered_zero_invalida
     )
 
     class Audit:
-        events = []
+        def __init__(self) -> None:
+            self.events = []
 
         async def add_authority_event(self, event):
             self.events.append(event)
@@ -8978,7 +8991,8 @@ async def _wait_for_database_lock(database_url: str, application_name: str) -> N
     engine = create_async_engine(database_url)
     try:
         async with engine.connect() as connection:
-            for _ in range(5000):
+            deadline = monotonic() + 5.0
+            while monotonic() < deadline:
                 waiting = await connection.scalar(
                     text(
                         "select exists(select 1 from pg_stat_activity where "
@@ -8988,7 +9002,7 @@ async def _wait_for_database_lock(database_url: str, application_name: str) -> N
                 )
                 if waiting:
                     return
-                await asyncio.sleep(0)
+                await asyncio.sleep(0.01)
     finally:
         await engine.dispose()
     raise AssertionError("concurrent reservation never reached the database lock")
@@ -9590,7 +9604,8 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
         observer = create_async_engine(authorization_database_env)
         try:
             async with observer.connect() as connection:
-                for _ in range(5000):
+                deadline = monotonic() + 5.0
+                while monotonic() < deadline:
                     waiting = await connection.scalar(
                         text(
                             "select exists(select 1 from pg_stat_activity where "
@@ -9600,7 +9615,7 @@ async def test_project_role_issue_postgresql_prep_binds_target_role_and_scope(
                     )
                     if waiting:
                         break
-                    await asyncio.sleep(0)
+                    await asyncio.sleep(0.01)
                 else:
                     raise AssertionError("PREP contender never waited on its database lock")
         finally:

--- a/docs/operations_authorization_service.md
+++ b/docs/operations_authorization_service.md
@@ -1129,8 +1129,14 @@ log the key, a cursor, or distinctions hidden by the shared 404. Authorization
 read exhaustion returns 429 with `Retry-After`, and unavailable rate/evidence
 persistence returns retryable 503 before private row lookup.
 
-This read activation adds no migration and changes no PREP, project-role grant
-issue/revoke, or other mutation behavior.
+AUTH-10C adds no migration. Its project-role mutations use the admin-mutation
+rate control, exact-project PREP, UUID idempotency keys, stable replay/conflict
+responses, and fail-closed retryable 503 handling for persistence failures.
+Operators may retry the same key and body after a 503; they must not invent a
+new key until the committed state is known. A revoked or suspended target may
+still have an active grant revoked. Issue writes snapshot-captured then
+grant-issued evidence without invalidation; revoke writes grant-revoked then a
+linked authority invalidation targeting the affected actor and exact grant.
 
 ## Authority Audit Custody
 

--- a/docs/operations_authorization_service.md
+++ b/docs/operations_authorization_service.md
@@ -1129,14 +1129,19 @@ log the key, a cursor, or distinctions hidden by the shared 404. Authorization
 read exhaustion returns 429 with `Retry-After`, and unavailable rate/evidence
 persistence returns retryable 503 before private row lookup.
 
-AUTH-10C adds no migration. Its project-role mutations use the admin-mutation
-rate control, exact-project PREP, UUID idempotency keys, stable replay/conflict
-responses, and fail-closed retryable 503 handling for persistence failures.
+AUTH-10C adds migration `0034_project_role_issue_evidence`. It performs no
+product-row rewrite: it replaces only the three frozen authority evidence
+function bodies, adds `qualification_snapshot` to the existing privacy resource
+registry, and leaves the existing fact constraint and trigger identities in
+place. Its project-role mutations use the admin-mutation rate control,
+exact-project PREP, UUID idempotency keys, stable replay/conflict responses, and
+fail-closed retryable 503 handling for persistence failures.
 Operators may retry the same key and body after a 503; they must not invent a
 new key until the committed state is known. A revoked or suspended target may
 still have an active grant revoked. Issue writes snapshot-captured then
 grant-issued evidence without invalidation; revoke writes grant-revoked then a
-linked authority invalidation targeting the affected actor and exact grant.
+linked authority invalidation bound to the affected actor, exact grant, role,
+project, and closed future-obligation token.
 
 ## Authority Audit Custody
 

--- a/docs/operations_authorization_service.md
+++ b/docs/operations_authorization_service.md
@@ -703,8 +703,8 @@ complete. Counts and mappings remain unchanged. The ART transfer adds no migrati
 The REV transfer adds no migration. The ART transfer does not grant Operator
 authority; its `OPERATOR` suffix denotes only future activation custody, and
 verification retry remains independently gated from read/status actions.
-Catalogue totals are 74 PermissionIds, 70 ActionIds, 20 active actions, and
-50 planned actions after AUTH-10B2 activates the three project-role read rows.
+Catalogue totals are 74 PermissionIds, 70 ActionIds, 22 active actions, and
+48 planned actions after AUTH-10C activates the two project-role mutation rows.
 Four later
 REV registrations add exactly four planned and zero active actions, while the
 review-evidence binding registration adds exactly one planned and zero active

--- a/docs/spec_authorization_service.md
+++ b/docs/spec_authorization_service.md
@@ -809,9 +809,15 @@ issue/revoke APIs, and local bootstrap command. AUTH-09C activates exact actor
 and identity-link reads for effective system Access Administrator or Audit
 Authority grants. AUTH-09D-A activates the three profile lifecycle routes for
 effective system Access Administrators only. AUTH-09D-B activates exact
-identity-link revoke and reactivate for the same authority; the project-role
-route family remains planned. Project-scoped
-`GET /api/v1/actors/me/authorization-context` begins in AUTH-10 after
+identity-link revoke and reactivate for the same authority. AUTH-10B activates
+the concealed project-role reads, and AUTH-10C activates exact-role issue and
+revoke mutations for covered Project Managers. Those mutations use
+`Idempotency-Key`, transaction-bound PREP, immutable qualification snapshots,
+canonical replay validation, and one route-owned commit. Issue requires a
+different active human with an active identity link; revoke remains available
+after target suspension or identity-link revocation so authority cannot become
+irremovable. Project-scoped
+`GET /api/v1/actors/me/authorization-context` begins in AUTH-11 after
 exact-project grant and canonical project capability composition exists.
 
 `WS-AUTH-001-CONTRIBUTOR-FOUNDATION` adds no permission or authorization path.

--- a/docs/spec_authorization_service.md
+++ b/docs/spec_authorization_service.md
@@ -238,9 +238,10 @@ approved Operator recovery identifiers, 21 artifact identifiers, and
 `review.queue.override` are the exact 25 post-`0020` permissions. AUTH-07A adds
 their matching typed/SQL audit parity without making them executable.
 
-The closed action registry contains 70 rows after AUTH-10B2: 20 active actions
-and 50 planned rows. AUTH-10A added five project-role read/manage rows,
-owned by AUTH-10B and AUTH-10C. AUTH-08 adds seven active administrative definition,
+The closed action registry contains 70 rows after AUTH-10C: 22 active actions
+and 48 planned rows. AUTH-10A added five project-role read/manage rows;
+AUTH-10B owns and activates the three reads, while AUTH-10C owns and activates
+the two reason-bound, idempotent project-role mutations. AUTH-08 adds seven active administrative definition,
 grant-history, issue, revoke, and local-bootstrap actions without adding a
 permission. AUTH-09A adds eight planned actor, identity-link, and service
 provisioning actions without activating a route; AUTH-09B activates only

--- a/docs/spec_authorization_service.md
+++ b/docs/spec_authorization_service.md
@@ -744,11 +744,13 @@ chunk. A `needs_revision` task retains a durable revision obligation and cannot
 be returned as ordinary ready work.
 
 Project-role invalidation is exact-role-specific. Submitter revocation alone can
-enter task-assignment reconciliation. Reviewer revocation creates only the
-REV-owned review obligation; adjudicator invalidation remains dormant until its
-lifecycle is enabled. Revoking any one project role leaves the other roles and
-all AdminRoleGrants unchanged. Consumers verify the cause event, grant ID,
-actor, project, and role before changing product state.
+enter task-assignment reconciliation and persists `auth13_assignment`. Reviewer
+revocation creates only the REV-owned review obligation and persists
+`rev_reviewer_obligation`; adjudicator invalidation persists `none` and remains
+dormant until its lifecycle is enabled. Revoking any one project role leaves the
+other roles and all AdminRoleGrants unchanged. Consumers verify the cause event,
+grant ID, actor, project, role, and closed future-obligation token before
+changing product state.
 
 ## Idempotency And Authority Evidence
 


### PR DESCRIPTION
# PR Trust Bundle: WS-AUTH-001-10C

## Chunk And Goal

`WS-AUTH-001-10C` adds PREP-bound, idempotent, auditable issue and revoke
mutations for independent exact-project contributor roles. Risk is L1
authorization, concurrency, migration, and audit integrity.

Reviewed code SHA: `3323184ef4010bba590908bbb6da9cd8e82bc407`

## Change, Design, And Scope

- A covered Project Manager can issue submitter, reviewer, or adjudicator for
  one exact project and revoke one exact stored grant.
- Issue captures an immutable qualification snapshot before the issued event.
  Revoke derives target and role only from the locked grant and emits the closed
  future-obligation invalidation projection.
- Replay reauthorizes and reloads canonical ownership and state. Exact action,
  permission, authority kind, project scope, grant, resource, digest, target,
  role, status, and version facts are bound before completion.
- Concealment paths expose one stable `404 resource_not_found`; explicit
  self-grant and self-revoke guards retain their contract errors.
- Migration 0034 freezes every inherited function, trigger, fact constraint,
  and privacy definition it rewrites. It admits only the exact issue pair and
  binds revoke invalidation to the same actor, grant, role, project, cause,
  target reference, and future obligation.
- Issue is available for draft, active, and paused projects; revoke remains
  available for every existing project state, including archived.

AUTH-11, frontend work, task assignment, review reconciliation, automated role
conversion, and unrelated migrations remain out of scope.

## Proof And Review

Focused lint, route, lifecycle, decision-binding, audit, PostgreSQL linkage,
migration drift/refusal, downgrade, stale-wording, markdown-link, and diff
checks pass. The isolated database proof includes exact schema teardown and
no-mutation assertions for rejected evidence. The exact migration refusal
aggregate passes all 11 variants: 2 incompatible pending states, 5 frozen
definition drifts, and 4 fact-constraint drifts. Focused SQL-NULL facts and
bounded lock-wait regressions also pass. The hosted API E2E identity-link
lifecycle path uses the canonical `identity_link_id` response field; its 15
helper tests pass. Replay concealment compares the complete stable error body
while excluding only per-request `correlation_id`.
The linked authority-event audit matrix and sequential upgrade/downgrade
refusal matrices pass after exact trigger/privacy cleanup repair.

All nine internal tracks pass the reviewed implementation SHA with no blocking
finding and no open sub-agent session. No test or CI gate was weakened. Ruff is
bounded below 0.16 after GitHub resolved the open range to incompatible 0.16.0;
the existing full-repository lint command passes on the retained 0.15 line.

GitHub Backend must run the full shards, hosted API E2E, repository-wide
78 percent coverage floor, and authorization-subsystem 90 percent floor.

## External Review, Risk, And Human Focus

GitHub CI, Agent Gates, CodeRabbit, and human review remain required after
publication. Human review should focus on transaction and lock order, PREP
decision binding, target concealment, project lifecycle rules, replay
reauthorization, exact migration hashes, issue evidence ordering, and revoke
invalidation linkage/atomicity.

The user retains merge ownership; do not merge without explicit approval of
the specific PR. The declared same-initiative successor `WS-AUTH-001-11`
requires a separate trusted-main explicit start and must not begin
automatically.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-role grant and revoke API operations with idempotent processing.
  * Added strict qualification evidence capture for role grants.
  * Added lifecycle-independent revocation, replay validation, and stable authorization responses.
  * Added audit records and invalidation tracking for role changes.

* **Bug Fixes**
  * Improved concealment of unauthorized or unavailable resources.
  * Strengthened validation against malformed qualification data and inconsistent replay requests.

* **Documentation**
  * Updated authorization rollout, API behavior, migration, and verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->