### PR TITLE
WS-ART-001-04C1: close durable lineage planning gap

### DIFF
--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
@@ -33,7 +33,7 @@ they cross multiple L1 boundaries.
 | `WS-ART-001-04B1` | Add the single versioned checker catalogue and compile one effective execution plan from platform defaults plus locked project policy. | L1 | Merged PR #276 |
 | `WS-ART-001-04B2` | Materialize the sealed manifest tree once and execute the mandatory platform/default catalogue phases. | L1 | Merged PR #282 |
 | `WS-ART-001-04B3` | Execute locked project-policy rules through the same plan and persist one bounded immutable evidence set. | L1 | Merged PR #291 as `8f516e6d` |
-| `WS-ART-001-04C1` | Reauthorize and atomically persist capacity plus durable put intent, then write the checked ZIP once. | L1 | Proposed after XINT-06A |
+| `WS-ART-001-04C1` | Reauthorize and atomically persist the evidence-linked submission intent, capacity, and generic put attempt, then write the checked ZIP once. | L1 | Planning correction after merged XINT-06A |
 | `WS-ART-001-04C2` | Reuse verification/recovery to publish one capacity-charged ready admission and compose the hidden continuous endpoint. | L1 | Proposed after 04C1 |
 | `WS-ART-001-05A` | Atomically consume ready admission into one immutable Submission and binding under fresh human/service authority. | L1 | Proposed after XINT-05A |
 | `WS-ART-001-05B` | Atomically cut the live Submission API/dispatch to verified admission and remove the complete legacy standalone/internal precheck and caller-owned package contract. | L1 | Proposed after XINT-05B |

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/PLAN.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/PLAN.md
@@ -400,6 +400,27 @@ or locked-context replacement may instead commit only the terminal stale
 transition and bounded evidence, with no Submission or binding. ART/TASK never
 imports or locks AUTH-owned tables.
 
+The submission producer is not encoded only in generic put-attempt columns or
+an opaque request digest. Before provider I/O, 04C1 persists one immutable,
+foreign-keyed durable intent joining the exact passing pre-submit evidence set
+to the generic put attempt. That intent preserves the actor and identity link,
+project, task, assignment, predecessor identity/version, locked guide/snapshot/
+policy lineage, semantic manifest, archive commitment, effective plan, and
+storage scheme needed for database-only 04C2 publication after process loss.
+Neither scratch state nor a process-local capability is durable lineage, and
+04C2 never reconstructs facts by parsing a request digest.
+
+The normal path consumes a live `PreSubmitPassCapability` and the exact
+`PreparedArtifact` immediately. If a worker dies after immutable passing
+evidence commits but before the durable intent transaction, recovery requires a
+complete fresh upload and checker execution with a new prepared generation,
+evidence identity, and immediate pass capability. An old durable evidence row
+never mints or remints process-local authority. Database uniqueness fences
+concurrent continuation of each live generation to one intent, one capacity
+effect, and one logical provider operation; content-addressed capacity and
+provider storage continue deduplicating identical bytes across later complete
+reuploads.
+
 ## Durable Verification And Recovery
 
 Background jobs have exactly one operation class:

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/PLAN.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/PLAN.md
@@ -411,7 +411,7 @@ Neither scratch state nor a process-local capability is durable lineage, and
 04C2 never reconstructs facts by parsing a request digest.
 
 The normal path consumes a live `PreSubmitPassCapability` and the exact
-`PreparedArtifact` immediately. If a worker dies after immutable passing
+`PreparedArtifact` immediately. If the process terminates after immutable passing
 evidence commits but before the durable intent transaction, recovery requires a
 complete fresh upload and checker execution with a new prepared generation,
 evidence identity, and immediate pass capability. An old durable evidence row

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md
@@ -133,8 +133,10 @@ project-policy execution, durable evidence/admission/Submission write, route
 exposure, provider I/O, or AUTH activation. `WS-ART-001-04B3` merged through
 PR #291 as `8f516e6d`. It executes the project-policy continuation through that
 same plan and sealed tree and persists one immutable platform-plus-project
-evidence set. ART-04C1 remains stopped until AUTH `WS-XINT-002-06A` activates
-the mandatory fixed pre-submit materializer.
+evidence set. AUTH `WS-XINT-002-06A` merged through PR #293 as `1ddb941e` and
+activated only the mandatory fixed pre-submit materializer. ART-04C1 is now
+unblocked; its preimplementation review requires the durable intent correction
+recorded in the current 04C1 contract before runtime implementation.
 
 ## Gate
 

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-04C1-durable-put-intent.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-04C1-durable-put-intent.md
@@ -50,7 +50,7 @@ provider redesign, second recovery aggregate, retention/deletion, or availabilit
 - The shared `ArtifactPutAttempt` producer constraints explicitly admit the
   submission-bundle producer. Generic scanner, verification, and recovery paths
   remain producer-neutral; guide setup continuation must ignore submission
-  attempts and no producer-specific worker path is added.
+  attempts and no producer-specific execution path is added.
 - Exact concurrent continuation of one live prepared generation is fenced by
   durable uniqueness and creates one intent, capacity effect, and logical put
   effect. If a process dies after immutable passing evidence commits but before

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-04C1-durable-put-intent.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-04C1-durable-put-intent.md
@@ -1,6 +1,6 @@
 # Chunk Contract: WS-ART-001-04C1 — Submission Durable Put Intent
 
-Parent initiative: `WS-ART-001` | Risk: L1 | Status: Proposed after XINT-06A
+Parent initiative: `WS-ART-001` | Risk: L1 | Status: Planning correction after XINT-06A
 
 ## Goal
 
@@ -9,8 +9,9 @@ persist one put attempt, and hand the checked ZIP to ArtifactStore once.
 
 ## Allowed Files
 
-Submission producer integration with generic admission/put attempt, typed
-TASK/PROJECT/AUTH seams, hidden orchestration, tests/docs/scoped CI.
+Submission producer integration with generic admission/put attempt, one typed
+durable submission-bundle intent model/migration, typed TASK/PROJECT/AUTH
+seams, hidden orchestration, tests/docs/scoped CI.
 
 ## Not Allowed Changes
 
@@ -19,15 +20,62 @@ provider redesign, second recovery aggregate, retention/deletion, or availabilit
 
 ## Acceptance Criteria
 
-Fresh transaction-local authority and locked actor/assignment/task/predecessor/
-context commit with capacity and put intent before provider I/O; denial/drift
-causes no durable/provider effect; exact replay is single-effect; post-intent
-ambiguity uses existing observation/recovery; scratch never crosses process.
+- A passing execution must present both the exact live `PreparedArtifact` and
+  its single-use process-local `PreSubmitPassCapability`; durable evidence by
+  itself is never mutation authority.
+- 04C1 adds the closed `SubmissionBundleArtifactAdmissionRequest` producer
+  shape and one narrow durable intent. The intent has unique foreign keys to
+  the exact immutable `PreSubmitEvidenceSet` and generic `ArtifactPutAttempt`;
+  it does not duplicate the evidence row's complete lineage. Service-level
+  locked validation requires that evidence to remain `passed` and `eligible`.
+  Those typed joins recover without digest parsing every fact needed by 04C2:
+  actor profile, identity link, project, task, assignment, predecessor
+  identity/version, locked guide, snapshot and policy lineage,
+  semantic-manifest identity/digest, archive digest/size/media type,
+  effective-plan digest, storage scheme, operation identity, and put-attempt
+  identity.
+- TASK/PROJECT typed capabilities lock and revalidate their owned task,
+  assignment, predecessor, guide, snapshot, and locked-policy facts. AUTH owns
+  actor/link/project-authority/action revalidation and supplies only the opaque
+  transaction-bound `PreparedAuthorizationHandle`; ART imports no AUTH
+  repositories and implements no local evaluator.
+- Fresh final authority consumption, the durable submission-bundle intent,
+  capacity reservation, authorization evidence, and generic put attempt commit
+  atomically before provider I/O. Denial or lineage drift creates none of those
+  effects and closes scratch.
+- The transaction commits before the exact prepared ZIP is handed once to the
+  existing `ArtifactStorageOrchestrator`. Provider acknowledgement ambiguity,
+  caller loss, and post-intent replay reuse the existing observation/recovery
+  machinery; no second recovery aggregate or provider write path is added.
+- The shared `ArtifactPutAttempt` producer constraints explicitly admit the
+  submission-bundle producer. Generic scanner, verification, and recovery paths
+  remain producer-neutral; guide setup continuation must ignore submission
+  attempts and no producer-specific worker path is added.
+- Exact concurrent continuation of one live prepared generation is fenced by
+  durable uniqueness and creates one intent, capacity effect, and logical put
+  effect. If a process dies after immutable passing evidence commits but before
+  durable intent, recovery requires a complete fresh upload and checker
+  execution with a new prepared generation, evidence identity, and immediate
+  pass capability. An old durable evidence row never mints or remints a pass
+  capability and old scratch/capability state is never reused.
+- 04C2 must be able to reconstruct the complete publication lineage from
+  PostgreSQL after scratch/process loss; scratch paths, handles, prepared
+  authorization, and opaque request-digest decoding are forbidden.
+- `artifact.submission_bundle.prepare` remains planned and unavailable. 04C1
+  supplies a deny-by-default production adapter plus bounded test authority;
+  XINT-05A alone may activate the production contributor action.
 
 ## Verification Commands
 
-Focused crossed-revocation/admission/put/replay tests, Ruff, hosted gates, 90%
-owned subsystem and 78% repository coverage.
+Focused tests must prove: evidence without a live capability denies; capability
+or generation mismatch denies; revocation and lineage drift deny before any
+durable/provider effect; concurrent continuation creates one intent/charge/
+logical put; pre-intent process loss requires complete reupload/rechecks and a
+new evidence identity; post-intent ambiguity resumes through existing
+observation/recovery; 04C2 lineage reload uses PostgreSQL only; and a provider
+spy observes no read/write before the durable transaction commits. Also run
+the guide-continuation regression proving submission attempts are ignored. Run
+Ruff, hosted gates, 90% owned-subsystem coverage, and the 78% repository gate.
 
 ## Required Reviewers
 

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-04C2-ready-admission-publication.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-04C2-ready-admission-publication.md
@@ -9,8 +9,9 @@ verification and compose the hidden continuous contributor endpoint.
 
 ## Allowed Files
 
-SubmissionBundleAdmission model/migration/repository, verification publication
-integration, bounded Operator projection, hidden route composition, tests/docs/CI.
+SubmissionBundleAdmission model/migration/repository, verified
+`SubmissionBundleDurableIntent` reload, verification publication integration,
+bounded Operator projection, hidden route composition, tests/docs/CI.
 
 ## Not Allowed Changes
 
@@ -19,11 +20,16 @@ candidate storage, review/contribution, or new recovery machinery.
 
 ## Acceptance Criteria
 
-Only verified matching bytes publish ready; lifecycle is ready->consumed|stale;
-actor/link/project/task/assignment/predecessor/context/manifest/evidence lineage
-is immutable; abandoned ready remains charged; exact POST replay returns the
-same operation/admission; 04A2-04C2 run in one request with no serialized local
-handle; fixed pre-submit materializer is active before later live activation.
+Only verified matching bytes publish ready. 04C2 locks and reloads the exact
+`SubmissionBundleDurableIntent`, its passing/eligible `PreSubmitEvidenceSet`,
+generic put attempt, verified content, replica, and receipt as the sole durable
+publication lineage; it never parses an opaque request digest or relies on
+scratch, prepared handles, or process-local capability state. Lifecycle is
+ready->consumed|stale; actor/link/project/task/assignment/predecessor/context/
+manifest/evidence lineage is immutable; abandoned ready remains charged; exact
+POST replay returns the same operation/admission; 04A2-04C2 run in one request
+with no serialized local handle; fixed pre-submit materializer is active before
+later live activation.
 
 ## Verification Commands
 

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-04C1-planning-correction-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-04C1-planning-correction-external-review-response.md
@@ -1,0 +1,30 @@
+# WS-ART-001-04C1 Planning Correction External Review Response
+
+## Comments Addressed
+
+- CodeRabbit completed review with no actionable comments.
+- GitHub Agent Gates identified two `HUMAN_WORKER_VOCABULARY` matches. The
+  crash description now says the process terminates, and the producer boundary
+  now says execution path. The durable behavior and scope are unchanged.
+
+## Comments Deferred
+
+None.
+
+## Human Decisions Needed
+
+None beyond normal PR review and merge ownership.
+
+## Commands Rerun
+
+```text
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+## Remaining Risks
+
+Hosted Agent Gates must pass on the repaired commit. Backend gates already
+passed on the prior planning-only head.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-04C1-planning-correction-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-04C1-planning-correction-pr-trust-bundle.md
@@ -1,0 +1,71 @@
+# WS-ART-001-04C1 Planning Correction PR Trust Bundle
+
+## Chunk
+
+`WS-ART-001-04C1` planning correction only.
+
+## Goal And Human Intent
+
+Make the next ART durable-put chunk implementable without losing the guarantee
+that the checked ZIP, durable storage intent, later verified admission, and
+eventual Submission all refer to the same exact lineage.
+
+## What Changed And Why
+
+Preimplementation review proved the generic `ArtifactPutAttempt` row alone
+could not reconstruct actor, assignment, predecessor, manifest, evidence, and
+locked-policy lineage for 04C2 after process loss. The corrected contract adds
+one narrow `SubmissionBundleDurableIntent` joining the immutable passing
+evidence set to the generic put attempt before provider I/O.
+
+The correction also fixes the pre-intent crash rule: old evidence never remints
+process-local authority; recovery requires complete reupload and checker
+execution with a new prepared generation and evidence identity.
+
+## Design Chosen
+
+- Unique foreign keys from the intent to `PreSubmitEvidenceSet` and
+  `ArtifactPutAttempt`; no duplicate lineage blob or request-digest parsing.
+- Live `PreparedArtifact` plus single-use `PreSubmitPassCapability` remain
+  required for the mutation.
+- Typed TASK/PROJECT locks and opaque AUTH PREP consumption commit with the
+  intent, provisional capacity, authorization evidence, and put attempt.
+- Provider I/O occurs only after commit and reuses existing generic
+  observation/recovery.
+- Production contributor preparation stays unavailable until XINT-05A.
+
+Rejected alternatives were generic metadata, parsing the request digest,
+persisting scratch/handles, reminting authority from evidence, and adding a
+submission-specific recovery path.
+
+## Scope Control And Product Behavior
+
+Changed only ART planning, status, chunk contracts, normative specification,
+and review evidence. No runtime behavior changes. 04C1 still excludes ready
+admission publication, Submission/binding, public routes, review/contribution,
+retention/deletion, provider redesign, and AUTH availability.
+
+## Acceptance Proof And Checks
+
+- `git diff --check`: passed.
+- stale artifact contract scan: passed.
+- Markdown link scan across six changed files: passed.
+- Test delta: none; planning-only.
+- CI integrity: no workflow, command, coverage, or dependency change.
+
+Internal architecture, security/auth, product/ops, QA, senior-engineering, and
+docs plan reviews passed after all material findings were incorporated.
+External CI and CodeRabbit remain pending after PR publication.
+
+## Remaining Risks And Follow-Up
+
+Implementation must keep the intent row narrow, update shared put-attempt
+constraints safely, prove guide continuation ignores submission attempts, and
+demonstrate provider I/O cannot occur before the durable transaction commits.
+After this planning PR merges, implement 04C1; 04C2 remains separate.
+
+## Human Review Focus And Merge Ownership
+
+Confirm the durable intent is necessary and sufficiently narrow, and that the
+crash/replay wording never permits durable evidence to become mutation
+authority. Human approval owns merge; the agent will not merge this PR.

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-04C1-planning-correction-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-04C1-planning-correction-pr-trust-bundle.md
@@ -49,13 +49,16 @@ retention/deletion, provider redesign, and AUTH availability.
 
 - `git diff --check`: passed.
 - stale artifact contract scan: passed.
-- Markdown link scan across six changed files: passed.
+- Markdown link scan across all changed Markdown files: passed.
+- stale authorization documentation scan: passed after replacing two ambiguous
+  human-role uses of “worker” with precise process/execution wording.
 - Test delta: none; planning-only.
 - CI integrity: no workflow, command, coverage, or dependency change.
 
 Internal architecture, security/auth, product/ops, QA, senior-engineering, and
 docs plan reviews passed after all material findings were incorporated.
-External CI and CodeRabbit remain pending after PR publication.
+CodeRabbit completed with no actionable comments. Backend gates passed on the
+initial PR head; hosted Agent Gates are rerun after the wording repair.
 
 ## Remaining Risks And Follow-Up
 

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-04C1-planning-correction-review-evidence.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/reviews/WS-ART-001-04C1-planning-correction-review-evidence.md
@@ -1,0 +1,42 @@
+# WS-ART-001-04C1 Planning Correction Review Evidence
+
+## Scope
+
+Planning-only correction after merged XINT-06A. No runtime, schema, migration,
+route, authorization availability, provider, test, dependency, or CI file is
+changed.
+
+## Deterministic Evidence
+
+```text
+git diff --check
+python3 scripts/check_stale_artifact_contracts.py
+python3 scripts/check_markdown_links.py
+```
+
+All passed. The Markdown link checker covered six changed Markdown files.
+
+Evidence gate: PASS. The diff is documentation-only, inside ART planning/spec
+scope, adds no dependency, changes no test or CI behavior, and does not weaken
+coverage or gates.
+
+## Plan Reviews
+
+- Architecture: initial FAIL because a generic put attempt could not recover
+  complete 04C2 lineage after process loss. Corrected to one narrow,
+  foreign-keyed `SubmissionBundleDurableIntent`; rereview passed with low risk.
+- Security/auth: required explicit proof that old durable evidence never remints
+  a process-local capability. Corrected crash-before-intent semantics; final
+  review passed.
+- Product/operations: passed with low risk; no Submission, review,
+  ContributionRecord, compensation, or reputation effect enters 04C1.
+- QA: passed with low risk after explicit crossed-state, provider-ordering,
+  crash-window, concurrency, and DB-only recovery tests were added to the
+  contract.
+- Senior engineering: passed with low risk after narrowing the intent row to a
+  join/fence, naming the closed request, requiring shared put-attempt constraint
+  updates, and adding the guide-continuation isolation regression.
+- Docs: passed with low risk after updating durable status, the 04C2 handoff,
+  and the normative artifact-storage specification.
+
+No Critical or High findings remain.

--- a/docs/spec_artifact_storage_service.md
+++ b/docs/spec_artifact_storage_service.md
@@ -1235,6 +1235,31 @@ identity, stable codes, counts and categories without submitted paths,
 filenames, scratch/provider references, credentials, raw output or free-form
 messages.
 
+### SubmissionBundleDurableIntent
+
+Before provider I/O, the final preparation transaction persists one immutable
+submission-producer intent linked by foreign keys to the exact passing
+`PreSubmitEvidenceSet` and generic `ArtifactPutAttempt`. It preserves the actor
+and identity link, project, task, assignment, predecessor identity/version,
+locked guide/snapshot/policy lineage, semantic-manifest identity/digest,
+archive digest/size/media type, effective-plan digest, storage scheme, and
+operation identity required for database-only verified-admission publication.
+It is not a bindable admission, Submission, review, or contribution fact.
+
+The intent, transaction-local authorization evidence, provisional capacity
+reservation, and put attempt commit atomically before the prepared ZIP is
+handed to `ArtifactStore`. One-to-one uniqueness on the evidence set and put
+attempt fences concurrent continuation. Recovery and 04C2 reload the typed
+row; they never parse the opaque put-attempt request digest and never depend on
+scratch, a prepared handle, or process-local capability state.
+
+If the process dies before this intent commits, the old evidence row cannot
+mint or remint authority. Recovery requires a complete fresh upload and checker
+execution, which produces a new prepared generation, evidence identity, and
+single-use pass capability. If the process dies after intent commit, the
+existing generic put-attempt observation and recovery machinery owns the
+technical obligation without another submission-specific recovery aggregate.
+
 ### SubmissionBundleAdmission
 
 One immutable verified preparation with closed status:


### PR DESCRIPTION
# WS-ART-001-04C1 Planning Correction PR Trust Bundle

## Chunk

`WS-ART-001-04C1` planning correction only.

## Goal And Human Intent

Make the next ART durable-put chunk implementable without losing the guarantee
that the checked ZIP, durable storage intent, later verified admission, and
eventual Submission all refer to the same exact lineage.

## What Changed And Why

Preimplementation review proved the generic `ArtifactPutAttempt` row alone
could not reconstruct actor, assignment, predecessor, manifest, evidence, and
locked-policy lineage for 04C2 after process loss. The corrected contract adds
one narrow `SubmissionBundleDurableIntent` joining the immutable passing
evidence set to the generic put attempt before provider I/O.

The correction also fixes the pre-intent crash rule: old evidence never remints
process-local authority; recovery requires complete reupload and checker
execution with a new prepared generation and evidence identity.

## Design Chosen

- Unique foreign keys from the intent to `PreSubmitEvidenceSet` and
  `ArtifactPutAttempt`; no duplicate lineage blob or request-digest parsing.
- Live `PreparedArtifact` plus single-use `PreSubmitPassCapability` remain
  required for the mutation.
- Typed TASK/PROJECT locks and opaque AUTH PREP consumption commit with the
  intent, provisional capacity, authorization evidence, and put attempt.
- Provider I/O occurs only after commit and reuses existing generic
  observation/recovery.
- Production contributor preparation stays unavailable until XINT-05A.

Rejected alternatives were generic metadata, parsing the request digest,
persisting scratch/handles, reminting authority from evidence, and adding a
submission-specific recovery path.

## Scope Control And Product Behavior

Changed only ART planning, status, chunk contracts, normative specification,
and review evidence. No runtime behavior changes. 04C1 still excludes ready
admission publication, Submission/binding, public routes, review/contribution,
retention/deletion, provider redesign, and AUTH availability.

## Acceptance Proof And Checks

- `git diff --check`: passed.
- stale artifact contract scan: passed.
- Markdown link scan across six changed files: passed.
- Test delta: none; planning-only.
- CI integrity: no workflow, command, coverage, or dependency change.

Internal architecture, security/auth, product/ops, QA, senior-engineering, and
docs plan reviews passed after all material findings were incorporated.
External CI and CodeRabbit remain pending after PR publication.

## Remaining Risks And Follow-Up

Implementation must keep the intent row narrow, update shared put-attempt
constraints safely, prove guide continuation ignores submission attempts, and
demonstrate provider I/O cannot occur before the durable transaction commits.
After this planning PR merges, implement 04C1; 04C2 remains separate.

## Human Review Focus And Merge Ownership

Confirm the durable intent is necessary and sufficiently narrow, and that the
crash/replay wording never permits durable evidence to become mutation
authority. Human approval owns merge; the agent will not merge this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Submission artifacts now retain durable, evidence-linked lineage before storage begins.
  - Recovery can resume from persisted submission intent instead of relying on temporary process state.
  - Interrupted preparations before persistence require a fresh upload and validation, preventing stale authorization reuse.
  - Concurrent submissions are fenced to prevent generation reuse while still allowing identical content to be deduplicated.

- **Documentation**
  - Updated artifact-storage specifications, acceptance criteria, status records, and review evidence to reflect the new durable submission and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->