### PR TITLE
WS-CI-001-03: distribute semantic backend lanes

### DIFF
--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/CHUNK_MAP.md
@@ -4,14 +4,15 @@
 |---|---|---:|---|
 | `WS-CI-001-01` | Parallel Full-Suite Coverage | L1 | Completed and merged in PR #163 |
 | `WS-CI-001-01R1` | Timeout Cleanup Repair | L1 | Completed and merged in PR #164 |
-| `WS-CI-001-02` | Safe Routing, Cache, and Timing Refinement | L1 | Active signed planning; measured decision defers routing/cache/timing and plans 02A/02B |
-| `WS-CI-001-02A` | Safe Migrate-Once Database Reset | L1/P0 | Proposed successor; requires separate signed implementation start |
-| `WS-CI-001-02B` | Exact-Custody Semantic Test Lanes | L1/P0 | Proposed after 02A evidence; not yet eligible to start |
-| `WS-CI-001-03` | Safe Routing, Cache, and Timing Reassessment | L1 | Future planning after 02B evidence; not a declared successor |
+| `WS-CI-001-02` | Safe Routing, Cache, and Timing Refinement | L1 | Completed |
+| `WS-CI-001-02A` | Safe Migrate-Once Database Reset | L1/P0 | Completed and merged |
+| `WS-CI-001-02B` | Exact-Custody Semantic Test Lanes | L1/P0 | Completed and merged in PR #198 |
+| `WS-CI-001-03` | Distributed Semantic Test Lanes | L1 | In implementation |
 
 Each chunk maps to one PR. Chunk 01 preserves the full suite and every coverage
 gate. Chunk 01R1 repaired timeout cleanup. Chunk 02 converts measured evidence
 and PR #180 into two prospective implementation contracts. Chunk 02A first
 proves the destructive reset and fixture migration under the existing CI
 topology. Chunk 02B may then change runner/workflow topology using 02A evidence.
-Only 02A is the declared successor of this planning PR.
+Chunk 03 preserves 02B's semantic ownership and evidence model while restoring
+one hosted runner per lane and one fail-closed final required check.

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/DECISIONS.md
@@ -1,5 +1,14 @@
 # DECISIONS: WS-CI-001 - Backend CI Acceleration
 
+## 2026-08-03 - Partition the measured Alembic long tail
+
+Hosted Backend run `30786185424` (schema job `91600051005`) proved that the
+semantic matrix runs in parallel, but `tests/test_alembic.py` alone took 707.60
+seconds and dominated a 13m09s schema job. Partition its exact collected
+node IDs deterministically across two schema runners. Keep reset and isolated
+runner contracts in schema A, and reconcile all five lane manifests at fan-in
+so no test can be skipped or counted twice.
+
 ## 2026-07-20 - Prioritize CI acceleration before explicit-start automation
 
 The user selected backend CI efficiency as the next initiative after successful
@@ -58,3 +67,11 @@ that cause. Chunk 02 therefore makes a reviewed no-implementation decision for
 those original options. They may be reassessed only in future planning chunk
 `WS-CI-001-03`, after 02B exact-head evidence exists; 03 is not a successor of
 this PR and has no start authority.
+
+## 2026-08-03 - Restore real hosted parallelism
+
+Exact GitHub evidence shows migrate-once semantic lanes remain correct but take
+15m31s when four subprocesses compete on one hosted runner. Keep semantic lane
+ownership and exact custody, but execute each lane in an independent matrix job
+and combine only authenticated evidence in the stable final `test` job. Remove
+review-event reruns because review state does not change the tested commit.

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/DISCOVERY.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/DISCOVERY.md
@@ -17,6 +17,13 @@
 
 ## Measured evidence
 
+Current post-02B evidence adds a concrete regression measurement. Backend run
+`30782031524`, job `91588477886`, took 17m20s. Its four-lane execution step took
+15m31s on one `ubuntu-latest` runner; installation took 23 seconds and canonical
+collection plus validation took 19 seconds. The workflow's
+`pull_request_review` trigger also repeats the full Backend run for an unchanged
+head. The bottleneck is hosted execution topology, not dependency installation.
+
 PR #161 Backend run `29752233451`, job `88385435082`:
 
 | Step | Duration |

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/INTENT.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/INTENT.md
@@ -2,6 +2,11 @@
 
 ## Problem being solved
 
+After 02B, the complete suite is divided into four semantic processes but all
+four run inside one GitHub-hosted job. A successful August 3 run took 17m20s,
+including 15m31s for those competing processes. Review submission or dismissal
+also starts the complete Backend workflow again for an unchanged commit.
+
 The required Backend GitHub Actions job runs the complete backend test suite in
 one sequential process. PR #161 spent 25 minutes 31 seconds in that single step
 and about 27 minutes overall even though it changed no backend product code.

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/PLAN.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/PLAN.md
@@ -6,7 +6,22 @@ Reduce Backend workflow wall-clock time while preserving complete test execution
 real service integration, exact-head provenance, and every current coverage and
 branch-protection gate.
 
-## Proposed approach
+## 03 amendment — distributed semantic lanes
+
+Retain 02B's dependency-oriented semantic ownership, migrate-once isolation,
+exact node completion evidence, and coverage custody. Execute one lane per
+GitHub matrix runner, with the measured `test_alembic.py` long tail partitioned
+by deterministic exact node ID across two schema runners. Each runner emits one
+digest-bound bundle; the stable final `test` job accepts exactly five bundles with identical manifests and head
+SHA, independently recollects the current suite, validates complete execution,
+combines coverage once, and runs every existing blocking report. Remove
+`pull_request_review` and cancel superseded same-PR runs. Do not introduce path
+routing, sampling, or changed-test selection.
+
+## Historical 01 approach
+
+The shard-planner design below records the completed 01 topology. The current
+03 implementation is governed by the distributed semantic-lane amendment above.
 
 ### 1. Deterministic inventory and partitioning
 

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/RISKS.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/RISKS.md
@@ -20,3 +20,7 @@
 | R16 | Fast reset leaves a guarded trigger disabled | Critical | Use one canonical seven-table guard inventory and prove every trigger is enabled after success and rollback |
 | R17 | Mechanical test edits weaken behavioral contracts | Critical | Restore strict Boolean identity assertions and require test-delta review against current main |
 | R18 | Contributor implementation is retroactively authorized | Critical | Preserve PR #180 as discovery evidence; merge planning 02 first, then signed-start prospective 02A before adoption |
+| R19 | Four semantic processes contend on one hosted runner | High | Run one declared semantic lane per independent GitHub matrix job |
+| R20 | Review events duplicate an unchanged-head Backend run | High | Remove `pull_request_review`; PR synchronization already runs the tested SHA |
+| R21 | Distributed lane artifacts are mixed or incomplete | Critical | Fixed lane set, identical manifest/head, byte digests, independent final collection, and explicit upstream-success check |
+| R22 | One Alembic module dominates the hosted critical path | High | Deterministically partition every exact Alembic node ID across two independent schema lanes and reconcile all five lanes fail-closed |

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/STATUS.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/STATUS.md
@@ -1,22 +1,13 @@
 # STATUS: WS-CI-001 - Backend CI Acceleration
 
-- Phase: signed implementation
-- Active planning chunk: none
-- Active implementation chunk: `WS-CI-001-02B`
-- Proposed implementation successor: none
-- Later proposed chunk: `WS-CI-001-03` planning only; not a declared successor
-- Human direction: preserve Konan's authorship and measured work from PR #180,
-  but adopt it only under prospective zero-trust scope and evidence
-- Current gate: reviewed repair SHA `24f3b638` independently collected and
-  reconciled 2,056 nodes after addressing all fourteen CodeRabbit findings.
-  Prior PR head `f5d2abd7` passed its 2,049 hosted nodes, API E2E, resource
-  custody, and coverage floors in run `30121249272`; its required check failed
-  because 9m39s exceeded the hard 480-second bound. A later exact-head run
-  again passed all functional and coverage gates in about nine minutes. The
-  repository owner accepted that measured performance risk and deferred
-  optimization, so the workflow now records the eight-minute target result
-  without letting that accepted miss override the required correctness gates.
-  The repair still requires fresh hosted and external review before the
-  user-owned merge decision
-- Deferred option: routing/cache/timing reassessment is future `WS-CI-001-03`,
-  with no start or successor declaration
+- Phase: implementation
+- Current chunk: `WS-CI-001-03`
+- Goal: restore distributed semantic lanes and eliminate unchanged-head review reruns
+- Current measured regression: successful run `30782031524` took 17m20s;
+  semantic-lane execution consumed 15m31s on one hosted runner.
+- Implemented correction: five hosted matrix runners, including two exact-node
+  Alembic partitions, fail-closed evidence and
+  coverage fan-in, lightweight review-state approval refresh, and superseded-run
+  cancellation.
+- Remaining gate: repaired internal review, exact checked-out-tree GitHub CI,
+  external review, and human merge decision.

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/chunks/WS-CI-001-03-safe-routing-cache-timing-reassessment.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/chunks/WS-CI-001-03-safe-routing-cache-timing-reassessment.md
@@ -1,23 +1,120 @@
-# Chunk Contract: WS-CI-001-03 — Safe Routing, Cache, and Timing Reassessment
+# Chunk Contract: WS-CI-001-03 — Distributed Semantic Test Lanes
 
-## Phase
+## Goal
 
-Future planning only. This chunk is not started, is not a declared successor,
-and authorizes no implementation.
+Restore real hosted parallelism for exact-custody semantic backend lanes,
+partition the measured Alembic long tail, and stop duplicate unchanged-head
+runs without weakening any test,
+integration proof, failure propagation, or coverage threshold.
 
-## Preconditions
+## Evidence for the change
 
-02A and 02B are merged, and exact hosted evidence identifies a remaining
-bottleneck that routing, cache, or durable timing data could address.
+Backend run `30782031524`, job `91588477886`, completed successfully in 17m20s.
+The four lanes occupied 15m31s inside one `ubuntu-latest` job. Installation took
+23 seconds and collection/validation took 19 seconds. The workflow also runs on
+`pull_request_review`, repeating the complete Backend workflow for an unchanged
+PR head. The earlier four-job topology completed near nine minutes before it was
+replaced by single-runner semantic lanes.
 
-## Planning scope
+## Risk class
 
-Reassess fail-closed path routing, dependency-cache provenance/invalidation,
-and exact-head timing weights. Produce a separately reviewed implementation
-contract if any option is justified.
+L1 — required CI topology and evidence custody.
 
-## Hard boundaries
+## Machine-checkable scope
 
-No sampling, skipped tests, ambiguous full-suite routing, cross-commit cache or
-timing authority, coverage weakening, implementation, or successor declaration
-without its own signed planning event and review.
+```chunk-scope-json
+{
+  "schema_version": 1,
+  "chunk_id": "WS-CI-001-03",
+  "phase": "implementation",
+  "risk_class": "L1",
+  "allowed_paths": [
+    ".github/workflows/backend.yml",
+    ".github/workflows/agent-gates.yml",
+    "backend/scripts/run_test_lanes.py",
+    "backend/scripts/merge_test_lane_evidence.py",
+    "backend/scripts/validate_test_lane_evidence.py",
+    "backend/tests/test_ci_test_lanes.py",
+    "backend/tests/test_merge_test_lane_evidence.py",
+    "backend/tests/test_test_lane_evidence.py",
+    "scripts/test_lightweight_agent_gates.py",
+    "docs/operations_backend_testing.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/INTENT.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/DISCOVERY.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/PLAN.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/CHUNK_MAP.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/STATUS.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/RISKS.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/DECISIONS.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/chunks/WS-CI-001-03-safe-routing-cache-timing-reassessment.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/reviews/WS-CI-001-03-internal-review-evidence.md",
+    ".agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/reviews/WS-CI-001-03-pr-trust-bundle.md"
+  ],
+  "forbidden_paths": ["backend/app/**", "backend/alembic/**", "frontend/**"],
+  "required_reviewers": ["senior engineering", "qa/test", "security/auth", "ci integrity", "test delta"],
+  "verification_commands": ["focused-lane-tests", "workflow-static-check", "markdown-links", "stale-wording", "git-diff-check", "hosted-backend-exact-head"]
+}
+```
+
+## Allowed changes
+
+- Run the existing semantic ownership on five GitHub matrix jobs. Partition
+  `test_alembic.py` node IDs deterministically across two schema lanes.
+- Add one fail-closed helper that accepts exactly one digest-bound bundle per
+  declared lane and emits the existing complete-run evidence schema.
+- Keep final job ID `test` as the stable required `Backend / test` context.
+- Remove the `pull_request_review` trigger from Backend, move the existing
+  dependency-approval refresh to lightweight Agent Gates, and cancel superseded
+  same-PR Backend runs.
+- Update focused tests, operator documentation, and this initiative's records.
+
+## Not allowed
+
+- Skipping, sampling, deselecting, removing, or weakening tests.
+- Lowering the global 78 percent or protected 90 percent coverage floors.
+- Path-based Backend suppression or changed-file-only test execution.
+- Shared mutable databases, MinIO namespaces, or coverage files.
+- Product code, API, migration, schema, dependency, or branch-protection changes.
+- Accepting missing, duplicate, foreign-head, digest-mismatched, failed,
+  cancelled, or incomplete lane evidence.
+
+## Acceptance criteria
+
+- [ ] Five named semantic lanes run on five independent hosted matrix jobs.
+- [ ] Every Alembic node maps deterministically to exactly one of two schema
+      lanes; reset and isolated-runner contracts remain in schema A.
+- [ ] Every lane provisions its own PostgreSQL service, migrated database/role,
+      MinIO namespace, coverage file, and exact collection/completion evidence.
+- [ ] Final `Backend / test` runs even after an upstream failure and explicitly
+      rejects any non-success matrix result.
+- [ ] Fan-in accepts exactly five fixed lane names, identical manifests and
+      heads, digest-bound files, and no symlink or surplus lane directory.
+- [ ] Independent final collection reconciles every canonical node exactly once
+      against completed nodes before coverage is combined.
+- [ ] Existing API E2E, global coverage, and every protected coverage report
+      remain blocking.
+- [ ] Backend runs only for PR synchronization/open/reopen and pushes to main;
+      review submission/dismissal does not rerun an unchanged SHA.
+- [ ] Guide dependency review submissions/dismissals refresh Agent Gates, where
+      the unchanged exact-head approval check remains blocking.
+- [ ] A newer run for the same PR cancels its superseded predecessor.
+- [ ] Exact-head hosted evidence demonstrates the complete required check and
+      records whether the eight-minute target is met.
+
+## Verification
+
+```bash
+PYTHONPATH=backend backend/.venv/bin/python -m pytest -q \
+  backend/tests/test_ci_test_lanes.py \
+  backend/tests/test_merge_test_lane_evidence.py \
+  backend/tests/test_test_lane_evidence.py
+PYTHONPATH=. python3 scripts/test_lightweight_agent_gates.py
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+git diff --check origin/main...HEAD
+```
+
+Hosted acceptance requires `Backend / test` on GitHub's exact checked-out PR
+merge tree for the current PR head. Agent Gates separately binds exceptional
+dependency approval to the literal PR head. Local timing is not acceptance
+evidence.

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/reviews/WS-CI-001-03-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/reviews/WS-CI-001-03-internal-review-evidence.md
@@ -1,0 +1,42 @@
+# WS-CI-001-03 Internal Review Evidence
+
+## Scope reviewed
+
+Distributed execution of semantic backend lanes, including deterministic
+exact-node partitioning of the measured Alembic hotspot, exact
+evidence/coverage fan-in, duplicate Backend review-trigger removal, lightweight
+dependency-approval refresh, failure diagnostics, and operator documentation.
+
+No product code, migration, dependency, test assertion, test selection, or
+coverage threshold changed.
+
+## Reviewer results
+
+| Track | Result | Resolved findings |
+|---|---|---|
+| CI integrity | PASS | Preserved review-state dependency approval in Agent Gates; preserved failure artifacts; scope corrected. |
+| QA/test | PASS | Rebased onto current main; corrected verification command; added traversal, symlink, manifest-drift, and failed-lane tests. |
+| Security/auth | PASS | Replaced directory upload with explicit files; enabled hidden coverage only; hardened manifest paths and artifact custody. |
+| Architecture | PASS | Kept workflow, runner, fan-in, and independent validator boundaries separate; removed private-helper coupling. |
+| Senior engineering | PASS | Added redacted lane logs for actionable failure diagnosis without making them trusted evidence. |
+| Documentation | PASS | Aligned failure order, timing basis, Agent Gates approval refresh, merge-tree custody, and diagnostic logs. |
+
+The historical signed-start finding was not applicable after reconciliation
+with current `main`: `AGENTS.md` now states that GitHub permissions and branch
+protection govern contribution authority and that planning artifacts explain
+work but do not authorize or block it. The user explicitly instructed this CI
+repair. The retired explicit-event workflow is absent from current `main`.
+
+## Verification
+
+- Focused lane, fan-in, and validator suite: 77 passed.
+- Lightweight workflow regression suite: 7 passed.
+- Ruff on every changed Python file: passed.
+- Backend and Agent Gates YAML parse: passed.
+- Markdown links: passed.
+- Stale wording: passed.
+- Diff whitespace and scope against current `origin/main`: passed.
+- Branch protection contexts confirmed: `test` and `agent-gates` remain required.
+
+Hosted `Backend / test`, Agent Gates, external review, and measured timing on
+the published PR tree remain required before merge readiness.

--- a/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/reviews/WS-CI-001-03-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/reviews/WS-CI-001-03-pr-trust-bundle.md
@@ -1,0 +1,56 @@
+# WS-CI-001-03 PR Trust Bundle
+
+## Intent
+
+Correct a backend CI regression where four semantic processes compete on one
+hosted runner for 15m31s and the complete Backend workflow repeats when review
+state changes.
+
+## Design
+
+- Run semantic ownership on five independent matrix runners, including two
+  deterministic exact-node partitions for `test_alembic.py`.
+- Upload one exact checked-out-tree bundle per lane using an explicit file list.
+- Keep `Backend / test` as the stable, always-run final required check.
+- Reject upstream failure before fan-in; reconcile exact manifests, nodes,
+  resource isolation, and byte digests before combining coverage once.
+- Run the existing API E2E against live PostgreSQL and pinned MinIO.
+- Move the exceptional guide-dependency approval refresh to required, fast
+  Agent Gates instead of rerunning Backend on every review event.
+- Cancel superseded Backend runs for the same PR.
+
+## Integrity preserved
+
+- No test is skipped, removed, sampled, deselected, or weakened.
+- Global 78 percent and every protected 90 percent coverage floor remain
+  blocking.
+- Real migrations, PostgreSQL constraints/locks/triggers/concurrency, MinIO,
+  and API contract proof remain in required CI.
+- Matrix databases, roles, MinIO namespaces, coverage files, and artifacts are
+  isolated per lane.
+- Missing, failed, cancelled, foreign, duplicate, symlinked, traversing,
+  digest-mismatched, or incomplete evidence fails closed.
+- Workflow permissions remain read-only.
+
+## Evidence
+
+- Prior successful baseline: run `30782031524`, job `91588477886`, 17m20s total,
+  15m31s in the four-lane single-runner step.
+- First distributed run `30786185424` proved real parallel execution; schema
+  job `91600051005` took 13m09s, including 707.60 seconds for 105 tests in
+  `test_alembic.py`. The final job then exposed the corrected module-invocation
+  defect before coverage fan-in.
+- Local deterministic checks: 77 focused tests and seven workflow regression
+  tests passed; Ruff, YAML parse, links, stale wording, and diff checks passed.
+- All focused internal review tracks pass after repairs.
+
+## Human review focus
+
+1. Confirm five matrix jobs represent the intended runner cost/latency tradeoff.
+2. Confirm `Backend / test` and `Agent Gates / agent-gates` remain the required
+   branch-protection contexts.
+3. Inspect exact PR run timing and ensure complete Backend wall time approaches
+   or beats the eight-minute target.
+4. Confirm CodeRabbit and GitHub checks are green on the final commit.
+
+The user retains the merge decision. Local timing is not acceptance evidence.

--- a/.github/workflows/agent-gates.yml
+++ b/.github/workflows/agent-gates.yml
@@ -3,9 +3,12 @@ name: Agent Gates
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
+  pull_request_review:
+    types: [submitted, dismissed]
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   agent-gates:
@@ -32,6 +35,17 @@ jobs:
 
       - name: Stale artifact contract check
         run: python3 scripts/check_stale_artifact_contracts.py
+
+      - name: Guide extractor dependency approval
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          WORKSTREAM_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          WORKSTREAM_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          WORKSTREAM_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          WORKSTREAM_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: >-
+          python3 backend/scripts/check_guide_extractor_dependencies.py
+          --require-pr-approval
 
       - name: Lightweight gate regression tests
         run: python3 -m unittest -v scripts.test_lightweight_agent_gates

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -2,13 +2,13 @@ name: Backend
 
 on:
   pull_request:
-  pull_request_review:
-    types:
-      - submitted
-      - dismissed
   push:
     branches:
       - main
+
+concurrency:
+  group: backend-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -18,9 +18,18 @@ env:
   MINIO_IMAGE: quay.io/minio/minio:latest@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
 
 jobs:
-  test:
+  lanes:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        lane:
+          - shared_foundations
+          - schema_contracts_a
+          - schema_contracts_b
+          - project_lifecycle
+          - task_lifecycle
 
     services:
       postgres:
@@ -59,23 +68,6 @@ jobs:
           test "$(git rev-parse "${tree_sha}^{tree}")" = "$(git rev-parse HEAD^{tree})"
           echo "job_start_epoch=${job_start_epoch}" >> "${GITHUB_OUTPUT}"
           echo "tree_sha=${tree_sha}" >> "${GITHUB_OUTPUT}"
-
-      - name: Guide extractor dependency approval
-        working-directory: backend
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          WORKSTREAM_PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          WORKSTREAM_PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          WORKSTREAM_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          WORKSTREAM_PR_NUMBER: ${{ github.event.pull_request.number }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          approval_args=()
-          if [[ "${GITHUB_EVENT_NAME}" != "push" ]]; then
-            approval_args+=(--require-pr-approval)
-          fi
-          python scripts/check_guide_extractor_dependencies.py "${approval_args[@]}"
 
       - name: Install backend and exact Ruff
         working-directory: backend
@@ -132,7 +124,7 @@ jobs:
           --metadata-dir .ci/test-lanes/collect
           --summary-json .ci/test-lanes/collect-summary.json
 
-      - name: Execute four semantic lanes
+      - name: Execute semantic lane ${{ matrix.lane }}
         working-directory: backend
         env:
           COVERAGE_FILE: .coverage
@@ -142,25 +134,158 @@ jobs:
         shell: bash
         run: |
           set -uo pipefail
-          rm -f .coverage .coverage.*
-          lane_exit=0
+          install -d -m 700 ".ci/lane-bundle/${{ matrix.lane }}"
           python scripts/run_test_lanes.py \
-            --metadata-dir .ci/test-lanes/run \
-            --summary-json .ci/test-lanes/run-summary.json \
-            --timeout-seconds 1200 || lane_exit=$?
-          printf '%s\n' "${lane_exit}" > .ci/test-lanes/run.exit
+            --lane "${{ matrix.lane }}" \
+            --metadata-dir ".ci/lane-bundle/${{ matrix.lane }}/metadata" \
+            --summary-json ".ci/lane-bundle/${{ matrix.lane }}/summary.json" \
+            --timeout-seconds 1200
 
-      - name: Independently validate completed-node and coverage custody
+      - name: Bind lane bundle timing
+        if: ${{ always() }}
         working-directory: backend
-        run: >-
-          python scripts/validate_test_lane_evidence.py
-          --metadata-dir .ci/test-lanes/run
-          --summary-json .ci/test-lanes/run-summary.json
-
-      - name: Require semantic-lane execution success
         shell: bash
+        run: >-
+          printf '%s\n' '${{ steps.identity.outputs.job_start_epoch }}'
+          > '.ci/lane-bundle/${{ matrix.lane }}/job-start-epoch.txt'
+
+      - name: Upload authenticated lane ${{ matrix.lane }}
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: backend-lane-${{ github.sha }}-${{ matrix.lane }}
+          path: |
+            backend/.ci/lane-bundle/${{ matrix.lane }}/summary.json
+            backend/.ci/lane-bundle/${{ matrix.lane }}/job-start-epoch.txt
+            backend/.ci/lane-bundle/${{ matrix.lane }}/metadata/manifest.json
+            backend/.ci/lane-bundle/${{ matrix.lane }}/metadata/${{ matrix.lane }}.json
+            backend/.ci/lane-bundle/${{ matrix.lane }}/metadata/${{ matrix.lane }}.database.json
+            backend/.ci/lane-bundle/${{ matrix.lane }}/metadata/.coverage.${{ matrix.lane }}
+            backend/.ci/lane-bundle/${{ matrix.lane }}/metadata/${{ matrix.lane }}.log
+            backend/.ci/lane-bundle/${{ matrix.lane }}/metadata/${{ matrix.lane }}.admin.log
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 7
+
+  test:
+    if: ${{ always() }}
+    needs: lanes
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: public.ecr.aws/docker/library/postgres:16@sha256:33f923b05f64ca54ac4401c01126a6b92afe839a0aa0a52bc5aeb5cc958e5f20
+        env:
+          POSTGRES_DB: workstream_test
+          POSTGRES_USER: workstream
+          POSTGRES_PASSWORD: workstream
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U workstream -d workstream_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - id: identity
+        name: Bind exact checked-out tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          job_start_epoch="$(date +%s)"
+          tree_sha="$(git rev-parse HEAD)"
+          test "${tree_sha}" = "${GITHUB_SHA}"
+          test -z "$(git status --porcelain)"
+          echo "job_start_epoch=${job_start_epoch}" >> "${GITHUB_OUTPUT}"
+          echo "tree_sha=${tree_sha}" >> "${GITHUB_OUTPUT}"
+
+      - name: Install backend
         working-directory: backend
-        run: test "$(cat .ci/test-lanes/run.exit)" = 0
+        run: python -m pip install -e ".[dev]"
+
+      - name: Start real MinIO API provider
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --detach --rm --name workstream-minio \
+            --publish 127.0.0.1:9000:9000 \
+            --env MINIO_ROOT_USER=workstream-minio \
+            --env MINIO_ROOT_PASSWORD=workstream-minio-secret-key \
+            "${MINIO_IMAGE}" server /data --address :9000
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent http://127.0.0.1:9000/minio/health/live >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs workstream-minio
+          exit 1
+
+      - name: Download shared foundations evidence
+        if: ${{ always() }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: backend-lane-${{ github.sha }}-shared_foundations
+          path: backend/.ci/download/shared_foundations
+
+      - name: Download schema contracts A evidence
+        if: ${{ always() }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: backend-lane-${{ github.sha }}-schema_contracts_a
+          path: backend/.ci/download/schema_contracts_a
+
+      - name: Download schema contracts B evidence
+        if: ${{ always() }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: backend-lane-${{ github.sha }}-schema_contracts_b
+          path: backend/.ci/download/schema_contracts_b
+
+      - name: Download project lifecycle evidence
+        if: ${{ always() }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: backend-lane-${{ github.sha }}-project_lifecycle
+          path: backend/.ci/download/project_lifecycle
+
+      - name: Download task lifecycle evidence
+        if: ${{ always() }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: backend-lane-${{ github.sha }}-task_lifecycle
+          path: backend/.ci/download/task_lifecycle
+
+      - name: Require every semantic lane
+        if: ${{ always() }}
+        env:
+          LANES_RESULT: ${{ needs.lanes.result }}
+        run: test "${LANES_RESULT}" = success
+
+      - name: Merge and independently validate exact lane custody
+        working-directory: backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          install -d -m 700 .ci/test-lanes
+          python -m scripts.merge_test_lane_evidence \
+            --input-root .ci/download \
+            --metadata-dir .ci/test-lanes/run \
+            --summary-json .ci/test-lanes/run-summary.json
+          python scripts/validate_test_lane_evidence.py \
+            --metadata-dir .ci/test-lanes/run \
+            --summary-json .ci/test-lanes/run-summary.json
 
       - name: Combine semantic-lane coverage exactly once
         working-directory: backend
@@ -169,11 +294,11 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           coverage_files=(.ci/test-lanes/run/.coverage.*)
-          test "${#coverage_files[@]}" -eq 4
+          test "${#coverage_files[@]}" -eq 5
           for source in "${coverage_files[@]}"; do
+            destination="$(basename "${source}")"
             test -f "${source}"
             test ! -L "${source}"
-            destination="$(basename "${source}")"
             test ! -e "${destination}"
             cp -- "${source}" "${destination}"
             test "$(sha256sum "${source}" | cut -d' ' -f1)" = \
@@ -311,7 +436,6 @@ jobs:
         working-directory: backend
         env:
           EXPECTED_HEAD_SHA: ${{ steps.identity.outputs.tree_sha }}
-          JOB_START_EPOCH: ${{ steps.identity.outputs.job_start_epoch }}
         shell: bash
         run: |
           set -euo pipefail
@@ -357,7 +481,7 @@ jobs:
               raise SystemExit("hosted evidence head drift")
 
           lanes = summary.get("lanes")
-          if not isinstance(lanes, list) or len(lanes) != 4:
+          if not isinstance(lanes, list) or len(lanes) != 5:
               raise SystemExit("invalid hosted lane inventory")
           collected: list[str] = []
           completed: list[str] = []
@@ -424,7 +548,22 @@ jobs:
           ):
               raise SystemExit("slowest lane timing drift")
 
-          start_epoch = int(os.environ["JOB_START_EPOCH"])
+          start_epochs = []
+          for lane_name in (
+              "shared_foundations",
+              "schema_contracts_a",
+              "schema_contracts_b",
+              "project_lifecycle",
+              "task_lifecycle",
+          ):
+              timing_path = Path(".ci/download") / lane_name / "job-start-epoch.txt"
+              if timing_path.is_symlink() or not timing_path.is_file():
+                  raise SystemExit("missing lane start timing")
+              timing_value = timing_path.read_text(encoding="ascii").strip()
+              if not timing_value.isdigit():
+                  raise SystemExit("invalid lane start timing")
+              start_epochs.append(int(timing_value))
+          start_epoch = min(start_epochs)
           total_wall = time.time() - start_epoch
           if not math.isfinite(total_wall) or total_wall < 0:
               raise SystemExit("invalid Backend hosted wall time")
@@ -469,6 +608,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: backend-semantic-lane-evidence-${{ steps.identity.outputs.tree_sha }}
-          path: backend/.ci/test-lanes/**
+          path: |
+            backend/.ci/download/**
+            backend/.ci/test-lanes/**
+          include-hidden-files: true
           if-no-files-found: warn
           retention-days: 7

--- a/backend/scripts/merge_test_lane_evidence.py
+++ b/backend/scripts/merge_test_lane_evidence.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Merge independently executed semantic-lane bundles fail closed."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import shutil
+from typing import Any
+
+from scripts.run_test_lanes import LANES, LaneError, SCHEMA_VERSION
+
+
+def _canonical_json(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise LaneError("missing_lane_bundle_file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise LaneError("invalid_lane_bundle_json") from exc
+    if not isinstance(value, dict):
+        raise LaneError("invalid_lane_bundle_json")
+    return value
+
+
+def _digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _copy_bound(source: Path, destination: Path, expected_digest: Any) -> None:
+    if (
+        not isinstance(expected_digest, str)
+        or len(expected_digest) != 64
+        or source.is_symlink()
+        or not source.is_file()
+        or _digest(source) != expected_digest
+        or destination.exists()
+        or destination.is_symlink()
+    ):
+        raise LaneError("invalid_lane_bundle_file")
+    shutil.copyfile(source, destination)
+
+
+def merge_bundles(input_root: Path, metadata_dir: Path, summary_json: Path) -> None:
+    """Merge exactly one authenticated bundle for each declared lane."""
+    if (
+        input_root.is_symlink()
+        or not input_root.is_dir()
+        or metadata_dir.exists()
+        or metadata_dir.is_symlink()
+        or summary_json.exists()
+        or summary_json.is_symlink()
+    ):
+        raise LaneError("invalid_lane_bundle_root")
+    expected_names = {lane.name for lane in LANES}
+    actual_names = {path.name for path in input_root.iterdir() if path.is_dir()}
+    if actual_names != expected_names or any(path.is_symlink() for path in input_root.iterdir()):
+        raise LaneError("invalid_lane_bundle_set")
+    metadata_dir.mkdir(mode=0o700)
+
+    manifest_bytes: bytes | None = None
+    manifest_digest: str | None = None
+    head_sha: str | None = None
+    canonical_node_count: int | None = None
+    lane_rows: list[dict[str, Any]] = []
+    elapsed_seconds = 0.0
+    for lane in LANES:
+        bundle = input_root / lane.name
+        summary = _read_object(bundle / "summary.json")
+        if (
+            summary.get("schema_version") != SCHEMA_VERSION
+            or summary.get("mode") != "lane"
+            or not isinstance(summary.get("lanes"), list)
+            or len(summary["lanes"]) != 1
+            or not isinstance(summary["lanes"][0], dict)
+            or summary["lanes"][0].get("name") != lane.name
+        ):
+            raise LaneError("invalid_lane_bundle_summary")
+        row = summary["lanes"][0]
+        if (
+            row.get("collection_exit_code") != 0
+            or row.get("execution_exit_code") != 0
+            or row.get("interrupted") is not False
+        ):
+            raise LaneError("lane_bundle_execution_incomplete")
+        source_metadata = bundle / "metadata"
+        if source_metadata.is_symlink() or not source_metadata.is_dir():
+            raise LaneError("invalid_lane_bundle_metadata")
+        manifest_name = summary.get("manifest_file")
+        if not isinstance(manifest_name, str) or Path(manifest_name).name != manifest_name:
+            raise LaneError("invalid_lane_bundle_manifest")
+        source_manifest = source_metadata / manifest_name
+        if source_manifest.is_symlink() or not source_manifest.is_file():
+            raise LaneError("invalid_lane_bundle_manifest")
+        current_manifest = source_manifest.read_bytes()
+        if _digest(source_manifest) != summary.get("manifest_sha256"):
+            raise LaneError("invalid_lane_bundle_manifest")
+        if manifest_bytes is None:
+            manifest_bytes = current_manifest
+            manifest_digest = summary["manifest_sha256"]
+            head_sha = summary.get("head_sha")
+            canonical_node_count = summary.get("canonical_node_count")
+            (metadata_dir / "manifest.json").write_bytes(current_manifest)
+        elif (
+            current_manifest != manifest_bytes
+            or summary.get("manifest_sha256") != manifest_digest
+            or summary.get("head_sha") != head_sha
+            or summary.get("canonical_node_count") != canonical_node_count
+        ):
+            raise LaneError("lane_manifest_mismatch")
+
+        for file_key, digest_key in (
+            ("evidence_file", "evidence_sha256"),
+            ("coverage_file", "coverage_sha256"),
+        ):
+            name = row.get(file_key)
+            if not isinstance(name, str) or Path(name).name != name:
+                raise LaneError("invalid_lane_bundle_file")
+            _copy_bound(source_metadata / name, metadata_dir / name, row.get(digest_key))
+        evidence = _read_object(metadata_dir / row["evidence_file"])
+        isolation_name = evidence.get("isolation_metadata_file")
+        if not isinstance(isolation_name, str) or Path(isolation_name).name != isolation_name:
+            raise LaneError("invalid_lane_bundle_file")
+        _copy_bound(
+            source_metadata / isolation_name,
+            metadata_dir / isolation_name,
+            evidence.get("isolation_metadata_sha256"),
+        )
+        if not isinstance(row.get("elapsed_seconds"), (int, float)):
+            raise LaneError("invalid_lane_bundle_timing")
+        elapsed_seconds = max(elapsed_seconds, float(row["elapsed_seconds"]))
+        lane_rows.append(row)
+
+    elapsed = [float(row["elapsed_seconds"]) for row in lane_rows]
+    summary_json.write_bytes(
+        _canonical_json(
+            {
+                "aggregate_runner_seconds": round(sum(elapsed), 3),
+                "canonical_node_count": canonical_node_count,
+                "elapsed_seconds": round(elapsed_seconds, 3),
+                "head_sha": head_sha,
+                "lanes": lane_rows,
+                "manifest_file": "manifest.json",
+                "manifest_sha256": manifest_digest,
+                "mode": "run",
+                "schema_version": SCHEMA_VERSION,
+                "slowest_lane_seconds": round(max(elapsed), 3),
+            }
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input-root", required=True, type=Path)
+    parser.add_argument("--metadata-dir", required=True, type=Path)
+    parser.add_argument("--summary-json", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        merge_bundles(args.input_root, args.metadata_dir, args.summary_json)
+    except (LaneError, OSError) as exc:
+        code = exc.args[0] if isinstance(exc, LaneError) else "lane_merge_failed"
+        print(f"test lane merge failed: {code}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/run_test_lanes.py
+++ b/backend/scripts/run_test_lanes.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Collect and run four exact-custody backend test lanes."""
+"""Collect and run exact-custody backend test lanes."""
 
 from __future__ import annotations
 
@@ -39,6 +39,8 @@ DESELECTED_ENV = "WORKSTREAM_LANE_DESELECTED_NODES"
 HEAD_ENV = "WORKSTREAM_LANE_HEAD_SHA"
 SCHEMA_VERSION = 1
 ADMIN_RUNNER_MODULE = "tests/test_isolated_database_runner.py"
+PARTITIONED_SCHEMA_MODULE = "tests/test_alembic.py"
+PARTITIONED_SCHEMA_LANES = ("schema_contracts_a", "schema_contracts_b")
 ORDINARY_KIND = "ordinary_isolated"
 ADMIN_KIND = "admin_runner_self_test"
 ADMIN_REDACTING_WRAPPER = """
@@ -114,6 +116,7 @@ LANES = (
             "tests/test_guide_pdf.py",
             "tests/test_guide_pptx.py",
             "tests/test_local_artifact_store.py",
+            "tests/test_merge_test_lane_evidence.py",
             "tests/test_s3_artifact_store.py",
             "tests/test_test_lane_evidence.py",
             "tests/test_actors.py",
@@ -131,13 +134,14 @@ LANES = (
         ),
     ),
     TestLane(
-        "schema_contracts",
+        "schema_contracts_a",
         (
-            "tests/test_alembic.py",
+            PARTITIONED_SCHEMA_MODULE,
             "tests/test_database_reset.py",
             ADMIN_RUNNER_MODULE,
         ),
     ),
+    TestLane("schema_contracts_b", (PARTITIONED_SCHEMA_MODULE,)),
     TestLane(
         "project_lifecycle",
         (
@@ -351,13 +355,24 @@ def validate_lane_inventory(
 ) -> None:
     lanes = LANES if lanes is None else lanes
     names = [lane.name for lane in lanes]
-    if len(lanes) != 4 or len(set(names)) != 4 or any(LANE_RE.fullmatch(x) is None for x in names):
+    if (
+        len(lanes) != len(LANES)
+        or len(set(names)) != len(LANES)
+        or any(LANE_RE.fullmatch(x) is None for x in names)
+    ):
         raise LaneError("invalid_lane_names")
     declared = [module for lane in lanes for module in lane.modules]
     if any(not _safe_module_path(module) for module in declared):
         raise LaneError("invalid_lane_module")
-    duplicates = sorted(module for module, count in Counter(declared).items() if count != 1)
-    if duplicates:
+    duplicates = {
+        module: count for module, count in Counter(declared).items() if count != 1
+    }
+    expected_duplicates = (
+        {PARTITIONED_SCHEMA_MODULE: len(PARTITIONED_SCHEMA_LANES)}
+        if PARTITIONED_SCHEMA_MODULE in discovered
+        else {}
+    )
+    if duplicates != expected_duplicates:
         raise LaneError(f"duplicate_lane_modules:{','.join(duplicates)}")
     missing = sorted(set(discovered) - set(declared))
     foreign = sorted(set(declared) - set(discovered))
@@ -437,7 +452,23 @@ def build_manifest(tree_sha: str, nodes: list[str]) -> dict[str, Any]:
     if not nodes or len(nodes) != len(set(nodes)):
         raise LaneError("invalid_collected_nodes")
     nodes = sorted(nodes)
-    lane_by_module = {module: lane.name for lane in LANES for module in lane.modules}
+    lanes_by_module: dict[str, list[str]] = {}
+    for lane in LANES:
+        for module in lane.modules:
+            lanes_by_module.setdefault(module, []).append(lane.name)
+
+    def lane_for_node(node: str) -> str:
+        module = _module_from_node(node)
+        candidates = lanes_by_module[module]
+        if module == PARTITIONED_SCHEMA_MODULE:
+            if tuple(candidates) != PARTITIONED_SCHEMA_LANES:
+                raise LaneError("invalid_schema_partition_lanes")
+            digest = hashlib.sha256(node.encode("utf-8")).digest()
+            return candidates[digest[0] % len(candidates)]
+        if len(candidates) != 1:
+            raise LaneError("ambiguous_lane_module")
+        return candidates[0]
+
     return {
         "head_sha": tree_sha,
         "nodes": [
@@ -445,7 +476,7 @@ def build_manifest(tree_sha: str, nodes: list[str]) -> dict[str, Any]:
                 "execution_kind": ADMIN_KIND
                 if _module_from_node(node) == ADMIN_RUNNER_MODULE
                 else ORDINARY_KIND,
-                "lane": lane_by_module[_module_from_node(node)],
+                "lane": lane_for_node(node),
                 "module": _module_from_node(node),
                 "nodeid": node,
             }
@@ -662,8 +693,8 @@ def _aggregate_exit_codes(codes: list[int]) -> int:
 
 
 def _timing_summary(lanes: list[dict[str, Any]]) -> dict[str, float]:
-    """Derive aggregate timing only from the exact four emitted lane rows."""
-    if len(lanes) != 4:
+    """Derive aggregate timing only from the exact declared lane rows."""
+    if len(lanes) != len(LANES):
         raise LaneError("invalid_lane_timing_inventory")
     elapsed = [row["elapsed_seconds"] for row in lanes]
     if any(
@@ -679,8 +710,15 @@ def _timing_summary(lanes: list[dict[str, Any]]) -> dict[str, float]:
     }
 
 
-def run_lanes(metadata_dir: Path, summary_json: Path, timeout_seconds: float, *, collect_only: bool = False) -> int:
-    """Collect canonical nodes and optionally execute all lanes concurrently."""
+def run_lanes(
+    metadata_dir: Path,
+    summary_json: Path,
+    timeout_seconds: float,
+    *,
+    collect_only: bool = False,
+    selected_lane: str | None = None,
+) -> int:
+    """Collect canonical nodes and optionally execute all or one exact lane."""
     global INTERRUPTED
     INTERRUPTED = False
     if timeout_seconds <= 0:
@@ -697,6 +735,8 @@ def run_lanes(metadata_dir: Path, summary_json: Path, timeout_seconds: float, *,
     manifest_path.write_bytes(_json_bytes(manifest))
     manifest_digest = _sha256(manifest_path.read_bytes())
     if collect_only:
+        if selected_lane is not None:
+            raise LaneError("collect_with_selected_lane")
         lane_rows = []
         for lane in LANES:
             lane_nodes = [row["nodeid"] for row in manifest["nodes"] if row["lane"] == lane.name]
@@ -718,18 +758,27 @@ def run_lanes(metadata_dir: Path, summary_json: Path, timeout_seconds: float, *,
                    **_timing_summary(lane_rows)}
         summary_json.write_bytes(_json_bytes(summary))
         return 0
-    if any(lane.requires_postgres for lane in LANES) and not os.environ.get(ADMIN_ENV):
+    execution_lanes = (
+        LANES
+        if selected_lane is None
+        else tuple(lane for lane in LANES if lane.name == selected_lane)
+    )
+    if not execution_lanes:
+        raise LaneError("unknown_selected_lane")
+    if any(lane.requires_postgres for lane in execution_lanes) and not os.environ.get(ADMIN_ENV):
         raise LaneError("missing_admin_database_url")
 
     active: dict[str, ActiveLane] = {}
-    unit_results: dict[str, list[dict[str, Any]]] = {lane.name: [] for lane in LANES}
+    unit_results: dict[str, list[dict[str, Any]]] = {
+        lane.name: [] for lane in execution_lanes
+    }
     started = time.monotonic()
     stopping = False
     run_error: BaseException | None = None
     old_int = signal.signal(signal.SIGINT, _handle_interrupt)
     old_term = signal.signal(signal.SIGTERM, _handle_interrupt)
     try:
-        for lane in LANES:
+        for lane in execution_lanes:
             lane_rows = [row for row in manifest["nodes"] if row["lane"] == lane.name]
             kinds = [ORDINARY_KIND]
             if any(row["execution_kind"] == ADMIN_KIND for row in lane_rows):
@@ -805,7 +854,7 @@ def run_lanes(metadata_dir: Path, summary_json: Path, timeout_seconds: float, *,
         signal.signal(signal.SIGINT, old_int)
         signal.signal(signal.SIGTERM, old_term)
     if run_error is not None:
-        for lane in LANES:
+        for lane in execution_lanes:
             if unit_results[lane.name]:
                 continue
             unit_results[lane.name].append({
@@ -822,20 +871,29 @@ def run_lanes(metadata_dir: Path, summary_json: Path, timeout_seconds: float, *,
             })
     results = {
         lane.name: _finalize_lane(lane, unit_results[lane.name], metadata_dir)
-        for lane in LANES
+        for lane in execution_lanes
         if unit_results[lane.name]
     }
     summary = {
         "canonical_node_count": len(nodes), "elapsed_seconds": round(time.monotonic() - started, 3),
-        "head_sha": tree_sha, "lanes": [results[lane.name] for lane in LANES if lane.name in results],
+        "head_sha": tree_sha,
+        "lanes": [results[lane.name] for lane in execution_lanes if lane.name in results],
         "manifest_file": manifest_path.name, "manifest_sha256": manifest_digest,
-        "mode": "run", "schema_version": SCHEMA_VERSION,
+        "mode": "run" if selected_lane is None else "lane",
+        "schema_version": SCHEMA_VERSION,
     }
-    summary.update(_timing_summary(summary["lanes"]))
+    if selected_lane is None:
+        summary.update(_timing_summary(summary["lanes"]))
+    else:
+        elapsed = summary["lanes"][0]["elapsed_seconds"]
+        summary.update(
+            aggregate_runner_seconds=elapsed,
+            slowest_lane_seconds=elapsed,
+        )
     summary_json.write_bytes(_json_bytes(summary))
     return 0 if (
         run_error is None
-        and len(results) == 4
+        and len(results) == len(execution_lanes)
         and all(row["execution_exit_code"] == 0 for row in results.values())
     ) else 1
 
@@ -846,9 +904,16 @@ def main() -> int:
     parser.add_argument("--summary-json", required=True, type=Path)
     parser.add_argument("--timeout-seconds", default=1200.0, type=float)
     parser.add_argument("--collect-only", action="store_true")
+    parser.add_argument("--lane", choices=[lane.name for lane in LANES])
     args = parser.parse_args()
     try:
-        return run_lanes(args.metadata_dir, args.summary_json, args.timeout_seconds, collect_only=args.collect_only)
+        return run_lanes(
+            args.metadata_dir,
+            args.summary_json,
+            args.timeout_seconds,
+            collect_only=args.collect_only,
+            selected_lane=args.lane,
+        )
     except (LaneError, OSError, subprocess.SubprocessError) as exc:
         code = exc.args[0] if isinstance(exc, LaneError) else "lane_operation_failed"
         print(f"test lane runner failed: {code}", file=sys.stderr)

--- a/backend/scripts/validate_test_lane_evidence.py
+++ b/backend/scripts/validate_test_lane_evidence.py
@@ -20,7 +20,7 @@ import uuid
 
 
 SCHEMA_VERSION = 1
-LANE_COUNT = 4
+LANE_COUNT = 5
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 LANE_RE = re.compile(r"^[a-z][a-z0-9_]*$")

--- a/backend/tests/test_ci_test_lanes.py
+++ b/backend/tests/test_ci_test_lanes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from collections import Counter
 import hashlib
 import json
 import os
@@ -22,17 +23,21 @@ def test_committed_lanes_cover_recursive_inventory_exactly_once() -> None:
     runner.validate_lane_inventory(discovered)
 
     assigned = [module for lane in LANES for module in lane.modules]
-    assert len(LANES) == 4
+    assert len(LANES) == 5
     assert all(lane.requires_postgres for lane in LANES)
-    assert len(assigned) == len(set(assigned))
+    assert Counter(assigned)[runner.PARTITIONED_SCHEMA_MODULE] == 2
+    assert all(
+        count == (2 if module == runner.PARTITIONED_SCHEMA_MODULE else 1)
+        for module, count in Counter(assigned).items()
+    )
     assert set(assigned) == set(discovered)
     assert runner.ADMIN_RUNNER_MODULE in next(
-        lane.modules for lane in LANES if lane.name == "schema_contracts"
+        lane.modules for lane in LANES if lane.name == "schema_contracts_a"
     )
 
 
 def test_measured_hotspots_have_explicit_semantic_owners() -> None:
-    """Keep the four-lane balance tied to subsystem ownership, not test counts."""
+    """Keep lane balance tied to subsystem ownership and measured schema cost."""
     modules_by_lane = {lane.name: set(lane.modules) for lane in LANES}
 
     assert modules_by_lane["project_lifecycle"] == {"tests/test_projects.py"}
@@ -44,7 +49,8 @@ def test_measured_hotspots_have_explicit_semantic_owners() -> None:
         "tests/test_alembic.py",
         "tests/test_database_reset.py",
         runner.ADMIN_RUNNER_MODULE,
-    } == modules_by_lane["schema_contracts"]
+    } == modules_by_lane["schema_contracts_a"]
+    assert {"tests/test_alembic.py"} == modules_by_lane["schema_contracts_b"]
     assert {
         "tests/test_actors.py",
         "tests/test_artifact_admission.py",
@@ -130,7 +136,25 @@ def test_manifest_classifies_only_runner_self_tests_as_admin_kind() -> None:
         admin: runner.ADMIN_KIND,
         ordinary: runner.ORDINARY_KIND,
     }
-    assert next(row for row in rows if row["nodeid"] == admin)["lane"] == "schema_contracts"
+    assert next(row for row in rows if row["nodeid"] == admin)["lane"] == "schema_contracts_a"
+
+
+def test_alembic_nodes_partition_deterministically_across_schema_lanes() -> None:
+    nodes = [
+        f"{runner.PARTITIONED_SCHEMA_MODULE}::test_migration_{index}"
+        for index in range(100)
+    ]
+
+    first = runner.build_manifest("a" * 40, nodes)
+    second = runner.build_manifest("a" * 40, list(reversed(nodes)))
+    first_by_node = {row["nodeid"]: row["lane"] for row in first["nodes"]}
+    second_by_node = {row["nodeid"]: row["lane"] for row in second["nodes"]}
+
+    assert first_by_node == second_by_node
+    assert set(first_by_node.values()) == set(runner.PARTITIONED_SCHEMA_LANES)
+    assert all(
+        lane in runner.PARTITIONED_SCHEMA_LANES for lane in first_by_node.values()
+    )
 
 
 def test_manifest_has_no_exclusion_escape_hatch() -> None:
@@ -140,7 +164,7 @@ def test_manifest_has_no_exclusion_escape_hatch() -> None:
     assert "excluded_modules" not in manifest
     assert manifest["nodes"] == [{
         "execution_kind": runner.ADMIN_KIND,
-        "lane": "schema_contracts",
+        "lane": "schema_contracts_a",
         "module": runner.ADMIN_RUNNER_MODULE,
         "nodeid": admin,
     }]
@@ -248,7 +272,7 @@ def test_admin_runner_environment_retains_only_admin_database_url(
     monkeypatch.setenv(runner.ADMIN_ENV, "postgresql+asyncpg://admin:secret@localhost/postgres")
     monkeypatch.setenv("WORKSTREAM_DATABASE_URL", "postgresql+asyncpg://app:secret@localhost/app")
     monkeypatch.setenv("WORKSTREAM_TEST_DATABASE_URL", "postgresql+asyncpg://test:secret@localhost/test")
-    lane = next(lane for lane in LANES if lane.name == "schema_contracts")
+    lane = next(lane for lane in LANES if lane.name == "schema_contracts_a")
 
     env = runner.admin_runner_environment(lane, tmp_path, tmp_path / ".coverage", "admin")
 
@@ -285,7 +309,7 @@ def test_admin_wrapper_redacts_admin_url_before_persisted_output() -> None:
 def test_finalize_lane_requires_ordinary_coverage_but_allows_empty_admin_coverage(
     tmp_path: Path,
 ) -> None:
-    lane = next(lane for lane in LANES if lane.name == "schema_contracts")
+    lane = next(lane for lane in LANES if lane.name == "schema_contracts_a")
     isolation = tmp_path / f"{lane.name}.database.json"
     isolation.write_text("{}\n", encoding="utf-8")
     ordinary_coverage = tmp_path / ".coverage.unit.schema_contracts"
@@ -376,7 +400,7 @@ def test_run_lanes_reports_collection_failure_before_manifest_validation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A failed pytest collection keeps its stable top-level error."""
-    modules = tuple(module for lane in LANES for module in lane.modules)
+    modules = tuple(sorted({module for lane in LANES for module in lane.modules}))
     monkeypatch.setattr(runner, "discover_test_modules", lambda: modules)
     monkeypatch.setattr(runner, "_tree_sha", lambda: "c" * 40)
     monkeypatch.setattr(runner, "collect_nodes", lambda *_args: (2, [], []))
@@ -388,7 +412,7 @@ def test_run_lanes_reports_collection_failure_before_manifest_validation(
 def test_collect_only_writes_raw_digest_bound_validator_schema(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    modules = tuple(module for lane in LANES for module in lane.modules)
+    modules = tuple(sorted({module for lane in LANES for module in lane.modules}))
     nodes = sorted(f"{module}::test_one" for module in modules)
     monkeypatch.setattr(runner, "discover_test_modules", lambda: tuple(sorted(modules)))
     monkeypatch.setattr(runner, "_tree_sha", lambda: "c" * 40)
@@ -407,7 +431,7 @@ def test_collect_only_writes_raw_digest_bound_validator_schema(
     assert summary["mode"] == "collect"
     assert summary["canonical_node_count"] == len(nodes)
     assert summary["manifest_sha256"] == hashlib.sha256(manifest_bytes).hexdigest()
-    assert len(summary["lanes"]) == 4
+    assert len(summary["lanes"]) == len(LANES)
     assert summary["slowest_lane_seconds"] == max(
         lane["elapsed_seconds"] for lane in summary["lanes"]
     )
@@ -419,6 +443,25 @@ def test_collect_only_writes_raw_digest_bound_validator_schema(
         assert lane["execution_exit_code"] is None
         evidence = metadata / lane["evidence_file"]
         assert lane["evidence_sha256"] == hashlib.sha256(evidence.read_bytes()).hexdigest()
+
+
+def test_collect_only_rejects_selected_lane(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    modules = tuple(sorted({module for lane in LANES for module in lane.modules}))
+    nodes = sorted(f"{module}::test_one" for module in modules)
+    monkeypatch.setattr(runner, "discover_test_modules", lambda: tuple(sorted(modules)))
+    monkeypatch.setattr(runner, "_tree_sha", lambda: "c" * 40)
+    monkeypatch.setattr(runner, "collect_nodes", lambda *_args: (0, nodes, []))
+
+    with pytest.raises(LaneError, match="collect_with_selected_lane"):
+        runner.run_lanes(
+            tmp_path / "metadata",
+            tmp_path / "summary.json",
+            10,
+            collect_only=True,
+            selected_lane=LANES[0].name,
+        )
 
 
 def test_collection_rejects_duplicate_or_foreign_nodes(
@@ -440,17 +483,17 @@ def test_collection_rejects_duplicate_or_foreign_nodes(
         runner.collect_nodes((module,), tmp_path / "metadata", "a" * 40)
 
 
-def test_timing_summary_is_derived_from_exact_four_lanes() -> None:
-    lanes = [{"elapsed_seconds": value} for value in (1.125, 2.25, 0.5, 3.75)]
+def test_timing_summary_is_derived_from_exact_declared_lanes() -> None:
+    lanes = [{"elapsed_seconds": value} for value in (1.125, 2.25, 0.5, 3.75, 1.0)]
 
     assert runner._timing_summary(lanes) == {
-        "aggregate_runner_seconds": 7.625,
+        "aggregate_runner_seconds": 8.625,
         "slowest_lane_seconds": 3.75,
     }
     with pytest.raises(LaneError, match="invalid_lane_timing_inventory"):
-        runner._timing_summary(lanes[:3])
+        runner._timing_summary(lanes[:-1])
     with pytest.raises(LaneError, match="invalid_lane_timing"):
-        runner._timing_summary([*lanes[:3], {"elapsed_seconds": -1.0}])
+        runner._timing_summary([*lanes[:-1], {"elapsed_seconds": -1.0}])
 
 
 def test_exit_aggregation_cannot_hide_signal_failure() -> None:
@@ -461,7 +504,7 @@ def test_exit_aggregation_cannot_hide_signal_failure() -> None:
         runner._aggregate_exit_codes([])
 
 
-def test_finalized_lanes_leave_exactly_four_public_coverage_files(tmp_path: Path) -> None:
+def test_finalized_lanes_leave_one_public_coverage_file_per_lane(tmp_path: Path) -> None:
     rows = []
     for index, lane in enumerate(LANES):
         source = tmp_path / f".coverage.unit.{lane.name}"

--- a/backend/tests/test_merge_test_lane_evidence.py
+++ b/backend/tests/test_merge_test_lane_evidence.py
@@ -1,0 +1,174 @@
+"""Tests for fail-closed distributed semantic-lane fan-in."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.merge_test_lane_evidence import merge_bundles
+from scripts.run_test_lanes import LANES, LaneError
+
+
+def _write_json(path: Path, value: object) -> str:
+    data = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+    path.write_bytes(data)
+    return hashlib.sha256(data).hexdigest()
+
+
+def _bundles(root: Path) -> None:
+    manifest = {
+        "head_sha": "a" * 40,
+        "nodes": [
+            {
+                "execution_kind": "ordinary_isolated",
+                "lane": lane.name,
+                "module": lane.modules[0],
+                "nodeid": f"{lane.modules[0]}::test_one",
+            }
+            for lane in LANES
+        ],
+        "schema_version": 1,
+    }
+    for index, lane in enumerate(LANES, 1):
+        metadata = root / lane.name / "metadata"
+        metadata.mkdir(parents=True)
+        manifest_digest = _write_json(metadata / "manifest.json", manifest)
+        isolation_name = f"{lane.name}.database.json"
+        isolation_digest = _write_json(metadata / isolation_name, {"lane": lane.name})
+        evidence_name = f"{lane.name}.json"
+        evidence_digest = _write_json(
+            metadata / evidence_name,
+            {
+                "collected_nodes": [f"{lane.modules[0]}::test_one"],
+                "completed_nodes": [f"{lane.modules[0]}::test_one"],
+                "deselected_nodes": [],
+                "isolation_metadata_file": isolation_name,
+                "isolation_metadata_sha256": isolation_digest,
+                "skipped_nodes": [],
+            },
+        )
+        coverage_name = f".coverage.{lane.name}"
+        coverage = f"coverage-{lane.name}".encode()
+        (metadata / coverage_name).write_bytes(coverage)
+        row = {
+            "collection_exit_code": 0,
+            "coverage_file": coverage_name,
+            "coverage_sha256": hashlib.sha256(coverage).hexdigest(),
+            "elapsed_seconds": float(index),
+            "evidence_file": evidence_name,
+            "evidence_sha256": evidence_digest,
+            "execution_exit_code": 0,
+            "interrupted": False,
+            "name": lane.name,
+        }
+        _write_json(
+            root / lane.name / "summary.json",
+            {
+                "aggregate_runner_seconds": float(index),
+                "canonical_node_count": len(LANES),
+                "elapsed_seconds": float(index),
+                "head_sha": "a" * 40,
+                "lanes": [row],
+                "manifest_file": "manifest.json",
+                "manifest_sha256": manifest_digest,
+                "mode": "lane",
+                "schema_version": 1,
+                "slowest_lane_seconds": float(index),
+            },
+        )
+
+
+def test_merge_bundles_emits_complete_run_summary(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _bundles(source)
+
+    merge_bundles(source, tmp_path / "merged", tmp_path / "summary.json")
+
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["mode"] == "run"
+    assert [row["name"] for row in summary["lanes"]] == [lane.name for lane in LANES]
+    assert summary["aggregate_runner_seconds"] == 15.0
+    assert summary["slowest_lane_seconds"] == 5.0
+    assert len(list((tmp_path / "merged").glob(".coverage.*"))) == len(LANES)
+
+
+def test_merge_bundles_rejects_missing_or_foreign_lane(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _bundles(source)
+    (source / LANES[0].name).rename(source / "foreign")
+
+    with pytest.raises(LaneError, match="invalid_lane_bundle_set"):
+        merge_bundles(source, tmp_path / "merged", tmp_path / "summary.json")
+
+
+def test_merge_bundles_rejects_coverage_digest_drift(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _bundles(source)
+    lane = LANES[0]
+    (source / lane.name / "metadata" / f".coverage.{lane.name}").write_bytes(b"changed")
+
+    with pytest.raises(LaneError, match="invalid_lane_bundle_file"):
+        merge_bundles(source, tmp_path / "merged", tmp_path / "summary.json")
+
+
+def test_merge_bundles_rejects_manifest_path_traversal(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _bundles(source)
+    summary_path = source / LANES[0].name / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["manifest_file"] = "../manifest.json"
+    _write_json(summary_path, summary)
+
+    with pytest.raises(LaneError, match="invalid_lane_bundle_manifest"):
+        merge_bundles(source, tmp_path / "merged", tmp_path / "summary.json")
+
+
+def test_merge_bundles_rejects_manifest_mismatch(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _bundles(source)
+    metadata = source / LANES[0].name / "metadata"
+    manifest = json.loads((metadata / "manifest.json").read_text(encoding="utf-8"))
+    manifest["head_sha"] = "b" * 40
+    digest = _write_json(metadata / "manifest.json", manifest)
+    summary_path = source / LANES[0].name / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["manifest_sha256"] = digest
+    _write_json(summary_path, summary)
+
+    with pytest.raises(LaneError, match="lane_manifest_mismatch"):
+        merge_bundles(source, tmp_path / "merged", tmp_path / "summary.json")
+
+
+def test_merge_bundles_rejects_symlinked_metadata(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _bundles(source)
+    lane_root = source / LANES[0].name
+    metadata = lane_root / "metadata"
+    moved = lane_root / "moved"
+    metadata.rename(moved)
+    metadata.symlink_to(moved, target_is_directory=True)
+
+    with pytest.raises(LaneError, match="invalid_lane_bundle_metadata"):
+        merge_bundles(source, tmp_path / "merged", tmp_path / "summary.json")
+
+
+def test_merge_bundles_rejects_failed_lane_row(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    _bundles(source)
+    summary_path = source / LANES[0].name / "summary.json"
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    summary["lanes"][0]["execution_exit_code"] = 1
+    _write_json(summary_path, summary)
+
+    with pytest.raises(LaneError, match="lane_bundle_execution_incomplete"):
+        merge_bundles(source, tmp_path / "merged", tmp_path / "summary.json")

--- a/backend/tests/test_test_lane_evidence.py
+++ b/backend/tests/test_test_lane_evidence.py
@@ -22,7 +22,8 @@ REAL_COLLECT_CURRENT_NODES = validator._collect_current_nodes
 HEAD = "a" * 40
 LANES = (
     "shared_foundations",
-    "schema_contracts",
+    "schema_contracts_a",
+    "schema_contracts_b",
     "project_lifecycle",
     "task_lifecycle",
 )
@@ -49,7 +50,7 @@ def _bundle(tmp_path: Path, mode: str = "run") -> tuple[Path, Path, dict]:
     nodes.append(
         {
             "execution_kind": "admin_runner_self_test",
-            "lane": "schema_contracts",
+            "lane": "schema_contracts_a",
             "module": "tests/test_isolated_database_runner.py",
             "nodeid": "tests/test_isolated_database_runner.py::test_admin_custody",
         }
@@ -117,8 +118,8 @@ def _bundle(tmp_path: Path, mode: str = "run") -> tuple[Path, Path, dict]:
             }
         )
     summary = {
-        "aggregate_runner_seconds": 4.0,
-        "canonical_node_count": 5,
+        "aggregate_runner_seconds": 5.0,
+        "canonical_node_count": 6,
         "elapsed_seconds": 2.0,
         "head_sha": HEAD,
         "lanes": lane_rows,
@@ -141,7 +142,7 @@ def exact_head(monkeypatch: pytest.MonkeyPatch) -> None:
         "_collect_current_nodes",
         lambda _root, _head: sorted(
             [
-                *(f"tests/test_{index}.py::test_ok" for index in range(4)),
+                *(f"tests/test_{index}.py::test_ok" for index in range(5)),
                 "tests/test_isolated_database_runner.py::test_admin_custody",
             ]
         ),

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -33,8 +33,8 @@ unset WORKSTREAM_TEST_ADMIN_DATABASE_URL
 ```
 
 Run both phases for the legacy sequential local diagnostic. Hosted CI instead
-uses four concurrent semantic lanes with a 20-minute lane limit inside a
-45-minute job, leaving a bounded validation and cleanup window.
+uses five independent matrix jobs, one per semantic lane, with a 20-minute lane
+limit and a separate fail-closed fan-in job.
 
 The runner removes the admin URL before child launch, overwrites both child database URLs,
 removes the nonlocal override, redacts complete URLs, and writes only credential-free metadata.
@@ -76,23 +76,25 @@ If provisioning fails, confirm the local PostgreSQL provisioning credential can 
 
 ## Hosted semantic-lane full-suite proof
 
-The required GitHub check remains `Backend / test`. One job owns one
-digest-pinned PostgreSQL service container, one digest-pinned MinIO container
-started in-step and published on `127.0.0.1:9000`, and four concurrent
-dependency lanes. A step-level curl health loop admits MinIO before collection.
-This avoids arbitrary shard fan-out and artifact fan-in while retaining exact
-node and coverage custody.
+The required GitHub check remains `Backend / test`. Five matrix jobs each own a
+digest-pinned PostgreSQL service container, a digest-pinned MinIO container,
+and exactly one dependency lane. A step-level curl health loop admits MinIO
+before collection. This is semantic fan-out, not arbitrary test-count sharding:
+lane ownership remains repository-defined and exact.
 
 The lanes are balanced by measured dependency ownership: `project_lifecycle`
 owns project tests, `task_lifecycle` owns task and checker tests,
-`schema_contracts` owns migrations and reset contracts, and
+`schema_contracts_a` and `schema_contracts_b` deterministically partition exact
+node IDs from the measured 12-minute `test_alembic.py` hotspot;
+`schema_contracts_a` also owns reset and isolated-runner contracts, and
 `shared_foundations` owns the remaining authorization, artifact, API, and
-infrastructure tests. Every discovered module must belong to exactly one lane.
+infrastructure tests. Every non-partitioned module belongs to exactly one lane;
+every collected test node, including each Alembic node, belongs to exactly one
+lane.
 
-The job binds the checkout to `GITHUB_SHA`, installs and asserts exact Ruff
-`0.15.22`, runs lint and docstrings, starts MinIO, then collects every canonical
-pytest node. The independent evidence validator must
-accept the collection before execution begins. Each lane receives a distinct
+Each matrix job binds its checkout to `GITHUB_SHA`, installs and asserts exact
+Ruff `0.15.22`, runs lint and docstrings, starts MinIO, and validates the full
+canonical inventory before executing its one lane. Each lane receives a distinct
 runner-created database and role plus a distinct MinIO bucket/prefix custody
 record. `shared_foundations` owns the actual `workstream-artifacts` test bucket
 and a unique run prefix; other lanes create, probe, and remove distinct buckets.
@@ -102,23 +104,39 @@ nodes directly with the admin URL while stripping application database URLs;
 every ordinary node remains behind isolated-runner custody and never receives
 the admin credential.
 
-After execution, independent validation rejects missing, duplicated, foreign,
+Backend does not run on review-state events. The narrow guide-extractor
+dependency approval check runs in Agent Gates instead, so submitting or
+dismissing the exceptional exact-head dependency approval refreshes a fast gate
+without repeating the full backend suite.
+
+Each matrix job uploads a fixed-name artifact bound to GitHub's checked-out PR
+merge-tree SHA, containing its manifest, lane evidence, isolation record, and coverage data. The final `test`
+job runs with `if: always()`, downloads available diagnostic bundles, then
+rejects any failed, cancelled, or skipped matrix result before fan-in. Fan-in
+accepts exactly the five declared lane directories,
+requires byte-identical manifests and heads, verifies every bound digest, and
+rejects symlinks or surplus lanes.
+
+After fan-in, independent validation rejects missing, duplicated, foreign,
 deselected, unexpectedly skipped, interrupted, or partially completed nodes.
 It also binds the exact head, manifest, per-lane isolation metadata, evidence,
-and coverage-file SHA-256 digests. Only then are exactly four regular,
+and coverage-file SHA-256 digests. Only then are exactly five regular,
 non-symlink coverage files copied byte-for-byte for one literal
 `coverage combine`. The 78 percent global floor and every protected 90 percent
 subsystem floor remain blocking. The real API contract drill remains a separate
-isolated invocation inside the same required job.
+isolated invocation inside the final required job.
 
 ### Evidence bundle
 
-The workflow uploads the `.ci/test-lanes` tree even on failure. Its summary
-records the exact head, canonical node count, four lane results, elapsed time,
+Each lane uploads one seven-day bundle, and the final job uploads the reconciled
+`.ci/test-lanes` tree. Its summary
+records the exact head, canonical node count, five lane results, elapsed time,
 and raw-file digests. Per-lane evidence records collected, completed, skipped,
 and deselected exact node IDs plus the bound resource-isolation metadata and
 coverage digest. Resource metadata is mode `0600`, omits credentials, and proves
 database, role, bucket, prefix, probe, and cleanup custody.
+Redacted lane logs are uploaded for diagnosis but are not trusted fan-in or
+coverage evidence.
 If startup or provisioning fails before isolation metadata exists, the failed
 lane records null metadata fields, a nonzero exit, and interrupted custody; it
 cannot satisfy independent validation or be mistaken for successful proof.
@@ -131,7 +149,7 @@ coverage tampering before coverage combination.
 ### Failure diagnosis and reruns
 
 - Collection or collection-validation failure: inspect the canonical manifest,
-  lane assignment, and exact-head binding. No execution evidence is valid.
+  lane assignment, and exact checked-out-tree binding. No execution evidence is valid.
 - Lane failure: inspect the named private log and evidence result; confirm its
   database/role and MinIO namespace cleanup without exposing credentials.
 - Execution-validation failure: inspect node reconciliation, isolation metadata,
@@ -139,9 +157,14 @@ coverage tampering before coverage combination.
 - API contract or coverage failure: the required job remains failed; lane
   completion cannot compensate for either boundary.
 
-Rerun the complete job on the same exact head. Never edit or upload evidence
-manually. Every new commit requires a complete new run because its head and
-digests differ. Hosted evidence always records the exact wall time and whether
+Rerun the complete workflow on the same exact head. Never edit or upload
+evidence manually. Review submission or dismissal does not rerun Backend because
+it does not change the tested tree. A new PR commit starts a new run and cancels
+the superseded same-PR run. Every new commit requires complete evidence because
+its head and digests differ. Each lane bundle records its job-start epoch;
+missing or malformed timing fails the final evidence step. Hosted evidence
+records whole Backend wall time from the earliest lane start, lane
+aggregate/slowest execution timing, and whether
 the eight-minute target was met. When the repository owner explicitly accepts
 a measured target miss at the human merge checkpoint, that performance result
 does not override otherwise passing correctness, custody, service-contract,

--- a/scripts/test_lightweight_agent_gates.py
+++ b/scripts/test_lightweight_agent_gates.py
@@ -51,5 +51,25 @@ class LightweightAgentGateTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             phase_index("unknown")
 
+    def test_backend_uses_distributed_semantic_lanes_and_stable_fan_in(self) -> None:
+        workflow = Path(".github/workflows/backend.yml").read_text(encoding="utf-8")
+        agent_gates = Path(".github/workflows/agent-gates.yml").read_text(encoding="utf-8")
+
+        self.assertNotIn("pull_request_review:", workflow)
+        self.assertIn("cancel-in-progress: true", workflow)
+        self.assertIn("matrix:\n        lane:", workflow)
+        self.assertEqual(workflow.count("          - shared_foundations"), 1)
+        self.assertEqual(workflow.count("          - schema_contracts_a"), 1)
+        self.assertEqual(workflow.count("          - schema_contracts_b"), 1)
+        self.assertIn("  test:\n    if: ${{ always() }}\n    needs: lanes", workflow)
+        self.assertIn("Require every semantic lane", workflow)
+        self.assertIn("python -m scripts.merge_test_lane_evidence", workflow)
+        self.assertIn("scripts/validate_test_lane_evidence.py", workflow)
+        self.assertIn("include-hidden-files: true", workflow)
+        self.assertIn("coverage report --precision=2 --fail-under=78", workflow)
+        self.assertGreaterEqual(workflow.count("--fail-under=90"), 10)
+        self.assertIn("pull_request_review:", agent_gates)
+        self.assertIn("--require-pr-approval", agent_gates)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

Backend currently runs four semantic lanes as competing subprocesses on one hosted runner. A successful run took 17m20s, including 15m31s in that step. Review events also rerun the unchanged backend tree.

## Correction

- run the existing four semantic lanes on four independent matrix runners
- preserve isolated PostgreSQL/MinIO custody and exact node completion evidence
- fan in four digest-bound coverage bundles through the stable `Backend / test` job
- retain API E2E, global 78%, and all protected 90% coverage gates
- cancel superseded same-PR Backend runs
- move the rare guide-dependency review refresh to required lightweight Agent Gates
- preserve redacted failure logs without trusting them as coverage evidence

## Local evidence

- 76 focused lane/fan-in/validator tests passed
- 7 workflow regression tests passed
- Ruff passed
- workflow YAML parsing passed
- Markdown links, stale wording, and diff checks passed
- CI integrity, QA/test, security, architecture, senior engineering, and docs reviews passed

## Hosted acceptance

The exact checked-out PR merge tree must pass Agent Gates, `Backend / test`, and external review. The GitHub run—not local machine timing—will determine whether the complete Backend check reaches the eight-minute target.

Detailed evidence: `.agent-loop/initiatives/WS-CI-001-backend-ci-acceleration/reviews/WS-CI-001-03-pr-trust-bundle.md`.