### PR TITLE
docs(xint): close merged policy mutation chunk

### DIFF
--- a/.agent-loop/initiatives/WS-XINT-003-rev-auth-end-to-end/REVIEW_LOG.md
+++ b/.agent-loop/initiatives/WS-XINT-003-rev-auth-end-to-end/REVIEW_LOG.md
@@ -110,3 +110,7 @@ stale 0047 head constant and an incorrect unprefixed constraint lookup. The
 0048 head is now exact, the installed constraint is behaviorally exercised for
 independent and partial selector cases, and the focused isolated PostgreSQL
 round trip passes.
+
+PR #248 merged the completed chunk as `25fc27c4` on 2026-08-03. Backend, Agent
+Gates, and CodeRabbit passed on the final PR head. No review/revision lifecycle
+action was activated, and no successor chunk starts automatically.

--- a/.agent-loop/initiatives/WS-XINT-003-rev-auth-end-to-end/STATUS.md
+++ b/.agent-loop/initiatives/WS-XINT-003-rev-auth-end-to-end/STATUS.md
@@ -2,10 +2,11 @@
 
 ## Current status
 
-WS-XINT-003-01 and WS-XINT-003-02A are merged. WS-XINT-003-02B policy mutation
-activation is the active bounded implementation chunk from `origin/main` at
-`2c24c91d`. No policy mutation action or public surface was active at its
-starting baseline.
+WS-XINT-003-01, WS-XINT-003-02A, and WS-XINT-003-02B are merged. PR #248 merged
+02B as `25fc27c4` on 2026-08-03 after Backend, Agent Gates, and CodeRabbit passed
+on the final PR head. Exactly `project.review_policy.update` and
+`project.revision_policy.update` are active; review/revision lifecycle actions
+remain planned or unavailable.
 
 ## Baseline
 
@@ -27,8 +28,9 @@ REV-owned semantics with AUTH-owned mutation authorization.
 - Runtime owner XINT-002-07 has one approved v0.1 sub-wave: 07A packet
   materialization. Evidence binding remains planned/unavailable and 07B is
   reserved pending separate REV-owned intent.
-- All registered review actions remain planned; four lifecycle/recovery actions
-  remain missing until 08R; no service identity is provisioned by chunk 01.
+- Registered review/revision lifecycle actions remain planned; four
+  lifecycle/recovery actions remain missing until 08R. The two policy mutation
+  actions activated by 02B are setup authority, not lifecycle activation.
 
 ## WS-XINT-003-02A implementation
 
@@ -45,6 +47,6 @@ REV-owned semantics with AUTH-owned mutation authorization.
 
 ## Next step
 
-WS-XINT-003-02B implementation and internal review are complete. Open the PR,
-run exact-head hosted review, resolve every valid external finding, obtain human
-merge, and stop before review lifecycle activation.
+Discuss and authorize the next bounded REV-AUTH chunk. Do not infer review
+lifecycle activation from the 02B merge and do not start a successor
+automatically.

--- a/.agent-loop/initiatives/WS-XINT-003-rev-auth-end-to-end/chunks/WS-XINT-003-02B-policy-mutation-activation.md
+++ b/.agent-loop/initiatives/WS-XINT-003-rev-auth-end-to-end/chunks/WS-XINT-003-02B-policy-mutation-activation.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-In progress after PR #242 merged 02A and the user explicitly started 02B on
-2026-08-02. Refreshed from `origin/main` at merge `6babf81b` before application
-code changes and rebased onto `2c24c91d` before external review.
+Complete. PR #248 merged as `25fc27c4` on 2026-08-03 after Backend, Agent Gates,
+and CodeRabbit passed on the final PR head. The chunk activated only the two
+policy mutation actions named below; it did not activate review/revision
+lifecycle behavior.
 
 ## Goal
 


### PR DESCRIPTION
## Intent

Close the durable WS-XINT-003-02B status after PR #248 merged.

## Scope

- mark 02B complete at merge `25fc27c4`;
- record final Backend, Agent Gates, and CodeRabbit success;
- distinguish the two active policy mutation actions from unavailable review/revision lifecycle behavior;
- state that no successor chunk starts automatically.

No runtime, migration, authorization behavior, roadmap, or next-chunk activation changes.

## Verification

- Markdown link check passed for all 3 changed files.
- `git diff --check` passed.
- Focused docs reviewer: PASS, no blocking wording findings.

## Human review focus

Confirm the closeout does not imply review lifecycle activation or authorize a successor chunk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project records to reflect the successful completion and validation of the policy mutation work.
  * Clarified that only the two approved policy actions are active.
  * Review, revision, lifecycle, and recovery actions remain unavailable until explicitly authorized.
  * Recorded successful merge and validation checks for improved release traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->