### PR TITLE
ci(qual): pilot changed-scope mutation evidence

### DIFF
--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/CHUNK_MAP.md
@@ -22,8 +22,8 @@ remain stopped historical experiments. Do not resume them.
 |---|---|---:|---|
 | `WS-QUAL-001-PLAN3` | Replace percentage-only closure with behavior/mutation assurance | L1 | Merged PR #272; late review corrected by PLAN3R1 |
 | `WS-QUAL-001-PLAN3R1` | Resolve five valid late CodeRabbit findings from PR #272 | L1 | Merged PR #278 |
-| `WS-QUAL-001-04P` | Establish protected hash-verified mutation dependency authority | L1 | In progress by explicit instruction |
-| `WS-QUAL-001-04M` | Pilot pinned changed-scope mutation evidence without a score gate | L1 | Proposed after 04P merge and explicit instruction |
+| `WS-QUAL-001-04P` | Establish protected hash-verified mutation dependency authority | L1 | Merged PR #281 |
+| `WS-QUAL-001-04M` | Pilot pinned changed-scope mutation evidence without a score gate | L1 | Implemented and internally reviewed; hosted PR-head evidence pending |
 | `WS-QUAL-001-05M` | Add calibrated blocking behavior-mutation policy | L1 | Proposed only after accepted 04M hosted evidence and explicit instruction |
 
 ## Dependency rule

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/STATUS.md
@@ -16,9 +16,16 @@ new or materially changed subsystem checks remain blocking at 90 percent.
 `WS-QUAL-001-PLAN3R1` merged through PR #278 after resolving all late CodeRabbit
 findings.
 
-`WS-QUAL-001-04P` is now the active bounded prerequisite. It establishes the
-protected, exactly pinned, hash-verified mutation dependency authority. It does
-not execute mutation testing or start `04M`.
+`WS-QUAL-001-04P` merged through PR #281 and established the protected, exactly
+pinned, hash-verified mutation dependency authority.
+
+`WS-QUAL-001-04M` is implemented and internally reviewed. Its rebased exact-head
+local pilot at `f8b59eec` completed in 254.672 seconds with 1,091 generated
+mutants fully reconciled: 84 killed, 59 survived, 948 excluded, and zero error,
+timeout, or suspicious outcomes. Strong calibration killed two representative
+mutants and deliberately weak calibration left two alive. The focused policy
+module is at 90.11 percent coverage. Hosted PR-head evidence remains required
+before the human calibration checkpoint.
 
 The corrected proposal remains two-stage:
 
@@ -28,10 +35,11 @@ The corrected proposal remains two-stage:
 3. `05M` — separately approved blocking survivor policy for eligible changed
    logic and explicit test-only behavior claims.
 
-No mutation workflow, policy script, execution, or blocking check has been
-implemented.
+The mutation score remains observational. Existing Backend semantic lanes,
+global 78-percent coverage, and protected 90-percent subsystem floors remain
+unchanged and blocking on their existing terms.
 
 ## Stop condition
 
-Stop after the 04P review and PR. Do not start 04M automatically. Do not start
-05M without accepted exact hosted pilot evidence and a new human instruction.
+Stop after the 04M review and PR. Do not start 05M without accepted exact hosted
+pilot evidence, a human calibration checkpoint, and a new human instruction.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-04M-changed-scope-mutation-pilot.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-04M-changed-scope-mutation-pilot.md
@@ -37,7 +37,6 @@ backend/pyproject.toml
 backend/scripts/mutation_policy.py
 backend/tests/test_mutation_policy.py
 backend/scripts/run_test_lanes.py
-backend/scripts/coverage_policy.py
 backend/tests/test_ci_test_lanes.py
 scripts/git_delta.py
 scripts/test_git_delta.py

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-04M-changed-scope-mutation-pilot.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/chunks/WS-QUAL-001-04M-changed-scope-mutation-pilot.md
@@ -36,6 +36,9 @@ P2.
 backend/pyproject.toml
 backend/scripts/mutation_policy.py
 backend/tests/test_mutation_policy.py
+backend/scripts/run_test_lanes.py
+backend/scripts/coverage_policy.py
+backend/tests/test_ci_test_lanes.py
 scripts/git_delta.py
 scripts/test_git_delta.py
 scripts/workstream_agent_gate.py

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-internal-review-evidence.md
@@ -65,6 +65,6 @@ replace GitHub Actions.
   `shared_foundations` semantic lane after hosted inventory failed closed with
   `missing_lane_modules`; no lane, runner, workflow, or coverage command was
   otherwise changed.
-- Corrected the existing coverage policy to consume `maybe_run` directly from
-  the extracted `git_delta` owner, preserving collection after the shared
-  helper refactor without changing coverage policy behavior.
+- Preserved the existing coverage-policy compatibility import by re-exporting
+  `maybe_run` from the agent gate after the shared `git_delta` extraction;
+  coverage policy behavior remains unchanged.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-internal-review-evidence.md
@@ -61,3 +61,10 @@ replace GitHub Actions.
 - Enforced canonical claim path and per-target callable/test/outcome/boundary ownership.
 - Bounded mutation execution to reviewed callable filters after full-file runtime exceeded the hard limit.
 - Added focused 90-percent subsystem coverage.
+- Registered the new focused test module in the canonical
+  `shared_foundations` semantic lane after hosted inventory failed closed with
+  `missing_lane_modules`; no lane, runner, workflow, or coverage command was
+  otherwise changed.
+- Corrected the existing coverage policy to consume `maybe_run` directly from
+  the extracted `git_delta` owner, preserving collection after the shared
+  helper refactor without changing coverage policy behavior.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-internal-review-evidence.md
@@ -1,0 +1,63 @@
+# WS-QUAL-001-04M Internal Review Evidence
+
+## Deterministic evidence gate
+
+Result: PASS with a documented size exception.
+
+The L1 diff exceeds the preferred 500-line guideline because the executable
+policy, shared Git primitive, workflow custody, typed schema, focused tests, and
+operator documentation form one approved review boundary. It does not modify
+application code, migrations, the Backend workflow, `backend/uv.lock`, the
+protected mutation manifest, coverage floors, or existing test inventory.
+
+Commands and results:
+
+- `pytest -q tests/test_mutation_policy.py --cov=scripts.mutation_policy --cov-fail-under=90`: 39 passed; 90.11 percent.
+- `ruff check scripts/mutation_policy.py tests/test_mutation_policy.py`: passed.
+- `python3 -m unittest -q scripts.test_git_delta`: passed.
+- `pytest -q scripts/test_lightweight_agent_gates.py`: 11 passed.
+- JSON Schema claim validation and workflow YAML parsing: passed.
+- Markdown links, stale Workstream wording, stale authorization docs, stale artifact contracts, and `git diff --check`: passed.
+
+## Exact pilot evidence
+
+Rebased implementation head: `f8b59eec269c93a3e502b5dfc7b818011e3ac93c`
+
+- Protected base: `98cf5f423c4c5010eba6dbfb3efa73843a96b4e4`
+- Exact tree: `12436f084d011e10b29d70c4c094fb940e3111f1`
+- Elapsed: 254.672 seconds
+- Generated: 1,091
+- Killed: 84
+- Survived: 59
+- Excluded: 948
+- Timeout, suspicious, error: 0
+- Strong calibration: 2 killed
+- Weak calibration: 2 survived
+
+The sum of all terminal categories equals the generated count. The hosted PR
+workflow must reproduce exact final-head evidence; local evidence does not
+replace GitHub Actions.
+
+## Reviewer results
+
+| Track | Result | Material outcome |
+|---|---|---|
+| Plan/architecture | PASS after fixes | Protected-only dependency authority, typed target ownership, and callable-bounded execution align with PLAN3. |
+| Senior engineering | PASS | Complexity remains concentrated in one fail-closed policy module with focused coverage. |
+| QA | PASS after fixes | Config triggers, exact claim path, ownership, calibration, and evidence reconciliation are proved. |
+| Security | PASS after fixes | No PR packaging install; runner-temp outputs; no persisted credentials; symlink/special-file rejection; token stripping. |
+| Product/ops | PASS after fixes | Engineering evidence remains observational and separate from Workstream product review/payment/reputation. |
+| CI integrity | PASS after fixes | Independent workflow, pinned Actions, protected manifest, bounded timeout, artifact custody, and unchanged Backend gates. |
+| Docs | PASS after correction | Operator guide now distinguishes checkout wrapper execution from disposable test/mutation execution and names the 05M checkpoint. |
+| Reuse/dedup | PASS | Shared policy-free Git delta primitive and reusable typed `target_owners`; no parallel custody dialect. |
+| Test delta | PASS | No test removal, skip, xfail, threshold lowering, or assertion weakening; intentional weak calibration is paired with strong proof. |
+
+## First-pass findings resolved
+
+- Removed PR-controlled editable backend installation from the mutation venv.
+- Added `backend/pyproject.toml` to both workflow path filters.
+- Moved toolchain and evidence to runner-temporary storage and enabled hidden-file artifact handling.
+- Rejected symlinks and special archive entries before execution.
+- Enforced canonical claim path and per-target callable/test/outcome/boundary ownership.
+- Bounded mutation execution to reviewed callable filters after full-file runtime exceeded the hard limit.
+- Added focused 90-percent subsystem coverage.

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-pr-trust-bundle.md
@@ -37,8 +37,10 @@ contributor checkout.
 ## Scope and product behavior
 
 No application, migration, product lifecycle, authorization, payment,
-reputation, Backend semantic-lane, coverage-floor, or existing test-inventory
-behavior changes. `backend/uv.lock` and the protected mutation manifest remain
+reputation, coverage-floor, or existing test behavior changes. The only
+Backend lane/inventory change registers the new focused mutation-policy test
+module in `shared_foundations`; lane structure, fan-in, and thresholds remain
+unchanged. `backend/uv.lock` and the protected mutation manifest remain
 unchanged. Workstream product review decisions remain `accept`,
 `needs_revision`, and `reject`; mutation evidence is engineering process proof.
 
@@ -57,7 +59,11 @@ unchanged. Workstream product review decisions remain `accept`,
 No test was removed, skipped, xfailed, deselected, or weakened. The intentional
 weak calibration is isolated and required to leave a representative survivor.
 Existing Backend and its 78-percent global and protected 90-percent floors are
-unchanged. The pilot is independent, read-only, SHA-pinned, credential-safe,
+unchanged. The new focused test is registered in the existing
+`shared_foundations` lane so canonical inventory remains exact. The coverage
+policy now imports Git delta helpers directly from their extracted owner; its
+policy and thresholds are unchanged. The pilot is
+independent, read-only, SHA-pinned, credential-safe,
 bounded to a 15-minute job/12-minute command, and uploads seven-day evidence.
 
 ## Reviewers and external review

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-pr-trust-bundle.md
@@ -60,9 +60,9 @@ No test was removed, skipped, xfailed, deselected, or weakened. The intentional
 weak calibration is isolated and required to leave a representative survivor.
 Existing Backend and its 78-percent global and protected 90-percent floors are
 unchanged. The new focused test is registered in the existing
-`shared_foundations` lane so canonical inventory remains exact. The coverage
-policy now imports Git delta helpers directly from their extracted owner; its
-policy and thresholds are unchanged. The pilot is
+`shared_foundations` lane so canonical inventory remains exact. The agent gate
+re-exports the extracted Git helper needed by the unchanged coverage-policy
+compatibility import; coverage policy and thresholds are unchanged. The pilot is
 independent, read-only, SHA-pinned, credential-safe,
 bounded to a 15-minute job/12-minute command, and uploads seven-day evidence.
 

--- a/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-001-backend-coverage-floor/reviews/WS-QUAL-001-04M-pr-trust-bundle.md
@@ -1,0 +1,84 @@
+# WS-QUAL-001-04M PR Trust Bundle
+
+## Chunk
+
+`WS-QUAL-001-04M` — Changed-Scope Mutation Pilot (L1).
+
+## Goal and approved intent
+
+Measure whether one protected, pinned mutation engine can provide useful,
+bounded, exact-head behavior evidence before any mutation result becomes a
+blocking contributor policy.
+
+## What changed and why
+
+- Added deterministic changed-target and typed behavior-ownership policy.
+- Extracted policy-free Git delta mechanics shared with the agent gate.
+- Added a protected-base, read-only, independent Mutation Pilot workflow.
+- Added complete result evidence, strong/weak calibration, focused tests, and
+  operator documentation.
+
+Coverage proves execution but not assertion sensitivity. This pilot measures
+test sensitivity, noise, selection integrity, supply-chain custody, and runtime.
+
+## Design chosen
+
+Every eligible changed target requires a schema-v1 ownership record naming its
+qualified callables, exact pytest nodes, observable outcomes, and essential real
+boundaries. The workflow installs only the protected base-revision hash-locked
+toolchain, rejects special archive entries, and runs baseline tests and exact
+callable mutations in a disposable archive. Scores are observational; custody,
+baseline, configuration, timeout, and evidence failures remain blocking.
+
+Rejected alternatives: full-backend mutation, uncalibrated score gating,
+PR-selected dependencies, mutable exclusion prose, and mutation in the
+contributor checkout.
+
+## Scope and product behavior
+
+No application, migration, product lifecycle, authorization, payment,
+reputation, Backend semantic-lane, coverage-floor, or existing test-inventory
+behavior changes. `backend/uv.lock` and the protected mutation manifest remain
+unchanged. Workstream product review decisions remain `accept`,
+`needs_revision`, and `reject`; mutation evidence is engineering process proof.
+
+## Acceptance proof
+
+- Focused policy tests: 39 passed; 90.11-percent module coverage.
+- Shared Git primitive and workflow invariants: 12 tests passed.
+- Exact rebased pilot: 1,091 generated = 84 killed + 59 survived + 948
+  excluded; zero timeout, suspicious, or error; 254.672 seconds.
+- Strong calibration killed two representative mutants; weak calibration left
+  two representative mutants alive.
+- Schema/YAML, Ruff, links, stale scans, and diff checks passed.
+
+## Test delta and CI integrity
+
+No test was removed, skipped, xfailed, deselected, or weakened. The intentional
+weak calibration is isolated and required to leave a representative survivor.
+Existing Backend and its 78-percent global and protected 90-percent floors are
+unchanged. The pilot is independent, read-only, SHA-pinned, credential-safe,
+bounded to a 15-minute job/12-minute command, and uploads seven-day evidence.
+
+## Reviewers and external review
+
+Architecture, senior engineering, QA, security, product/ops, CI integrity,
+docs, reuse/dedup, and test-delta internal tracks pass after valid findings were
+fixed. CodeRabbit and GitHub Actions remain external checks after publication;
+their findings are not predeclared complete.
+
+## Remaining risks and follow-up
+
+Hosted runtime and platform behavior must be confirmed on the final PR head.
+Equivalent/excluded survivors require human calibration before any blocking
+policy. `WS-QUAL-001-05M` is not started or pre-approved by this chunk.
+
+## Human review focus and merge ownership
+
+- Confirm protected-base dependency custody and untrusted PR isolation.
+- Confirm target ownership and callable filtering cannot omit changed behavior.
+- Inspect hosted runtime and complete outcome reconciliation.
+- Confirm no mutation score or existing CI weakening was introduced.
+
+Only the user may approve this specific PR for merge. After merge, stop at the
+human calibration checkpoint; do not start `05M` automatically.

--- a/.ci/behavior-claims/README.md
+++ b/.ci/behavior-claims/README.md
@@ -5,9 +5,11 @@ They are additive: every eligible changed production or CI-runtime Python target
 is selected independently, and a claim cannot remove or replace one.
 
 The filename and `chunk_id` must match. Targets are repository-relative Python
-files under `backend/app/` or `backend/scripts/`; tests are exact pytest nodes
-under `backend/tests/`. Unknown fields, unsafe paths, missing files, duplicate
-entries, or stale chunk identifiers fail closed.
+files under `backend/app/` or `backend/scripts/`; each target also names its
+qualified callables, exact owning pytest nodes, typed observable outcomes, and
+any essential real boundaries. Unknown fields, unsafe paths, missing files,
+duplicate entries, unowned changed targets, or stale chunk identifiers fail
+closed.
 
 During the `WS-QUAL-001-04M` pilot, results are observational. Infrastructure,
 custody, selection, baseline-test, or evidence failures remain blocking, but no

--- a/.ci/behavior-claims/README.md
+++ b/.ci/behavior-claims/README.md
@@ -1,0 +1,15 @@
+# Behavior mutation claims
+
+Schema-v1 claim files provide bounded owning pytest nodes for mutation targets.
+They are additive: every eligible changed production or CI-runtime Python target
+is selected independently, and a claim cannot remove or replace one.
+
+The filename and `chunk_id` must match. Targets are repository-relative Python
+files under `backend/app/` or `backend/scripts/`; tests are exact pytest nodes
+under `backend/tests/`. Unknown fields, unsafe paths, missing files, duplicate
+entries, or stale chunk identifiers fail closed.
+
+During the `WS-QUAL-001-04M` pilot, results are observational. Infrastructure,
+custody, selection, baseline-test, or evidence failures remain blocking, but no
+mutation percentage is a contributor requirement until a later human-approved
+policy chunk.

--- a/.ci/behavior-claims/WS-QUAL-001-04M.json
+++ b/.ci/behavior-claims/WS-QUAL-001-04M.json
@@ -4,12 +4,18 @@
   "claims": [
     {
       "target": "backend/scripts/mutation_policy.py",
+      "callables": [
+        "scripts.mutation_policy.build_selection",
+        "scripts.mutation_policy.execute_pilot"
+      ],
       "tests": [
         "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_changed_targets_are_mandatory_and_claims_are_additive",
         "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_claim_validation_fails_closed",
         "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_strong_calibration_asserts_the_exact_boundary",
         "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_weak_calibration_deliberately_asserts_only_the_result_type"
-      ]
+      ],
+      "outcomes": ["return", "mapped_error"],
+      "boundaries": []
     }
   ]
 }

--- a/.ci/behavior-claims/WS-QUAL-001-04M.json
+++ b/.ci/behavior-claims/WS-QUAL-001-04M.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": 1,
+  "chunk_id": "WS-QUAL-001-04M",
+  "claims": [
+    {
+      "target": "backend/scripts/mutation_policy.py",
+      "tests": [
+        "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_changed_targets_are_mandatory_and_claims_are_additive",
+        "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_claim_validation_fails_closed"
+      ]
+    }
+  ]
+}

--- a/.ci/behavior-claims/WS-QUAL-001-04M.json
+++ b/.ci/behavior-claims/WS-QUAL-001-04M.json
@@ -6,7 +6,9 @@
       "target": "backend/scripts/mutation_policy.py",
       "tests": [
         "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_changed_targets_are_mandatory_and_claims_are_additive",
-        "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_claim_validation_fails_closed"
+        "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_claim_validation_fails_closed",
+        "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_strong_calibration_asserts_the_exact_boundary",
+        "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_weak_calibration_deliberately_asserts_only_the_result_type"
       ]
     }
   ]

--- a/.ci/behavior-claims/WS-QUAL-001-04M.json
+++ b/.ci/behavior-claims/WS-QUAL-001-04M.json
@@ -6,7 +6,9 @@
       "target": "backend/scripts/mutation_policy.py",
       "callables": [
         "scripts.mutation_policy.build_selection",
-        "scripts.mutation_policy.execute_pilot"
+        "scripts.mutation_policy.execute_pilot",
+        "scripts.mutation_policy._strong_calibration",
+        "scripts.mutation_policy._weak_calibration"
       ],
       "tests": [
         "backend/tests/test_mutation_policy.py::TestMutationPolicy::test_changed_targets_are_mandatory_and_claims_are_additive",

--- a/.ci/behavior-claims/WS-QUAL-001-04M.json
+++ b/.ci/behavior-claims/WS-QUAL-001-04M.json
@@ -18,6 +18,23 @@
       ],
       "outcomes": ["return", "mapped_error"],
       "boundaries": []
+    },
+    {
+      "target": "backend/scripts/run_test_lanes.py",
+      "callables": [
+        "scripts.run_test_lanes.discover_test_modules",
+        "scripts.run_test_lanes.validate_lane_inventory"
+      ],
+      "tests": [
+        "backend/tests/test_ci_test_lanes.py::test_committed_lanes_cover_recursive_inventory_exactly_once",
+        "backend/tests/test_ci_test_lanes.py::test_measured_hotspots_have_explicit_semantic_owners",
+        "backend/tests/test_ci_test_lanes.py::test_inventory_fails_closed"
+      ],
+      "outcomes": [
+        "return",
+        "mapped_error"
+      ],
+      "boundaries": []
     }
   ]
 }

--- a/.github/workflows/mutation-pilot.yml
+++ b/.github/workflows/mutation-pilot.yml
@@ -70,6 +70,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m venv .ci/mutation-pilot/venv
+          .ci/mutation-pilot/venv/bin/python -m pip install -e "backend[dev]"
           .ci/mutation-pilot/venv/bin/python -m pip install \
             --disable-pip-version-check \
             --require-hashes \

--- a/.github/workflows/mutation-pilot.yml
+++ b/.github/workflows/mutation-pilot.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "backend/scripts/mutation_policy.py"
       - "backend/tests/test_mutation_policy.py"
+      - "backend/pyproject.toml"
       - "scripts/git_delta.py"
       - "scripts/test_git_delta.py"
       - "scripts/behavior-claim.schema.json"
@@ -16,6 +17,7 @@ on:
     paths:
       - "backend/scripts/mutation_policy.py"
       - "backend/tests/test_mutation_policy.py"
+      - "backend/pyproject.toml"
       - "scripts/git_delta.py"
       - "scripts/test_git_delta.py"
       - "scripts/behavior-claim.schema.json"
@@ -36,6 +38,7 @@ jobs:
     env:
       PILOT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       PILOT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+      PILOT_DIR: ${{ runner.temp }}/workstream-mutation-pilot
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -57,10 +60,10 @@ jobs:
           test -z "$(git status --porcelain)"
           head_tree="$(git rev-parse 'HEAD^{tree}')"
           base_sha="$(git rev-parse "${PILOT_BASE_SHA}^{commit}")"
-          install -d -m 700 .ci/mutation-pilot
+          install -d -m 700 "${PILOT_DIR}"
           git show "${base_sha}:scripts/mutation-requirements.txt" \
-            > .ci/mutation-pilot/protected-requirements.txt
-          manifest_sha256="$(sha256sum .ci/mutation-pilot/protected-requirements.txt | cut -d ' ' -f 1)"
+            > "${PILOT_DIR}/protected-requirements.txt"
+          manifest_sha256="$(sha256sum "${PILOT_DIR}/protected-requirements.txt" | cut -d ' ' -f 1)"
           echo "head_tree=${head_tree}" >> "${GITHUB_OUTPUT}"
           echo "base_sha=${base_sha}" >> "${GITHUB_OUTPUT}"
           echo "manifest_sha256=${manifest_sha256}" >> "${GITHUB_OUTPUT}"
@@ -69,31 +72,30 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m venv .ci/mutation-pilot/venv
-          .ci/mutation-pilot/venv/bin/python -m pip install -e "backend[dev]"
-          .ci/mutation-pilot/venv/bin/python -m pip install \
+          python -m venv "${PILOT_DIR}/venv"
+          "${PILOT_DIR}/venv/bin/python" -m pip install \
             --disable-pip-version-check \
             --require-hashes \
-            -r .ci/mutation-pilot/protected-requirements.txt
-          test "$(.ci/mutation-pilot/venv/bin/python -c 'import importlib.metadata; print(importlib.metadata.version("mutmut"))')" = "3.7.0"
+            -r "${PILOT_DIR}/protected-requirements.txt"
+          test "$("${PILOT_DIR}/venv/bin/python" -c 'import importlib.metadata; print(importlib.metadata.version("mutmut"))')" = "3.7.0"
 
       - name: Run bounded changed-scope mutation pilot
         shell: bash
         run: |
           set -euo pipefail
           timeout --signal=TERM --kill-after=15s 720s \
-            .ci/mutation-pilot/venv/bin/python backend/scripts/mutation_policy.py \
+            "${PILOT_DIR}/venv/bin/python" backend/scripts/mutation_policy.py \
               --repository-root . \
               --base-sha "${{ steps.custody.outputs.base_sha }}" \
               --head-sha "${PILOT_HEAD_SHA}" \
               --chunk-id WS-QUAL-001-04M \
               --claim-file .ci/behavior-claims/WS-QUAL-001-04M.json \
-              --selection-output .ci/mutation-pilot/selection.json \
+              --selection-output "${PILOT_DIR}/selection.json" \
               --execute \
-              --manifest .ci/mutation-pilot/protected-requirements.txt \
+              --manifest "${PILOT_DIR}/protected-requirements.txt" \
               --manifest-digest "${{ steps.custody.outputs.manifest_sha256 }}" \
-              --mutmut-executable .ci/mutation-pilot/venv/bin/mutmut \
-              --evidence-output .ci/mutation-pilot/evidence.json \
+              --mutmut-executable "${PILOT_DIR}/venv/bin/mutmut" \
+              --evidence-output "${PILOT_DIR}/evidence.json" \
               --timeout-seconds 700
           test -z "$(git status --porcelain --untracked-files=no)"
           test "$(git rev-parse 'HEAD^{tree}')" = "${{ steps.custody.outputs.head_tree }}"
@@ -104,7 +106,8 @@ jobs:
         with:
           name: mutation-pilot-${{ env.PILOT_HEAD_SHA }}
           path: |
-            .ci/mutation-pilot/selection.json
-            .ci/mutation-pilot/evidence.json
+            ${{ env.PILOT_DIR }}/selection.json
+            ${{ env.PILOT_DIR }}/evidence.json
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/mutation-pilot.yml
+++ b/.github/workflows/mutation-pilot.yml
@@ -38,7 +38,6 @@ jobs:
     env:
       PILOT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       PILOT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-      PILOT_DIR: ${{ runner.temp }}/workstream-mutation-pilot
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -56,14 +55,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          pilot_dir="${RUNNER_TEMP}/workstream-mutation-pilot"
           test "$(git rev-parse HEAD)" = "${PILOT_HEAD_SHA}"
           test -z "$(git status --porcelain)"
           head_tree="$(git rev-parse 'HEAD^{tree}')"
           base_sha="$(git rev-parse "${PILOT_BASE_SHA}^{commit}")"
-          install -d -m 700 "${PILOT_DIR}"
+          install -d -m 700 "${pilot_dir}"
           git show "${base_sha}:scripts/mutation-requirements.txt" \
-            > "${PILOT_DIR}/protected-requirements.txt"
-          manifest_sha256="$(sha256sum "${PILOT_DIR}/protected-requirements.txt" | cut -d ' ' -f 1)"
+            > "${pilot_dir}/protected-requirements.txt"
+          manifest_sha256="$(sha256sum "${pilot_dir}/protected-requirements.txt" | cut -d ' ' -f 1)"
           echo "head_tree=${head_tree}" >> "${GITHUB_OUTPUT}"
           echo "base_sha=${base_sha}" >> "${GITHUB_OUTPUT}"
           echo "manifest_sha256=${manifest_sha256}" >> "${GITHUB_OUTPUT}"
@@ -72,30 +72,32 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m venv "${PILOT_DIR}/venv"
-          "${PILOT_DIR}/venv/bin/python" -m pip install \
+          pilot_dir="${RUNNER_TEMP}/workstream-mutation-pilot"
+          python -m venv "${pilot_dir}/venv"
+          "${pilot_dir}/venv/bin/python" -m pip install \
             --disable-pip-version-check \
             --require-hashes \
-            -r "${PILOT_DIR}/protected-requirements.txt"
-          test "$("${PILOT_DIR}/venv/bin/python" -c 'import importlib.metadata; print(importlib.metadata.version("mutmut"))')" = "3.7.0"
+            -r "${pilot_dir}/protected-requirements.txt"
+          test "$("${pilot_dir}/venv/bin/python" -c 'import importlib.metadata; print(importlib.metadata.version("mutmut"))')" = "3.7.0"
 
       - name: Run bounded changed-scope mutation pilot
         shell: bash
         run: |
           set -euo pipefail
+          pilot_dir="${RUNNER_TEMP}/workstream-mutation-pilot"
           timeout --signal=TERM --kill-after=15s 720s \
-            "${PILOT_DIR}/venv/bin/python" backend/scripts/mutation_policy.py \
+            "${pilot_dir}/venv/bin/python" backend/scripts/mutation_policy.py \
               --repository-root . \
               --base-sha "${{ steps.custody.outputs.base_sha }}" \
               --head-sha "${PILOT_HEAD_SHA}" \
               --chunk-id WS-QUAL-001-04M \
               --claim-file .ci/behavior-claims/WS-QUAL-001-04M.json \
-              --selection-output "${PILOT_DIR}/selection.json" \
+              --selection-output "${pilot_dir}/selection.json" \
               --execute \
-              --manifest "${PILOT_DIR}/protected-requirements.txt" \
+              --manifest "${pilot_dir}/protected-requirements.txt" \
               --manifest-digest "${{ steps.custody.outputs.manifest_sha256 }}" \
-              --mutmut-executable "${PILOT_DIR}/venv/bin/mutmut" \
-              --evidence-output "${PILOT_DIR}/evidence.json" \
+              --mutmut-executable "${pilot_dir}/venv/bin/mutmut" \
+              --evidence-output "${pilot_dir}/evidence.json" \
               --timeout-seconds 700
           test -z "$(git status --porcelain --untracked-files=no)"
           test "$(git rev-parse 'HEAD^{tree}')" = "${{ steps.custody.outputs.head_tree }}"
@@ -106,8 +108,8 @@ jobs:
         with:
           name: mutation-pilot-${{ env.PILOT_HEAD_SHA }}
           path: |
-            ${{ env.PILOT_DIR }}/selection.json
-            ${{ env.PILOT_DIR }}/evidence.json
+            ${{ runner.temp }}/workstream-mutation-pilot/selection.json
+            ${{ runner.temp }}/workstream-mutation-pilot/evidence.json
           include-hidden-files: true
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/mutation-pilot.yml
+++ b/.github/workflows/mutation-pilot.yml
@@ -1,0 +1,109 @@
+name: Mutation Pilot
+
+on:
+  pull_request:
+    paths:
+      - "backend/scripts/mutation_policy.py"
+      - "backend/tests/test_mutation_policy.py"
+      - "scripts/git_delta.py"
+      - "scripts/test_git_delta.py"
+      - "scripts/behavior-claim.schema.json"
+      - ".ci/behavior-claims/WS-QUAL-001-04M.json"
+      - ".github/workflows/mutation-pilot.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/scripts/mutation_policy.py"
+      - "backend/tests/test_mutation_policy.py"
+      - "scripts/git_delta.py"
+      - "scripts/test_git_delta.py"
+      - "scripts/behavior-claim.schema.json"
+      - ".ci/behavior-claims/WS-QUAL-001-04M.json"
+      - ".github/workflows/mutation-pilot.yml"
+
+concurrency:
+  group: mutation-pilot-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pilot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      PILOT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      PILOT_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: "3.12"
+
+      - id: custody
+        name: Bind exact tree and protected dependency authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${PILOT_HEAD_SHA}"
+          test -z "$(git status --porcelain)"
+          head_tree="$(git rev-parse 'HEAD^{tree}')"
+          base_sha="$(git rev-parse "${PILOT_BASE_SHA}^{commit}")"
+          install -d -m 700 .ci/mutation-pilot
+          git show "${base_sha}:scripts/mutation-requirements.txt" \
+            > .ci/mutation-pilot/protected-requirements.txt
+          manifest_sha256="$(sha256sum .ci/mutation-pilot/protected-requirements.txt | cut -d ' ' -f 1)"
+          echo "head_tree=${head_tree}" >> "${GITHUB_OUTPUT}"
+          echo "base_sha=${base_sha}" >> "${GITHUB_OUTPUT}"
+          echo "manifest_sha256=${manifest_sha256}" >> "${GITHUB_OUTPUT}"
+
+      - name: Install protected hash-locked mutation toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m venv .ci/mutation-pilot/venv
+          .ci/mutation-pilot/venv/bin/python -m pip install \
+            --disable-pip-version-check \
+            --require-hashes \
+            -r .ci/mutation-pilot/protected-requirements.txt
+          test "$(.ci/mutation-pilot/venv/bin/python -c 'import importlib.metadata; print(importlib.metadata.version("mutmut"))')" = "3.7.0"
+
+      - name: Run bounded changed-scope mutation pilot
+        shell: bash
+        run: |
+          set -euo pipefail
+          timeout --signal=TERM --kill-after=15s 720s \
+            .ci/mutation-pilot/venv/bin/python backend/scripts/mutation_policy.py \
+              --repository-root . \
+              --base-sha "${{ steps.custody.outputs.base_sha }}" \
+              --head-sha "${PILOT_HEAD_SHA}" \
+              --chunk-id WS-QUAL-001-04M \
+              --claim-file .ci/behavior-claims/WS-QUAL-001-04M.json \
+              --selection-output .ci/mutation-pilot/selection.json \
+              --execute \
+              --manifest .ci/mutation-pilot/protected-requirements.txt \
+              --manifest-digest "${{ steps.custody.outputs.manifest_sha256 }}" \
+              --mutmut-executable .ci/mutation-pilot/venv/bin/mutmut \
+              --evidence-output .ci/mutation-pilot/evidence.json \
+              --timeout-seconds 700
+          test -z "$(git status --porcelain --untracked-files=no)"
+          test "$(git rev-parse 'HEAD^{tree}')" = "${{ steps.custody.outputs.head_tree }}"
+
+      - name: Upload exact-head pilot evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: mutation-pilot-${{ env.PILOT_HEAD_SHA }}
+          path: |
+            .ci/mutation-pilot/selection.json
+            .ci/mutation-pilot/evidence.json
+          if-no-files-found: error
+          retention-days: 7

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -63,7 +63,7 @@ pytest_add_cli_args_test_selection = [
   "tests/test_mutation_policy.py::TestMutationPolicy::test_strong_calibration_asserts_the_exact_boundary",
   "tests/test_mutation_policy.py::TestMutationPolicy::test_weak_calibration_deliberately_asserts_only_the_result_type",
 ]
-pytest_add_cli_args = ["-q"]
+pytest_add_cli_args = ["-q", "--noconftest"]
 use_git_change_detection = false
 debug = true
 timeout_multiplier = 4.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -60,6 +60,8 @@ only_mutate = ["scripts/mutation_policy.py"]
 pytest_add_cli_args_test_selection = [
   "tests/test_mutation_policy.py::TestMutationPolicy::test_changed_targets_are_mandatory_and_claims_are_additive",
   "tests/test_mutation_policy.py::TestMutationPolicy::test_claim_validation_fails_closed",
+  "tests/test_mutation_policy.py::TestMutationPolicy::test_strong_calibration_asserts_the_exact_boundary",
+  "tests/test_mutation_policy.py::TestMutationPolicy::test_weak_calibration_deliberately_asserts_only_the_result_type",
 ]
 pytest_add_cli_args = ["-q"]
 use_git_change_detection = false

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -63,5 +63,6 @@ pytest_add_cli_args_test_selection = [
 ]
 pytest_add_cli_args = ["-q"]
 use_git_change_detection = false
+debug = true
 timeout_multiplier = 4.0
 timeout_constant = 2.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -53,3 +53,15 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+[tool.mutmut]
+source_paths = ["scripts"]
+only_mutate = ["scripts/mutation_policy.py"]
+pytest_add_cli_args_test_selection = [
+  "tests/test_mutation_policy.py::TestMutationPolicy::test_changed_targets_are_mandatory_and_claims_are_additive",
+  "tests/test_mutation_policy.py::TestMutationPolicy::test_claim_validation_fails_closed",
+]
+pytest_add_cli_args = ["-q"]
+use_git_change_detection = false
+timeout_multiplier = 4.0
+timeout_constant = 2.0

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -56,8 +56,11 @@ target-version = "py311"
 
 [tool.mutmut]
 source_paths = ["scripts"]
-only_mutate = ["scripts/mutation_policy.py"]
+only_mutate = ["scripts/mutation_policy.py", "scripts/run_test_lanes.py"]
 pytest_add_cli_args_test_selection = [
+  "tests/test_ci_test_lanes.py::test_committed_lanes_cover_recursive_inventory_exactly_once",
+  "tests/test_ci_test_lanes.py::test_inventory_fails_closed",
+  "tests/test_ci_test_lanes.py::test_measured_hotspots_have_explicit_semantic_owners",
   "tests/test_mutation_policy.py::TestMutationPolicy::test_changed_targets_are_mandatory_and_claims_are_additive",
   "tests/test_mutation_policy.py::TestMutationPolicy::test_claim_validation_fails_closed",
   "tests/test_mutation_policy.py::TestMutationPolicy::test_strong_calibration_asserts_the_exact_boundary",

--- a/backend/scripts/coverage_policy.py
+++ b/backend/scripts/coverage_policy.py
@@ -22,7 +22,7 @@ from run_isolated_tests import NAME_RE
 BACKEND = Path(__file__).resolve().parents[1]
 REPO = BACKEND.parent
 sys.path.insert(0, str(REPO / "scripts"))
-from workstream_agent_gate import changed_files, diff_text, maybe_run, numstat  # noqa: E402
+from git_delta import changed_files, diff_text, maybe_run, numstat  # noqa: E402
 
 SHA_RE = re.compile(r"[a-f0-9]{40}")
 DECIMAL_RE = re.compile(r"\d+\.\d{6}")

--- a/backend/scripts/coverage_policy.py
+++ b/backend/scripts/coverage_policy.py
@@ -22,7 +22,7 @@ from run_isolated_tests import NAME_RE
 BACKEND = Path(__file__).resolve().parents[1]
 REPO = BACKEND.parent
 sys.path.insert(0, str(REPO / "scripts"))
-from git_delta import changed_files, diff_text, maybe_run, numstat  # noqa: E402
+from workstream_agent_gate import changed_files, diff_text, maybe_run, numstat  # noqa: E402
 
 SHA_RE = re.compile(r"[a-f0-9]{40}")
 DECIMAL_RE = re.compile(r"\d+\.\d{6}")

--- a/backend/scripts/mutation_policy.py
+++ b/backend/scripts/mutation_policy.py
@@ -57,11 +57,29 @@ STATUS_BY_EXIT_CODE: dict[int | None, str] = {
     255: "timeout",
     35: "suspicious",
     36: "timeout",
+    5: "excluded",
+    33: "excluded",
+    34: "excluded",
+    37: "killed",
+    2: "error",
+    -11: "error",
+    -9: "error",
+    None: "error",
 }
 
 
 class MutationPolicyError(RuntimeError):
     """The mutation pilot contract is unsafe, incomplete, or stale."""
+
+
+def _strong_calibration(value: int) -> bool:
+    """Provide a behavior whose boundary is asserted exactly by the pilot."""
+    return value > 0
+
+
+def _weak_calibration(value: int) -> bool:
+    """Provide an intentionally under-asserted behavior for pilot calibration."""
+    return value > 0
 
 
 def _json_bytes(value: Any) -> bytes:
@@ -235,7 +253,7 @@ def _parse_outcomes(backend: Path, selected_count: int) -> tuple[dict[str, int],
         for name, exit_code in sorted(results.items()):
             if not isinstance(name, str) or not (isinstance(exit_code, int) or exit_code is None):
                 raise MutationPolicyError("invalid_mutmut_result")
-            status = STATUS_BY_EXIT_CODE.get(exit_code, "error")
+            status = STATUS_BY_EXIT_CODE.get(exit_code, "suspicious")
             counts[status] += 1
             mutants.append({"name": name, "outcome": status})
     counts["generated"] = len(mutants)
@@ -319,6 +337,24 @@ def execute_pilot(
         if result.returncode != 0:
             raise MutationPolicyError("mutation_engine_error")
         counts, mutants = _parse_outcomes(backend, len(selection["targets"]))
+        strong = [
+            mutant
+            for mutant in mutants
+            if ".x__strong_calibration__mutmut_" in mutant["name"]
+        ]
+        weak = [
+            mutant
+            for mutant in mutants
+            if ".x__weak_calibration__mutmut_" in mutant["name"]
+        ]
+        if not any(mutant["outcome"] == "killed" for mutant in strong):
+            raise MutationPolicyError("strong_calibration_not_killed")
+        if not any(mutant["outcome"] == "survived" for mutant in weak):
+            raise MutationPolicyError("weak_calibration_not_survived")
+        calibration = {
+            "strong": dict(Counter(mutant["outcome"] for mutant in strong)),
+            "weak": dict(Counter(mutant["outcome"] for mutant in weak)),
+        }
         elapsed = round(time.monotonic() - started, 3)
     if (
         _git(root, "status", "--porcelain", "--untracked-files=no")
@@ -341,6 +377,7 @@ def execute_pilot(
         "selection_sha256": _sha256(_json_bytes(selection)),
         "elapsed_seconds": elapsed,
         "outcomes": counts,
+        "calibration": calibration,
         "mutants": mutants,
     }
     output.parent.mkdir(parents=True, exist_ok=True)

--- a/backend/scripts/mutation_policy.py
+++ b/backend/scripts/mutation_policy.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Select and execute bounded changed-scope mutation pilots fail closed."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import tomllib
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.git_delta import changed_files  # noqa: E402
+
+
+SCHEMA_VERSION = 1
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+CHUNK_RE = re.compile(r"^WS-[A-Z]+-[0-9]{3}-[A-Z0-9]+$")
+TEST_NODE_RE = re.compile(r"^backend/tests/test_[A-Za-z0-9_/]+\.py::[^\s]+$")
+ELIGIBLE_PREFIXES = ("backend/app/", "backend/scripts/")
+OUTCOMES = (
+    "generated",
+    "killed",
+    "survived",
+    "timeout",
+    "suspicious",
+    "excluded",
+    "error",
+)
+STATUS_BY_EXIT_CODE: dict[int | None, str] = {
+    0: "survived",
+    1: "killed",
+    3: "killed",
+    -24: "timeout",
+    24: "timeout",
+    152: "timeout",
+    255: "timeout",
+    35: "suspicious",
+    36: "timeout",
+}
+
+
+class MutationPolicyError(RuntimeError):
+    """The mutation pilot contract is unsafe, incomplete, or stale."""
+
+
+def _json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode()
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _git(root: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=root,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    output = result.stdout.strip()
+    if result.returncode != 0:
+        raise MutationPolicyError(f"git_command_failed:{arguments[0]}")
+    return output
+
+
+def _safe_path(value: str) -> PurePosixPath:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or path.is_absolute()
+        or ".." in path.parts
+        or value != path.as_posix()
+    ):
+        raise MutationPolicyError("unsafe_path")
+    return path
+
+
+def _eligible_target(path: str) -> bool:
+    candidate = _safe_path(path)
+    return (
+        candidate.suffix == ".py"
+        and candidate.name != "__init__.py"
+        and any(path.startswith(prefix) for prefix in ELIGIBLE_PREFIXES)
+        and "/tests/" not in f"/{path}"
+    )
+
+
+def _read_claim(path: Path | None, root: Path, expected_chunk: str) -> list[dict[str, Any]]:
+    if path is None:
+        return []
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise MutationPolicyError("invalid_behavior_claim_json") from exc
+    if not isinstance(value, dict) or set(value) != {"schema_version", "chunk_id", "claims"}:
+        raise MutationPolicyError("invalid_behavior_claim_shape")
+    if value["schema_version"] != SCHEMA_VERSION:
+        raise MutationPolicyError("unsupported_behavior_claim_schema")
+    if value["chunk_id"] != expected_chunk or CHUNK_RE.fullmatch(expected_chunk) is None:
+        raise MutationPolicyError("stale_behavior_claim_chunk")
+    claims = value["claims"]
+    if not isinstance(claims, list) or len(claims) > 8:
+        raise MutationPolicyError("invalid_behavior_claim_count")
+    normalized: list[dict[str, Any]] = []
+    seen_targets: set[str] = set()
+    for claim in claims:
+        if not isinstance(claim, dict) or set(claim) != {"target", "tests"}:
+            raise MutationPolicyError("invalid_behavior_claim")
+        target = claim["target"]
+        tests = claim["tests"]
+        if not isinstance(target, str) or not _eligible_target(target):
+            raise MutationPolicyError("ineligible_claim_target")
+        if target in seen_targets:
+            raise MutationPolicyError("duplicate_claim_target")
+        seen_targets.add(target)
+        if not (root / target).is_file():
+            raise MutationPolicyError("missing_claim_target")
+        if not isinstance(tests, list) or not tests or len(tests) > 12:
+            raise MutationPolicyError("invalid_claim_tests")
+        normalized_tests: list[str] = []
+        for node in tests:
+            if not isinstance(node, str) or TEST_NODE_RE.fullmatch(node) is None:
+                raise MutationPolicyError("invalid_claim_test_node")
+            module = node.split("::", 1)[0]
+            _safe_path(module)
+            if not (root / module).is_file():
+                raise MutationPolicyError("missing_claim_test_module")
+            if node in normalized_tests:
+                raise MutationPolicyError("duplicate_claim_test_node")
+            normalized_tests.append(node)
+        normalized.append({"target": target, "tests": sorted(normalized_tests)})
+    return sorted(normalized, key=lambda item: item["target"])
+
+
+def build_selection(
+    root: Path,
+    base_sha: str,
+    head_sha: str,
+    chunk_id: str,
+    claim_path: Path | None,
+) -> dict[str, Any]:
+    """Build deterministic mandatory changed targets plus additive claims."""
+    if SHA_RE.fullmatch(base_sha) is None or SHA_RE.fullmatch(head_sha) is None:
+        raise MutationPolicyError("invalid_revision")
+    resolved_head = _git(root, "rev-parse", head_sha)
+    resolved_base = _git(root, "rev-parse", base_sha)
+    if resolved_head != head_sha or resolved_base != base_sha:
+        raise MutationPolicyError("non_exact_revision")
+    changed = changed_files(
+        base_sha,
+        head_sha,
+        repository_root=root,
+        include_local=False,
+    )
+    changed_targets = sorted(path for path in changed if _eligible_target(path))
+    claims = _read_claim(claim_path, root, chunk_id)
+    targets = sorted(set(changed_targets) | {claim["target"] for claim in claims})
+    tests = sorted({node for claim in claims for node in claim["tests"]})
+    if not targets:
+        raise MutationPolicyError("zero_mutation_targets")
+    if not tests:
+        raise MutationPolicyError("zero_owning_tests")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "chunk_id": chunk_id,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+        "head_tree": _git(root, "rev-parse", f"{head_sha}^{{tree}}"),
+        "changed_paths": changed,
+        "changed_targets": changed_targets,
+        "claims": claims,
+        "targets": targets,
+        "tests": tests,
+    }
+
+
+def _verify_mutmut_config(backend: Path, selection: dict[str, Any]) -> None:
+    pyproject = backend / "pyproject.toml"
+    try:
+        config = tomllib.loads(pyproject.read_text(encoding="utf-8"))["tool"]["mutmut"]
+    except (OSError, UnicodeDecodeError, tomllib.TOMLDecodeError, KeyError) as exc:
+        raise MutationPolicyError("invalid_mutation_config") from exc
+    relative_targets = [target.removeprefix("backend/") for target in selection["targets"]]
+    source_paths = sorted({target.split("/", 1)[0] for target in relative_targets})
+    test_nodes = [node.removeprefix("backend/") for node in selection["tests"]]
+    expected = {
+        "source_paths": source_paths,
+        "only_mutate": relative_targets,
+        "pytest_add_cli_args_test_selection": test_nodes,
+        "pytest_add_cli_args": ["-q"],
+        "use_git_change_detection": False,
+        "timeout_multiplier": 4.0,
+        "timeout_constant": 2.0,
+    }
+    if config != expected:
+        raise MutationPolicyError("mutation_config_selection_mismatch")
+
+
+def _parse_outcomes(backend: Path, selected_count: int) -> tuple[dict[str, int], list[dict[str, str]]]:
+    counts = Counter({outcome: 0 for outcome in OUTCOMES})
+    mutants: list[dict[str, str]] = []
+    for meta_path in sorted((backend / "mutants").rglob("*.meta")):
+        try:
+            value = json.loads(meta_path.read_text(encoding="utf-8"))
+            results = value["exit_code_by_key"]
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, KeyError) as exc:
+            raise MutationPolicyError("invalid_mutmut_metadata") from exc
+        if not isinstance(results, dict):
+            raise MutationPolicyError("invalid_mutmut_results")
+        for name, exit_code in sorted(results.items()):
+            if not isinstance(name, str) or not (isinstance(exit_code, int) or exit_code is None):
+                raise MutationPolicyError("invalid_mutmut_result")
+            status = STATUS_BY_EXIT_CODE.get(exit_code, "error")
+            counts[status] += 1
+            mutants.append({"name": name, "outcome": status})
+    counts["generated"] = len(mutants)
+    counts["excluded"] = max(0, selected_count - len(mutants))
+    if not mutants:
+        raise MutationPolicyError("zero_generated_mutants")
+    return dict(counts), mutants
+
+
+def execute_pilot(
+    root: Path,
+    selection: dict[str, Any],
+    manifest: Path,
+    manifest_digest: str,
+    mutmut_executable: Path,
+    output: Path,
+    timeout_seconds: int,
+) -> None:
+    """Run mutation testing in an archived disposable tree and emit evidence."""
+    if timeout_seconds < 1 or timeout_seconds > 720:
+        raise MutationPolicyError("invalid_timeout")
+    manifest_bytes = manifest.read_bytes()
+    if DIGEST_RE.fullmatch(manifest_digest) is None or _sha256(manifest_bytes) != manifest_digest:
+        raise MutationPolicyError("untrusted_manifest_digest")
+    if _git(root, "status", "--porcelain", "--untracked-files=no"):
+        raise MutationPolicyError("dirty_source_tree")
+    before_tree = _git(root, "rev-parse", "HEAD^{tree}")
+    started = time.monotonic()
+    with tempfile.TemporaryDirectory(prefix="workstream-mutation-") as temporary:
+        disposable = Path(temporary) / "repository"
+        disposable.mkdir()
+        archive = subprocess.run(
+            ["git", "archive", selection["head_sha"]],
+            cwd=root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if archive.returncode != 0:
+            raise MutationPolicyError("archive_failed")
+        extract = subprocess.run(
+            ["tar", "-x", "-C", str(disposable)],
+            input=archive.stdout,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if extract.returncode != 0:
+            raise MutationPolicyError("archive_extract_failed")
+        backend = disposable / "backend"
+        _verify_mutmut_config(backend, selection)
+        environment = os.environ.copy()
+        environment.pop("GITHUB_TOKEN", None)
+        environment.pop("GH_TOKEN", None)
+        environment["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+        baseline = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", *[node.removeprefix("backend/") for node in selection["tests"]]],
+            cwd=backend,
+            env=environment,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=min(timeout_seconds, 180),
+        )
+        if baseline.returncode != 0:
+            raise MutationPolicyError("baseline_test_failure")
+        try:
+            result = subprocess.run(
+                [str(mutmut_executable), "run", "--max-children", "2"],
+                cwd=backend,
+                env=environment,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise MutationPolicyError("mutation_timeout") from exc
+        if result.returncode != 0:
+            raise MutationPolicyError("mutation_engine_error")
+        counts, mutants = _parse_outcomes(backend, len(selection["targets"]))
+        elapsed = round(time.monotonic() - started, 3)
+    if (
+        _git(root, "status", "--porcelain", "--untracked-files=no")
+        or _git(root, "rev-parse", "HEAD^{tree}") != before_tree
+    ):
+        raise MutationPolicyError("source_tree_changed")
+    evidence = {
+        "schema_version": SCHEMA_VERSION,
+        "chunk_id": selection["chunk_id"],
+        "base_sha": selection["base_sha"],
+        "head_sha": selection["head_sha"],
+        "head_tree": selection["head_tree"],
+        "tool": {"name": "mutmut", "version": "3.7.0"},
+        "manifest": {"sha256": manifest_digest},
+        "config": {
+            "timeout_seconds": timeout_seconds,
+            "targets": selection["targets"],
+            "tests": selection["tests"],
+        },
+        "selection_sha256": _sha256(_json_bytes(selection)),
+        "elapsed_seconds": elapsed,
+        "outcomes": counts,
+        "mutants": mutants,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(output, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as stream:
+        stream.write(_json_bytes(evidence))
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository-root", type=Path, default=ROOT)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--chunk-id", required=True)
+    parser.add_argument("--claim-file", type=Path)
+    parser.add_argument("--selection-output", type=Path)
+    parser.add_argument("--execute", action="store_true")
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--manifest-digest")
+    parser.add_argument("--mutmut-executable", type=Path)
+    parser.add_argument("--evidence-output", type=Path)
+    parser.add_argument("--timeout-seconds", type=int, default=720)
+    args = parser.parse_args()
+    try:
+        root = args.repository_root.resolve(strict=True)
+        selection = build_selection(
+            root,
+            args.base_sha,
+            args.head_sha,
+            args.chunk_id,
+            args.claim_file,
+        )
+        if args.selection_output:
+            args.selection_output.write_bytes(_json_bytes(selection))
+        if args.execute:
+            if not all((args.manifest, args.manifest_digest, args.mutmut_executable, args.evidence_output)):
+                raise MutationPolicyError("missing_execution_argument")
+            execute_pilot(
+                root,
+                selection,
+                args.manifest,
+                args.manifest_digest,
+                args.mutmut_executable,
+                args.evidence_output,
+                args.timeout_seconds,
+            )
+    except (MutationPolicyError, OSError, subprocess.TimeoutExpired) as exc:
+        print(f"mutation_policy_error:{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/scripts/mutation_policy.py
+++ b/backend/scripts/mutation_policy.py
@@ -10,6 +10,7 @@ import json
 import os
 from pathlib import Path, PurePosixPath
 import re
+import stat
 import subprocess
 import sys
 import tempfile
@@ -37,7 +38,18 @@ SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 CHUNK_RE = re.compile(r"^WS-[A-Z]+-[0-9]{3}-[A-Z0-9]+$")
 TEST_NODE_RE = re.compile(r"^backend/tests/test_[A-Za-z0-9_/]+\.py::[^\s]+$")
+CALLABLE_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]+$")
 ELIGIBLE_PREFIXES = ("backend/app/", "backend/scripts/")
+OBSERVABLE_OUTCOMES = {
+    "return",
+    "persisted_state",
+    "emitted_fact",
+    "denial",
+    "mapped_error",
+    "idempotent_replay",
+    "recovery_outcome",
+}
+REAL_BOUNDARIES = {"postgresql", "minio", "http", "lock", "trigger", "concurrency"}
 OUTCOMES = (
     "generated",
     "killed",
@@ -127,6 +139,19 @@ def _eligible_target(path: str) -> bool:
     )
 
 
+def _regular_repository_file(root: Path, value: str) -> bool:
+    """Return whether every component is non-symlink and the leaf is regular."""
+    candidate = root
+    try:
+        for part in _safe_path(value).parts:
+            candidate = candidate / part
+            if candidate.is_symlink():
+                return False
+        return candidate.is_file()
+    except OSError:
+        return False
+
+
 def _read_claim(path: Path | None, root: Path, expected_chunk: str) -> list[dict[str, Any]]:
     if path is None:
         return []
@@ -146,7 +171,13 @@ def _read_claim(path: Path | None, root: Path, expected_chunk: str) -> list[dict
     normalized: list[dict[str, Any]] = []
     seen_targets: set[str] = set()
     for claim in claims:
-        if not isinstance(claim, dict) or set(claim) != {"target", "tests"}:
+        if not isinstance(claim, dict) or set(claim) != {
+            "target",
+            "callables",
+            "tests",
+            "outcomes",
+            "boundaries",
+        }:
             raise MutationPolicyError("invalid_behavior_claim")
         target = claim["target"]
         tests = claim["tests"]
@@ -155,22 +186,54 @@ def _read_claim(path: Path | None, root: Path, expected_chunk: str) -> list[dict
         if target in seen_targets:
             raise MutationPolicyError("duplicate_claim_target")
         seen_targets.add(target)
-        if not (root / target).is_file():
+        if not _regular_repository_file(root, target):
             raise MutationPolicyError("missing_claim_target")
         if not isinstance(tests, list) or not tests or len(tests) > 12:
             raise MutationPolicyError("invalid_claim_tests")
+        callables = claim["callables"]
+        if (
+            not isinstance(callables, list)
+            or not callables
+            or len(callables) > 12
+            or any(not isinstance(item, str) or CALLABLE_RE.fullmatch(item) is None for item in callables)
+            or len(set(callables)) != len(callables)
+        ):
+            raise MutationPolicyError("invalid_claim_callables")
         normalized_tests: list[str] = []
         for node in tests:
             if not isinstance(node, str) or TEST_NODE_RE.fullmatch(node) is None:
                 raise MutationPolicyError("invalid_claim_test_node")
             module = node.split("::", 1)[0]
             _safe_path(module)
-            if not (root / module).is_file():
+            if not _regular_repository_file(root, module):
                 raise MutationPolicyError("missing_claim_test_module")
             if node in normalized_tests:
                 raise MutationPolicyError("duplicate_claim_test_node")
             normalized_tests.append(node)
-        normalized.append({"target": target, "tests": sorted(normalized_tests)})
+        outcomes = claim["outcomes"]
+        if (
+            not isinstance(outcomes, list)
+            or not outcomes
+            or any(not isinstance(item, str) or item not in OBSERVABLE_OUTCOMES for item in outcomes)
+            or len(set(outcomes)) != len(outcomes)
+        ):
+            raise MutationPolicyError("invalid_claim_outcomes")
+        boundaries = claim["boundaries"]
+        if (
+            not isinstance(boundaries, list)
+            or any(not isinstance(item, str) or item not in REAL_BOUNDARIES for item in boundaries)
+            or len(set(boundaries)) != len(boundaries)
+        ):
+            raise MutationPolicyError("invalid_claim_boundaries")
+        normalized.append(
+            {
+                "target": target,
+                "callables": sorted(callables),
+                "tests": sorted(normalized_tests),
+                "outcomes": sorted(outcomes),
+                "boundaries": sorted(boundaries),
+            }
+        )
     return sorted(normalized, key=lambda item: item["target"])
 
 
@@ -195,8 +258,20 @@ def build_selection(
         include_local=False,
     )
     changed_targets = sorted(path for path in changed if _eligible_target(path))
+    if claim_path is not None:
+        expected_claim = root / ".ci" / "behavior-claims" / f"{chunk_id}.json"
+        try:
+            resolved_claim = claim_path.resolve(strict=True)
+        except OSError as exc:
+            raise MutationPolicyError("invalid_behavior_claim_path") from exc
+        if resolved_claim != expected_claim.resolve(strict=False) or claim_path.is_symlink():
+            raise MutationPolicyError("invalid_behavior_claim_path")
     claims = _read_claim(claim_path, root, chunk_id)
-    targets = sorted(set(changed_targets) | {claim["target"] for claim in claims})
+    claims_by_target = {claim["target"]: claim for claim in claims}
+    unowned_targets = sorted(set(changed_targets) - set(claims_by_target))
+    if unowned_targets:
+        raise MutationPolicyError("changed_target_without_behavior_claim")
+    targets = sorted(set(changed_targets) | set(claims_by_target))
     tests = sorted({node for claim in claims for node in claim["tests"]})
     if not targets:
         raise MutationPolicyError("zero_mutation_targets")
@@ -211,6 +286,13 @@ def build_selection(
         "changed_paths": changed,
         "changed_targets": changed_targets,
         "claims": claims,
+        "target_owners": [
+            {
+                **claims_by_target[target],
+                "selection_reason": "changed" if target in changed_targets else "claim",
+            }
+            for target in targets
+        ],
         "targets": targets,
         "tests": tests,
     }
@@ -229,7 +311,7 @@ def _verify_mutmut_config(backend: Path, selection: dict[str, Any]) -> None:
         "source_paths": source_paths,
         "only_mutate": relative_targets,
         "pytest_add_cli_args_test_selection": test_nodes,
-        "pytest_add_cli_args": ["-q"],
+        "pytest_add_cli_args": ["-q", "--noconftest"],
         "use_git_change_detection": False,
         "debug": True,
         "timeout_multiplier": 4.0,
@@ -237,6 +319,17 @@ def _verify_mutmut_config(backend: Path, selection: dict[str, Any]) -> None:
     }
     if config != expected:
         raise MutationPolicyError("mutation_config_selection_mismatch")
+
+
+def _reject_disposable_special_files(disposable: Path) -> None:
+    """Reject symlinks and non-regular archive entries before PR code runs."""
+    for candidate in disposable.rglob("*"):
+        try:
+            mode = candidate.lstat().st_mode
+        except OSError as exc:
+            raise MutationPolicyError("invalid_disposable_entry") from exc
+        if not (stat.S_ISREG(mode) or stat.S_ISDIR(mode)):
+            raise MutationPolicyError("invalid_disposable_entry")
 
 
 def _parse_outcomes(backend: Path) -> tuple[dict[str, int], list[dict[str, str]]]:
@@ -302,6 +395,7 @@ def execute_pilot(
         )
         if extract.returncode != 0:
             raise MutationPolicyError("archive_extract_failed")
+        _reject_disposable_special_files(disposable)
         backend = disposable / "backend"
         _verify_mutmut_config(backend, selection)
         environment = os.environ.copy()

--- a/backend/scripts/mutation_policy.py
+++ b/backend/scripts/mutation_policy.py
@@ -205,6 +205,7 @@ def _verify_mutmut_config(backend: Path, selection: dict[str, Any]) -> None:
         "pytest_add_cli_args_test_selection": test_nodes,
         "pytest_add_cli_args": ["-q"],
         "use_git_change_detection": False,
+        "debug": True,
         "timeout_multiplier": 4.0,
         "timeout_constant": 2.0,
     }

--- a/backend/scripts/mutation_policy.py
+++ b/backend/scripts/mutation_policy.py
@@ -239,7 +239,7 @@ def _verify_mutmut_config(backend: Path, selection: dict[str, Any]) -> None:
         raise MutationPolicyError("mutation_config_selection_mismatch")
 
 
-def _parse_outcomes(backend: Path, selected_count: int) -> tuple[dict[str, int], list[dict[str, str]]]:
+def _parse_outcomes(backend: Path) -> tuple[dict[str, int], list[dict[str, str]]]:
     counts = Counter({outcome: 0 for outcome in OUTCOMES})
     mutants: list[dict[str, str]] = []
     for meta_path in sorted((backend / "mutants").rglob("*.meta")):
@@ -257,7 +257,6 @@ def _parse_outcomes(backend: Path, selected_count: int) -> tuple[dict[str, int],
             counts[status] += 1
             mutants.append({"name": name, "outcome": status})
     counts["generated"] = len(mutants)
-    counts["excluded"] = max(0, selected_count - len(mutants))
     if not mutants:
         raise MutationPolicyError("zero_generated_mutants")
     return dict(counts), mutants
@@ -336,7 +335,7 @@ def execute_pilot(
             raise MutationPolicyError("mutation_timeout") from exc
         if result.returncode != 0:
             raise MutationPolicyError("mutation_engine_error")
-        counts, mutants = _parse_outcomes(backend, len(selection["targets"]))
+        counts, mutants = _parse_outcomes(backend)
         strong = [
             mutant
             for mutant in mutants

--- a/backend/scripts/mutation_policy.py
+++ b/backend/scripts/mutation_policy.py
@@ -17,7 +17,15 @@ import time
 import tomllib
 from typing import Any
 
-ROOT = Path(__file__).resolve().parents[2]
+def _repository_root() -> Path:
+    """Locate the archive root from either original or mutmut-copied code."""
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "scripts/git_delta.py").is_file():
+            return candidate
+    raise RuntimeError("repository_root_not_found")
+
+
+ROOT = _repository_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/backend/scripts/mutation_policy.py
+++ b/backend/scripts/mutation_policy.py
@@ -76,7 +76,7 @@ STATUS_BY_EXIT_CODE: dict[int | None, str] = {
     2: "error",
     -11: "error",
     -9: "error",
-    None: "error",
+    None: "excluded",
 }
 
 
@@ -199,6 +199,9 @@ def _read_claim(path: Path | None, root: Path, expected_chunk: str) -> list[dict
             or len(set(callables)) != len(callables)
         ):
             raise MutationPolicyError("invalid_claim_callables")
+        target_module = target.removeprefix("backend/").removesuffix(".py").replace("/", ".")
+        if any(not item.startswith(f"{target_module}.") for item in callables):
+            raise MutationPolicyError("claim_callable_target_mismatch")
         normalized_tests: list[str] = []
         for node in tests:
             if not isinstance(node, str) or TEST_NODE_RE.fullmatch(node) is None:
@@ -332,6 +335,16 @@ def _reject_disposable_special_files(disposable: Path) -> None:
             raise MutationPolicyError("invalid_disposable_entry")
 
 
+def _mutant_filters(selection: dict[str, Any]) -> list[str]:
+    """Translate reviewed qualified callables into exact mutmut name globs."""
+    filters: list[str] = []
+    for owner in selection["target_owners"]:
+        for callable_name in owner["callables"]:
+            module, function = callable_name.rsplit(".", 1)
+            filters.append(f"{module}.x_{function}__mutmut_*")
+    return sorted(set(filters))
+
+
 def _parse_outcomes(backend: Path) -> tuple[dict[str, int], list[dict[str, str]]]:
     counts = Counter({outcome: 0 for outcome in OUTCOMES})
     mutants: list[dict[str, str]] = []
@@ -423,7 +436,13 @@ def execute_pilot(
             raise MutationPolicyError("baseline_test_failure")
         try:
             result = subprocess.run(
-                [str(mutmut_executable), "run", "--max-children", "2"],
+                [
+                    str(mutmut_executable),
+                    "run",
+                    "--max-children",
+                    "2",
+                    *_mutant_filters(selection),
+                ],
                 cwd=backend,
                 env=environment,
                 check=False,

--- a/backend/scripts/mutation_policy.py
+++ b/backend/scripts/mutation_policy.py
@@ -403,7 +403,14 @@ def execute_pilot(
         environment.pop("GH_TOKEN", None)
         environment["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
         baseline = subprocess.run(
-            [sys.executable, "-m", "pytest", "-q", *[node.removeprefix("backend/") for node in selection["tests"]]],
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-q",
+                "--noconftest",
+                *[node.removeprefix("backend/") for node in selection["tests"]],
+            ],
             cwd=backend,
             env=environment,
             check=False,
@@ -466,6 +473,7 @@ def execute_pilot(
             "timeout_seconds": timeout_seconds,
             "targets": selection["targets"],
             "tests": selection["tests"],
+            "target_owners": selection["target_owners"],
         },
         "selection_sha256": _sha256(_json_bytes(selection)),
         "elapsed_seconds": elapsed,

--- a/backend/scripts/run_test_lanes.py
+++ b/backend/scripts/run_test_lanes.py
@@ -121,6 +121,7 @@ LANES = (
             "tests/test_guide_pptx.py",
             "tests/test_local_artifact_store.py",
             "tests/test_merge_test_lane_evidence.py",
+            "tests/test_mutation_policy.py",
             "tests/test_s3_artifact_store.py",
             "tests/test_submission_archive.py",
             "tests/test_submission_change_gate.py",

--- a/backend/tests/test_ci_test_lanes.py
+++ b/backend/tests/test_ci_test_lanes.py
@@ -60,6 +60,7 @@ def test_measured_hotspots_have_explicit_semantic_owners() -> None:
         "tests/test_artifact_admission.py",
         "tests/test_authorization.py",
         "tests/test_guide_artifacts.py",
+        "tests/test_mutation_policy.py",
     } <= modules_by_lane["shared_foundations"]
 
 

--- a/backend/tests/test_mutation_policy.py
+++ b/backend/tests/test_mutation_policy.py
@@ -11,6 +11,8 @@ import pytest
 
 from scripts.mutation_policy import MutationPolicyError
 from scripts.mutation_policy import _parse_outcomes
+from scripts.mutation_policy import _strong_calibration
+from scripts.mutation_policy import _weak_calibration
 from scripts.mutation_policy import build_selection
 
 
@@ -97,7 +99,7 @@ class TestMutationPolicy:
                             "survived": 0,
                             "timeout": 36,
                             "suspicious": 35,
-                            "error": 99,
+                            "error": -11,
                         }
                     }
                 ),
@@ -116,6 +118,14 @@ class TestMutationPolicy:
                 "error": 1,
             }
             assert len(mutants) == 5
+
+    def test_strong_calibration_asserts_the_exact_boundary(self) -> None:
+        assert _strong_calibration(1) is True
+        assert _strong_calibration(0) is False
+        assert _strong_calibration(-1) is False
+
+    def test_weak_calibration_deliberately_asserts_only_the_result_type(self) -> None:
+        assert isinstance(_weak_calibration(1), bool)
 
     def _initialize(self, root: Path) -> None:
         self._git(root, "init")

--- a/backend/tests/test_mutation_policy.py
+++ b/backend/tests/test_mutation_policy.py
@@ -3,17 +3,27 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from pathlib import Path
 import subprocess
+import sys
 import tempfile
 
 import pytest
 
 from scripts.mutation_policy import MutationPolicyError
+from scripts.mutation_policy import _eligible_target
+from scripts.mutation_policy import _main
 from scripts.mutation_policy import _parse_outcomes
+from scripts.mutation_policy import _reject_disposable_special_files
+from scripts.mutation_policy import _read_claim
+from scripts.mutation_policy import _regular_repository_file
+from scripts.mutation_policy import _safe_path
 from scripts.mutation_policy import _strong_calibration
 from scripts.mutation_policy import _weak_calibration
+from scripts.mutation_policy import _verify_mutmut_config
 from scripts.mutation_policy import build_selection
+from scripts.mutation_policy import execute_pilot
 
 
 class TestMutationPolicy:
@@ -37,10 +47,22 @@ class TestMutationPolicy:
                         "chunk_id": "WS-QUAL-001-04M",
                         "claims": [
                             {
-                                "target": "backend/scripts/claimed.py",
+                                "target": "backend/scripts/changed.py",
+                                "callables": ["scripts.changed.changed"],
                                 "tests": [
                                     "backend/tests/test_claimed.py::test_claimed"
                                 ],
+                                "outcomes": ["return"],
+                                "boundaries": [],
+                            },
+                            {
+                                "target": "backend/scripts/claimed.py",
+                                "callables": ["scripts.claimed.claimed"],
+                                "tests": [
+                                    "backend/tests/test_claimed.py::test_claimed"
+                                ],
+                                "outcomes": ["return"],
+                                "boundaries": [],
                             }
                         ],
                     }
@@ -66,7 +88,8 @@ class TestMutationPolicy:
             root = Path(temporary)
             self._initialize(root)
             head = self._git(root, "rev-parse", "HEAD")
-            claim = root / "claim.json"
+            claim = root / ".ci/behavior-claims/WS-QUAL-001-04M.json"
+            claim.parent.mkdir(parents=True)
             claim.write_text(
                 json.dumps(
                     {
@@ -75,7 +98,10 @@ class TestMutationPolicy:
                         "claims": [
                             {
                                 "target": "../escape.py",
+                                "callables": ["scripts.escape.escape"],
                                 "tests": ["backend/tests/test_claimed.py::test_claimed"],
+                                "outcomes": ["return"],
+                                "boundaries": [],
                             }
                         ],
                     }
@@ -128,6 +154,347 @@ class TestMutationPolicy:
     def test_weak_calibration_deliberately_asserts_only_the_result_type(self) -> None:
         assert isinstance(_weak_calibration(1), bool)
 
+    @pytest.mark.parametrize(
+        ("path", "eligible"),
+        [
+            ("backend/app/service.py", True),
+            ("backend/scripts/tool.py", True),
+            ("backend/app/__init__.py", False),
+            ("backend/tests/test_service.py", False),
+            ("docs/tool.py", False),
+        ],
+    )
+    def test_target_eligibility_is_closed(self, path: str, eligible: bool) -> None:
+        assert _eligible_target(path) is eligible
+
+    @pytest.mark.parametrize("path", ["", "/absolute.py", "../escape.py", "a/../b.py", "a//b.py"])
+    def test_unsafe_paths_fail_closed(self, path: str) -> None:
+        with pytest.raises(MutationPolicyError, match="unsafe_path"):
+            _safe_path(path)
+
+    @pytest.mark.parametrize(
+        ("claim", "error"),
+        [
+            ({"schema_version": 1, "chunk_id": "WS-QUAL-001-04M", "claims": [], "extra": True}, "invalid_behavior_claim_shape"),
+            ({"schema_version": 1, "chunk_id": "WS-QUAL-001-04M", "claims": [42]}, "invalid_behavior_claim"),
+            ({"schema_version": 2, "chunk_id": "WS-QUAL-001-04M", "claims": []}, "unsupported_behavior_claim_schema"),
+            ({"schema_version": 1, "chunk_id": "WS-QUAL-001-04M", "claims": "bad"}, "invalid_behavior_claim_count"),
+            (
+                {
+                    "schema_version": 1,
+                    "chunk_id": "WS-QUAL-001-04M",
+                    "claims": [{"target": "docs/no.py", "callables": ["docs.no.no"], "tests": ["backend/tests/test_claimed.py::test_claimed"], "outcomes": ["return"], "boundaries": []}],
+                },
+                "ineligible_claim_target",
+            ),
+            (
+                {
+                    "schema_version": 1,
+                    "chunk_id": "WS-QUAL-001-04M",
+                    "claims": [{"target": "backend/scripts/missing.py", "callables": ["scripts.missing.missing"], "tests": ["backend/tests/test_claimed.py::test_claimed"], "outcomes": ["return"], "boundaries": []}],
+                },
+                "missing_claim_target",
+            ),
+            (
+                {
+                    "schema_version": 1,
+                    "chunk_id": "WS-QUAL-001-04M",
+                    "claims": [{"target": "backend/scripts/claimed.py", "callables": ["scripts.claimed.claimed"], "tests": [], "outcomes": ["return"], "boundaries": []}],
+                },
+                "invalid_claim_tests",
+            ),
+            (
+                {
+                    "schema_version": 1,
+                    "chunk_id": "WS-QUAL-001-04M",
+                    "claims": [{"target": "backend/scripts/claimed.py", "callables": ["scripts.claimed.claimed"], "tests": ["not-a-node"], "outcomes": ["return"], "boundaries": []}],
+                },
+                "invalid_claim_test_node",
+            ),
+            (
+                {
+                    "schema_version": 1,
+                    "chunk_id": "WS-QUAL-001-04M",
+                    "claims": [{"target": "backend/scripts/claimed.py", "callables": ["scripts.claimed.claimed"], "tests": ["backend/tests/test_missing.py::test_missing"], "outcomes": ["return"], "boundaries": []}],
+                },
+                "missing_claim_test_module",
+            ),
+        ],
+    )
+    def test_claim_shapes_fail_closed(self, claim: dict[str, object], error: str) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self._initialize(root)
+            claim_path = root / ".ci/behavior-claims/WS-QUAL-001-04M.json"
+            claim_path.parent.mkdir(parents=True)
+            claim_path.write_text(json.dumps(claim), encoding="utf-8")
+            head = self._git(root, "rev-parse", "HEAD")
+            with pytest.raises(MutationPolicyError, match=error):
+                build_selection(root, self.base, head, "WS-QUAL-001-04M", claim_path)
+
+    def test_claim_path_must_match_the_chunk_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self._initialize(root)
+            wrong = root / "claim.json"
+            wrong.write_text(
+                json.dumps({"schema_version": 1, "chunk_id": "WS-QUAL-001-04M", "claims": []}),
+                encoding="utf-8",
+            )
+            head = self._git(root, "rev-parse", "HEAD")
+            with pytest.raises(MutationPolicyError, match="invalid_behavior_claim_path"):
+                build_selection(root, self.base, head, "WS-QUAL-001-04M", wrong)
+
+    @pytest.mark.parametrize(
+        ("overrides", "error"),
+        [
+            ({"callables": []}, "invalid_claim_callables"),
+            ({"tests": ["backend/tests/test_claimed.py::test_claimed"] * 2}, "duplicate_claim_test_node"),
+            ({"outcomes": ["unknown"]}, "invalid_claim_outcomes"),
+            ({"boundaries": ["unknown"]}, "invalid_claim_boundaries"),
+        ],
+    )
+    def test_typed_claim_metadata_fails_closed(
+        self, overrides: dict[str, object], error: str
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self._initialize(root)
+            item: dict[str, object] = {
+                "target": "backend/scripts/claimed.py",
+                "callables": ["scripts.claimed.claimed"],
+                "tests": ["backend/tests/test_claimed.py::test_claimed"],
+                "outcomes": ["return"],
+                "boundaries": [],
+            }
+            item.update(overrides)
+            claim = root / ".ci/behavior-claims/WS-QUAL-001-04M.json"
+            claim.parent.mkdir(parents=True)
+            claim.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "chunk_id": "WS-QUAL-001-04M",
+                        "claims": [item],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            head = self._git(root, "rev-parse", "HEAD")
+            with pytest.raises(MutationPolicyError, match=error):
+                build_selection(root, self.base, head, "WS-QUAL-001-04M", claim)
+
+    def test_malformed_and_duplicate_claims_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self._initialize(root)
+            head = self._git(root, "rev-parse", "HEAD")
+            claim = root / ".ci/behavior-claims/WS-QUAL-001-04M.json"
+            claim.parent.mkdir(parents=True)
+            claim.write_text("not-json", encoding="utf-8")
+            with pytest.raises(MutationPolicyError, match="invalid_behavior_claim_json"):
+                build_selection(root, self.base, head, "WS-QUAL-001-04M", claim)
+            item = {
+                "target": "backend/scripts/claimed.py",
+                "callables": ["scripts.claimed.claimed"],
+                "tests": ["backend/tests/test_claimed.py::test_claimed"],
+                "outcomes": ["return"],
+                "boundaries": [],
+            }
+            claim.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "chunk_id": "WS-QUAL-001-04M",
+                        "claims": [item, item],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with pytest.raises(MutationPolicyError, match="duplicate_claim_target"):
+                build_selection(root, self.base, head, "WS-QUAL-001-04M", claim)
+
+    def test_invalid_mutmut_metadata_and_zero_mutants_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            backend = Path(temporary)
+            meta = backend / "mutants/scripts/example.py.meta"
+            meta.parent.mkdir(parents=True)
+            meta.write_text("not-json", encoding="utf-8")
+            with pytest.raises(MutationPolicyError, match="invalid_mutmut_metadata"):
+                _parse_outcomes(backend)
+            meta.write_text(json.dumps({"exit_code_by_key": []}), encoding="utf-8")
+            with pytest.raises(MutationPolicyError, match="invalid_mutmut_results"):
+                _parse_outcomes(backend)
+            meta.write_text(json.dumps({"exit_code_by_key": {}}), encoding="utf-8")
+            with pytest.raises(MutationPolicyError, match="zero_generated_mutants"):
+                _parse_outcomes(backend)
+
+    def test_mutmut_configuration_parse_and_selection_drift_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            backend = Path(temporary)
+            pyproject = backend / "pyproject.toml"
+            selection = {
+                "targets": ["backend/scripts/example.py"],
+                "tests": ["backend/tests/test_example.py::test_example"],
+            }
+            pyproject.write_text("not = [valid", encoding="utf-8")
+            with pytest.raises(MutationPolicyError, match="invalid_mutation_config"):
+                _verify_mutmut_config(backend, selection)
+            pyproject.write_text(
+                "[tool.mutmut]\nsource_paths = ['wrong']\n",
+                encoding="utf-8",
+            )
+            with pytest.raises(MutationPolicyError, match="mutation_config_selection_mismatch"):
+                _verify_mutmut_config(backend, selection)
+
+    def test_disposable_symlinks_and_invalid_result_values_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            regular = root / "regular.py"
+            regular.write_text("pass\n", encoding="utf-8")
+            _reject_disposable_special_files(root)
+            (root / "link.py").symlink_to(regular)
+            with pytest.raises(MutationPolicyError, match="invalid_disposable_entry"):
+                _reject_disposable_special_files(root)
+        with tempfile.TemporaryDirectory() as temporary:
+            backend = Path(temporary)
+            meta = backend / "mutants/scripts/example.py.meta"
+            meta.parent.mkdir(parents=True)
+            meta.write_text(
+                json.dumps({"exit_code_by_key": {"mutant": "invalid"}}),
+                encoding="utf-8",
+            )
+            with pytest.raises(MutationPolicyError, match="invalid_mutmut_result"):
+                _parse_outcomes(backend)
+
+    def test_optional_claim_and_regular_file_custody(self) -> None:
+        assert _read_claim(None, Path.cwd(), "WS-QUAL-001-04M") == []
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "backend/scripts/target.py"
+            target.parent.mkdir(parents=True)
+            target.write_text("pass\n", encoding="utf-8")
+            assert _regular_repository_file(root, "backend/scripts/target.py") is True
+            link = root / "backend/scripts/link.py"
+            link.symlink_to(target)
+            assert _regular_repository_file(root, "backend/scripts/link.py") is False
+
+    def test_zero_targets_and_invalid_revisions_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self._initialize(root)
+            head = self._git(root, "rev-parse", "HEAD")
+            with pytest.raises(MutationPolicyError, match="invalid_revision"):
+                build_selection(root, "bad", head, "WS-QUAL-001-04M", None)
+            with pytest.raises(MutationPolicyError, match="zero_mutation_targets"):
+                build_selection(root, self.base, head, "WS-QUAL-001-04M", None)
+            changed = root / "backend/scripts/changed.py"
+            changed.write_text("def changed():\n    return True\n", encoding="utf-8")
+            self._git(root, "add", ".")
+            self._git(root, "commit", "-m", "changed")
+            changed_head = self._git(root, "rev-parse", "HEAD")
+            with pytest.raises(MutationPolicyError, match="changed_target_without_behavior_claim"):
+                build_selection(root, self.base, changed_head, "WS-QUAL-001-04M", None)
+
+    def test_execute_pilot_uses_disposable_tree_and_writes_reconciled_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "repository"
+            root.mkdir()
+            self._initialize_execution_repository(root)
+            head = self._git(root, "rev-parse", "HEAD")
+            claim = root / ".ci/behavior-claims/WS-QUAL-001-04M.json"
+            selection = build_selection(root, self.base, head, "WS-QUAL-001-04M", claim)
+            manifest = root / "trusted.txt"
+            manifest.write_text("trusted\n", encoding="utf-8")
+            manifest_digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+            executable = root / "fake-mutmut"
+            executable.write_text(
+                """#!/usr/bin/env python3
+import json
+from pathlib import Path
+path = Path('mutants/scripts/mutation_policy.py.meta')
+path.parent.mkdir(parents=True)
+path.write_text(json.dumps({'exit_code_by_key': {
+    'scripts.mutation_policy.x__strong_calibration__mutmut_1': 1,
+    'scripts.mutation_policy.x__weak_calibration__mutmut_1': 0,
+    'scripts.mutation_policy.x_other__mutmut_1': 34,
+}}))
+""",
+                encoding="utf-8",
+            )
+            executable.chmod(0o700)
+            output = root / "evidence.json"
+
+            execute_pilot(
+                root,
+                selection,
+                manifest,
+                manifest_digest,
+                executable,
+                output,
+                30,
+            )
+
+            evidence = json.loads(output.read_text(encoding="utf-8"))
+            assert evidence["head_sha"] == head
+            assert evidence["outcomes"] == {
+                "generated": 3,
+                "killed": 1,
+                "survived": 1,
+                "timeout": 0,
+                "suspicious": 0,
+                "excluded": 1,
+                "error": 0,
+            }
+            assert evidence["calibration"] == {
+                "strong": {"killed": 1},
+                "weak": {"survived": 1},
+            }
+            assert self._git(root, "status", "--porcelain", "--untracked-files=no") == ""
+
+    def test_execution_rejects_bad_digest_timeout_and_dirty_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "repository"
+            root.mkdir()
+            self._initialize_execution_repository(root)
+            head = self._git(root, "rev-parse", "HEAD")
+            selection = build_selection(
+                root,
+                self.base,
+                head,
+                "WS-QUAL-001-04M",
+                root / ".ci/behavior-claims/WS-QUAL-001-04M.json",
+            )
+            manifest = root / "trusted.txt"
+            manifest.write_text("trusted\n", encoding="utf-8")
+            executable = root / "unused"
+            output = root / "evidence.json"
+            with pytest.raises(MutationPolicyError, match="untrusted_manifest_digest"):
+                execute_pilot(root, selection, manifest, "0" * 64, executable, output, 30)
+            digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+            with pytest.raises(MutationPolicyError, match="invalid_timeout"):
+                execute_pilot(root, selection, manifest, digest, executable, output, 0)
+            (root / "backend/scripts/mutation_policy.py").write_text("dirty\n", encoding="utf-8")
+            with pytest.raises(MutationPolicyError, match="dirty_source_tree"):
+                execute_pilot(root, selection, manifest, digest, executable, output, 30)
+
+    def test_main_reports_policy_errors(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "mutation_policy.py",
+                "--base-sha",
+                "bad",
+                "--head-sha",
+                "bad",
+                "--chunk-id",
+                "WS-QUAL-001-04M",
+            ],
+        )
+        assert _main() == 1
+        assert "mutation_policy_error:invalid_revision" in capsys.readouterr().err
+
     def _initialize(self, root: Path) -> None:
         self._git(root, "init")
         self._git(root, "config", "user.email", "test@example.com")
@@ -142,6 +509,61 @@ class TestMutationPolicy:
         self._git(root, "add", ".")
         self._git(root, "commit", "-m", "base")
         self.base = self._git(root, "rev-parse", "HEAD")
+
+    def _initialize_execution_repository(self, root: Path) -> None:
+        self._git(root, "init")
+        self._git(root, "config", "user.email", "test@example.com")
+        self._git(root, "config", "user.name", "Test")
+        files = {
+            "backend/scripts/mutation_policy.py": "def policy():\n    return True\n",
+            "backend/tests/test_mutation_policy.py": (
+                "def test_claim():\n    assert True\n"
+                "def test_strong():\n    assert True\n"
+                "def test_weak():\n    assert True\n"
+            ),
+            "backend/pyproject.toml": (
+                "[tool.pytest.ini_options]\ntestpaths = ['tests']\n"
+                "[tool.mutmut]\nsource_paths = ['scripts']\n"
+                "only_mutate = ['scripts/mutation_policy.py']\n"
+                "pytest_add_cli_args_test_selection = ['tests/test_mutation_policy.py::test_claim', "
+                "'tests/test_mutation_policy.py::test_strong', 'tests/test_mutation_policy.py::test_weak']\n"
+                "pytest_add_cli_args = ['-q', '--noconftest']\n"
+                "use_git_change_detection = false\ndebug = true\n"
+                "timeout_multiplier = 4.0\ntimeout_constant = 2.0\n"
+            ),
+            "scripts/git_delta.py": "# shared helper\n",
+        }
+        for path, contents in files.items():
+            destination = root / path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(contents, encoding="utf-8")
+        self._git(root, "add", ".")
+        self._git(root, "commit", "-m", "base")
+        self.base = self._git(root, "rev-parse", "HEAD")
+        claim = root / ".ci/behavior-claims/WS-QUAL-001-04M.json"
+        claim.parent.mkdir(parents=True)
+        claim.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "chunk_id": "WS-QUAL-001-04M",
+                    "claims": [
+                        {
+                            "target": "backend/scripts/mutation_policy.py",
+                            "callables": ["scripts.mutation_policy.policy"],
+                            "tests": [
+                                "backend/tests/test_mutation_policy.py::test_claim",
+                                "backend/tests/test_mutation_policy.py::test_strong",
+                                "backend/tests/test_mutation_policy.py::test_weak",
+                            ],
+                            "outcomes": ["return"],
+                            "boundaries": [],
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
 
     @staticmethod
     def _git(root: Path, *arguments: str) -> str:

--- a/backend/tests/test_mutation_policy.py
+++ b/backend/tests/test_mutation_policy.py
@@ -99,6 +99,7 @@ class TestMutationPolicy:
                             "survived": 0,
                             "timeout": 36,
                             "suspicious": 35,
+                            "excluded": 34,
                             "error": -11,
                         }
                     }
@@ -106,10 +107,10 @@ class TestMutationPolicy:
                 encoding="utf-8",
             )
 
-            outcomes, mutants = _parse_outcomes(backend, selected_count=6)
+            outcomes, mutants = _parse_outcomes(backend)
 
             assert outcomes == {
-                "generated": 5,
+                "generated": 6,
                 "killed": 1,
                 "survived": 1,
                 "timeout": 1,
@@ -117,7 +118,7 @@ class TestMutationPolicy:
                 "excluded": 1,
                 "error": 1,
             }
-            assert len(mutants) == 5
+            assert len(mutants) == 6
 
     def test_strong_calibration_asserts_the_exact_boundary(self) -> None:
         assert _strong_calibration(1) is True

--- a/backend/tests/test_mutation_policy.py
+++ b/backend/tests/test_mutation_policy.py
@@ -1,0 +1,139 @@
+"""Contract tests for bounded changed-scope mutation selection and evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+
+import pytest
+
+from scripts.mutation_policy import MutationPolicyError
+from scripts.mutation_policy import _parse_outcomes
+from scripts.mutation_policy import build_selection
+
+
+class TestMutationPolicy:
+    """Keep selection additive and evidence outcome parsing complete."""
+
+    def test_changed_targets_are_mandatory_and_claims_are_additive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self._initialize(root)
+            changed = root / "backend/scripts/changed.py"
+            changed.write_text("def changed():\n    return True\n", encoding="utf-8")
+            self._git(root, "add", ".")
+            self._git(root, "commit", "-m", "changed")
+            head = self._git(root, "rev-parse", "HEAD")
+            claim = root / ".ci/behavior-claims/WS-QUAL-001-04M.json"
+            claim.parent.mkdir(parents=True)
+            claim.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "chunk_id": "WS-QUAL-001-04M",
+                        "claims": [
+                            {
+                                "target": "backend/scripts/claimed.py",
+                                "tests": [
+                                    "backend/tests/test_claimed.py::test_claimed"
+                                ],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            selection = build_selection(
+                root, self.base, head, "WS-QUAL-001-04M", claim
+            )
+
+            assert selection["changed_targets"] == ["backend/scripts/changed.py"]
+            assert selection["targets"] == [
+                "backend/scripts/changed.py",
+                "backend/scripts/claimed.py",
+            ]
+            assert selection["tests"] == [
+                "backend/tests/test_claimed.py::test_claimed"
+            ]
+
+    def test_claim_validation_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self._initialize(root)
+            head = self._git(root, "rev-parse", "HEAD")
+            claim = root / "claim.json"
+            claim.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "chunk_id": "WS-QUAL-001-OTHER",
+                        "claims": [
+                            {
+                                "target": "../escape.py",
+                                "tests": ["backend/tests/test_claimed.py::test_claimed"],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with pytest.raises(MutationPolicyError, match="stale_behavior_claim_chunk"):
+                build_selection(root, self.base, head, "WS-QUAL-001-04M", claim)
+
+    def test_outcomes_include_killed_survived_timeout_suspicious_and_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            backend = Path(temporary)
+            meta = backend / "mutants/scripts/example.py.meta"
+            meta.parent.mkdir(parents=True)
+            meta.write_text(
+                json.dumps(
+                    {
+                        "exit_code_by_key": {
+                            "killed": 1,
+                            "survived": 0,
+                            "timeout": 36,
+                            "suspicious": 35,
+                            "error": 99,
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            outcomes, mutants = _parse_outcomes(backend, selected_count=6)
+
+            assert outcomes == {
+                "generated": 5,
+                "killed": 1,
+                "survived": 1,
+                "timeout": 1,
+                "suspicious": 1,
+                "excluded": 1,
+                "error": 1,
+            }
+            assert len(mutants) == 5
+
+    def _initialize(self, root: Path) -> None:
+        self._git(root, "init")
+        self._git(root, "config", "user.email", "test@example.com")
+        self._git(root, "config", "user.name", "Test")
+        for path, contents in {
+            "backend/scripts/claimed.py": "def claimed():\n    return True\n",
+            "backend/tests/test_claimed.py": "def test_claimed():\n    assert True\n",
+        }.items():
+            destination = root / path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(contents, encoding="utf-8")
+        self._git(root, "add", ".")
+        self._git(root, "commit", "-m", "base")
+        self.base = self._git(root, "rev-parse", "HEAD")
+
+    @staticmethod
+    def _git(root: Path, *arguments: str) -> str:
+        return subprocess.check_output(
+            ["git", *arguments], cwd=root, text=True, stderr=subprocess.STDOUT
+        ).strip()

--- a/backend/tests/test_mutation_policy.py
+++ b/backend/tests/test_mutation_policy.py
@@ -14,6 +14,7 @@ import pytest
 from scripts.mutation_policy import MutationPolicyError
 from scripts.mutation_policy import _eligible_target
 from scripts.mutation_policy import _main
+from scripts.mutation_policy import _mutant_filters
 from scripts.mutation_policy import _parse_outcomes
 from scripts.mutation_policy import _reject_disposable_special_files
 from scripts.mutation_policy import _read_claim
@@ -378,6 +379,23 @@ class TestMutationPolicy:
             link = root / "backend/scripts/link.py"
             link.symlink_to(target)
             assert _regular_repository_file(root, "backend/scripts/link.py") is False
+
+    def test_callable_filters_are_exact_and_deterministic(self) -> None:
+        selection = {
+            "target_owners": [
+                {
+                    "callables": [
+                        "scripts.example.public",
+                        "scripts.example._private",
+                        "scripts.example.public",
+                    ]
+                }
+            ]
+        }
+        assert _mutant_filters(selection) == [
+            "scripts.example.x__private__mutmut_*",
+            "scripts.example.x_public__mutmut_*",
+        ]
 
     def test_zero_targets_and_invalid_revisions_fail_closed(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -191,9 +191,11 @@ For pull requests, the hash-locked mutation toolchain is read only from
 with `pip --require-hashes`. It does not run PR-controlled packaging hooks or
 install the backend package; the focused tests run with conftest loading
 disabled because they use only the protected mutation-test toolchain. The
-workflow has read-only permissions, checks out without credentials, receives no
-secrets, and executes the PR head in a Git archive extracted to disposable
-storage. Symlinks and special archive entries are rejected before execution.
+workflow has read-only permissions, disables persisted checkout credentials,
+and receives no secrets. The policy wrapper runs from the exact PR-head
+checkout; it archives that same head and runs baseline tests and mutmut only in
+the disposable extraction with token environment variables removed. Symlinks
+and special archive entries are rejected before test or mutation execution.
 Evidence and the virtual environment live in runner-temporary storage outside
 the PR checkout. The checked-out source tree must stay clean and retain the
 same exact tree hash.
@@ -204,4 +206,6 @@ manifest digest, exact configuration, selected targets and tests, elapsed time,
 and generated, killed, survived, timeout, suspicious, excluded, and error
 outcomes. Mutation score is not a contributor gate during this pilot. Baseline
 test failure, dependency-custody failure, target escape, engine error, timeout,
-or malformed evidence still fails the workflow.
+or malformed evidence still fails the workflow. Only separately instructed
+`WS-QUAL-001-05M`, after accepted hosted evidence and a human calibration
+checkpoint, may propose a blocking survivor policy.

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -180,16 +180,23 @@ policy, tests, claim, schema, Git-delta helper, or workflow changes.
 
 The pilot always selects eligible changed Python targets under `backend/app/`
 or `backend/scripts/`. Schema-v1 files under `.ci/behavior-claims/` may add a
-bounded target with exact owning pytest nodes; they cannot remove or replace a
-changed target. Malformed claims, stale chunk identifiers, unsafe paths,
-missing targets or tests, empty selection, and configuration drift fail closed.
+bounded target with qualified callables, exact owning pytest nodes, typed
+observable outcomes, and any essential real boundaries. Every eligible changed
+target requires this ownership mapping; claims cannot remove or replace one.
+Malformed claims, stale chunk identifiers, unsafe paths, symlinks, missing
+targets or tests, empty selection, and configuration drift fail closed.
 
 For pull requests, the hash-locked mutation toolchain is read only from
 `scripts/mutation-requirements.txt` at the protected base revision and installed
-with `pip --require-hashes`. The workflow has read-only permissions, checks out
-without credentials, receives no secrets, and executes the PR head in a Git
-archive extracted to disposable storage. The checked-out source tree must stay
-clean and retain the same exact tree hash.
+with `pip --require-hashes`. It does not run PR-controlled packaging hooks or
+install the backend package; the focused tests run with conftest loading
+disabled because they use only the protected mutation-test toolchain. The
+workflow has read-only permissions, checks out without credentials, receives no
+secrets, and executes the PR head in a Git archive extracted to disposable
+storage. Symlinks and special archive entries are rejected before execution.
+Evidence and the virtual environment live in runner-temporary storage outside
+the PR checkout. The checked-out source tree must stay clean and retain the
+same exact tree hash.
 
 The independent job is limited to 15 minutes, with mutation execution bounded
 below 12 minutes. Its seven-day artifact binds base SHA, head SHA and tree,

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -170,3 +170,31 @@ a measured target miss at the human merge checkpoint, that performance result
 does not override otherwise passing correctness, custody, service-contract,
 API, and coverage gates. Never lower coverage, skip nodes, or add a silent
 fallback to meet the target.
+
+## Changed-scope mutation pilot
+
+`Mutation Pilot` is an independent, observational WS-QUAL-001-04M workflow. It
+does not join the required Backend fan-in, alter the 78 percent global floor, or
+alter any protected 90 percent subsystem floor. It runs only when the pilot's
+policy, tests, claim, schema, Git-delta helper, or workflow changes.
+
+The pilot always selects eligible changed Python targets under `backend/app/`
+or `backend/scripts/`. Schema-v1 files under `.ci/behavior-claims/` may add a
+bounded target with exact owning pytest nodes; they cannot remove or replace a
+changed target. Malformed claims, stale chunk identifiers, unsafe paths,
+missing targets or tests, empty selection, and configuration drift fail closed.
+
+For pull requests, the hash-locked mutation toolchain is read only from
+`scripts/mutation-requirements.txt` at the protected base revision and installed
+with `pip --require-hashes`. The workflow has read-only permissions, checks out
+without credentials, receives no secrets, and executes the PR head in a Git
+archive extracted to disposable storage. The checked-out source tree must stay
+clean and retain the same exact tree hash.
+
+The independent job is limited to 15 minutes, with mutation execution bounded
+below 12 minutes. Its seven-day artifact binds base SHA, head SHA and tree,
+manifest digest, exact configuration, selected targets and tests, elapsed time,
+and generated, killed, survived, timeout, suspicious, excluded, and error
+outcomes. Mutation score is not a contributor gate during this pilot. Baseline
+test failure, dependency-custody failure, target escape, engine error, timeout,
+or malformed evidence still fails the workflow.

--- a/scripts/behavior-claim.schema.json
+++ b/scripts/behavior-claim.schema.json
@@ -14,15 +14,35 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["target", "tests"],
+        "required": ["target", "callables", "tests", "outcomes", "boundaries"],
         "properties": {
           "target": {"type": "string", "pattern": "^backend/(app|scripts)/.+\\.py$"},
+          "callables": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "uniqueItems": true,
+            "items": {"type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_.]+$"}
+          },
           "tests": {
             "type": "array",
             "minItems": 1,
             "maxItems": 12,
             "uniqueItems": true,
             "items": {"type": "string", "pattern": "^backend/tests/test_.+\\.py::\\S+$"}
+          },
+          "outcomes": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "enum": ["return", "persisted_state", "emitted_fact", "denial", "mapped_error", "idempotent_replay", "recovery_outcome"]
+            }
+          },
+          "boundaries": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {"enum": ["postgresql", "minio", "http", "lock", "trigger", "concurrency"]}
           }
         }
       }

--- a/scripts/behavior-claim.schema.json
+++ b/scripts/behavior-claim.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://workstream.dev/schemas/behavior-claim-v1.json",
+  "title": "Workstream bounded behavior mutation claim",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "chunk_id", "claims"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "chunk_id": {"type": "string", "pattern": "^WS-[A-Z]+-[0-9]{3}-[A-Z0-9]+$"},
+    "claims": {
+      "type": "array",
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["target", "tests"],
+        "properties": {
+          "target": {"type": "string", "pattern": "^backend/(app|scripts)/.+\\.py$"},
+          "tests": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 12,
+            "uniqueItems": true,
+            "items": {"type": "string", "pattern": "^backend/tests/test_.+\\.py::\\S+$"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/git_delta.py
+++ b/scripts/git_delta.py
@@ -1,0 +1,183 @@
+"""Deterministic Git delta primitives shared by repository policy tools."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def maybe_run(command: list[str], *, repository_root: Path | None = None) -> str:
+    """Return stdout for a successful Git command, otherwise an empty string."""
+    result = subprocess.run(
+        command,
+        cwd=repository_root,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def add_unique(paths: list[str], output: str) -> None:
+    """Append unique non-empty paths from newline-delimited output."""
+    for path in output.splitlines():
+        if path and path not in paths:
+            paths.append(path)
+
+
+def ref_exists(ref: str, *, repository_root: Path | None = None) -> bool:
+    """Return whether a Git ref resolves."""
+    return bool(maybe_run(["git", "rev-parse", "--verify", ref], repository_root=repository_root))
+
+
+def first_existing_ref(
+    *refs: str, repository_root: Path | None = None
+) -> str | None:
+    """Return the first resolvable Git ref."""
+    for ref in refs:
+        if ref_exists(ref, repository_root=repository_root):
+            return ref
+    return None
+
+
+def changed_files(
+    base: str,
+    head: str,
+    *,
+    repository_root: Path | None = None,
+    include_local: bool = True,
+) -> list[str]:
+    """Return deterministically ordered changed paths for a Git delta."""
+    paths: list[str] = []
+    add_unique(
+        paths,
+        maybe_run(
+            ["git", "diff", "--name-only", f"{base}...{head}"],
+            repository_root=repository_root,
+        ),
+    )
+    if include_local:
+        for command in (
+            ["git", "diff", "--name-only", "--cached"],
+            ["git", "diff", "--name-only"],
+            ["git", "ls-files", "--others", "--exclude-standard"],
+        ):
+            add_unique(paths, maybe_run(command, repository_root=repository_root))
+    return sorted(paths)
+
+
+def count_text_lines(path: str, *, repository_root: Path | None = None) -> int:
+    """Return a text-file line count and zero for binary or unreadable data."""
+    candidate = (repository_root / path) if repository_root else Path(path)
+    try:
+        data = candidate.read_bytes()
+    except OSError:
+        return 0
+    return 0 if b"\x00" in data else len(data.splitlines())
+
+
+def numstat(
+    base: str,
+    head: str,
+    *,
+    repository_root: Path | None = None,
+    include_local: bool = True,
+) -> tuple[int, int, list[tuple[str, int, int]]]:
+    """Return added/deleted totals and deterministic per-file Git numstat."""
+    outputs = [
+        maybe_run(
+            ["git", "diff", "--numstat", f"{base}...{head}"],
+            repository_root=repository_root,
+        )
+    ]
+    if include_local:
+        outputs.extend(
+            [
+                maybe_run(["git", "diff", "--numstat", "--cached"], repository_root=repository_root),
+                maybe_run(["git", "diff", "--numstat"], repository_root=repository_root),
+            ]
+        )
+    rows_by_path: dict[str, tuple[int, int]] = {}
+    for output in outputs:
+        for line in output.splitlines():
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+            added, deleted, path = parts
+            try:
+                add_count = int(added)
+            except ValueError:
+                add_count = 0
+            try:
+                delete_count = int(deleted)
+            except ValueError:
+                delete_count = 0
+            prior_added, prior_deleted = rows_by_path.get(path, (0, 0))
+            rows_by_path[path] = (prior_added + add_count, prior_deleted + delete_count)
+    if include_local:
+        untracked = maybe_run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            repository_root=repository_root,
+        )
+        for path in untracked.splitlines():
+            if path and path not in rows_by_path:
+                rows_by_path[path] = (
+                    count_text_lines(path, repository_root=repository_root),
+                    0,
+                )
+    rows = [
+        (path, added, deleted)
+        for path, (added, deleted) in sorted(rows_by_path.items())
+    ]
+    return (
+        sum(row[1] for row in rows),
+        sum(row[2] for row in rows),
+        rows,
+    )
+
+
+def diff_text(
+    base: str,
+    head: str,
+    paths: list[str] | None = None,
+    *,
+    repository_root: Path | None = None,
+    include_local: bool = True,
+) -> str:
+    """Return zero-context diff text for the selected Git delta."""
+    path_args = ["--", *paths] if paths else []
+    parts = [
+        maybe_run(
+            ["git", "diff", "--unified=0", f"{base}...{head}", *path_args],
+            repository_root=repository_root,
+        )
+    ]
+    if include_local:
+        parts.extend(
+            [
+                maybe_run(
+                    ["git", "diff", "--unified=0", "--cached", *path_args],
+                    repository_root=repository_root,
+                ),
+                maybe_run(
+                    ["git", "diff", "--unified=0", *path_args],
+                    repository_root=repository_root,
+                ),
+            ]
+        )
+        path_filter = set(paths or [])
+        untracked = maybe_run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            repository_root=repository_root,
+        )
+        for path in untracked.splitlines():
+            if path_filter and path not in path_filter:
+                continue
+            candidate = (repository_root / path) if repository_root else Path(path)
+            try:
+                text = candidate.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            parts.append(f"--- /dev/null\n+++ b/{path}\n{text}")
+    return "\n".join(part for part in parts if part)

--- a/scripts/test_git_delta.py
+++ b/scripts/test_git_delta.py
@@ -1,0 +1,54 @@
+"""Tests for deterministic shared Git delta primitives."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.git_delta import changed_files
+from scripts.git_delta import diff_text
+from scripts.git_delta import numstat
+
+
+class GitDeltaTests(unittest.TestCase):
+    """Exercise committed and optional local delta discovery."""
+
+    def test_committed_delta_is_sorted_and_local_changes_are_optional(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            self._git(root, "init")
+            self._git(root, "config", "user.email", "test@example.com")
+            self._git(root, "config", "user.name", "Test")
+            (root / "b.txt").write_text("one\n", encoding="utf-8")
+            self._git(root, "add", "b.txt")
+            self._git(root, "commit", "-m", "base")
+            base = self._git(root, "rev-parse", "HEAD")
+            (root / "b.txt").write_text("one\ntwo\n", encoding="utf-8")
+            (root / "a.txt").write_text("alpha\n", encoding="utf-8")
+            self._git(root, "add", ".")
+            self._git(root, "commit", "-m", "head")
+            head = self._git(root, "rev-parse", "HEAD")
+            (root / "local.txt").write_text("local\n", encoding="utf-8")
+
+            self.assertEqual(
+                changed_files(base, head, repository_root=root, include_local=False),
+                ["a.txt", "b.txt"],
+            )
+            self.assertEqual(
+                changed_files(base, head, repository_root=root),
+                ["a.txt", "b.txt", "local.txt"],
+            )
+            self.assertEqual(numstat(base, head, repository_root=root, include_local=False)[:2], (2, 0))
+            self.assertIn("+++ b/a.txt", diff_text(base, head, repository_root=root, include_local=False))
+
+    @staticmethod
+    def _git(root: Path, *arguments: str) -> str:
+        return subprocess.check_output(
+            ["git", *arguments], cwd=root, text=True, stderr=subprocess.STDOUT
+        ).strip()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_lightweight_agent_gates.py
+++ b/scripts/test_lightweight_agent_gates.py
@@ -135,6 +135,7 @@ class LightweightAgentGateTests(unittest.TestCase):
         self.assertNotIn("contents: write", workflow)
         self.assertNotIn("continue-on-error", workflow)
         self.assertIn("timeout-minutes: 15", workflow)
+        self.assertEqual(workflow.count('      - "backend/pyproject.toml"'), 2)
         self.assertIn("timeout --signal=TERM --kill-after=15s 720s", workflow)
         self.assertIn("persist-credentials: false", workflow)
         self.assertIn("--require-hashes", workflow)
@@ -143,6 +144,8 @@ class LightweightAgentGateTests(unittest.TestCase):
         )
         self.assertIn("--timeout-seconds 700", workflow)
         self.assertIn("retention-days: 7", workflow)
+        self.assertIn("include-hidden-files: true", workflow)
+        self.assertNotIn('pip install -e "backend[dev]"', workflow)
         self.assertNotIn("mutation-pilot", backend)
 
 if __name__ == "__main__":

--- a/scripts/test_lightweight_agent_gates.py
+++ b/scripts/test_lightweight_agent_gates.py
@@ -124,5 +124,26 @@ class LightweightAgentGateTests(unittest.TestCase):
         self.assertIn("pull_request_review:", agent_gates)
         self.assertIn("--require-pr-approval", agent_gates)
 
+    def test_mutation_pilot_is_bounded_read_only_and_independent(self) -> None:
+        workflow = Path(".github/workflows/mutation-pilot.yml").read_text(encoding="utf-8")
+        backend = Path(".github/workflows/backend.yml").read_text(encoding="utf-8")
+
+        self.assertIn("  pull_request:\n", workflow)
+        self.assertIn("  push:\n", workflow)
+        self.assertNotIn("pull_request_target", workflow)
+        self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertNotIn("continue-on-error", workflow)
+        self.assertIn("timeout-minutes: 15", workflow)
+        self.assertIn("timeout --signal=TERM --kill-after=15s 720s", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("--require-hashes", workflow)
+        self.assertIn(
+            'git show "${base_sha}:scripts/mutation-requirements.txt"', workflow
+        )
+        self.assertIn("--timeout-seconds 700", workflow)
+        self.assertIn("retention-days: 7", workflow)
+        self.assertNotIn("mutation-pilot", backend)
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/workstream_agent_gate.py
+++ b/scripts/workstream_agent_gate.py
@@ -10,9 +10,20 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import subprocess
 from dataclasses import asdict, dataclass
-from pathlib import Path
+
+try:
+    from scripts.git_delta import changed_files
+    from scripts.git_delta import diff_text
+    from scripts.git_delta import first_existing_ref
+    from scripts.git_delta import numstat
+    from scripts.git_delta import ref_exists
+except ModuleNotFoundError:  # Direct ``python scripts/...`` execution.
+    from git_delta import changed_files
+    from git_delta import diff_text
+    from git_delta import first_existing_ref
+    from git_delta import numstat
+    from git_delta import ref_exists
 
 
 RISKY_PATTERNS = re.compile(
@@ -45,122 +56,6 @@ class Finding:
     severity: str
     code: str
     message: str
-
-
-def run(cmd: list[str]) -> str:
-    """Run a command and return trimmed stdout."""
-    return subprocess.check_output(cmd, text=True, stderr=subprocess.STDOUT).strip()
-
-
-def maybe_run(cmd: list[str]) -> str:
-    """Run a command and return stdout, or an empty string on failure."""
-    result = subprocess.run(
-        cmd,
-        check=False,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    if result.returncode != 0:
-        return ""
-    return result.stdout.strip()
-
-
-def add_unique(paths: list[str], output: str) -> None:
-    """Append unique paths from command output."""
-    for path in output.splitlines():
-        if path and path not in paths:
-            paths.append(path)
-
-
-def ref_exists(ref: str) -> bool:
-    """Return whether a git ref exists."""
-    return bool(maybe_run(["git", "rev-parse", "--verify", ref]))
-
-
-def first_existing_ref(*refs: str) -> str | None:
-    """Return the first git ref that exists."""
-    for ref in refs:
-        if ref_exists(ref):
-            return ref
-    return None
-
-
-def changed_files(base: str, head: str) -> list[str]:
-    """Return changed file paths, including local dirty-tree paths."""
-    paths: list[str] = []
-    add_unique(paths, maybe_run(["git", "diff", "--name-only", f"{base}...{head}"]))
-    add_unique(paths, maybe_run(["git", "diff", "--name-only", "--cached"]))
-    add_unique(paths, maybe_run(["git", "diff", "--name-only"]))
-    add_unique(paths, maybe_run(["git", "ls-files", "--others", "--exclude-standard"]))
-    return paths
-
-
-def numstat(base: str, head: str) -> tuple[int, int, list[tuple[str, int, int]]]:
-    """Return added/deleted line totals and per-file rows, including dirty files."""
-    outputs = [
-        maybe_run(["git", "diff", "--numstat", f"{base}...{head}"]),
-        maybe_run(["git", "diff", "--numstat", "--cached"]),
-        maybe_run(["git", "diff", "--numstat"]),
-    ]
-    rows_by_path: dict[str, tuple[int, int]] = {}
-    for output in outputs:
-        for line in output.splitlines():
-            parts = line.split("\t")
-            if len(parts) != 3:
-                continue
-            add, delete, path = parts
-            try:
-                a = int(add)
-            except ValueError:
-                a = 0
-            try:
-                d = int(delete)
-            except ValueError:
-                d = 0
-            previous_add, previous_del = rows_by_path.get(path, (0, 0))
-            rows_by_path[path] = (previous_add + a, previous_del + d)
-
-    for path in maybe_run(["git", "ls-files", "--others", "--exclude-standard"]).splitlines():
-        if not path or path in rows_by_path:
-            continue
-        added = count_text_lines(path)
-        rows_by_path[path] = (added, 0)
-    rows = [(path, added, deleted) for path, (added, deleted) in rows_by_path.items()]
-    total_add = sum(added for _, added, _ in rows)
-    total_del = sum(deleted for _, _, deleted in rows)
-    return total_add, total_del, rows
-
-
-def count_text_lines(path: str) -> int:
-    """Return a line count for text files and zero for binary/unreadable files."""
-    try:
-        data = Path(path).read_bytes()
-    except OSError:
-        return 0
-    if b"\x00" in data:
-        return 0
-    return len(data.splitlines())
-
-
-def diff_text(base: str, head: str, paths: list[str] | None = None) -> str:
-    """Return zero-context diff text, including local dirty changes."""
-    path_args = ["--", *paths] if paths else []
-    parts = [
-        maybe_run(["git", "diff", "--unified=0", f"{base}...{head}", *path_args]),
-        maybe_run(["git", "diff", "--unified=0", "--cached", *path_args]),
-        maybe_run(["git", "diff", "--unified=0", *path_args]),
-    ]
-    path_filter = set(paths or [])
-    for path in maybe_run(["git", "ls-files", "--others", "--exclude-standard"]).splitlines():
-        if path_filter and path not in path_filter:
-            continue
-        try:
-            text = Path(path).read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
-        parts.append(f"--- /dev/null\n+++ b/{path}\n{text}")
-    return "\n".join(part for part in parts if part)
 
 
 def analyze(base: str, head: str, max_l1_lines: int = 500) -> dict:

--- a/scripts/workstream_agent_gate.py
+++ b/scripts/workstream_agent_gate.py
@@ -16,12 +16,14 @@ try:
     from scripts.git_delta import changed_files
     from scripts.git_delta import diff_text
     from scripts.git_delta import first_existing_ref
+    from scripts.git_delta import maybe_run
     from scripts.git_delta import numstat
     from scripts.git_delta import ref_exists
 except ModuleNotFoundError:  # Direct ``python scripts/...`` execution.
     from git_delta import changed_files
     from git_delta import diff_text
     from git_delta import first_existing_ref
+    from git_delta import maybe_run
     from git_delta import numstat
     from git_delta import ref_exists
 


### PR DESCRIPTION
# WS-QUAL-001-04M PR Trust Bundle

## Chunk

`WS-QUAL-001-04M` — Changed-Scope Mutation Pilot (L1).

## Goal and approved intent

Measure whether one protected, pinned mutation engine can provide useful,
bounded, exact-head behavior evidence before any mutation result becomes a
blocking contributor policy.

## What changed and why

- Added deterministic changed-target and typed behavior-ownership policy.
- Extracted policy-free Git delta mechanics shared with the agent gate.
- Added a protected-base, read-only, independent Mutation Pilot workflow.
- Added complete result evidence, strong/weak calibration, focused tests, and
  operator documentation.

Coverage proves execution but not assertion sensitivity. This pilot measures
test sensitivity, noise, selection integrity, supply-chain custody, and runtime.

## Design chosen

Every eligible changed target requires a schema-v1 ownership record naming its
qualified callables, exact pytest nodes, observable outcomes, and essential real
boundaries. The workflow installs only the protected base-revision hash-locked
toolchain, rejects special archive entries, and runs baseline tests and exact
callable mutations in a disposable archive. Scores are observational; custody,
baseline, configuration, timeout, and evidence failures remain blocking.

Rejected alternatives: full-backend mutation, uncalibrated score gating,
PR-selected dependencies, mutable exclusion prose, and mutation in the
contributor checkout.

## Scope and product behavior

No application, migration, product lifecycle, authorization, payment,
reputation, Backend semantic-lane, coverage-floor, or existing test-inventory
behavior changes. `backend/uv.lock` and the protected mutation manifest remain
unchanged. Workstream product review decisions remain `accept`,
`needs_revision`, and `reject`; mutation evidence is engineering process proof.

## Acceptance proof

- Focused policy tests: 39 passed; 90.11-percent module coverage.
- Shared Git primitive and workflow invariants: 12 tests passed.
- Exact rebased pilot: 1,091 generated = 84 killed + 59 survived + 948
  excluded; zero timeout, suspicious, or error; 254.672 seconds.
- Strong calibration killed two representative mutants; weak calibration left
  two representative mutants alive.
- Schema/YAML, Ruff, links, stale scans, and diff checks passed.

## Test delta and CI integrity

No test was removed, skipped, xfailed, deselected, or weakened. The intentional
weak calibration is isolated and required to leave a representative survivor.
Existing Backend and its 78-percent global and protected 90-percent floors are
unchanged. The pilot is independent, read-only, SHA-pinned, credential-safe,
bounded to a 15-minute job/12-minute command, and uploads seven-day evidence.

## Reviewers and external review

Architecture, senior engineering, QA, security, product/ops, CI integrity,
docs, reuse/dedup, and test-delta internal tracks pass after valid findings were
fixed. CodeRabbit and GitHub Actions remain external checks after publication;
their findings are not predeclared complete.

## Remaining risks and follow-up

Hosted runtime and platform behavior must be confirmed on the final PR head.
Equivalent/excluded survivors require human calibration before any blocking
policy. `WS-QUAL-001-05M` is not started or pre-approved by this chunk.

## Human review focus and merge ownership

- Confirm protected-base dependency custody and untrusted PR isolation.
- Confirm target ownership and callable filtering cannot omit changed behavior.
- Inspect hosted runtime and complete outcome reconciliation.
- Confirm no mutation score or existing CI weakening was introduced.

Only the user may approve this specific PR for merge. After merge, stop at the
human calibration checkpoint; do not start `05M` automatically.
