### PR TITLE
Plan ART-AUTH end-to-end authorization contract

### DIFF
--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/AUTH_HANDOFF.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/AUTH_HANDOFF.md
@@ -98,3 +98,6 @@ action string, or hidden feature code is never executable authority.
 Any dependency not enumerated by WS-XINT-002 is contract drift. Stop and amend
 the cross-initiative plan; do not add a local action string, permission alias,
 service identity, matrix row, or alternate prepared-capability path.
+`WS-XINT-002-01` must delete all six obsolete upload-session ActionIds and
+PermissionIds, plus scheduler expiry membership, with no unavailable retained
+row or compatibility alias; its enumerated deletion list is authoritative.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/AUTH_HANDOFF.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/AUTH_HANDOFF.md
@@ -1,5 +1,10 @@
 # WS-ART-001 Authorization Handoff
 
+> The complete v0.1 dependency inventory and replacement sequencing are owned
+> by `../WS-XINT-002-art-auth-end-to-end/`. This handoff remains the historical
+> ART-03 through ART-06 baseline and must not be used to invent a missing AUTH
+> action or capability during implementation.
+
 ART owns hidden artifact behavior, canonical product resource facts, lifecycle
 guards, surface manifests, and feature tests. AUTH owns ActionId/PermissionId
 catalogues, service identities, fixed matrices, evaluator integration, grants,
@@ -89,3 +94,7 @@ An ART implementation contract stops if its required AUTH registration or
 activation contract is absent, unmerged, inactive, differently mapped, or
 targets a different resource fact shape. Planned catalogue presence, a local
 action string, or hidden feature code is never executable authority.
+
+Any dependency not enumerated by WS-XINT-002 is contract drift. Stop and amend
+the cross-initiative plan; do not add a local action string, permission alias,
+service identity, matrix row, or alternate prepared-capability path.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
@@ -5,6 +5,10 @@ waves are superseded prospectively by
 `../WS-XINT-002-art-auth-end-to-end/`. Existing rows below remain the trusted
 baseline until WS-XINT-002-01 merges; no prose in either plan changes runtime
 availability.
+The reconciliation baseline is trusted `main` commit
+`2fb322bd2249a5fe9d3fa706dc63f033074e38ce`: 76 PermissionIds, 81 ActionIds,
+22 active actions, and 59 planned actions. Older counts below are explicitly
+historical snapshots at their named commits, not the WS-XINT-002 entry state.
 
 ## Authority
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
@@ -1,5 +1,11 @@
 # Activation Custody: WS-AUTH-001
 
+The final v0.1 ART catalogue reconciliation, PREP extension, and activation
+waves are superseded prospectively by
+`../WS-XINT-002-art-auth-end-to-end/`. Existing rows below remain the trusted
+baseline until WS-XINT-002-01 merges; no prose in either plan changes runtime
+availability.
+
 ## Authority
 
 This plan applies the merged `WS-XINT-001` handoffs to AUTH. It distinguishes:
@@ -168,6 +174,11 @@ WS-AUTH-001-XINT planning reconciliation
 -> feature-gated registration and activation chunks as their manifests merge
 -> AUTH-16 aggregate conformance and live proof
 ```
+
+For ART dependencies, replace the generic final two steps with the exact
+WS-XINT-002 sequence: complete registration, prepared feature boundaries,
+fixed internal services, guide, submission, checker, review artifact access, and
+end-to-end conformance. AUTH-14 and AUTH-15 are not alternate activation paths.
 
 Only one WS-AUTH implementation chunk is active at a time. ART, REV, and CON
 may build hidden behavior in their own worktrees while real actions remain

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -1,5 +1,10 @@
 # Chunk Map: WS-AUTH-001 - Workstream Authorization Service
 
+The complete ART-facing catalogue and runtime dependency is now planned in
+`../WS-XINT-002-art-auth-end-to-end/CHUNK_MAP.md`. The historical ART custody
+entries in this file remain baseline identifiers only until that planning
+amendment is approved and its first reconciliation chunk merges.
+
 ## Rule
 
 Only one chunk may be active at a time. Do not start the next chunk until the

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/CHUNK_MAP.md
@@ -1,0 +1,19 @@
+# Chunk Map: WS-XINT-002 ART-AUTH End-to-End Contract
+
+| Chunk | Purpose | Risk | Dependency |
+|---|---|---|---|
+| `WS-XINT-002-01` | Reconcile the entire ART catalogue, permissions, owners, migration parity, and fixed-service matrix while every new action stays planned. | L1 | approved plan |
+| `WS-XINT-002-02` | Extend PREP with closed feature-owned typed composition contracts and ART lock plans; activate nothing. | L1 | 01 |
+| `WS-XINT-002-03` | Activate verifier, scheduler scan, and put resolver services from merged ART recovery evidence. | L1 | 02 plus ART 02C/02D evidence |
+| `WS-XINT-002-04` | Activate guide ingest, guide binding, and guide read in evidence-ordered substeps. | L1 | 02 plus ART 03A/03B evidence |
+| `WS-XINT-002-05A` | Activate initial contributor bundle preparation and durable ready admission. | L1 | 02 plus ART 04A-C evidence |
+| `WS-XINT-002-05B` | Activate fresh human Submission creation plus fixed artifact binding with exactly-once admission consumption. | L1 | 05A plus ART 05/TASK evidence |
+| `WS-XINT-002-05C` | Activate checker-remediation submission preparation/creation against one final CheckerRun. | L1 | 05B plus checker remediation evidence |
+| `WS-XINT-002-05D` | Activate human-review revision preparation/creation against exact revision obligations. | L1 | 05B plus REV revision-preparation evidence |
+| `WS-XINT-002-06` | Activate pre/post-submit materialization and checker output/binding. | L1 | 02 plus ART 04B/06A/06B evidence |
+| `WS-XINT-002-07` | Activate lease-scoped review packets and finding/response evidence binding. | L1 | 02 plus merged ART/REV manifests |
+| `WS-XINT-002-08` | Prove complete catalogue, least privilege, revocation, replay, concurrency, audit, and live lifecycle conformance. | L1 | 03-07 including 05A-D |
+
+Chunks 03-07 may be split only by the evidence boundaries named above. A split
+cannot add catalogue values, permissions, identities, matrix rows, or a second
+runtime protocol; such a discovery is contract drift and returns to planning.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/DECISIONS.md
@@ -1,0 +1,19 @@
+# Decisions: WS-XINT-002 ART-AUTH End-to-End Contract
+
+1. The dependency is owned end to end by a cross-initiative plan, not by ART-03A.
+2. One outer ZIP replaces the six upload-session actions with
+   `artifact.submission_bundle.prepare`; no compatibility aliases remain.
+3. Initial, checker-remediation, and human-review revision submissions share the
+   public preparation/create actions; each has an exact closed typed context.
+4. Reviewer packet materialization is a fixed-service action plus a separate
+   human lease decision. Neither substitutes for the other.
+5. Finding and response evidence require separate human operation authority and
+   fixed artifact binding authority.
+6. Existing artifact materializer and binding identities gain the two review
+   memberships; no new service identity is introduced.
+7. Operators request and inspect; fixed internal services execute recovery. Artifact
+   audit is not broadened implicitly to general Audit Authority.
+8. Catalogue and reusable PREP dependencies are front-loaded. Activation stays
+   evidence-gated and cannot be eliminated safely.
+9. The simple contribution loop applies: planning does not require a signed
+   start/cancel event or merge-intent file.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/DECISIONS.md
@@ -2,15 +2,20 @@
 
 1. The dependency is owned end to end by a cross-initiative plan, not by ART-03A.
 2. One outer ZIP replaces the six upload-session actions with
-   `artifact.submission_bundle.prepare`; no compatibility aliases remain.
+   `artifact.submission_bundle.prepare`; no compatibility aliases or retained
+   unavailable rows remain. The exact deleted ActionId and PermissionId values
+   are `artifact.upload_session.create`, `artifact.upload_session.read`,
+   `artifact.upload_item.write`, `artifact.upload_session.seal`,
+   `artifact.upload_session.cancel`, and `artifact.upload_session.expire`.
 3. Initial, checker-remediation, and human-review revision submissions share the
    public preparation/create actions; each has an exact closed typed context.
 4. Reviewer packet materialization is a fixed-service action plus a separate
    human lease decision. Neither substitutes for the other.
 5. Finding and response evidence require separate human operation authority and
    fixed artifact binding authority.
-6. Existing artifact materializer and binding identities gain the two review
-   memberships; no new service identity is introduced.
+6. Existing artifact materializer and binding identities gain review-packet and
+   review-evidence memberships; scheduler loses upload-session-expiry
+   membership. No new service identity is introduced.
 7. Operators request and inspect; fixed internal services execute recovery. Artifact
    audit is not broadened implicitly to general Audit Authority.
 8. Catalogue and reusable PREP dependencies are front-loaded. Activation stays

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/DISCOVERY.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/DISCOVERY.md
@@ -1,0 +1,71 @@
+# Discovery: WS-XINT-002 ART-AUTH End-to-End Contract
+
+## Observations on trusted main
+
+- `backend/app/modules/authorization/catalogue.py` contains 81 ActionIds and 76
+  PermissionIds. All current artifact actions are planned and unavailable.
+- The fixed service matrix has seven artifact identities and eleven memberships:
+  verifier, put resolver, scheduler, binding, guide reader, materializer, and
+  checker output.
+- Six planned upload-session actions still exist even though the approved ART
+  design uses one continuous outer-ZIP preparation surface.
+- `artifact.submission_bundle.prepare`,
+  `artifact.review_packet.materialize`, and
+  `artifact.review_evidence.binding.create` are absent from the catalogue.
+- Human review evidence actions already exist as planned:
+  `review.finding_evidence.ingest` maps to `review.decision`, and
+  `review.finding_response_evidence.ingest` maps to `submission.create`.
+- `PreparedAuthorizationService` in
+  `backend/app/modules/authorization/prepared.py` binds an opaque handle to the
+  exact service, session, root transaction, action, actor, scope, idempotency
+  key, and canonical request digest. It is single-use and rejects copying and
+  serialization.
+- `_scope_from_resource()` supports only actor-self and admin-mutation resource
+  types. `AuthorizationService._prepare_prelocked()` rejects every service
+  action as unavailable and has no assigned-contributor or ART resource plan.
+- The existing ART 03A worktree has substantial uncommitted implementation plus
+  a preserved `AUTH_END_TO_END_CONTRACT.md`. It must not be edited or mixed into
+  this planning change.
+- AUTH-11A is merged on `main`; the earlier migration dependency is resolved.
+
+## Existing plans affected
+
+- `WS-ART-001` chunks 03A-07 cover guide ingest/use, one-ZIP submission
+  admission, submission binding, checker materialization/output, and recovery.
+- `WS-AUTH-001/ACTIVATION_CUSTODY.md` assigns the existing 25 ART actions to
+  eight AUTH custodians but does not contain the final submission/review action
+  set.
+- `WS-AUTH-001-14` mixes broader submission/checker cutover with artifact
+  dependencies and must not be treated as an alternate ART activation path.
+- REV plans own lease, decision, finding, response, and revision facts. They do
+  not grant artifact bytes directly.
+
+## Confirmed gaps
+
+1. One closed catalogue migration must add the three missing actions and remove
+   the six obsolete upload-session actions and permissions without aliases.
+2. The service matrix must remove scheduler expiry and add review packet and
+   review-evidence memberships to existing identities.
+3. PREP needs a closed extension mechanism for exact feature-owned typed
+   resource contexts and lock plans; a generic callback or dictionary context
+   would violate the authorization boundary.
+4. Guide ingest, submission preparation/finalization, binding, review packet,
+   and evidence binding need explicit transaction choreographies and crossed
+   concurrency proof.
+5. Initial, checker-remediation, and human-review revision submissions use the
+   same public action but different closed locked facts. Checker remediation is
+   rooted in one final `needs_revision` CheckerRun without human-review facts.
+   Human-review revision facts include exact predecessor, active preparation
+   head/digest, required responses/evidence, replacement assignment, limits,
+   deadline, and predecessor advancement fencing.
+6. Checker authority must remain byte-bounded and cannot create or consume a
+   Submission.
+
+## Assumptions requiring implementation-time confirmation
+
+- `Submission`, not a separate `SubmissionVersion` table, remains the immutable
+  version node linked by `supersedes_submission_id`.
+- Existing service identities are sufficient; review packet uses the artifact
+  materializer and review evidence binding uses the artifact binding service.
+- Operator artifact audit stays Operator-only unless a separately reviewed
+  exact Audit Authority projection is approved.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/DISCOVERY.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/DISCOVERY.md
@@ -2,8 +2,9 @@
 
 ## Observations on trusted main
 
-- `backend/app/modules/authorization/catalogue.py` contains 81 ActionIds and 76
-  PermissionIds. All current artifact actions are planned and unavailable.
+- Baseline commit `2fb322bd2249a5fe9d3fa706dc63f033074e38ce` contains
+  76 PermissionIds and 81 ActionIds: 22 active and 59 planned. All current
+  artifact actions are planned and unavailable.
 - The fixed service matrix has seven artifact identities and eleven memberships:
   verifier, put resolver, scheduler, binding, guide reader, materializer, and
   checker output.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/INTENT.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/INTENT.md
@@ -1,0 +1,45 @@
+# Intent: WS-XINT-002 ART-AUTH End-to-End Contract
+
+## Outcome
+
+Freeze and deliver the complete v0.1 authorization surface required by the
+artifact lifecycle so ART implementation does not discover new AUTH catalogue,
+principal, matrix, prepared-capability, or evidence dependencies mid-chunk.
+
+## Why now
+
+The existing ART plan defines guide ingestion, contributor ZIP admission,
+submission binding, checker materialization, recovery, and later review use in
+separate chunks. AUTH currently owns 25 planned ART actions, but the plan still
+contains six obsolete upload-session actions, omits three required end-to-end
+actions, and its prepared protocol cannot consume ART product resource types.
+That makes ART repeatedly stop for newly discovered AUTH work.
+
+## Boundaries
+
+- AUTH owns ActionId/PermissionId registration, mappings, availability,
+  fixed-service identities and matrices, authority locking/evaluation, prepared
+  handles, and decision evidence.
+- ART owns bytes, commitments, manifests, storage/admission facts, lifecycle
+  guards, resource-context composition ports, and hidden feature behavior.
+- Project, task, submission, checker, and review modules own their domain rows,
+  lock order after AUTH authority locking, and lifecycle invariants.
+- Registration and reusable runtime support may merge before feature behavior,
+  but every new action remains unavailable until its exact hidden behavior and
+  crossed-state evidence exist.
+
+## Non-goals
+
+- No ART, REV, task, submission, or checker implementation in this planning
+  amendment.
+- No action activation, grant broadening, compatibility alias, generic artifact
+  download permission, dynamic service grants, or provider access from AUTH.
+- No client delivery, marketplace, external adapter, or post-v0.1 surface.
+
+## Proof strategy
+
+Each implementation chunk must prove closed catalogue/database parity, typed
+resource composition, least-privilege actor/service admission, transaction-local
+single-use consumption, atomic decision evidence, crossed revocation/staleness,
+and at least 90 percent coverage for materially changed backend subsystems.
+Full-suite coverage remains hosted in GitHub Actions.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/PLAN.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/PLAN.md
@@ -40,17 +40,17 @@ change its availability; it may not invent another action or permission.
 
 | ActionId | PermissionId | Service identity |
 |---|---|---|
-| `artifact.verification.execute` | same | `workstream.artifact.verifier` |
-| `artifact.pending_work.scan` | same | `workstream.artifact.scheduler` |
-| `artifact.put_attempt.resolve` | same | `workstream.artifact.put_resolver` |
-| `artifact.guide_source.read` | same | `workstream.artifact.guide_reader` |
+| `artifact.verification.execute` | `artifact.verification.execute` | `workstream.artifact.verifier` |
+| `artifact.pending_work.scan` | `artifact.pending_work.scan` | `workstream.artifact.scheduler` |
+| `artifact.put_attempt.resolve` | `artifact.put_attempt.resolve` | `workstream.artifact.put_resolver` |
+| `artifact.guide_source.read` | `artifact.guide_source.read` | `workstream.artifact.guide_reader` |
 | `artifact.guide_source.binding.create` | `artifact.binding.create` | `workstream.artifact.binding` |
 | `artifact.submission.binding.create` | `artifact.binding.create` | `workstream.artifact.binding` |
 | `artifact.pre_submit.checker_input.materialize` | `artifact.checker_input.materialize` | `workstream.artifact.materializer` |
 | `artifact.post_submit.checker_input.materialize` | `artifact.checker_input.materialize` | `workstream.artifact.materializer` |
-| `artifact.checker_output.write` | same | `workstream.artifact.checker_output` |
+| `artifact.checker_output.write` | `artifact.checker_output.write` | `workstream.artifact.checker_output` |
 | `artifact.checker_output.binding.create` | `artifact.binding.create` | `workstream.artifact.binding` |
-| `artifact.review_packet.materialize` | same | `workstream.artifact.materializer` |
+| `artifact.review_packet.materialize` | `artifact.review_packet.materialize` | `workstream.artifact.materializer` |
 | `artifact.review_evidence.binding.create` | `artifact.binding.create` | `workstream.artifact.binding` |
 
 The existing bounded Operator actions remain unchanged. Fixed recovery services execute

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/PLAN.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/PLAN.md
@@ -1,0 +1,101 @@
+# Plan: WS-XINT-002 ART-AUTH End-to-End Contract
+
+## Design
+
+Deliver the dependency in two front-loaded AUTH foundations followed by thin,
+evidence-gated activation waves:
+
+1. Reconcile the complete v0.1 catalogue and static service matrix once.
+2. Extend PREP once with closed typed feature integration contracts.
+3. Activate fixed internal recovery services before any durable provider work.
+4. Activate guide ingest/use only after the matching hidden ART behavior.
+5. Activate initial contributor preparation, then atomic Submission/binding
+   consumption, then checker-remediation and human-review revision variants as
+   separate reviewable gates.
+6. Activate checker materialization/output only after exact checker behavior.
+7. Activate reviewer packet and evidence binding only after both ART and REV
+   provide their hidden typed facts and lease/revision guards.
+8. Run end-to-end conformance and crossed-state proof.
+
+Registration is deliberately complete up front. Activation remains separate
+because AUTH cannot safely allow an action until the protected implementation,
+resource composer, and denial tests exist. Each activation chunk may only
+connect a previously registered action to an exact merged feature manifest and
+change its availability; it may not invent another action or permission.
+
+## Canonical action and permission set
+
+### Human-facing actions
+
+| ActionId | PermissionId | Authority |
+|---|---|---|
+| `artifact.guide_source.ingest` | `artifact.guide_source.ingest` | exact Project Manager project grant |
+| `artifact.submission_bundle.prepare` | `submission.create` | active assigned contributor |
+| `submission.create` | `submission.create` | fresh active assigned contributor |
+| `review.context.read` | `submission.read_for_review` | exact active reviewer lease |
+| `review.finding_evidence.ingest` | `review.decision` | active reviewer lease and exact review context |
+| `review.finding_response_evidence.ingest` | `submission.create` | contributor with exact revision obligation |
+
+### Fixed-service actions
+
+| ActionId | PermissionId | Service identity |
+|---|---|---|
+| `artifact.verification.execute` | same | `workstream.artifact.verifier` |
+| `artifact.pending_work.scan` | same | `workstream.artifact.scheduler` |
+| `artifact.put_attempt.resolve` | same | `workstream.artifact.put_resolver` |
+| `artifact.guide_source.read` | same | `workstream.artifact.guide_reader` |
+| `artifact.guide_source.binding.create` | `artifact.binding.create` | `workstream.artifact.binding` |
+| `artifact.submission.binding.create` | `artifact.binding.create` | `workstream.artifact.binding` |
+| `artifact.pre_submit.checker_input.materialize` | `artifact.checker_input.materialize` | `workstream.artifact.materializer` |
+| `artifact.post_submit.checker_input.materialize` | `artifact.checker_input.materialize` | `workstream.artifact.materializer` |
+| `artifact.checker_output.write` | same | `workstream.artifact.checker_output` |
+| `artifact.checker_output.binding.create` | `artifact.binding.create` | `workstream.artifact.binding` |
+| `artifact.review_packet.materialize` | same | `workstream.artifact.materializer` |
+| `artifact.review_evidence.binding.create` | `artifact.binding.create` | `workstream.artifact.binding` |
+
+The existing bounded Operator actions remain unchanged. Fixed recovery services execute
+recovery; Operators request retry/reconciliation and inspect bounded state.
+There is no generic artifact-download action.
+
+Submission preparation has three closed context variants under the same action:
+initial submission; checker remediation rooted in the exact final
+`needs_revision` CheckerRun; and human-review revision rooted in the exact
+revision obligation. Checker remediation records the server-derived
+`remediation_source_checker_run_id`, immediate same-task predecessor, existing
+locked task context, and current `allow_review`; it has no ReviewFinding
+response, revision preparation, human revision deadline/round consumption,
+reviewer contribution, or synthetic human actor.
+
+## Universal durable-boundary protocol
+
+Every durable ART/product mutation must:
+
+1. authorize before accepting expensive or sensitive bytes;
+2. prepare authority inside the caller-owned root transaction;
+3. lock AUTH actor/link/grant or fixed-service authority first;
+4. lock and recompose exact feature facts through typed feature-owned ports;
+5. consume the opaque capability against the final resource context;
+6. stage bounded decision evidence and the protected mutation atomically;
+7. commit once before provider I/O; and
+8. obtain fresh authority for each later binding or product mutation.
+
+Copied, serialized, replayed, cross-session, cross-action, cross-resource,
+replaced-transaction, revoked, stale, or already consumed handles deny.
+
+## Ownership rule
+
+AUTH evaluates authority but does not load feature rows or encode product
+lifecycle. Feature modules expose closed typed composers/loaders and own their
+locks and invariants. ART orchestrates bytes and receives only opaque prepared
+handles plus typed decisions; it never imports AUTH repositories.
+
+## Verification
+
+- focused PostgreSQL catalogue/migration/PREP/concurrency suites per chunk;
+- static route/command/action and service-matrix parity gates;
+- stale-action and forbidden-import scans;
+- 90 percent coverage for materially changed backend subsystems;
+- hosted GitHub Actions full backend suite preserving the 78 percent global
+  floor; and
+- security, architecture, QA, product/ops, senior, CI, docs, reuse, and test
+  delta review as applicable to each L1 chunk.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/REVIEW_LOG.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/REVIEW_LOG.md
@@ -1,0 +1,21 @@
+# Review Log: WS-XINT-002
+
+## Planning review
+
+Architecture, security/auth, QA/test, product/ops, senior engineering, and CI
+integrity initially returned blocking findings. The plan was repaired to split
+submission activation, add checker remediation, require paired reviewer/service
+authority, complete every chunk contract, and pass repository documentation
+gates. All six tracks then passed with no blocking findings.
+
+## PR #209 external review
+
+CodeRabbit raised twelve actionable comments on the initial PR head
+`95090be5`. All were accepted and repaired as recorded in
+`reviews/WS-XINT-002-PLAN-external-review-response.md`. Focused internal
+security/architecture re-review and exact-head hosted checks are required after
+the repair commit.
+
+Product/ops re-review found that CodeRabbit's 05C atomic-fact suggestion would
+prematurely include `allow_review` in Submission creation. The repair instead
+keeps `allow_review` in the later checker/routing spine for the new Submission.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/RISKS.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/RISKS.md
@@ -1,0 +1,15 @@
+# Risks: WS-XINT-002 ART-AUTH End-to-End Contract
+
+| Risk | Severity | Control |
+|---|---|---|
+| Catalogue registration is mistaken for usable authority | Critical | Every new action remains planned until exact hidden behavior and evidence merge. |
+| Product lifecycle leaks into AUTH | Critical | Feature-owned typed composers and locks; no feature repository imports in AUTH. |
+| Human authority implies service byte authority | Critical | Separate capabilities, identities, evidence, and matrix rows for every binding/materialization. |
+| Revocation races durable writes | Critical | AUTH-first lock order, final recomposition, single-use consume, one transaction. |
+| Revision uses stale predecessor/context | Critical | Lock predecessor, preparation head/digest, obligation, assignment, limits, deadline, and advancement fence. |
+| Checker remediation inherits human-review authority or facts | Critical | Use a distinct closed context rooted in the final CheckerRun, with no finding response, revision preparation, reviewer contribution, or synthetic actor. |
+| Reviewer gets generic artifact access | Critical | Exact active-lease packet action scoped to one Submission and immutable bindings. |
+| Obsolete upload sessions survive as a second path | Critical | Remove six actions, permissions, matrix membership, migrations/reference docs, and prove no runtime references. |
+| Activation happens before feature readiness | Critical | Planned-by-default registration and evidence-only activation chunks. |
+| One giant implementation becomes unreviewable | High | Two reusable foundations, narrow activation waves, final conformance. |
+| ART work is lost or mixed with planning | High | Do not edit the dirty ART-03A worktree; plan from a clean main-based branch. |

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/STATUS.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/STATUS.md
@@ -1,0 +1,7 @@
+# Status: WS-XINT-002 ART-AUTH End-to-End Contract
+
+Planning proposed from trusted `main` after AUTH-11A merged. No implementation
+or action activation has started. The dirty ART-03A worktree is preserved and
+untouched.
+
+Immediate successor after human approval: `WS-XINT-002-01`.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-01-catalogue-reconciliation.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-01-catalogue-reconciliation.md
@@ -1,0 +1,73 @@
+# Chunk Contract: WS-XINT-002-01 ART Catalogue Reconciliation
+
+## Goal
+
+Make AUTH's closed catalogue and fixed-service matrix contain the complete v0.1
+ART surface before further ART implementation, with every added action planned.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/catalogue.py
+backend/alembic/versions/<then-current-next>_*.py
+backend/tests/test_authorization.py
+backend/tests/test_alembic.py
+docs/spec_authorization_service.md
+docs/operations_authorization_service.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/AUTH_HANDOFF.md
+```
+
+## Not allowed
+
+- action activation, evaluator/resource implementation, route or asynchronous-command changes;
+- new service identity, grant, generic download permission, or compatibility alias;
+- ART/REV/task/submission/checker lifecycle behavior.
+
+## Acceptance criteria
+
+- Add planned `artifact.submission_bundle.prepare -> submission.create`.
+- Add planned `artifact.review_packet.materialize ->
+  artifact.review_packet.materialize` and its one new PermissionId.
+- Add planned `artifact.review_evidence.binding.create ->
+  artifact.binding.create`.
+- Remove all six upload-session ActionIds and PermissionIds and scheduler expiry
+  membership; prove no route, command, audit, idempotency, test, migration-head,
+  or documentation contract retains them.
+- Add review packet to `workstream.artifact.materializer` and review evidence
+  binding to `workstream.artifact.binding`; preserve all-pairs denial.
+- Update closed enum/count/owner/static-matrix and PostgreSQL migration parity.
+- Every new action is planned/unavailable and no existing active action changes.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_alembic.py -q --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass GitHub checks `Backend / test` and
+`Agent Gates / agent-gates`, preserving the 78 percent global and 90 percent
+materially changed subsystem coverage floors.
+
+Full backend coverage runs in GitHub Actions.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Exact removals/additions, mapping correctness, least-privilege matrix, and zero
+availability changes.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-01-catalogue-reconciliation.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-01-catalogue-reconciliation.md
@@ -18,7 +18,9 @@ backend/tests/test_authorization.py
 backend/tests/test_alembic.py
 docs/spec_authorization_service.md
 docs/operations_authorization_service.md
-.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/STATUS.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-01-catalogue-reconciliation.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/reviews/WS-XINT-002-01-*.md
 .agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
 .agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
 .agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/AUTH_HANDOFF.md
@@ -33,13 +35,21 @@ docs/operations_authorization_service.md
 ## Acceptance criteria
 
 - Add planned `artifact.submission_bundle.prepare -> submission.create`.
-- Add planned `artifact.review_packet.materialize ->
-  artifact.review_packet.materialize` and its one new PermissionId.
+- Add planned ActionId `artifact.review_packet.materialize` mapped to distinct
+  typed PermissionId `artifact.review_packet.materialize`; add that one new
+  PermissionId and prove action/permission type parity despite equal values.
 - Add planned `artifact.review_evidence.binding.create ->
   artifact.binding.create`.
-- Remove all six upload-session ActionIds and PermissionIds and scheduler expiry
-  membership; prove no route, command, audit, idempotency, test, migration-head,
-  or documentation contract retains them.
+- Remove ActionIds and PermissionIds `artifact.upload_session.create`,
+  `artifact.upload_session.read`, `artifact.upload_item.write`,
+  `artifact.upload_session.seal`, `artifact.upload_session.cancel`, and
+  `artifact.upload_session.expire`, plus scheduler expiry membership. Prove no
+  route, command, audit, idempotency, test, migration-head, or documentation
+  contract retains them and no compatibility/unavailable row replaces them.
+- Starting from 76 permissions, 81 actions, 22 active, 59 planned, seven service
+  identities and eleven memberships, prove the exact resulting closed counts:
+  71 permissions, 78 actions, 22 active, 56 planned, seven identities and twelve
+  memberships. The delta is +1/-6 permissions, +3/-6 actions, +2/-1 memberships.
 - Add review packet to `workstream.artifact.materializer` and review evidence
   binding to `workstream.artifact.binding`; preserve all-pairs denial.
 - Update closed enum/count/owner/static-matrix and PostgreSQL migration parity.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-02-prepared-feature-boundaries.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-02-prepared-feature-boundaries.md
@@ -1,0 +1,87 @@
+# Chunk Contract: WS-XINT-002-02 Prepared Feature Boundaries
+
+## Goal
+
+Extend the existing opaque transaction-local PREP protocol once for all durable
+ART boundaries using closed typed feature-owned composition contracts.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/kernel.py
+backend/app/modules/authorization/prepared.py
+backend/app/modules/authorization/runtime.py
+backend/app/modules/authorization/repository.py
+backend/app/interfaces/artifact_operations.py
+backend/app/modules/artifacts/authorization.py
+backend/tests/test_authorization.py
+backend/tests/test_auth.py
+backend/tests/test_artifact_authorization.py
+docs/spec_authorization_service.md
+docs/spec_artifact_storage_service.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+- action activation or catalogue/migration changes;
+- feature repository imports in AUTH, caller callbacks, open dictionaries,
+  generic service locators, or a second capability implementation;
+- provider I/O, ART durable writes, or product lifecycle mutation.
+
+## Acceptance criteria
+
+- Define closed typed contexts and authority plans for guide ingest, submission
+  preparation/create, artifact binding, checker materialization/output, review
+  packet, and review evidence binding.
+- Preserve exact service/session/root-transaction/action/actor/scope/key/digest
+  binding, opacity, non-copyability, non-serialization, and single use.
+- Human plans lock exact actor/link plus effective project grant/assignment;
+  service plans lock exact profile/link and validate immutable identity, matrix,
+  and availability.
+- Feature modules own row loading/locking and final context composition through
+  typed ports; AUTH owns no feature repository and accepts no caller assertion
+  as authority.
+- Initial, checker-remediation, and human-review revision contexts are closed
+  variants. Checker remediation binds the final `needs_revision` CheckerRun,
+  server-derived remediation source, immediate predecessor, locked task context,
+  and current `allow_review`, without human-review facts. Revision binds exact
+  predecessor, preparation head/digest, obligation/findings/responses,
+  replacement assignment, limits, deadline, and advancement fence.
+- Consume stages one final decision in the caller transaction; denial and any
+  participant failure roll back with no reusable handle.
+- PostgreSQL tests cover revoke/suspend, wrong action/resource/session/service,
+  replay/concurrent consume, transaction replacement, stale feature facts, and
+  evidence failure.
+- No planned ART action becomes executable in this chunk.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_auth.py tests/test_artifact_authorization.py -q --cov=app.modules.authorization --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+git diff --check
+```
+
+The exact PR head must pass GitHub checks `Backend / test` and
+`Agent Gates / agent-gates`, preserving the 78 percent global and 90 percent
+materially changed subsystem coverage floors.
+
+Full backend coverage runs in GitHub Actions.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+No feature truth in AUTH, no caller-asserted authority, exact lock order, and
+atomic evidence/mutation semantics.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-02-prepared-feature-boundaries.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-02-prepared-feature-boundaries.md
@@ -23,7 +23,9 @@ backend/tests/test_auth.py
 backend/tests/test_artifact_authorization.py
 docs/spec_authorization_service.md
 docs/spec_artifact_storage_service.md
-.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/STATUS.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-02-prepared-feature-boundaries.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/reviews/WS-XINT-002-02-*.md
 ```
 
 ## Not allowed
@@ -53,10 +55,14 @@ docs/spec_artifact_storage_service.md
   predecessor, preparation head/digest, obligation/findings/responses,
   replacement assignment, limits, deadline, and advancement fence.
 - Consume stages one final decision in the caller transaction; denial and any
-  participant failure roll back with no reusable handle.
+  participant failure roll back with no reusable handle. The service-local
+  issuance registry burns the handle before evaluation outside database
+  rollback semantics; denial, evidence failure, participant failure, caller
+  rollback, timeout, or cancellation cannot restore it.
 - PostgreSQL tests cover revoke/suspend, wrong action/resource/session/service,
   replay/concurrent consume, transaction replacement, stale feature facts, and
-  evidence failure.
+  evidence failure. Each rollback class retries the identical handle and proves
+  rejection before authority evaluation, evidence, or participant mutation.
 - No planned ART action becomes executable in this chunk.
 
 ## Verification

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-03-internal-worker-activation.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-03-internal-worker-activation.md
@@ -1,0 +1,62 @@
+# Chunk Contract: WS-XINT-002-03 Internal Service Activation
+
+## Goal
+
+Activate only `artifact.verification.execute`, `artifact.pending_work.scan`, and
+`artifact.put_attempt.resolve` against merged ART recovery facts.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/authorization.py
+backend/app/modules/artifacts/service.py
+backend/app/**/artifacts.py
+backend/tests/test_authorization.py
+backend/tests/test_artifact_verification.py
+backend/tests/test_artifact_recovery.py
+backend/tests/test_artifact_put_resolution.py
+docs/operations_artifact_storage.md
+docs/spec_authorization_service.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+Human grants, provider semantics, Operator retry execution, other action
+activation, or new catalogue values.
+
+## Acceptance criteria
+
+- Each fixed identity can execute only its matrix action against one exact job,
+  scan page, or put attempt and execution fence.
+- Profile/link revocation, wrong identity, wrong action, stale fence, duplicate
+  lease, and concurrent execution deny before durable ART mutation.
+- Decision evidence and lease/state mutation commit atomically; provider I/O
+  begins only after durable intent.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_artifact_verification.py tests/test_artifact_recovery.py tests/test_artifact_put_resolution.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and `Agent Gates / agent-gates`.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Service least privilege, recovery ownership, provider-I/O ordering, and replay.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-04-guide-activation.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-04-guide-activation.md
@@ -1,0 +1,63 @@
+# Chunk Contract: WS-XINT-002-04 Guide Authorization Activation
+
+## Goal
+
+Activate guide ingest after ART-03A evidence, then guide binding/read after
+ART-03B evidence, without weakening the ART-03C clean cut.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/authorization.py
+backend/app/modules/artifacts/service.py
+backend/app/modules/projects/**
+backend/tests/test_authorization.py
+backend/tests/test_guide_artifacts.py
+backend/tests/test_artifact_admission.py
+docs/spec_authorization_service.md
+docs/spec_artifact_storage_service.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+Submission/review behavior, provider redesign, token roles, generic guide
+download, or new catalogue values.
+
+## Acceptance criteria
+
+- Ingest requires an exact Project Manager grant and locks actor/link, project,
+  draft guide, snapshot/item, policy generation, request digest, and operation.
+- Final PREP consumption occurs before capacity/put intent commit and provider
+  I/O; revoke/stale/cross-project/replay cases deny atomically.
+- Guide binding/read use separate fixed identities and exact verified content,
+  binding role, guide item, and setup generation.
+- Activation is split at the 03A/03B evidence boundary if both manifests are not
+  already merged; no later action is enabled early.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_guide_artifacts.py tests/test_artifact_admission.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov=app.modules.projects --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and `Agent Gates / agent-gates`.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Manager-only ingest, separate service authority, exact generations, and clean cut.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05A-initial-submission-preparation.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05A-initial-submission-preparation.md
@@ -1,0 +1,65 @@
+# Chunk Contract: WS-XINT-002-05A Initial Submission Preparation
+
+## Goal
+
+Activate one-ZIP preparation through one durable ready admission for an initial submission.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/authorization.py
+backend/app/modules/artifacts/service.py
+backend/app/modules/artifacts/repository.py
+backend/app/modules/artifacts/router.py
+backend/app/modules/artifacts/schemas.py
+backend/app/modules/tasks/service.py
+backend/app/modules/tasks/repository.py
+backend/tests/test_authorization.py
+backend/tests/test_submission_bundle_admission.py
+backend/tests/test_submission_concurrency.py
+docs/spec_authorization_service.md
+docs/spec_artifact_storage_service.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+Submission creation/binding, revisions, reviewer behavior, upload sessions,
+provider I/O before committed intent, compatibility aliases, or new catalogue values.
+
+## Acceptance criteria
+
+- Require exact active assignment, task/project, no predecessor, locked
+  guide/policy/checker context, request digest, operation generation, and key.
+- Consume final prepared authority before capacity/put intent and provider I/O.
+- Revoked, stale, cross-project, replayed, and concurrent attempts create no
+  partial or duplicate ready admission; denial evidence is atomic and concealed.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_submission_bundle_admission.py tests/test_submission_concurrency.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and
+`Agent Gates / agent-gates`, preserving the 78 percent global and 90 percent
+materially changed subsystem coverage floors.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Assignment scope, final revalidation, provider-I/O ordering, and admission uniqueness.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05B-submission-binding-consumption.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05B-submission-binding-consumption.md
@@ -1,0 +1,65 @@
+# Chunk Contract: WS-XINT-002-05B Submission Binding Consumption
+
+## Goal
+
+Activate fresh human Submission creation and separate fixed artifact binding in
+one exactly-once ready-admission transaction.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/authorization.py
+backend/app/modules/artifacts/service.py
+backend/app/modules/artifacts/repository.py
+backend/app/modules/tasks/**
+backend/tests/test_authorization.py
+backend/tests/test_submission_api.py
+backend/tests/test_submission_concurrency.py
+backend/tests/test_submission_history.py
+docs/spec_authorization_service.md
+docs/spec_artifact_storage_service.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+Revision obligations, checker/reviewer lifecycle changes, provider calls from
+product modules, compatibility paths, or new catalogue values.
+
+## Acceptance criteria
+
+- Consume fresh human `submission.create` and independent fixed
+  `artifact.submission.binding.create` capabilities in one transaction.
+- Lock exact admission/task/assignment/context/content, create one immutable
+  Submission/binding, consume admission, and commit once.
+- Wrong/revoked/stale/cross-resource/replayed/concurrent attempts create zero or
+  exactly one complete result; denial precedes admission-state disclosure.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_submission_api.py tests/test_submission_concurrency.py tests/test_submission_history.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov=app.modules.tasks --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and
+`Agent Gates / agent-gates`, preserving the 78 percent global and 90 percent
+materially changed subsystem coverage floors.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Dual authority, one transaction, concealment, and exactly-once creation.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05B-submission-binding-consumption.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05B-submission-binding-consumption.md
@@ -3,7 +3,8 @@
 ## Goal
 
 Activate fresh human Submission creation and separate fixed artifact binding in
-one exactly-once ready-admission transaction.
+one exactly-once Submission/binding transaction. It consumes the durable ready
+admission created by 05A; it does not re-admit the work.
 
 ## Risk class
 

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05C-checker-remediation-submission.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05C-checker-remediation-submission.md
@@ -34,10 +34,19 @@ reviewer contribution, synthetic human actors, review decision changes, or new c
 
 - Bind exact final CheckerRun, server-derived immutable
   `remediation_source_checker_run_id`, immediate same-task predecessor, existing
-  locked task context, assignment, and current `allow_review` before routing.
-- Use the same prepare/create actions and dual binding transaction as 05A/05B.
+  locked task context, and assignment. No prior `allow_review` result carries
+  into the corrected Submission.
+- Reuse `artifact.submission_bundle.prepare` from 05A, then fresh
+  `submission.create` plus `artifact.submission.binding.create` from 05B.
+  Atomically consume the ready admission and locked remediation context while
+  committing final CheckerRun binding, immutable
+  `remediation_source_checker_run_id`, predecessor binding, task context,
+  assignment, corrected Submission, and artifact binding. The new Submission
+  then reruns the normal checker/finalization spine; only a later current
+  successful `allow_review` result may admit it to review routing.
 - Reject stale/non-final/wrong-task CheckerRun, predecessor advancement,
-  revocation, replay, and concurrency; success returns to open routing.
+  revocation, replay, and concurrency; success returns only to the normal
+  checker/finalization spine, not directly to review routing.
 
 ## Verification
 
@@ -61,4 +70,4 @@ integrity, docs, reuse/dedup, and test delta.
 
 ## Human review focus
 
-Checker provenance, absence of human-review facts, and open routing.
+Checker provenance, absence of human-review facts, and mandatory checker rerun.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05C-checker-remediation-submission.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05C-checker-remediation-submission.md
@@ -1,0 +1,64 @@
+# Chunk Contract: WS-XINT-002-05C Checker Remediation Submission
+
+## Goal
+
+Activate the submission variant rooted in one exact final `needs_revision` CheckerRun.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/authorization.py
+backend/app/modules/artifacts/service.py
+backend/app/modules/tasks/**
+backend/app/modules/checkers/**
+backend/tests/test_authorization.py
+backend/tests/test_submission_concurrency.py
+backend/tests/test_submission_history.py
+backend/tests/test_checkers.py
+docs/spec_authorization_service.md
+docs/spec_review_lifecycle.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+ReviewFinding responses, revision preparation/deadline/round consumption,
+reviewer contribution, synthetic human actors, review decision changes, or new catalogue values.
+
+## Acceptance criteria
+
+- Bind exact final CheckerRun, server-derived immutable
+  `remediation_source_checker_run_id`, immediate same-task predecessor, existing
+  locked task context, assignment, and current `allow_review` before routing.
+- Use the same prepare/create actions and dual binding transaction as 05A/05B.
+- Reject stale/non-final/wrong-task CheckerRun, predecessor advancement,
+  revocation, replay, and concurrency; success returns to open routing.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_submission_concurrency.py tests/test_submission_history.py tests/test_checkers.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov=app.modules.tasks --cov=app.modules.checkers --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and
+`Agent Gates / agent-gates`, preserving the 78 percent global and 90 percent
+materially changed subsystem coverage floors.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Checker provenance, absence of human-review facts, and open routing.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05D-human-review-revision.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05D-human-review-revision.md
@@ -1,0 +1,66 @@
+# Chunk Contract: WS-XINT-002-05D Human-Review Revision Submission
+
+## Goal
+
+Activate the revision variant against one exact durable `needs_revision` obligation.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/authorization.py
+backend/app/modules/artifacts/service.py
+backend/app/modules/tasks/**
+backend/app/modules/reviews/**
+backend/tests/test_authorization.py
+backend/tests/test_submission_concurrency.py
+backend/tests/test_submission_history.py
+backend/tests/test_review_revision.py
+docs/spec_authorization_service.md
+docs/spec_review_lifecycle.md
+docs/reference_specs/WS-REV-001-review-lifecycle-specification.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+Review decision semantics, reviewer-created revisions, checker remediation,
+initial-submission behavior changes, provider redesign, or new catalogue values.
+
+## Acceptance criteria
+
+- Lock exact predecessor, active preparation head/digest, obligation/round,
+  required finding responses/evidence, current/replacement assignment, limit,
+  deadline, and predecessor advancement fence.
+- Use the same public prepare/create actions with a closed revision context.
+- Deny stale/missing/expired/over-limit/invalid-replacement/revoked/replayed or
+  concurrent attempts. Success creates one immutable successor and atomically
+  consumes the exact obligation/admission without changing prior history.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_submission_concurrency.py tests/test_submission_history.py tests/test_review_revision.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov=app.modules.tasks --cov=app.modules.reviews --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and
+`Agent Gates / agent-gates`, preserving the 78 percent global and 90 percent
+materially changed subsystem coverage floors.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Exact obligation/predecessor fencing, replacement assignment, and immutable history.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05D-human-review-revision.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-05D-human-review-revision.md
@@ -38,8 +38,10 @@ initial-submission behavior changes, provider redesign, or new catalogue values.
   deadline, and predecessor advancement fence.
 - Use the same public prepare/create actions with a closed revision context.
 - Deny stale/missing/expired/over-limit/invalid-replacement/revoked/replayed or
-  concurrent attempts. Success creates one immutable successor and atomically
-  consumes the exact obligation/admission without changing prior history.
+  concurrent attempts. The durable `needs_revision` obligation remains open
+  through preparation, storage, and retries. Only the transaction that creates
+  the immutable successor and binding may atomically close that obligation and
+  consume the exact admission; failure leaves it open without changing history.
 
 ## Verification
 

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-06-checker-activation.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-06-checker-activation.md
@@ -1,0 +1,63 @@
+# Chunk Contract: WS-XINT-002-06 Checker Authorization Activation
+
+## Goal
+
+Activate bounded pre/post-submit checker input and checker output/binding actions.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/authorization.py
+backend/app/modules/artifacts/service.py
+backend/app/modules/checkers/**
+backend/tests/test_authorization.py
+backend/tests/test_checker_materialization.py
+backend/tests/test_checkers.py
+docs/spec_authorization_service.md
+docs/spec_artifact_storage_service.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+Human submission authority for checkers, Submission consumption, review
+decisions, generic artifact reads, or new catalogue values.
+
+## Acceptance criteria
+
+- Pre-submit access binds the process-local admission generation, manifest,
+  guide, policy, task, and checker definition; no scratch path is serialized.
+- Post-submit access binds exact Submission, checker run, and immutable bindings.
+- Output write and output binding are distinct fixed actions with exact generated
+  commitment/run/role facts and separate evidence.
+- Checker services cannot prepare/create/consume a Submission or access another
+  admission/version.
+- Revocation, action disablement, stale context, digest mismatch, replay, and
+  cross-service attempts deny without product review outcomes.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_checker_materialization.py tests/test_checkers.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov=app.modules.checkers --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and `Agent Gates / agent-gates`.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Byte minimization, service separation, exact context binding, and no product authority.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-07-review-artifact-activation.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-07-review-artifact-activation.md
@@ -1,0 +1,73 @@
+# Chunk Contract: WS-XINT-002-07 Review Artifact Authorization Activation
+
+## Goal
+
+Activate exact lease-scoped reviewer packets and verified finding/response
+evidence binding after both ART and REV publish their hidden manifests.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/authorization.py
+backend/app/modules/artifacts/service.py
+backend/app/modules/reviews/**
+backend/tests/test_authorization.py
+backend/tests/test_review_artifacts.py
+backend/tests/test_review_revision.py
+docs/spec_authorization_service.md
+docs/spec_artifact_storage_service.md
+docs/spec_review_lifecycle.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+Review lifecycle redesign, generic downloads, reviewer authority for artifact
+binding, service authority for review decisions, or new catalogue values.
+
+## Acceptance criteria
+
+- Human `review.context.read` independently authorizes the exact reviewer actor
+  and link, active lease/generation/deadline, exact Submission, guide/policy/
+  checker context, request digest, and key. Fixed
+  `artifact.review_packet.materialize` independently permits byte access.
+- Packet facts bind reviewer actor/link reference, lease, Submission, checker
+  run, guide/policy context, and immutable binding IDs.
+- Expiry, release, reassignment, revocation, version advancement, digest/size
+  mismatch, replay, materializer-only, wrong-reviewer, and cross-submission
+  access deny and disclose no bytes.
+- Finding evidence binds exact review/lease/finding slot, Submission, verified
+  commitment, and guide/policy context. Response evidence binds exact assigned
+  contributor, response/obligation slot, revision round, predecessor/current
+  Submission, preparation head/digest, verified commitment, and supersession
+  denial. Both require their existing human actions plus separate
+  `artifact.review_evidence.binding.create` service authority.
+- Human and service evidence plus protected review/evidence mutation commit or
+  roll back together. No service can decide review or create Submission.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_review_artifacts.py tests/test_review_revision.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov=app.modules.reviews --cov-report=term-missing --cov-fail-under=90)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and `Agent Gates / agent-gates`.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Lease scope, version freshness, dual authority, and absence of generic byte access.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-08-conformance.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-08-conformance.md
@@ -1,0 +1,81 @@
+# Chunk Contract: WS-XINT-002-08 End-to-End Conformance
+
+## Goal
+
+Prove that the complete ART lifecycle uses only the frozen catalogue and denies
+every unauthorized, stale, replayed, or cross-boundary operation.
+
+## Risk class
+
+L1.
+
+## Allowed files
+
+```text
+backend/app/modules/authorization/**
+backend/app/modules/artifacts/**
+backend/app/modules/tasks/**
+backend/app/modules/checkers/**
+backend/app/modules/reviews/**
+backend/tests/**
+backend/scripts/auth_api_e2e.py
+backend/scripts/api_contract_e2e.py
+scripts/check_stale_authorization_docs.py
+scripts/check_stale_artifact_contracts.py
+docs/spec_authorization_service.md
+docs/spec_artifact_storage_service.md
+docs/spec_review_lifecycle.md
+docs/operations_artifact_storage.md
+.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/**
+```
+
+## Not allowed
+
+New actions, permissions, identities, grants, lifecycle behavior, provider
+redesign, or gate weakening.
+
+## Acceptance criteria
+
+- Generated parity covers every ART route/command, action/permission/owner,
+  availability, resource type, service membership, and human/service isolation.
+- Live proof covers guide ingest/use, initial and revision submission, checker
+  remediation submission, human-review revision submission, checker input/output,
+  reviewer packet/evidence, recovery, Operator reads/retry, and bounded audit behavior.
+- Crossed proof covers actor/link/grant/assignment/lease revocation, action
+  disablement, stale guide/policy/predecessor/version facts, concurrent consume,
+  transaction replacement, evidence/participant/commit failure, timeout, and
+  cancellation.
+- Every durable mutation has atomic bounded decision evidence; no token, raw
+  claim, byte content, scratch path, provider secret, or capability identity is
+  persisted or logged.
+- Stale scanners find no upload-session action, direct AUTH repository import
+  from ART, generic download permission, token-role fallback, or alternate
+  capability path.
+- Focused tests and API drill pass locally; full backend coverage and migration
+  matrix pass in GitHub Actions without weakening the 78/90 percent gates.
+
+## Verification
+
+```bash
+(cd backend && .venv/bin/python -m ruff check app tests scripts)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_artifact_recovery.py tests/test_submission_concurrency.py tests/test_checkers.py tests/test_review_artifacts.py tests/test_review_revision.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov=app.modules.tasks --cov=app.modules.checkers --cov=app.modules.reviews --cov-report=term-missing --cov-fail-under=90)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
+(cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/python scripts/auth_api_e2e.py)
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+The exact PR head must pass `Backend / test` and `Agent Gates / agent-gates`,
+preserving the 78 percent global and 90 percent materially changed subsystem floors.
+
+## Required reviewers
+
+Senior engineering, QA/test, security/auth, product/ops, architecture, CI
+integrity, docs, reuse/dedup, and test delta.
+
+## Human review focus
+
+Complete matrix coverage, privacy, revocation races, and proof that no new AUTH
+dependency was discovered after chunk 02.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-08-conformance.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-08-conformance.md
@@ -61,6 +61,7 @@ redesign, or gate weakening.
 (cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/pytest tests/test_authorization.py tests/test_artifact_recovery.py tests/test_submission_concurrency.py tests/test_checkers.py tests/test_review_artifacts.py tests/test_review_revision.py -q --cov=app.modules.authorization --cov=app.modules.artifacts --cov=app.modules.tasks --cov=app.modules.checkers --cov=app.modules.reviews --cov-report=term-missing --cov-fail-under=90)
 (cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/python scripts/api_contract_e2e.py)
 (cd backend && WORKSTREAM_TEST_DATABASE_URL=<test-db> .venv/bin/python scripts/auth_api_e2e.py)
+python3 -m scripts.test_lightweight_agent_gates
 python3 scripts/check_stale_authorization_docs.py
 python3 scripts/check_stale_artifact_contracts.py
 python3 scripts/check_markdown_links.py
@@ -68,7 +69,11 @@ git diff --check
 ```
 
 The exact PR head must pass `Backend / test` and `Agent Gates / agent-gates`,
-preserving the 78 percent global and 90 percent materially changed subsystem floors.
+preserving the full migration matrix, generated route/command/catalogue/service
+parity, API drills, the 78 percent global floor, and 90 percent materially
+changed subsystem floors. The two stale scanners must cover removed upload
+sessions, token-role fallbacks, generic downloads, direct ART-to-AUTH repository
+imports, alternate capabilities, and generated contract/documentation parity.
 
 ## Required reviewers
 

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/reviews/WS-XINT-002-PLAN-external-review-response.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/reviews/WS-XINT-002-PLAN-external-review-response.md
@@ -1,0 +1,44 @@
+# External Review Response: WS-XINT-002-PLAN
+
+## Comments addressed
+
+All twelve CodeRabbit comments on PR #209 were accepted and repaired:
+
+- mandatory enumerated upload-session deletion and exact count delta;
+- trusted-main baseline commit and current catalogue counts;
+- exact action/PermissionId names and fixed-service membership delta;
+- narrow 01/02 planning/evidence allowances;
+- non-transactional handle burn across every rollback class;
+- precise 05B transaction name, 05C reused actions/atomic facts, and 05D open
+  obligation semantics;
+- complete conformance command/gate mapping; and
+- explicit service PermissionIds instead of `same` shorthand.
+
+## Comments deferred
+
+None.
+
+## Human decisions needed
+
+None beyond normal review and explicit merge approval for PR #209.
+
+Internal product/ops re-review corrected one overreach in the accepted 05C
+comment: the remediation Submission transaction records the source CheckerRun
+but does not commit `allow_review`. The new Submission must rerun the normal
+checker/finalization spine before a later current `allow_review` result routes it.
+
+## Commands rerun
+
+```text
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+python3 -m scripts.test_lightweight_agent_gates
+git diff --check
+```
+
+## Remaining risks
+
+Implementation must derive then-current migration names and keep actual diffs
+inside each contract's narrow semantic boundary. Registration remains planned;
+no external-review repair activates a runtime action.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/reviews/WS-XINT-002-PLAN-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/reviews/WS-XINT-002-PLAN-pr-trust-bundle.md
@@ -1,0 +1,37 @@
+# PR Trust Bundle: WS-XINT-002-PLAN
+
+## Intent and scope
+
+Freeze the complete v0.1 ART-to-AUTH dependency in planning only. This PR adds
+no application code, migration, grant, service identity, or action activation.
+
+## Design
+
+One closed catalogue reconciliation and one reusable PREP extension precede
+narrow evidence-gated activation chunks. ART owns bytes; product modules own
+feature truth; AUTH owns authority, prepared capabilities, and decision evidence.
+
+## Evidence
+
+- stale AUTH and ART contract scans;
+- Markdown link and diff-integrity checks;
+- lightweight deterministic Agent Gates;
+- six required internal plan-review tracks.
+
+Exact-head hosted Backend, Agent Gates, and CodeRabbit checks are required after
+the external-review repair commit and are not claimed as passed here yet.
+
+## Reviewer results
+
+All initial internal blockers were repaired. CodeRabbit's twelve initial-head
+comments were accepted; exact repairs are recorded in the external response.
+
+## Remaining risks
+
+Later implementation must keep broad module globs from becoming scope drift and
+must not activate an action before exact merged feature evidence exists.
+
+## Human review focus
+
+Confirm catalogue completeness, mandatory legacy deletion, typed authority/
+feature ownership, permanent capability burn, and evidence-ordered activation.


### PR DESCRIPTION
## Chunk
WS-XINT-002-PLAN — ART-AUTH end-to-end planning amendment.

## Goal
Freeze the complete v0.1 ART-to-AUTH dependency before ART implementation resumes.

## Why this exists
The dependency had been discovered per ART chunk. This plan closes the catalogue, prepared-capability, service-matrix, submission, checker, review, recovery, and activation surfaces end to end.

## What changed
- Added the WS-XINT-002 planning set, review log, and eleven executable implementation contracts.
- Planned three missing actions and mandatory deletion of six obsolete upload-session actions and permissions.
- Split initial preparation, Submission/binding consumption, checker remediation, and human-review revision.
- Required paired human and fixed-service authorization for reviewer packets and evidence.
- Redirected existing ART/AUTH handoffs to this source of truth.

## Design chosen
One closed catalogue reconciliation and one reusable PREP extension merge first with all new actions unavailable. Narrow activation chunks follow only after exact hidden feature evidence exists. AUTH owns authority and evidence; ART owns bytes; product modules own lifecycle truth and typed fact composition.

## Not in scope
No application code, migration, action activation, grant, provider behavior, or ART-03A implementation change.

## Tests and evidence
| Evidence | Result |
|---|---|
| stale authorization documentation | pass |
| stale artifact contracts | pass |
| Markdown links | pass |
| lightweight deterministic Agent Gates | pass |
| diff integrity | pass |
| architecture | pass |
| security/auth | pass with low risks |
| QA/test | pass with low risks |
| product/ops | pass with low risks |
| senior engineering | pass with low risks |
| CI integrity | pass |

## Test delta
Planning-only Markdown change. No production or test code changed. Future contracts contain exact PostgreSQL, coverage, migration, and hosted verification requirements.

## External review response
All twelve initial CodeRabbit comments were addressed on repair head `834ff13b`. Product/ops corrected one overbroad suggestion so remediation reruns the checker spine before a new `allow_review` can route it.

## Remaining risks
Implementation reviews must enforce forbidden-change lists despite some broad module globs. Baseline counts must be reconfirmed from then-current main before implementation.

## Human review focus
Catalogue completeness, mandatory legacy deletion, permanent handle burn, human/service separation, and evidence-ordered activation.

## Merge ownership
Human-owned. Do not merge without explicit approval for PR #209.