### PR TITLE
WS-REV-001-03A2: persist reviewer leases

### DIFF
--- a/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/CHUNK_MAP.md
@@ -8,8 +8,8 @@ PLAN4 is the current-main end-to-end refresh after merged AUTH 02D.
 | Chunk | Purpose | Gate | Status |
 |---|---|---|---|
 | `WS-REV-001-PLAN4` | Current-main full lifecycle replan | AUTH 02D merged PR #257 | Proposed planning PR |
-| `WS-REV-001-03A1` | Queue and admission-idempotency persistence | PLAN4 approved | First proposed runtime child |
-| `WS-REV-001-03A2` | REV-owned lease and preference persistence | 03A1 + existing CON-03B ContributionPolicyVersion table solely as the required FK target | Skeleton |
+| `WS-REV-001-03A1` | Queue and admission-idempotency persistence | PLAN4 approved | Merged PR #262 |
+| `WS-REV-001-03A2` | REV-owned lease and preference persistence | Merged 03A1 + CON-03B PR #274 policy-version FK target | Active exact contract |
 | `WS-REV-001-03B` | Normalized packet-manifest persistence | 03A2 + ART-owned contract-only packet membership port published before ART-07A runtime | Skeleton |
 | `WS-REV-001-04A` | Immutable Review/finding/resolution/decision-request persistence | 03B | Skeleton |
 | `WS-REV-001-04B` | FinalAcceptance and shared audit/outbox linkage persistence | 04A + CON-02A outbox persistence + CON-02C audit participant | Skeleton; enables CON-03C schema work |

--- a/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/STATUS.md
+++ b/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/STATUS.md
@@ -2,6 +2,12 @@
 
 ## Current status
 
+`WS-REV-001-03A2` is the active bounded child from current main `e2057d0f`.
+Merged CON-03B PR #274 supplies the canonical
+`contribution_policy_versions(id, project_id)` foreign-key target. 03A2 owns
+only ReviewLease and preference persistence integrity; it adds no claim,
+transition, policy-selection, route, or external-owner behavior.
+
 WS-CON-001-PLAN5 is the active cross-specification input for revision behavior:
 a human `needs_revision` atomically keeps/rebases/blocks the complete applicable
 next-attempt guide and policy context, including the submitter
@@ -49,7 +55,7 @@ REV does not own Project/Task/Submission/Checker/AUTH/ART/CON internals.
 
 ## Next step
 
-Publish and review only the `WS-REV-001-03A1` PR. GitHub Actions must provide
-the full-suite and repository-coverage proof. After human merge approval, stop;
-`WS-REV-001-03A2` remains a separate explicit start and still depends on its
-named CON policy-version FK target.
+Implement and review only `WS-REV-001-03A2` from its refreshed exact contract.
+Run focused PostgreSQL and coverage proof locally; GitHub Actions provides the
+full-suite and repository-coverage proof. Stop after its PR and do not begin
+packet persistence or claim behavior automatically.

--- a/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/chunks/WS-REV-001-03A2-lease-preference-persistence.md
+++ b/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/chunks/WS-REV-001-03A2-lease-preference-persistence.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Planning skeleton. Refresh only after 03A1 and CON-03B merge; do not start
-automatically.
+Active implementation contract refreshed from `main` at `e2057d0f` after
+merged REV-03A1 PR #262 and CON-03B PR #274.
 
 ## Parent initiative
 
@@ -11,51 +11,130 @@ automatically.
 
 ## Goal
 
-Persist ReviewLease attempts and preferred-routing state with database-enforced
-active-capacity invariants, without implementing claim, release, decline, or
-timer behavior.
+Persist immutable ReviewLease attempt identities and enforce the existing queue
+preference actor boundary with PostgreSQL-backed active-capacity invariants,
+without implementing claim, release, decline, expiry, selection, or any public
+behavior.
 
-REV owns this model, migration, repository, constraints, and every later lease
-transition. CON neither persists nor manages leases. CON-03B is ordered first
-only because this REV migration references its canonical policy-version table.
+REV owns every lease row, constraint, timestamp, and later transition. This
+chunk consumes only CON's canonical `contribution_policy_versions(id,
+project_id)` foreign-key target; it neither selects policy nor imports CON
+repositories or behavior.
 
 ## Why this chunk exists
 
-Lease uniqueness and preference chronology form a separate high-risk
-concurrency boundary from queue identity.
+Lease attempt history, reviewer capacity, frozen reviewer policy identity, and
+preference actor integrity form one L1 concurrency boundary separate from queue
+admission and later claim choreography.
 
 ## Risk class and SLA
 
-L1 database concurrency; no expedited SLA.
+L1 database concurrency and immutable cross-domain economic lineage. No
+expedited SLA.
 
 ## Allowed files
 
-Refresh exact review model/repository/migration/test paths from post-03A1 main.
+```text
+backend/app/modules/reviews/models.py
+backend/app/modules/reviews/schemas.py
+backend/app/modules/reviews/repository.py
+backend/app/db/models.py (ReviewLease metadata registration only)
+backend/alembic/versions/0056_review_lease_preference.py
+backend/tests/test_review_lease_persistence.py
+backend/tests/test_review_queue_persistence.py (preference-integrity regression only)
+backend/tests/test_alembic.py
+backend/tests/conftest.py (reset inventory/schema fingerprint only)
+backend/scripts/run_test_lanes.py (new test-module lane registration only)
+backend/tests/test_ci_test_lanes.py (lane registration assertion only)
+docs/architecture_data_model.md
+.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/CHUNK_MAP.md
+.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/STATUS.md
+.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/chunks/WS-REV-001-03A2-lease-preference-persistence.md
+.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/reviews/WS-REV-001-03A2-*.md
+```
+
+Migration `0056_review_lease_preference` is the exact successor of merged
+`0055_contribution_policy`.
 
 ## Not allowed changes
 
-No routes, AUTH evaluation, claims, transitions, timers, packet manifests,
-Review decisions, ART/CON calls, or action activation.
+- No route, service, AUTH evaluation, grant lookup, queue selection, claim,
+  release, decline, expiry job, lazy recovery, packet manifest, Review,
+  finding, decision, revision, audit, outbox, ART operation, or CON operation.
+- No callable queue-state transition. This schema chunk adds the reserved
+  `leased` state and exact `active_lease_id` relationship promised by 03A1;
+  queue claim choreography remains in 06A.
+- No policy lookup or moving selector. Callers of the later claim command will
+  supply the already-selected canonical policy-version ID.
+- No CON model duplication, nullable/conditional policy FK, compatibility
+  alias, placeholder table, contribution record, award, or compensation logic.
+- No action activation, router registration, frontend behavior, historical
+  backfill, or upstream row mutation.
+
+## Persistence shape
+
+Each `ReviewLease` stores:
+
+- UUID identity and exact queue/project/task/Submission/version lineage;
+- canonical human reviewer `ActorProfile.id`;
+- immutable non-null reviewer `ContributionPolicyVersion.id` with same-project
+  composite FK;
+- positive per-queue attempt generation;
+- status `active | consumed | released | expired | revoked`;
+- database-written `claimed_at`, caller-bounded future `expires_at`, and
+  terminal `closed_at`/`close_reason` provenance.
+
+Close reasons are `review_recorded | manual_release | lease_expired |
+grant_revoked | admin_override` and must match their terminal status.
 
 ## Acceptance criteria
 
-- One active lease per queue entry and one globally per human reviewer through
-  PostgreSQL partial uniqueness.
-- Every lease stores an immutable, non-null FK to CON's canonical reviewer
-  `ContributionPolicyVersion`; REV neither duplicates its fields nor selects a
-  substitute policy source.
-- Completed attempts are immutable and retain reviewer, queue, frozen policy-
-  version reference, database timestamps, generation, and close provenance.
-- Preference state preserves immutable queue age separately from availability
-  time and lease expiry.
-- Canonical ActorProfile FKs and human-kind guards prevent service identities
-  occupying reviewer fields.
-- No behavior is callable and every lifecycle action remains unavailable.
+- PostgreSQL partial unique indexes permit at most one active lease per queue
+  entry and one active lease globally per reviewer.
+- `ReviewQueueEntry` gains `leased` and an exact active-lease pointer. Deferred
+  database integrity requires active lease, leased queue state, and the
+  queue-local pointer to agree at transaction commit while still permitting a
+  later atomic claim command to stage both rows in either safe write order.
+- Queue lineage is enforced through the exact 03A1 composite queue identity;
+  crossed project/task/Submission/version values are rejected.
+- Every lease stores an immutable, non-null same-project FK to CON's canonical
+  `ContributionPolicyVersion`; REV neither duplicates fields nor selects a
+  substitute source.
+- Inserted attempts begin active, use database `claimed_at`, have
+  `expires_at > claimed_at`, and use a unique positive generation per queue.
+  The database rejects a draft or already-retired version at insertion;
+  CON-06 still owns claim-time lookup and selection of that published identity.
+- Reviewer and preferred-reviewer references must resolve to canonical human
+  ActorProfiles; service actors are rejected by database guards.
+- Lease identity, reviewer, frozen policy, lineage, generation, claimed time,
+  and expiry never change. Terminal attempts are wholly immutable and cannot
+  reopen; active-to-terminal state shapes retain exact close provenance.
+- Existing `ReviewQueueEntry.first_queued_at` remains immutable and independent
+  from `available_since`, `preference_expires_at`, and lease expiry.
+- Repository methods only add/flush caller-transaction persistence records;
+  they do not commit, authorize, select, claim, update the queue pointer, or
+  perform lifecycle transitions.
+- Migration performs no historical backfill, changes no existing queue state,
+  and refuses downgrade while lease rows exist.
+- No route is registered and every review lifecycle action remains unavailable.
 
 ## Verification commands
 
-Freeze exact migration, direct-SQL, concurrency, coverage, Ruff, stale-doc, and
-GitHub full-suite commands at start.
+```text
+cd backend && .venv/bin/alembic heads
+cd backend && .venv/bin/pytest -q tests/test_alembic.py -k review_lease_preference
+cd backend && .venv/bin/pytest -q tests/test_review_lease_persistence.py tests/test_review_queue_persistence.py
+cd backend && .venv/bin/pytest -q tests/test_ci_test_lanes.py
+cd backend && .venv/bin/ruff check app/modules/reviews tests/test_review_lease_persistence.py tests/test_review_queue_persistence.py tests/test_alembic.py tests/test_ci_test_lanes.py scripts/run_test_lanes.py
+cd backend && .venv/bin/pytest --cov=app.modules.reviews --cov-branch --cov-report=term-missing --cov-fail-under=90 -q tests/test_review_lease_persistence.py tests/test_review_queue_persistence.py
+python3 scripts/check_stale_review_contracts.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+GitHub Actions owns the full sharded suite and repository-wide coverage floor.
+Local proof remains focused on this chunk.
 
 ## Required reviewers
 
@@ -64,9 +143,12 @@ reuse/dedup, docs, test-delta, and CI integrity.
 
 ## Human review focus
 
-Partial uniqueness, immutable attempts, exact CON policy-version FK, actor kind,
-timer separation, and no claim behavior.
+Partial uniqueness, exact queue and CON policy-version composite FKs, canonical
+human actor enforcement, immutable attempt history, terminal provenance,
+timer separation, downgrade safety, and absence of claim behavior.
 
 ## Stop conditions
 
-Merge and stop before packet persistence or claim behavior.
+Stop if implementation requires policy selection, a CON write, AUTH evaluation,
+callable queue claim choreography, or a foreign schema change. Merge and stop
+before packet persistence or claim behavior.

--- a/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/reviews/WS-REV-001-03A2-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/reviews/WS-REV-001-03A2-internal-review-evidence.md
@@ -1,0 +1,42 @@
+# Internal Review Evidence: WS-REV-001-03A2
+
+## Candidate
+
+- Trusted base: `e2057d0f`
+- Scope: hidden REV lease and preference persistence only
+- Runtime exposure: none; no review route or callable lifecycle action
+
+## Reviewer results
+
+| Track | Result |
+|---|---:|
+| Architecture | PASS |
+| Security/auth | PASS |
+| Product/ops | PASS |
+| QA/test and test delta | PASS |
+| Senior engineering and reuse/dedup | PASS |
+| Docs and CI integrity | PASS |
+
+No final reviewer reported an actionable finding. Earlier findings were closed
+by locking and preflighting queue preferences during upgrade, enforcing a
+published same-project policy version at lease insertion, updating the schema
+fingerprint, and adding cross-lineage, cross-project, draft-policy, global
+reviewer-capacity, two-session race, preference, and downgrade tests.
+
+## Deterministic evidence
+
+- Focused queue and lease PostgreSQL suite: 20 passed.
+- REV package branch coverage: 98.70 percent.
+- Migration 0056 empty round trip: passed.
+- Populated downgrade and invalid-preference upgrade refusal: passed.
+- CI lane integrity: 33 passed.
+- Alembic one-head, Ruff, stale contract/wording, Markdown links, compile, and
+  diff integrity: passed.
+
+The full repository suite and global coverage floor remain GitHub Actions
+responsibilities.
+
+## Disposition
+
+PASS for PR publication. GitHub Actions, CodeRabbit, and human review remain
+required before user-authorized merge.

--- a/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/reviews/WS-REV-001-03A2-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/reviews/WS-REV-001-03A2-pr-trust-bundle.md
@@ -1,0 +1,38 @@
+# PR Trust Bundle: WS-REV-001-03A2
+
+## Goal and boundary
+
+Persist immutable REV-owned lease attempts and enforce reviewer-preference
+actor integrity. The change consumes ART submission/version lineage, AUTH actor
+profiles, and CON's canonical published policy-version identity without
+performing any upstream operation or adding claim, review, revision, decision,
+FinalAcceptance, or contribution behavior.
+
+## Design
+
+- `ReviewLease` records exact queue/project/task/Submission/version, human
+  reviewer, frozen same-project policy version, generation, and timestamps.
+- Partial unique indexes allow one active lease per queue and one globally per
+  reviewer.
+- Deferred constraints permit either safe write order while requiring the
+  queue's `leased` state and active pointer to match the active lease at commit.
+- Database guards enforce human actors, published policy identity, immutable
+  attempt facts, terminal provenance, delete/truncate refusal, and preference
+  integrity.
+- The repository only adds and flushes a supplied lease; it does not authorize,
+  select, commit, or update the queue.
+
+## Proof
+
+The focused PostgreSQL queue/lease suite passes 20 tests with 98.70 percent REV
+branch coverage. Migration round-trip, upgrade preflight, populated downgrade,
+real two-session capacity races, schema fingerprint, lane integrity, Ruff,
+stale wording/contracts, Markdown links, and diff integrity pass. All required
+internal reviewer tracks pass with no actionable findings.
+
+## Human review focus
+
+Review the deferred queue/lease graph, partial uniqueness, canonical human and
+published-policy guards, immutable terminal history, migration safety, and the
+absence of callable review behavior. GitHub Actions must run the full suite and
+repository coverage. Only the user may authorize merge.

--- a/backend/alembic/versions/0056_review_lease_preference.py
+++ b/backend/alembic/versions/0056_review_lease_preference.py
@@ -1,0 +1,361 @@
+"""add hidden review lease and preference persistence
+
+Revision ID: 0056_review_lease_preference
+Revises: 0055_contribution_policy
+Create Date: 2026-08-05
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0056_review_lease_preference"
+down_revision = "0055_contribution_policy"
+branch_labels = depends_on = None
+
+
+def _replace_queue_checks(*, with_leases: bool) -> None:
+    op.drop_constraint("ck_review_queue_entries_queue_state", "review_queue_entries", type_="check")
+    op.drop_constraint(
+        "ck_review_queue_entries_lifecycle_shape", "review_queue_entries", type_="check"
+    )
+    states = "'pending','leased','closed'" if with_leases else "'pending','closed'"
+    op.create_check_constraint(
+        "ck_review_queue_entries_queue_state",
+        "review_queue_entries",
+        f"queue_state in ({states})",
+    )
+    if with_leases:
+        shape = (
+            "(queue_state='pending' and active_lease_id is null "
+            "and closed_at is null and closed_reason is null) or "
+            "(queue_state='leased' and active_lease_id is not null "
+            "and closed_at is null and closed_reason is null) or "
+            "(queue_state='closed' and active_lease_id is null and closed_at is not null "
+            "and closed_reason in ('review_recorded','task_closed','admin_cancelled') "
+            "and closed_at >= first_queued_at)"
+        )
+    else:
+        shape = (
+            "(queue_state='pending' and closed_at is null and closed_reason is null) or "
+            "(queue_state='closed' and closed_at is not null and "
+            "closed_reason in ('review_recorded','task_closed','admin_cancelled') "
+            "and closed_at >= first_queued_at)"
+        )
+    op.create_check_constraint(
+        "ck_review_queue_entries_lifecycle_shape", "review_queue_entries", shape
+    )
+
+
+def _create_lease_table() -> None:
+    op.create_unique_constraint(
+        "uq_review_queue_lease_lineage",
+        "review_queue_entries",
+        ["id", "project_id", "task_id", "submission_id", "submission_version"],
+    )
+    op.create_table(
+        "review_leases",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("review_queue_entry_id", sa.Uuid(), nullable=False),
+        sa.Column("project_id", sa.String(36), nullable=False),
+        sa.Column("task_id", sa.String(36), nullable=False),
+        sa.Column("submission_id", sa.String(36), nullable=False),
+        sa.Column("submission_version", sa.Integer(), nullable=False),
+        sa.Column("reviewer_id", sa.String(36), nullable=False),
+        sa.Column("reviewer_contribution_policy_version_id", sa.Uuid(), nullable=False),
+        sa.Column("attempt_generation", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(16), server_default="active", nullable=False),
+        sa.Column(
+            "claimed_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("statement_timestamp()"),
+            nullable=False,
+        ),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("closed_at", sa.DateTime(timezone=True)),
+        sa.Column("close_reason", sa.String(32)),
+        sa.CheckConstraint("attempt_generation > 0", name="attempt_generation_positive"),
+        sa.CheckConstraint(
+            "status in ('active','consumed','released','expired','revoked')", name="status"
+        ),
+        sa.CheckConstraint("expires_at > claimed_at", name="expiry_after_claim"),
+        sa.CheckConstraint(
+            "(status='active' and closed_at is null and close_reason is null) or "
+            "(status='consumed' and closed_at is not null and close_reason='review_recorded') or "
+            "(status='released' and closed_at is not null and close_reason='manual_release') or "
+            "(status='expired' and closed_at is not null and close_reason='lease_expired') or "
+            "(status='revoked' and closed_at is not null "
+            "and close_reason in ('grant_revoked','admin_override'))",
+            name="lifecycle_shape",
+        ),
+        sa.CheckConstraint(
+            "closed_at is null or closed_at >= claimed_at", name="closure_after_claim"
+        ),
+        sa.ForeignKeyConstraint(
+            ["review_queue_entry_id", "project_id", "task_id", "submission_id", "submission_version"],
+            ["review_queue_entries.id", "review_queue_entries.project_id", "review_queue_entries.task_id", "review_queue_entries.submission_id", "review_queue_entries.submission_version"],
+            name="fk_review_lease_queue_lineage",
+        ),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], name="fk_review_lease_project"),
+        sa.ForeignKeyConstraint(["task_id"], ["workstream_tasks.id"], name="fk_review_lease_task"),
+        sa.ForeignKeyConstraint(["submission_id"], ["submissions.id"], name="fk_review_lease_submission"),
+        sa.ForeignKeyConstraint(["reviewer_id"], ["actor_profiles.id"], name="fk_review_lease_reviewer"),
+        sa.ForeignKeyConstraint(
+            ["reviewer_contribution_policy_version_id", "project_id"],
+            ["contribution_policy_versions.id", "contribution_policy_versions.project_id"],
+            name="fk_review_lease_policy_version",
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_review_leases"),
+        sa.UniqueConstraint("review_queue_entry_id", "id", name="uq_review_lease_queue_identity"),
+        sa.UniqueConstraint(
+            "review_queue_entry_id", "attempt_generation", name="uq_review_lease_attempt"
+        ),
+    )
+    op.create_index(
+        "uq_review_lease_active_queue",
+        "review_leases",
+        ["review_queue_entry_id"],
+        unique=True,
+        postgresql_where=sa.text("status='active'"),
+    )
+    op.create_index(
+        "uq_review_lease_active_reviewer",
+        "review_leases",
+        ["reviewer_id"],
+        unique=True,
+        postgresql_where=sa.text("status='active'"),
+    )
+    op.create_index("ix_review_lease_expiry", "review_leases", ["status", "expires_at", "id"])
+
+
+def _create_guards() -> None:
+    op.execute(
+        """
+        create function guard_review_lease() returns trigger language plpgsql as $$
+        declare
+          actor_type text;
+          policy_status text;
+        begin
+          if tg_op='DELETE' then
+            raise exception 'review leases cannot be deleted' using errcode='55000';
+          end if;
+          if tg_op='INSERT' then
+            if new.status <> 'active' then
+              raise exception 'review lease must begin active' using errcode='23514';
+            end if;
+            new.claimed_at := statement_timestamp();
+            new.closed_at := null;
+            new.close_reason := null;
+          else
+            if old.status <> 'active' then
+              raise exception 'terminal review leases are immutable' using errcode='55000';
+            end if;
+            if (new.id,new.review_queue_entry_id,new.project_id,new.task_id,new.submission_id,
+                new.submission_version,new.reviewer_id,
+                new.reviewer_contribution_policy_version_id,new.attempt_generation,
+                new.claimed_at,new.expires_at)
+               is distinct from
+               (old.id,old.review_queue_entry_id,old.project_id,old.task_id,old.submission_id,
+                old.submission_version,old.reviewer_id,
+                old.reviewer_contribution_policy_version_id,old.attempt_generation,
+                old.claimed_at,old.expires_at) then
+              raise exception 'review lease identity is immutable' using errcode='55000';
+            end if;
+            if new.status='active' then
+              raise exception 'review lease update must close attempt' using errcode='23514';
+            end if;
+          end if;
+          select actor_kind into actor_type from actor_profiles where id=new.reviewer_id;
+          if actor_type is distinct from 'human' then
+            raise exception 'review lease reviewer must be human' using errcode='23514';
+          end if;
+          if tg_op='INSERT' then
+            select status into policy_status from contribution_policy_versions
+             where id=new.reviewer_contribution_policy_version_id and project_id=new.project_id;
+            if policy_status is distinct from 'published' then
+              raise exception 'review lease policy version must be published' using errcode='23514';
+            end if;
+          end if;
+          return new;
+        end $$
+        """
+    )
+    op.execute(
+        "create trigger review_leases_guard before insert or update or delete on review_leases "
+        "for each row execute function guard_review_lease()"
+    )
+    op.execute(
+        """
+        create function validate_review_active_lease() returns trigger language plpgsql as $$
+        declare
+          queue_row review_queue_entries%rowtype;
+          active_count integer;
+        begin
+          if tg_table_name='review_queue_entries' then
+            queue_row := new;
+          else
+            select * into queue_row from review_queue_entries
+             where id=coalesce(new.review_queue_entry_id,old.review_queue_entry_id);
+          end if;
+          if not found and tg_table_name='review_leases' then
+            raise exception 'review lease queue is missing' using errcode='23514';
+          end if;
+          select count(*) into active_count from review_leases
+           where review_queue_entry_id=queue_row.id and status='active';
+          if queue_row.queue_state='leased' then
+            if queue_row.active_lease_id is null or active_count <> 1 or not exists(
+              select 1 from review_leases where id=queue_row.active_lease_id
+               and review_queue_entry_id=queue_row.id and status='active'
+            ) then
+              raise exception 'leased queue must identify its active lease' using errcode='23514';
+            end if;
+          elsif queue_row.active_lease_id is not null or active_count <> 0 then
+            raise exception 'non-leased queue cannot retain an active lease' using errcode='23514';
+          end if;
+          return null;
+        end $$
+        """
+    )
+    for table in ("review_queue_entries", "review_leases"):
+        op.execute(
+            f"create constraint trigger {table}_active_lease_guard "
+            f"after insert or update on {table} deferrable initially deferred "
+            "for each row execute function validate_review_active_lease()"
+        )
+    op.execute(
+        """
+        create function reject_review_lease_truncate() returns trigger language plpgsql as $$
+        begin
+          raise exception 'review leases cannot be truncated' using errcode='55000';
+        end $$
+        """
+    )
+    op.execute(
+        "create trigger review_leases_reject_truncate before truncate on review_leases "
+        "execute function reject_review_lease_truncate()"
+    )
+
+
+def _replace_queue_guard(*, with_preference_guard: bool) -> None:
+    op.execute("drop trigger review_queue_entries_guard on review_queue_entries")
+    op.execute("drop function guard_review_queue_entry()")
+    preference = """
+          if new.preferred_reviewer_id is not null and not exists(
+            select 1 from actor_profiles where id=new.preferred_reviewer_id and actor_kind='human'
+          ) then
+            raise exception 'preferred reviewer must be human' using errcode='23514';
+          end if;
+    """ if with_preference_guard else ""
+    op.execute(
+        f"""
+        create function guard_review_queue_entry() returns trigger language plpgsql as $$
+        declare
+          task_project text;
+          checker_row checker_runs%rowtype;
+        begin
+          if tg_op='DELETE' then
+            raise exception 'review queue entries cannot be deleted' using errcode='55000';
+          end if;
+          if tg_op='INSERT' then
+            if new.queue_state <> 'pending' then
+              raise exception 'review queue must begin pending' using errcode='23514';
+            end if;
+            new.first_queued_at := statement_timestamp();
+            new.available_since := new.first_queued_at;
+            new.routing_generation := 1;
+            new.lifecycle_generation := 1;
+            new.created_at := new.first_queued_at;
+          end if;
+          if tg_op='UPDATE' then
+            if (new.id,new.project_id,new.task_id,new.submission_id,new.submission_version,
+                new.admitting_checker_run_id,new.first_queued_at,new.created_at)
+               is distinct from
+               (old.id,old.project_id,old.task_id,old.submission_id,old.submission_version,
+                old.admitting_checker_run_id,old.first_queued_at,old.created_at) then
+              raise exception 'review queue identity is immutable' using errcode='55000';
+            end if;
+            if old.queue_state='closed' and new.queue_state <> 'closed' then
+              raise exception 'closed review queue entries cannot reopen' using errcode='23514';
+            end if;
+            if new.routing_generation < old.routing_generation
+               or new.lifecycle_generation < old.lifecycle_generation then
+              raise exception 'review queue generations cannot decrease' using errcode='23514';
+            end if;
+          end if;
+          {preference}
+          if tg_op='UPDATE' then return new; end if;
+          select project_id into task_project from workstream_tasks where id=new.task_id;
+          if task_project is null or task_project <> new.project_id then
+            raise exception 'review queue task project mismatch' using errcode='23514';
+          end if;
+          select * into checker_row from checker_runs where id=new.admitting_checker_run_id;
+          if not found or checker_row.task_id <> new.task_id
+             or checker_row.submission_id <> new.submission_id
+             or checker_row.submission_version <> new.submission_version then
+            raise exception 'review queue checker lineage mismatch' using errcode='23514';
+          end if;
+          if checker_row.status <> 'completed' or checker_row.routing_recommendation <> 'allow_review'
+             or checker_row.is_current_for_submission is not true then
+            raise exception 'review queue checker is not admissible' using errcode='23514';
+          end if;
+          return new;
+        end $$
+        """
+    )
+    op.execute(
+        "create trigger review_queue_entries_guard before insert or update or delete "
+        "on review_queue_entries for each row execute function guard_review_queue_entry()"
+    )
+
+
+def upgrade() -> None:
+    """Install empty lease persistence after the canonical CON policy target."""
+    bind = op.get_bind()
+    bind.execute(sa.text("lock table review_queue_entries in share row exclusive mode"))
+    invalid_preference = bind.execute(
+        sa.text(
+            "select exists(select 1 from review_queue_entries queue "
+            "left join actor_profiles actor on actor.id=queue.preferred_reviewer_id "
+            "where queue.preferred_reviewer_id is not null "
+            "and actor.actor_kind is distinct from 'human')"
+        )
+    ).scalar_one()
+    if invalid_preference:
+        raise RuntimeError("cannot add lease persistence with nonhuman reviewer preference")
+    op.add_column("review_queue_entries", sa.Column("active_lease_id", sa.Uuid()))
+    _replace_queue_checks(with_leases=True)
+    _create_lease_table()
+    op.create_foreign_key(
+        "fk_review_queue_active_lease",
+        "review_queue_entries",
+        "review_leases",
+        ["active_lease_id", "id"],
+        ["id", "review_queue_entry_id"],
+        deferrable=True,
+        initially="DEFERRED",
+    )
+    _replace_queue_guard(with_preference_guard=True)
+    _create_guards()
+
+
+def downgrade() -> None:
+    """Remove only unused lease persistence; never discard attempt history."""
+    bind = op.get_bind()
+    bind.execute(sa.text("lock table review_leases in access exclusive mode"))
+    if bind.execute(sa.text("select exists(select 1 from review_leases)" )).scalar_one():
+        raise RuntimeError("cannot downgrade populated review lease persistence")
+    op.execute("drop trigger review_leases_reject_truncate on review_leases")
+    op.execute("drop function reject_review_lease_truncate()")
+    for table in ("review_queue_entries", "review_leases"):
+        op.execute(f"drop trigger {table}_active_lease_guard on {table}")
+    op.execute("drop function validate_review_active_lease()")
+    op.execute("drop trigger review_leases_guard on review_leases")
+    op.execute("drop function guard_review_lease()")
+    _replace_queue_guard(with_preference_guard=False)
+    op.drop_constraint("fk_review_queue_active_lease", "review_queue_entries", type_="foreignkey")
+    op.drop_table("review_leases")
+    op.drop_constraint("uq_review_queue_lease_lineage", "review_queue_entries", type_="unique")
+    _replace_queue_checks(with_leases=False)
+    op.drop_column("review_queue_entries", "active_lease_id")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -56,6 +56,7 @@ from app.modules.projects.models import (  # noqa: F401
 )
 from app.modules.reviews.models import (  # noqa: F401
     ReviewAdmissionIdempotencyRecord,
+    ReviewLease,
     ReviewQueueEntry,
 )
 from app.modules.tasks.models import (  # noqa: F401

--- a/backend/app/modules/reviews/models.py
+++ b/backend/app/modules/reviews/models.py
@@ -32,7 +32,23 @@ class ReviewQueueEntry(Base):
             ["submissions.id", "submissions.task_id", "submissions.version"],
             name="fk_review_queue_submission_lineage",
         ),
+        ForeignKeyConstraint(
+            ["active_lease_id", "id"],
+            ["review_leases.id", "review_leases.review_queue_entry_id"],
+            name="fk_review_queue_active_lease",
+            use_alter=True,
+            deferrable=True,
+            initially="DEFERRED",
+        ),
         UniqueConstraint("submission_id", name="uq_review_queue_submission"),
+        UniqueConstraint(
+            "id",
+            "project_id",
+            "task_id",
+            "submission_id",
+            "submission_version",
+            name="uq_review_queue_lease_lineage",
+        ),
         UniqueConstraint(
             "id",
             "project_id",
@@ -43,7 +59,7 @@ class ReviewQueueEntry(Base):
             name="uq_review_queue_admission_identity",
         ),
         CheckConstraint("submission_version > 0", name="submission_version_positive"),
-        CheckConstraint("queue_state in ('pending','closed')", name="queue_state"),
+        CheckConstraint("queue_state in ('pending','leased','closed')", name="queue_state"),
         CheckConstraint(
             "routing_mode in ('open','preferred')",
             name="routing_mode",
@@ -61,8 +77,12 @@ class ReviewQueueEntry(Base):
             name="routing_shape",
         ),
         CheckConstraint(
-            "(queue_state='pending' and closed_at is null and closed_reason is null) or "
+            "(queue_state='pending' and active_lease_id is null "
+            "and closed_at is null and closed_reason is null) or "
+            "(queue_state='leased' and active_lease_id is not null "
+            "and closed_at is null and closed_reason is null) or "
             "(queue_state='closed' and closed_at is not null and "
+            "active_lease_id is null and "
             "closed_reason in ('review_recorded','task_closed','admin_cancelled') "
             "and closed_at >= first_queued_at)",
             name="lifecycle_shape",
@@ -109,6 +129,7 @@ class ReviewQueueEntry(Base):
     queue_state: Mapped[str] = mapped_column(
         String(16), nullable=False, server_default=text("'pending'")
     )
+    active_lease_id: Mapped[UUID | None] = mapped_column(Uuid())
     routing_mode: Mapped[str] = mapped_column(String(16), nullable=False)
     routing_reason: Mapped[str] = mapped_column(String(32), nullable=False)
     first_queued_at: Mapped[datetime] = mapped_column(
@@ -214,3 +235,99 @@ class ReviewAdmissionIdempotencyRecord(Base):
         DateTime(timezone=True), nullable=False, server_default=text("statement_timestamp()")
     )
     committed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class ReviewLease(Base):
+    """Immutable identity and terminal provenance for one review claim attempt."""
+
+    __tablename__ = "review_leases"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            [
+                "review_queue_entry_id",
+                "project_id",
+                "task_id",
+                "submission_id",
+                "submission_version",
+            ],
+            [
+                "review_queue_entries.id",
+                "review_queue_entries.project_id",
+                "review_queue_entries.task_id",
+                "review_queue_entries.submission_id",
+                "review_queue_entries.submission_version",
+            ],
+            name="fk_review_lease_queue_lineage",
+        ),
+        ForeignKeyConstraint(
+            ["reviewer_contribution_policy_version_id", "project_id"],
+            ["contribution_policy_versions.id", "contribution_policy_versions.project_id"],
+            name="fk_review_lease_policy_version",
+        ),
+        UniqueConstraint(
+            "review_queue_entry_id", "id", name="uq_review_lease_queue_identity"
+        ),
+        UniqueConstraint(
+            "review_queue_entry_id", "attempt_generation", name="uq_review_lease_attempt"
+        ),
+        CheckConstraint("attempt_generation > 0", name="attempt_generation_positive"),
+        CheckConstraint(
+            "status in ('active','consumed','released','expired','revoked')",
+            name="status",
+        ),
+        CheckConstraint("expires_at > claimed_at", name="expiry_after_claim"),
+        CheckConstraint(
+            "(status='active' and closed_at is null and close_reason is null) or "
+            "(status='consumed' and closed_at is not null and close_reason='review_recorded') or "
+            "(status='released' and closed_at is not null and close_reason='manual_release') or "
+            "(status='expired' and closed_at is not null and close_reason='lease_expired') or "
+            "(status='revoked' and closed_at is not null "
+            "and close_reason in ('grant_revoked','admin_override'))",
+            name="lifecycle_shape",
+        ),
+        CheckConstraint(
+            "closed_at is null or closed_at >= claimed_at", name="closure_after_claim"
+        ),
+        Index(
+            "uq_review_lease_active_queue",
+            "review_queue_entry_id",
+            unique=True,
+            postgresql_where=text("status='active'"),
+        ),
+        Index(
+            "uq_review_lease_active_reviewer",
+            "reviewer_id",
+            unique=True,
+            postgresql_where=text("status='active'"),
+        ),
+        Index("ix_review_lease_expiry", "status", "expires_at", "id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    review_queue_entry_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    project_id: Mapped[str] = mapped_column(
+        ForeignKey("projects.id", name="fk_review_lease_project"), nullable=False
+    )
+    task_id: Mapped[str] = mapped_column(
+        ForeignKey("workstream_tasks.id", name="fk_review_lease_task"), nullable=False
+    )
+    submission_id: Mapped[str] = mapped_column(
+        ForeignKey("submissions.id", name="fk_review_lease_submission"), nullable=False
+    )
+    submission_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    reviewer_id: Mapped[str] = mapped_column(
+        ForeignKey("actor_profiles.id", name="fk_review_lease_reviewer"), nullable=False
+    )
+    reviewer_contribution_policy_version_id: Mapped[UUID] = mapped_column(
+        Uuid(), nullable=False
+    )
+    attempt_generation: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, server_default=text("'active'")
+    )
+    claimed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("statement_timestamp()")
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    close_reason: Mapped[str | None] = mapped_column(String(32))

--- a/backend/app/modules/reviews/repository.py
+++ b/backend/app/modules/reviews/repository.py
@@ -11,10 +11,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.reviews.models import (
     ReviewAdmissionIdempotencyRecord,
+    ReviewLease,
     ReviewQueueEntry,
 )
 from app.modules.reviews.schemas import (
     ReviewAdmissionReservationInput,
+    ReviewLeaseInput,
     ReviewQueueEntryInput,
 )
 
@@ -51,6 +53,27 @@ class ReviewQueueRepository:
             routing_reason=value.routing_reason.value,
             preferred_reviewer_id=value.preferred_reviewer_id,
             preference_expires_at=value.preference_expires_at,
+        )
+        self._session.add(record)
+        await self._session.flush()
+        return record
+
+    async def add_lease(self, value: ReviewLeaseInput) -> ReviewLease:
+        """Flush one active lease attempt without claiming or committing."""
+        record = ReviewLease(
+            id=value.id,
+            review_queue_entry_id=value.review_queue_entry_id,
+            project_id=value.project_id,
+            task_id=value.task_id,
+            submission_id=value.submission_id,
+            submission_version=value.submission_version,
+            reviewer_id=value.reviewer_id,
+            reviewer_contribution_policy_version_id=(
+                value.reviewer_contribution_policy_version_id
+            ),
+            attempt_generation=value.attempt_generation,
+            status="active",
+            expires_at=value.expires_at,
         )
         self._session.add(record)
         await self._session.flush()

--- a/backend/app/modules/reviews/schemas.py
+++ b/backend/app/modules/reviews/schemas.py
@@ -55,3 +55,20 @@ class ReviewAdmissionReservationInput(BaseModel):
     submission_id: str = Field(min_length=36, max_length=36)
     submission_version: int = Field(gt=0)
     admitting_checker_run_id: str = Field(min_length=36, max_length=36)
+
+
+class ReviewLeaseInput(BaseModel):
+    """Exact persistence facts for one later caller-owned claim transaction."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: UUID
+    review_queue_entry_id: UUID
+    project_id: str = Field(min_length=36, max_length=36)
+    task_id: str = Field(min_length=36, max_length=36)
+    submission_id: str = Field(min_length=36, max_length=36)
+    submission_version: int = Field(gt=0)
+    reviewer_id: str = Field(min_length=36, max_length=36)
+    reviewer_contribution_policy_version_id: UUID
+    attempt_generation: int = Field(gt=0)
+    expires_at: datetime

--- a/backend/scripts/run_test_lanes.py
+++ b/backend/scripts/run_test_lanes.py
@@ -160,6 +160,7 @@ LANES = (
         (
             "tests/test_checkers.py",
             "tests/test_review_queue_persistence.py",
+            "tests/test_review_lease_persistence.py",
             "tests/test_tasks.py",
         ),
     ),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -21,7 +21,7 @@ from app.db import session as db_session
 from scripts.run_isolated_tests import LOOPBACK, NAME_RE, ROLE_RE
 
 DDL_LOCK_DIRECTORY = Path("/tmp")
-EXPECTED_PUBLIC_SCHEMA_SHA256 = "e52ae0ebd83dbd1786fc2ea2dac25608a0c61f8b0f623cb0d19fa854c8db95c9"
+EXPECTED_PUBLIC_SCHEMA_SHA256 = "f89ce8bc78ed5089544b32eeb96489c54f25355a924aecd598a8f15317ec8122"
 PROTECTED_TEST_TABLES = (
     "actor_profile_migration_state",
     "alembic_version",
@@ -88,6 +88,7 @@ RESETTABLE_TEST_TABLES = (
     "review_policies",
     "revision_policies",
     "review_admission_idempotency_records",
+    "review_leases",
     "review_queue_entries",
     "submission_artifact_policies",
     "submissions",
@@ -113,6 +114,7 @@ TRUNCATE_GUARDED_TABLES = (
     "project_role_grants",
     "project_role_qualification_snapshots",
     "review_admission_idempotency_records",
+    "review_leases",
     "review_queue_entries",
     "review_policies",
     "revision_policies",

--- a/backend/tests/test_alembic.py
+++ b/backend/tests/test_alembic.py
@@ -73,7 +73,7 @@ from app.modules.actors.service_identity_migration import (
     snapshot_existing_service_rows,
 )
 
-HEAD_REVISION = "0055_contribution_policy"
+HEAD_REVISION = "0056_review_lease_preference"
 
 pytestmark = pytest.mark.postgres_schema_contract
 
@@ -365,6 +365,47 @@ async def _review_queue_foundation_state(database_url: str) -> dict[str, object]
             "admission_truncate_guard": (
                 "review_admission_idempotency_records_reject_truncate" in triggers
             ),
+        }
+    finally:
+        await engine.dispose()
+
+
+async def _review_lease_preference_state(database_url: str) -> dict[str, object]:
+    engine = create_async_engine(database_url)
+    try:
+        async with engine.connect() as connection:
+            revision = await connection.scalar(text("select version_num from alembic_version"))
+            lease_count = await connection.scalar(text("select count(*) from review_leases"))
+            queue_columns = set(
+                (
+                    await connection.scalars(
+                        text(
+                            "select column_name from information_schema.columns "
+                            "where table_schema=current_schema() "
+                            "and table_name='review_queue_entries'"
+                        )
+                    )
+                ).all()
+            )
+            triggers = set(
+                (
+                    await connection.scalars(
+                        text(
+                            "select tgname from pg_trigger where tgrelid in "
+                            "('review_queue_entries'::regclass,'review_leases'::regclass) "
+                            "and not tgisinternal"
+                        )
+                    )
+                ).all()
+            )
+        return {
+            "revision": str(revision),
+            "lease_count": int(lease_count or 0),
+            "active_lease_column": "active_lease_id" in queue_columns,
+            "lease_guard": "review_leases_guard" in triggers,
+            "queue_graph_guard": "review_queue_entries_active_lease_guard" in triggers,
+            "lease_graph_guard": "review_leases_active_lease_guard" in triggers,
+            "truncate_guard": "review_leases_reject_truncate" in triggers,
         }
     finally:
         await engine.dispose()
@@ -749,6 +790,28 @@ def test_0051_review_queue_foundation_empty_round_trip(
             "admission_truncate_guard": True,
         }
         command.downgrade(config, "0050_guide_source_v2")
+        command.upgrade(config, "head")
+
+
+def test_0056_review_lease_preference_empty_round_trip(
+    isolated_database_env: str,
+    migration_lock,
+) -> None:
+    """0056 installs no attempts and reverses exactly while unused."""
+    config = _alembic_config()
+    with migration_lock():
+        command.downgrade(config, "0055_contribution_policy")
+        command.upgrade(config, "0056_review_lease_preference")
+        assert asyncio.run(_review_lease_preference_state(isolated_database_env)) == {
+            "revision": "0056_review_lease_preference",
+            "lease_count": 0,
+            "active_lease_column": True,
+            "lease_guard": True,
+            "queue_graph_guard": True,
+            "lease_graph_guard": True,
+            "truncate_guard": True,
+        }
+        command.downgrade(config, "0055_contribution_policy")
         command.upgrade(config, "head")
 
 

--- a/backend/tests/test_ci_test_lanes.py
+++ b/backend/tests/test_ci_test_lanes.py
@@ -43,6 +43,7 @@ def test_measured_hotspots_have_explicit_semantic_owners() -> None:
     assert modules_by_lane["project_lifecycle"] == {"tests/test_projects.py"}
     assert modules_by_lane["task_lifecycle"] == {
         "tests/test_checkers.py",
+        "tests/test_review_lease_persistence.py",
         "tests/test_review_queue_persistence.py",
         "tests/test_tasks.py",
     }

--- a/backend/tests/test_review_lease_persistence.py
+++ b/backend/tests/test_review_lease_persistence.py
@@ -1,0 +1,613 @@
+"""Focused PostgreSQL proof for hidden ReviewLease persistence."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID, uuid4
+
+from alembic import command
+from alembic.config import Config
+from httpx import ASGITransport, AsyncClient
+import pytest
+from sqlalchemy import text, update
+from sqlalchemy.exc import DBAPIError, IntegrityError
+
+from app.core.config import get_settings
+from app.db import session as db_session
+from app.db.base import Base
+from app.main import create_app
+from app.modules.actors.models import ActorIdentityLink, ActorProfile
+from app.modules.actors.service_identities import ServiceIdentity
+from app.modules.contributions.models import (
+    ContributionPolicy,
+    ContributionPolicyVersion,
+    ContributionRule,
+)
+from app.modules.reviews.models import ReviewLease, ReviewQueueEntry
+from app.modules.reviews.repository import ReviewQueueRepository
+from app.modules.reviews.schemas import ReviewLeaseInput
+from project_create_fixtures import grant_system_project_manager
+from tests.test_review_queue_persistence import (
+    _additional_reviewable_submission,
+    _queue_input,
+    _reviewable_lineage,
+)
+from tests.test_tasks import auth_headers, set_dev_actor
+
+
+@pytest.fixture
+def review_lease_database_env(
+    monkeypatch: pytest.MonkeyPatch,
+    clean_postgres_database: str,
+) -> Iterator[str]:
+    """Bind lease tests to one runner-owned migrated PostgreSQL database."""
+    monkeypatch.setenv("WORKSTREAM_DATABASE_URL", clean_postgres_database)
+    monkeypatch.setenv("WORKSTREAM_CELERY_TASK_ALWAYS_EAGER", "true")
+    monkeypatch.setenv(
+        "WORKSTREAM_API_RATE_LIMIT_KEY_SECRET",
+        "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=",
+    )
+    set_dev_actor(monkeypatch, roles="project_manager", subject="project-manager-subject")
+    get_settings.cache_clear()
+    try:
+        yield clean_postgres_database
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+async def review_lease_client(
+    review_lease_database_env: str,
+) -> AsyncIterator[AsyncClient]:
+    """Create only canonical upstream facts through existing test helpers."""
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client:
+        response = await client.get("/api/v1/auth/me", headers=auth_headers())
+        assert response.status_code == 200, response.text
+        async with db_session.get_session_factory()() as session:
+            await grant_system_project_manager(
+                session,
+                issuer="flow-test",
+                subject="project-manager-subject",
+            )
+            await session.commit()
+        yield client
+
+
+async def _human_actor(session, *, label: str) -> str:
+    actor_id = str(uuid4())
+    session.add(
+        ActorProfile(
+            id=actor_id,
+            actor_kind="human",
+            status="active",
+            provisioning_method="automatic_first_access",
+            created_by=actor_id,
+        )
+    )
+    await session.flush()
+    session.add(
+        ActorIdentityLink(
+            id=str(uuid4()),
+            actor_profile_id=actor_id,
+            issuer="https://review-lease.test",
+            subject=f"{label}-{actor_id}",
+            subject_kind="human",
+            status="active",
+            linked_by=actor_id,
+            last_verified_at=datetime.now(UTC),
+        )
+    )
+    return actor_id
+
+
+async def _service_actor(session) -> str:
+    actor_id = str(uuid4())
+    session.add(
+        ActorProfile(
+            id=actor_id,
+            actor_kind="service",
+            status="active",
+            provisioning_method="manual_service_provisioning",
+            service_identity=ServiceIdentity.REVIEW_LEASE_EXPIRY.value,
+            created_by="workstream:test",
+        )
+    )
+    await session.flush()
+    session.add(
+        ActorIdentityLink(
+            id=str(uuid4()),
+            actor_profile_id=actor_id,
+            issuer="https://review-lease.test",
+            subject=f"service-{actor_id}",
+            subject_kind="service",
+            status="active",
+            linked_by="workstream:test",
+        )
+    )
+    await session.flush()
+    return actor_id
+
+
+async def _published_reviewer_policy(session, project_id: str, actor_id: str) -> UUID:
+    policy_id = uuid4()
+    version_id = uuid4()
+    policy = ContributionPolicy(
+        id=policy_id,
+        project_id=project_id,
+        name=f"Reviewer policy {policy_id}",
+        status="draft",
+        created_by=actor_id,
+    )
+    version = ContributionPolicyVersion(
+        id=version_id,
+        contribution_policy_id=policy_id,
+        project_id=project_id,
+        version_number=1,
+        status="draft",
+        created_by=actor_id,
+    )
+    session.add_all([policy, version])
+    await session.flush()
+    session.add_all(
+        [
+            ContributionRule(
+                id=uuid4(),
+                contribution_policy_version_id=version_id,
+                project_id=project_id,
+                contribution_type=kind,
+                compensation_mode="unpaid",
+            )
+            for kind in ("accepted_submission", "completed_review")
+        ]
+    )
+    await session.flush()
+    await session.execute(
+        update(ContributionPolicyVersion)
+        .where(ContributionPolicyVersion.id == version_id)
+        .values(
+            status="published",
+            published_by=actor_id,
+            published_at=datetime.now(UTC),
+        )
+    )
+    await session.flush()
+    return version_id
+
+
+async def _draft_reviewer_policy(session, project_id: str, actor_id: str) -> UUID:
+    policy_id = uuid4()
+    version_id = uuid4()
+    session.add_all(
+        [
+            ContributionPolicy(
+                id=policy_id,
+                project_id=project_id,
+                name=f"Draft reviewer policy {policy_id}",
+                status="draft",
+                created_by=actor_id,
+            ),
+            ContributionPolicyVersion(
+                id=version_id,
+                contribution_policy_id=policy_id,
+                project_id=project_id,
+                version_number=1,
+                status="draft",
+                created_by=actor_id,
+            ),
+        ]
+    )
+    await session.flush()
+    return version_id
+
+
+def _lease_input(
+    queue: ReviewQueueEntry,
+    reviewer_id: str,
+    policy_version_id: UUID,
+    *,
+    generation: int = 1,
+) -> ReviewLeaseInput:
+    return ReviewLeaseInput(
+        id=uuid4(),
+        review_queue_entry_id=queue.id,
+        project_id=queue.project_id,
+        task_id=queue.task_id,
+        submission_id=queue.submission_id,
+        submission_version=queue.submission_version,
+        reviewer_id=reviewer_id,
+        reviewer_contribution_policy_version_id=policy_version_id,
+        attempt_generation=generation,
+        expires_at=datetime.now(UTC) + timedelta(hours=2),
+    )
+
+
+async def _seed_queue_and_policy(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict, ReviewQueueEntry, str, UUID]:
+    project, task, submission = await _reviewable_lineage(client, monkeypatch)
+    async with db_session.get_session_factory()() as session:
+        queue = await ReviewQueueRepository(session).add_queue_entry(
+            _queue_input(project, task, submission)
+        )
+        reviewer_id = await _human_actor(session, label="reviewer")
+        version_id = await _published_reviewer_policy(session, project["id"], reviewer_id)
+        await session.commit()
+        return project, queue, reviewer_id, version_id
+
+
+async def _add_second_queue(
+    client: AsyncClient,
+    project: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> ReviewQueueEntry:
+    task, submission = await _additional_reviewable_submission(client, project, monkeypatch)
+    async with db_session.get_session_factory()() as session:
+        queue = await ReviewQueueRepository(session).add_queue_entry(
+            _queue_input(project, task, submission)
+        )
+        await session.commit()
+        return queue
+
+
+def test_review_lease_metadata_is_hidden_and_exact() -> None:
+    assert "review_leases" in Base.metadata.tables
+    assert "active_lease_id" in Base.metadata.tables["review_queue_entries"].columns
+    assert set(ReviewLeaseInput.model_fields) == {
+        "id",
+        "review_queue_entry_id",
+        "project_id",
+        "task_id",
+        "submission_id",
+        "submission_version",
+        "reviewer_id",
+        "reviewer_contribution_policy_version_id",
+        "attempt_generation",
+        "expires_at",
+    }
+    assert not any(
+        getattr(route, "path", "").startswith("/api/v1/reviews")
+        for route in create_app().routes
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_flushes_exact_active_lease_without_committing(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, queue, reviewer_id, version_id = await _seed_queue_and_policy(
+        review_lease_client, monkeypatch
+    )
+    value = _lease_input(queue, reviewer_id, version_id)
+    async with db_session.get_session_factory()() as session:
+        lease = await ReviewQueueRepository(session).add_lease(value)
+        await session.execute(
+            update(ReviewQueueEntry)
+            .where(ReviewQueueEntry.id == queue.id)
+            .values(queue_state="leased", active_lease_id=lease.id, lifecycle_generation=2)
+        )
+        await session.commit()
+    async with db_session.get_session_factory()() as session:
+        stored = await session.get(ReviewLease, value.id)
+        assert stored is not None
+        assert stored.status == "active"
+        assert stored.claimed_at < stored.expires_at
+        assert stored.reviewer_contribution_policy_version_id == version_id
+
+
+@pytest.mark.asyncio
+async def test_active_capacity_and_queue_pointer_are_database_enforced(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, queue, reviewer_id, version_id = await _seed_queue_and_policy(
+        review_lease_client, monkeypatch
+    )
+    first = _lease_input(queue, reviewer_id, version_id)
+    async with db_session.get_session_factory()() as session:
+        await ReviewQueueRepository(session).add_lease(first)
+        with pytest.raises(DBAPIError, match="non-leased queue cannot retain an active lease"):
+            await session.commit()
+        await session.rollback()
+    async with db_session.get_session_factory()() as session:
+        await ReviewQueueRepository(session).add_lease(first)
+        await session.execute(
+            text(
+                "update review_queue_entries set queue_state='leased',active_lease_id=:lease,"
+                "lifecycle_generation=lifecycle_generation+1 where id=:queue"
+            ),
+            {"lease": first.id, "queue": queue.id},
+        )
+        await session.commit()
+    async with db_session.get_session_factory()() as session:
+        duplicate = _lease_input(queue, reviewer_id, version_id, generation=2)
+        with pytest.raises(IntegrityError, match="uq_review_lease_active_queue"):
+            await ReviewQueueRepository(session).add_lease(duplicate)
+
+
+@pytest.mark.asyncio
+async def test_reviewer_policy_lineage_and_human_kind_are_database_enforced(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, queue, reviewer_id, version_id = await _seed_queue_and_policy(
+        review_lease_client, monkeypatch
+    )
+    async with db_session.get_session_factory()() as session:
+        service_id = await _service_actor(session)
+        value = _lease_input(queue, service_id, version_id)
+        with pytest.raises(DBAPIError, match="review lease reviewer must be human"):
+            await ReviewQueueRepository(session).add_lease(value)
+
+
+@pytest.mark.asyncio
+async def test_queue_lineage_policy_project_and_published_status_are_enforced(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, queue, reviewer_id, version_id = await _seed_queue_and_policy(
+        review_lease_client, monkeypatch
+    )
+    second_queue = await _add_second_queue(review_lease_client, project, monkeypatch)
+
+    crossed = _lease_input(queue, reviewer_id, version_id).model_copy(
+        update={"task_id": second_queue.task_id, "submission_id": second_queue.submission_id}
+    )
+    async with db_session.get_session_factory()() as session:
+        with pytest.raises(IntegrityError, match="fk_review_lease_queue_lineage"):
+            await ReviewQueueRepository(session).add_lease(crossed)
+
+    other_project_key = str(uuid4())
+    response = await review_lease_client.post(
+        "/api/v1/projects",
+        headers=auth_headers() | {"Idempotency-Key": str(uuid4())},
+        json={
+            "name": "Other lease policy project",
+            "slug": f"other-lease-policy-{other_project_key}",
+            "description": "Cross-project lease policy proof",
+        },
+    )
+    assert response.status_code == 201, response.text
+    other_project_id = response.json()["id"]
+    async with db_session.get_session_factory()() as session:
+        other_policy = await _published_reviewer_policy(
+            session, other_project_id, reviewer_id
+        )
+        await session.commit()
+    async with db_session.get_session_factory()() as session:
+        with pytest.raises(DBAPIError, match="policy version must be published"):
+            await ReviewQueueRepository(session).add_lease(
+                _lease_input(queue, reviewer_id, other_policy)
+            )
+
+    async with db_session.get_session_factory()() as session:
+        draft_policy = await _draft_reviewer_policy(session, project["id"], reviewer_id)
+        await session.commit()
+    async with db_session.get_session_factory()() as session:
+        with pytest.raises(DBAPIError, match="policy version must be published"):
+            await ReviewQueueRepository(session).add_lease(
+                _lease_input(queue, reviewer_id, draft_policy)
+            )
+
+
+@pytest.mark.asyncio
+async def test_preferred_reviewer_and_global_active_capacity_are_enforced(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, queue, reviewer_id, version_id = await _seed_queue_and_policy(
+        review_lease_client, monkeypatch
+    )
+    second_queue = await _add_second_queue(review_lease_client, project, monkeypatch)
+    async with db_session.get_session_factory()() as session:
+        service_id = await _service_actor(session)
+        with pytest.raises(DBAPIError, match="preferred reviewer must be human"):
+            await session.execute(
+                update(ReviewQueueEntry)
+                .where(ReviewQueueEntry.id == second_queue.id)
+                .values(
+                    routing_mode="preferred",
+                    routing_reason="revision_return",
+                    preferred_reviewer_id=service_id,
+                    preference_expires_at=datetime.now(UTC) + timedelta(hours=1),
+                    routing_generation=2,
+                )
+            )
+
+    first = _lease_input(queue, reviewer_id, version_id)
+    async with db_session.get_session_factory()() as session:
+        await ReviewQueueRepository(session).add_lease(first)
+        await session.execute(
+            update(ReviewQueueEntry)
+            .where(ReviewQueueEntry.id == queue.id)
+            .values(queue_state="leased", active_lease_id=first.id, lifecycle_generation=2)
+        )
+        await session.commit()
+    async with db_session.get_session_factory()() as session:
+        with pytest.raises(IntegrityError, match="uq_review_lease_active_reviewer"):
+            await ReviewQueueRepository(session).add_lease(
+                _lease_input(second_queue, reviewer_id, version_id)
+            )
+
+
+@pytest.mark.asyncio
+async def test_two_sessions_cannot_race_active_leases_for_one_reviewer(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project, queue, reviewer_id, version_id = await _seed_queue_and_policy(
+        review_lease_client, monkeypatch
+    )
+    second_queue = await _add_second_queue(review_lease_client, project, monkeypatch)
+    first = _lease_input(queue, reviewer_id, version_id)
+    second = _lease_input(second_queue, reviewer_id, version_id)
+    first_flushed = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def winner() -> None:
+        async with db_session.get_session_factory()() as session:
+            await ReviewQueueRepository(session).add_lease(first)
+            await session.execute(
+                update(ReviewQueueEntry)
+                .where(ReviewQueueEntry.id == queue.id)
+                .values(queue_state="leased", active_lease_id=first.id, lifecycle_generation=2)
+            )
+            first_flushed.set()
+            await second_started.wait()
+            await session.commit()
+
+    async def loser() -> None:
+        await first_flushed.wait()
+        async with db_session.get_session_factory()() as session:
+            second_started.set()
+            with pytest.raises(IntegrityError, match="uq_review_lease_active_reviewer"):
+                await ReviewQueueRepository(session).add_lease(second)
+
+    await asyncio.gather(winner(), loser())
+
+
+@pytest.mark.asyncio
+async def test_terminal_attempt_is_immutable_and_cannot_reopen(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, queue, reviewer_id, version_id = await _seed_queue_and_policy(
+        review_lease_client, monkeypatch
+    )
+    value = _lease_input(queue, reviewer_id, version_id)
+    async with db_session.get_session_factory()() as session:
+        await ReviewQueueRepository(session).add_lease(value)
+        await session.execute(
+            update(ReviewQueueEntry)
+            .where(ReviewQueueEntry.id == queue.id)
+            .values(queue_state="leased", active_lease_id=value.id, lifecycle_generation=2)
+        )
+        await session.commit()
+    async with db_session.get_session_factory()() as session:
+        await session.execute(
+            text(
+                "update review_leases set status='released',closed_at=statement_timestamp(),"
+                "close_reason='manual_release' where id=:id"
+            ),
+            {"id": value.id},
+        )
+        await session.execute(
+            update(ReviewQueueEntry)
+            .where(ReviewQueueEntry.id == queue.id)
+            .values(queue_state="pending", active_lease_id=None, lifecycle_generation=3)
+        )
+        await session.commit()
+    async with db_session.get_session_factory()() as session:
+        with pytest.raises(DBAPIError, match="terminal review leases are immutable"):
+            await session.execute(
+                text("update review_leases set status='active' where id=:id"),
+                {"id": value.id},
+            )
+
+
+@pytest.mark.postgres_schema_contract
+@pytest.mark.asyncio
+async def test_populated_lease_persistence_refuses_downgrade(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    migration_lock,
+) -> None:
+    _, queue, reviewer_id, version_id = await _seed_queue_and_policy(
+        review_lease_client, monkeypatch
+    )
+    value = _lease_input(queue, reviewer_id, version_id)
+    async with db_session.get_session_factory()() as session:
+        await ReviewQueueRepository(session).add_lease(value)
+        await session.execute(
+            update(ReviewQueueEntry)
+            .where(ReviewQueueEntry.id == queue.id)
+            .values(queue_state="leased", active_lease_id=value.id, lifecycle_generation=2)
+        )
+        await session.commit()
+    await db_session.dispose_engine()
+
+    backend_root = Path(__file__).resolve().parents[1]
+    config = Config(str(backend_root / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_root / "alembic"))
+
+    def downgrade() -> None:
+        with migration_lock():
+            command.downgrade(config, "0055_contribution_policy")
+
+    with pytest.raises(RuntimeError, match="cannot downgrade populated review lease"):
+        await asyncio.to_thread(downgrade)
+
+    async with db_session.get_session_factory()() as session:
+        assert await session.scalar(text("select version_num from alembic_version")) == (
+            "0056_review_lease_preference"
+        )
+        assert await session.get(ReviewLease, value.id) is not None
+
+
+@pytest.mark.postgres_schema_contract
+@pytest.mark.asyncio
+async def test_upgrade_refuses_preexisting_nonhuman_preference(
+    review_lease_client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    migration_lock,
+) -> None:
+    _, queue, _, _ = await _seed_queue_and_policy(review_lease_client, monkeypatch)
+    async with db_session.get_session_factory()() as session:
+        service_id = await _service_actor(session)
+        await session.commit()
+    await db_session.dispose_engine()
+
+    backend_root = Path(__file__).resolve().parents[1]
+    config = Config(str(backend_root / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_root / "alembic"))
+
+    def migrate(revision: str) -> None:
+        with migration_lock():
+            if revision == "0055_contribution_policy":
+                command.downgrade(config, revision)
+            else:
+                command.upgrade(config, revision)
+
+    await asyncio.to_thread(migrate, "0055_contribution_policy")
+    async with db_session.get_session_factory()() as session:
+        await session.execute(
+            text(
+                "update review_queue_entries set routing_mode='preferred',"
+                "routing_reason='revision_return',preferred_reviewer_id=:reviewer,"
+                "preference_expires_at=statement_timestamp()+interval '1 hour',"
+                "routing_generation=routing_generation+1 where id=:queue"
+            ),
+            {"reviewer": service_id, "queue": queue.id},
+        )
+        await session.commit()
+    await db_session.dispose_engine()
+
+    try:
+        with pytest.raises(
+            RuntimeError, match="cannot add lease persistence with nonhuman reviewer preference"
+        ):
+            await asyncio.to_thread(migrate, "head")
+        async with db_session.get_session_factory()() as session:
+            assert await session.scalar(text("select version_num from alembic_version")) == (
+                "0055_contribution_policy"
+            )
+    finally:
+        await db_session.dispose_engine()
+        async with db_session.get_session_factory()() as session:
+            await session.execute(
+                text(
+                    "update review_queue_entries set routing_mode='open',"
+                    "routing_reason='first_submission',preferred_reviewer_id=null,"
+                    "preference_expires_at=null,routing_generation=routing_generation+1 "
+                    "where id=:queue"
+                ),
+                {"queue": queue.id},
+            )
+            await session.commit()
+        await db_session.dispose_engine()
+        await asyncio.to_thread(migrate, "head")

--- a/backend/tests/test_review_queue_persistence.py
+++ b/backend/tests/test_review_queue_persistence.py
@@ -167,8 +167,7 @@ def test_review_models_are_registered_without_routes() -> None:
     """Alembic sees the tables while the application exposes no REV router."""
     assert "review_queue_entries" in Base.metadata.tables
     assert "review_admission_idempotency_records" in Base.metadata.tables
-    assert "active_lease_id" not in Base.metadata.tables["review_queue_entries"].columns
-    assert "review_lease_id" not in Base.metadata.tables["review_queue_entries"].columns
+    assert "active_lease_id" in Base.metadata.tables["review_queue_entries"].columns
     assert {
         "queue_state",
         "closed_at",

--- a/docs/architecture_data_model.md
+++ b/docs/architecture_data_model.md
@@ -1592,7 +1592,39 @@ offer, or none; it never exposes the full backlog.
 canonical human reviewer ActorProfile ID, queue/Submission lineage, database
 lease times, disposition, and the independently frozen reviewer
 ContributionPolicyVersion. PostgreSQL enforces one active lease per reviewer and
-queue entry. `ReviewLease` is not part of the 03A1 foundation.
+queue entry. The queue's deferred `active_lease_id` relationship must agree
+with the single active lease at transaction commit, allowing later claim and
+close commands to stage both sides atomically without exposing behavior in the
+persistence chunk.
+
+Fields:
+
+- `id`
+- `review_queue_entry_id`
+- `project_id`
+- `task_id`
+- `submission_id`
+- `submission_version`
+- `reviewer_id`
+- `reviewer_contribution_policy_version_id`
+- `attempt_generation`
+- `status`
+- `claimed_at`
+- `expires_at`
+- `closed_at`
+- `close_reason`
+
+Status is `active`, `consumed`, `released`, `expired`, or `revoked`. An active
+attempt has no close fields. Terminal close provenance is exact:
+`review_recorded`, `manual_release`, `lease_expired`, `grant_revoked`, or
+`admin_override`. Identity, queue/Submission lineage, reviewer, frozen policy,
+generation, and lease times never change; terminal attempts are wholly
+immutable. The reviewer policy FK is non-null and same-project through CON's
+canonical `ContributionPolicyVersion(id, project_id)` identity, and a new lease
+may freeze only a currently published version. CON owns claim-time selection;
+REV's database guard prevents a mutable draft or already-retired identity from
+being recorded as the new attempt's freeze. Reviewer and preferred-reviewer FKs
+accept only canonical human ActorProfiles.
 
 `ReviewPacketManifest` is an immutable REV semantic projection over the exact
 lease, Submission, admitting CheckerRun/results, stamped context, response


### PR DESCRIPTION
## What changed

- add hidden REV-owned ReviewLease persistence and queue active-lease linkage
- enforce human reviewer/preference actors, published same-project CON policy identity, immutable attempt history, and active capacity in PostgreSQL
- add migration safety, concurrency, lineage, downgrade, lane, and coverage proof

## Boundary

Persistence only. No route, authorization evaluation, policy selection, claim/release/expiry command, Review, revision, decision, FinalAcceptance, or ContributionRecord behavior.

## Validation

- focused queue/lease PostgreSQL tests: 20 passed
- REV branch coverage: 98.70%
- migration 0056 round trip and safety tests: passed
- CI lane integrity: 33 passed
- Ruff, Alembic one-head, stale wording/contracts, Markdown links, and diff integrity: passed
- all required internal reviewer tracks: PASS

GitHub Actions owns the full repository suite and global coverage floor.