### PR TITLE
Reconcile unified project guide compilation plans

### DIFF
--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/CHUNK_MAP.md
@@ -33,12 +33,12 @@ they cross multiple L1 boundaries.
 | `WS-ART-001-04B1` | Add the single versioned checker catalogue and compile one effective execution plan from platform defaults plus locked project policy. | L1 | Merged PR #276 |
 | `WS-ART-001-04B2` | Materialize the sealed manifest tree once and execute the mandatory platform/default catalogue phases. | L1 | Merged PR #282 |
 | `WS-ART-001-04B3` | Execute locked project-policy rules through the same plan and persist one bounded immutable evidence set. | L1 | Merged PR #291 as `8f516e6d` |
-| `WS-ART-001-04C1` | Reauthorize and atomically persist the evidence-linked submission intent, capacity, and generic put attempt, then write the checked ZIP once. | L1 | Planning correction after merged XINT-06A |
+| `WS-ART-001-04C1` | Reauthorize and atomically persist the evidence-linked submission intent, capacity, and generic put attempt, then write the checked ZIP once. | L1 | Ready after merged XINT-06A |
 | `WS-ART-001-04C2` | Reuse verification/recovery to publish one capacity-charged ready admission and compose the hidden continuous endpoint. | L1 | Proposed after 04C1 |
 | `WS-ART-001-05A` | Atomically consume ready admission into one immutable Submission and binding under fresh human/service authority. | L1 | Proposed after XINT-05A |
 | `WS-ART-001-05B` | Atomically cut the live Submission API/dispatch to verified admission and remove the complete legacy standalone/internal precheck and caller-owned package contract. | L1 | Proposed after XINT-05B |
-| `WS-ART-001-06A` | Persist post-submit checker input snapshot and integrity-checking materialization. | L1 | Proposed after 05B |
-| `WS-ART-001-06B` | Store/bind checker outputs and preserve checker-owned routing. | L1 | Proposed after 06A |
+| `WS-ART-001-06A` | Persist post-submit checker input snapshot and materialization bound to the unified compilation and compiled checker plan. | L1 | Proposed after 05B and POL-06B/07 |
+| `WS-ART-001-06B` | Store/bind checker outputs and preserve POL-owned single-port routing. | L1 | Proposed after 06A |
 | `WS-ART-001-07A` | Add lease-scoped exact-binding reviewer packet materialization without review lifecycle ownership. | L1 | Proposed after 06B plus hidden REV manifest |
 | `WS-ART-001-07B` | Bind accepted Submission/ART identity into the CON handoff without provider I/O. | L1 | Proposed after REV acceptance and CON hidden contract |
 | `WS-ART-001-08A` | Prove Local/MinIO product lifecycle through real APIs and durable background services. | L1 | Proposed after 07B |
@@ -56,7 +56,7 @@ AUTH-04B implementation [merged PR #245]
 -> XINT-05A contributor preparation activation
 -> ART-05A
 -> XINT-05B Submission/binding activation
--> ART-05B -> 06A -> 06B
+-> ART-05B -> POL-06B -> POL-07 -> ART-06A -> ART-06B
 -> XINT-06B post-submit/output activation
 -> ART/REV-07A hidden packet contract
 -> XINT-07A packet activation only

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/PLAN.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/PLAN.md
@@ -746,6 +746,8 @@ AUTH-04B implementation/activation [merged PR #245]
 -> ART-05A atomic Submission/binding/admission consumption
 -> XINT-05B Submission/binding activation
 -> ART-05B admission-backed Submission/API/dispatch cutover plus complete legacy precheck removal
+-> POL-06B deterministic unified post-submit projection
+-> POL-07 sole checker service port
 -> ART-06A post-submit checker snapshot/materialization
 -> ART-06B checker output binding and routing
 -> XINT-06B post-submit/output activation

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-06A-checker-input-materialization.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-06A-checker-input-materialization.md
@@ -1,6 +1,6 @@
 # Chunk Contract: WS-ART-001-06A - Checker Input And Materialization
 
-Initiative: `WS-ART-001` | Risk: L1 | Status: Proposed after 05B
+Initiative: `WS-ART-001` | Risk: L1 | Status: Proposed after 05B and POL-06B/07
 
 Artifact contract phase: `submission_cutover`
 
@@ -38,8 +38,11 @@ bounded isolated checker workspaces.
 ## Acceptance Criteria
 
 - `CheckerInputSnapshot` commits to submission version, submission-bundle
-  manifest, exact binding/content IDs, hashes/sizes, locked policy/checker versions, and checker
+  manifest, exact binding/content IDs, hashes/sizes, unified compilation/result,
+  pre/post component and catalogue hashes, compiled checker-plan identity, and checker
   implementation identity;
+- stale pre-unified, mixed-generation, missing-plan, or non-POL-07 lineage
+  fails before materialization;
 - pre-submit evidence and post-submit input prove the same archive commitment,
   semantic-manifest hash, and exact binding;
 - the post-submit runner receives only authorized immutable Workstream binding
@@ -116,3 +119,4 @@ reuse/dedup, CI integrity, test delta, and docs.
 - Is materialization bounded, isolated, and integrity checked?
 - Can any post-submit path bypass the exact materializer already used by
   pre-submit or leave a writable/orphaned workspace?
+- Does every materialization consume the POL-07 single-port compiled plan?

--- a/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-06B-checker-output-routing.md
+++ b/.agent-loop/initiatives/WS-ART-001-immutable-artifact-storage/chunks/WS-ART-001-06B-checker-output-routing.md
@@ -1,6 +1,6 @@
 # Chunk Contract: WS-ART-001-06B Checker Output And Post-Submit Routing
 
-Initiative: `WS-ART-001` | Risk: L1 | Status: Proposed after 06A
+Initiative: `WS-ART-001` | Risk: L1 | Status: Proposed after 06A and POL-07
 
 Artifact contract phase: `checker_cutover`
 
@@ -54,8 +54,10 @@ lease, assignment, or decision.
   only when expired; slow-active, cancellation, and crash cases are tested;
 - non-reproducible crash replay fails the old checker attempt and uses a new
   attempt identity;
-- the project `PostSubmitCheckerPolicy` selects project checks and non-bypassable
-  Workstream defaults remain included;
+- the exact unified compilation post-submit component and POL-07 compiled plan
+  select project checks; non-bypassable Workstream defaults remain included;
+- output facts retain compilation/result/component/catalogue/plan hashes;
+  stale pre-unified, mixed-generation, or out-of-plan output denies;
 - transient provider failure keeps `evaluation_pending` and uses checker
   infrastructure retry; it creates no product decision;
 - after checker outputs and completion facts commit atomically, the existing
@@ -115,3 +117,4 @@ reuse/dedup, CI integrity, test delta, and docs.
 - Are checker outputs bound to the exact run and independently verified?
 - Can infrastructure failure ever become contributor blame?
 - Is the WS-REV ownership boundary preserved?
+- Is POL-07 the sole routing port with no caller-selected checker path?

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -63,7 +63,7 @@ stopped.
 | `WS-AUTH-001-12` | Project Mutation Cutover Planning Parent | L1 | Split before runtime implementation after failed L1 review |
 | `WS-AUTH-001-12A` | Project Mutation Catalogue And PREP Foundation | L1 | Merged as PR #226 with AUTH `0041`; zero activation |
 | `WS-AUTH-001-12B` | Fixed Project Setup Service Foundation | L1 | Merged through PR #227; identity/matrix registration only, zero activation |
-| `WS-AUTH-001-12B2` | Project Setup Service Runtime Cutover | L1 | Proposed after 12E, 12F4, and 12G |
+| `WS-AUTH-001-12B2` | Unified Setup Ledger Activation | L1 | Proposed after hidden POL-04A and AUTH-12I; before POL-04B live cutover |
 | `WS-AUTH-001-12C` | Project Creation Cutover | L1 | Merged through PR #229 |
 | `WS-AUTH-001-12D` | Draft Guide And Source Metadata Cutover | L1 | Merged through PR #232 |
 | `WS-AUTH-001-12D2` | Review And Revision Policy Mutation Separation | L1 | Superseded by merged XINT-003-02A/02B; economic policy remains CON-owned |
@@ -71,10 +71,11 @@ stopped.
 | `WS-AUTH-001-12F` | Submission Artifact Policy Planning Parent | L1 | Split after failed L1 pre-start review; zero activation |
 | `WS-AUTH-001-12F1` | Submission Policy Authority Foundation | L1 | Merged through PR #286; zero activation |
 | `WS-AUTH-001-12F2` | Manual Submission Policy Drafts | L1 | Merged through PR #292 as `81f281bd` |
-| `WS-AUTH-001-12F3` | Fixed-Service Policy Derivation | L1 | PR #295; external checks pending |
-| `WS-AUTH-001-12F4` | Submission Policy Approval Chain | L1 | Proposed after 12F3 |
-| `WS-AUTH-001-12G` | Post-Submit Checker Policy Mutation Cutover | L1 | Proposed after 12F4 |
-| `WS-AUTH-001-12H` | Guide Activation Cutover | L1 | Proposed after 12B2 and the owning CON clean cut |
+| `WS-AUTH-001-12F3` | Transitional Fixed-Service Policy Derivation | L1 | Merged through PR #295 as `99c0aaf0`; superseded at POL-04B live cutover |
+| `WS-AUTH-001-12I` | Unified Compilation Request/Execute Activation | L1 | Proposed after hidden POL-03A; before POL-03B |
+| `WS-AUTH-001-12F4` | Unified Pre-Submit Approval Activation | L1 | Proposed after hidden POL-05A; before POL-05B |
+| `WS-AUTH-001-12G` | Unified Post-Submit Projection Activation | L1 | Proposed after hidden POL-06A; zero model calls |
+| `WS-AUTH-001-12H` | Unified Guide Activation Cutover | L1 | Proposed after POL-06B/07 and complete approved unified lineage |
 | `WS-AUTH-001-13` | Task Management And Assignment Cutover | L1 | Proposed |
 | `WS-AUTH-001-14` | Submission, Checker, And Audit Visibility Cutover | L1 | Proposed |
 | `WS-AUTH-001-15` | Remaining Internal Service Cutover And Obsolete Authority Removal | L1 | Proposed |
@@ -92,10 +93,10 @@ feature manifest exists, then requires a separate explicit start.
 | `WS-AUTH-001-ART-02D-INTERNAL` | ART 02D Internal Action Activation | L1 | Feature-gated |
 | `WS-AUTH-001-ART-02D-OPERATOR` | ART 02D Operator Read/Status And Independently Evaluated Retry Activation | L1 | Feature-gated |
 | `WS-AUTH-001-ART-03` | ART 03 Guide Source Action Activation | L1 | Feature-gated |
-| `WS-XINT-002-06A` | Pre-Submit Materialization Activation | L1 | After merged ART-04B3/AUTH-12F2; before ART-04C1 and 05A |
+| `WS-XINT-002-06A` | Pre-Submit Materialization Activation | L1 | Merged through PR #293; ART-04C1 is its next ART consumer |
 | `WS-XINT-002-05A` | Submission Bundle Preparation Activation | L1 | Feature-gated on complete ART-04A1-04C2 hidden behavior and 06A |
 | `WS-XINT-002-05B` | Submission Binding Activation | L1 | Feature-gated on hidden ART-05A |
-| `WS-XINT-002-06B` | Post-Submit Materialization And Checker Output Activation | L1 | Feature-gated on ART-06A/06B |
+| `WS-XINT-002-06B` | Post-Submit Materialization And Checker Output Activation | L1 | Feature-gated on POL-06B/07 unified plan plus ART-06A/06B evidence |
 | `WS-AUTH-001-REV-05` | REV 05 Queue Read Activation | L1 | Feature-gated |
 | `WS-AUTH-001-REV-06` | REV 06 Claim Lease And Expiry Activation | L1 | Feature/service-gated |
 | `WS-AUTH-001-REV-07` | REV 07 Context Chain And Finding Evidence Activation | L1 | Feature/ART-gated |
@@ -155,12 +156,14 @@ WS-AUTH-001-PLAN
 -> WS-AUTH-001-12F1
 -> WS-AUTH-001-12F2
 -> WS-AUTH-001-12F3
--> WS-AUTH-001-12F4
--> WS-AUTH-001-12G
--> WS-AUTH-001-12B2
--> WS-AUTH-001-12H
+-> WS-POL-003-01 -> 02 -> 03A
+-> WS-AUTH-001-12I -> WS-POL-003-03B -> 04A
+-> WS-AUTH-001-12B2 -> WS-POL-003-04B -> 05A
+-> WS-AUTH-001-12F4 -> WS-POL-003-05B -> 06A
+-> WS-AUTH-001-12G -> WS-POL-003-06B -> 07
+-> WS-AUTH-001-12H -> WS-POL-003-08
 -> WS-AUTH-001-13
--> WS-AUTH-001-14
+-> ART/XINT submission and checker gates -> WS-AUTH-001-14
 -> WS-AUTH-001-15
 -> all registration/activation chunks whose feature surfaces have merged
 -> WS-AUTH-001-16
@@ -169,6 +172,9 @@ WS-AUTH-001-PLAN
 ## Boundary notes
 
 - Chunk 02 authenticates tokens but grants no product authority.
+- `WS-POL-003` owns unified guide compilation and product orchestration. AUTH
+  owns only catalogue/evaluator/PREP activation and evidence. Hidden behavior
+  precedes each AUTH activation; live cutover follows it.
 - Chunk 03 provides a supported classification gate before schema migration.
 - Parent chunk 04 was split before implementation. Chunk 04A establishes
   request/correlation and additive error compatibility; chunk 04B later owns

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/DECISIONS.md
@@ -861,3 +861,26 @@ result is usable only when its acknowledgement has the complete merged 12E
 actor, identity-link, grant, action, decision, scope, report, snapshot, and
 setup-generation custody. The legacy role-string acknowledgement is not
 authority.
+
+## D38: WS-POL-003 owns unified guide compilation; AUTH owns only gates
+
+Status: accepted planning correction on 2026-08-08.
+
+One logical/provider attempt produces one immutable result containing guide
+sufficiency plus artifact, pre-submit, and post-submit policy proposals before
+any Project Manager approval. Approval never invokes inference. Post-submit
+policy is a deterministic projection of that stored result and performs zero
+model calls.
+
+Merged AUTH-12E and AUTH-12F3 remain valid transitional authority and
+provenance foundations. Their separate inference entry points become
+unreachable at `WS-POL-003-04B` and are physically removed at
+`WS-POL-003-08`. Future AUTH chunks activate only already-hidden POL behavior:
+12I compilation request/execute, 12B2 setup-ledger mutation, 12F4 pre-submit
+approval, 12G post-submit projection, and 12H terminal activation.
+
+External I/O uses pre-I/O authorization plus a committed attempt/idempotency
+reservation. No database transaction or prepared handle spans provider I/O.
+Accepted output receives fresh result-bound PREP authority for persistence.
+This decision supersedes D35/D36 only where they describe separate future
+inference passes or AUTH ownership of product orchestration.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/PLAN.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/PLAN.md
@@ -206,16 +206,17 @@ proving the same issuer role metadata alone no longer authorizes.
     10C activates PREP-bound issue/revoke mutations and concurrency proof.
 13. Cut project identity, guide, source, and visibility queries over to local
    permissions.
-14. Treat AUTH-12 as a planning-only parent. Its ordered children register
-    exact mutation/PREP contracts, establish a zero-activation fixed setup
-    identity, cut project/guide/sufficiency/policy families separately, leave
-    retired guide-bound economic policy to CON ownership, cut the Celery call
-    graph only after its product actions are active, and finish with guide
-    activation only after the owning CON clean cut. ART-owned `0040` is now
-    merged; the first AUTH migration is allocated from that trusted head.
+14. Treat AUTH-12 as a planning-only parent. Merged 12E and 12F3 are
+    transitional authority/provenance foundations, not the final product call
+    graph. `WS-POL-003` owns one unified compilation attempt and every product
+    projection. AUTH-12I activates only the hidden request/execute boundary;
+    12B2, 12F4, 12G, and 12H are narrow activation/cutover gates after their
+    hidden POL behavior exists. No AUTH chunk owns agent orchestration or a
+    second inference path.
 15. Cut task management, queue, assignment, claim, and start operations over.
-16. Cut submission, pre-submit, checker trigger/read, and task audit visibility
-    over.
+16. Activate admission-backed submission authority, bounded checker
+    read/repair, and audit visibility only after ART/POL hidden behavior exists;
+    never add a standalone precheck or caller-selected checker trigger.
 17. Cut remaining internal services over, verify the project-setup cutover,
     remove old runtime authority, and enforce a
     deterministic stale-authority scanner.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/RISKS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/RISKS.md
@@ -15,10 +15,10 @@ merge and activate their exact actions.
 - Agent-backed setup operations deliberately break transactions around external
   work. Carrying PREP across that boundary would make stale authority usable;
   runtime children require fresh terminal authorization.
-- The Celery setup service currently fabricates human roles. 12B provisions one
-  exact fixed identity with four planned memberships; 12B2 performs the runtime
-  cut only after 12E/12F2/12F3/12F4/12G own the complete manual and
-  fixed-service product actions and provenance.
+- Historical AUTH-12 risk context: the Celery setup service fabricated human
+  roles and 12B provisioned one fixed identity. D38/`CHUNK_MAP.md` supersede the
+  old 12B2 sequence: POL-04A hidden behavior precedes 12B2 ledger activation,
+  and POL-04B owns the live one-call cutover.
 - ART-03B2 migration `0040` is merged on trusted main. AUTH-12 must allocate
   the next revision from that exact head and must not reuse `0040`.
 
@@ -48,8 +48,8 @@ merge and activate their exact actions.
 | A10 | Approval provenance breaks | Existing policy activation becomes unreadable or forgeable | Preserve historical values; new actions reference matched local grant | Migration and project approval tests |
 | A11 | API namespace forks | Client and documentation drift | Adopt `/api/v1` only and update references together | Route/OpenAPI and stale-reference scan |
 | A12 | Existing intake regresses | Project/task/checker pipeline stops | Run full current suite and API drill after actor migration and each cutover surface | Existing backend suite and live drill |
-| A13 | Auth initiative becomes one oversized PR | Review failure and hidden coupling | Sixteen bounded implementation chunks, one active at a time | Circuit-breaker and PR-size evidence |
-| A14 | Later WS-POL work resumes on obsolete auth | Rework and inconsistent authority | Keep WS-POL-002-04 inactive until PR #90 merges, auth proof exists, and the user starts it | Loop-memory gate |
+| A13 | Auth initiative becomes one oversized PR | Review failure and hidden coupling | Bounded executable child chunks, one active at a time | Circuit-breaker and PR-size evidence |
+| A14 | Later WS-POL work resumes the obsolete standalone derivation path | Rework, extra model calls, and inconsistent policy lineage | WS-POL-003 is current authority; POL-002-04 consumes the unified component only | Zero-call and stale-path scanner proof |
 | A15 | Authority mutation ships before durable evidence | Missing provenance cannot be reconstructed | Introduce correlation/idempotency/shared audit with canonical actor persistence | Atomic state+idempotency+event tests in every authority chunk |
 | A16 | Identity-link revocation strands final administrator | Administrative lockout despite active grant row | Apply AuthorityControl lock to link revoke plus grant/profile changes | Mixed concurrent link/grant/profile final-admin tests |
 | A17 | Canonical actor migration deletes typed-profile workflow eligibility before task/submission cutover | An intermediate merged release cannot claim, start, or submit work | Bounded non-authoritative workflow-eligibility adapter in chunk 06; remove task consumers in 13 and final consumer plus adapter in 14 | Full suite/API drill after chunks 06, 13, 14, and scanner proof in 15 |
@@ -69,6 +69,9 @@ merge and activate their exact actions.
 | A31 | Service provisioning crosses inverse actor/link locks | Administrative and lifecycle mutations deadlock or admit stale authority | Canonical AuthorityControl -> profile -> exact link -> exact grant order before fixed-identity and issuer/subject advisory locks | Independent-session same-key, identity collision, revoke/lifecycle crossing, rollback, and no-deadlock proof |
 | A32 | Sensitive authorization reads have no dedicated abuse control or leak resource existence through errors | Enumeration, privacy breach, or cross-project intelligence disclosure | Add one durable `authorization_read` scope before routes; map only the three read actions to one audited not-found boundary | Migration/concurrency/rate tests plus identical-response and persisted-denial-evidence tests |
 | A33 | Pagination cursors replay across actions, projects, or filters | Hidden rows disclose or pagination crosses authority scope | Distinct required 32-byte HMAC key, canonical versioned payload, complete query binding, and constant-time verification | Tamper, cross-scope/filter/limit, equal-boundary, no-gap, and no-query tests |
+| A34 | AUTH activates before hidden feature behavior exists | Deny-only or alternate live path | Hidden POL/ART manifest, then narrow AUTH activation, then live owner cutover | Dependency and availability-delta proof |
+| A35 | Prepared authority or a database transaction spans model/provider I/O | Lock exhaustion, stale authority, or replay ambiguity | Pre-I/O authorization plus committed attempt reservation; fresh result-bound PREP after I/O | Timeout/cancellation/revocation/cross-transaction tests |
+| A36 | Separate approval restarts inference or accepts an incomplete result | Policy components drift across one guide generation | Persist all four components before approval; approvals only project stored components | One-attempt and zero-approval-call proof |
 
 ## Required reviewers
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -181,7 +181,7 @@ with explicit path scope, commands, and named reviewers before human start.
 | `WS-AUTH-001-12C` | Merged | `codex/ws-auth-001-12c-project-create` | #229 | System-scoped project creation cutover merged as `67f2c14b`. |
 | `WS-AUTH-001-12D` | Merged | `codex/ws-auth-001-12d-guide-draft-source` | #232 | Draft guide and source metadata mutation cutover merged as `99dc0b34`. |
 | `WS-AUTH-001-12D2` | Superseded | - | #248 | XINT-003-02A/02B own immutable review/revision policy lineage and the sole authorized mutation path; 02B merged as `25fc27c4`. |
-| `WS-AUTH-001-12E` | Merged | `codex/ws-auth-001-12e-guide-sufficiency` | #263 | Three guide-sufficiency actions plus fixed setup-service run PREP merged as `b510bc4f`. |
+| `WS-AUTH-001-12E` | Merged; transitional | `codex/ws-auth-001-12e-guide-sufficiency` | #263 | Merged as `b510bc4f`; projection custody remains reusable, but the standalone inference entry point becomes unreachable at POL-04B and is deleted at POL-08. |
 | `WS-AUTH-001-12F` | Planning split | `codex/ws-auth-001-12f-submission-artifact-policy` | - | Combined contract failed required L1 pre-start review; parent now activates nothing and delegates to 12F1-12F4. |
 | `WS-AUTH-001-12F1` | Merged | `codex/ws-auth-001-12f1-submission-policy-foundation` | #286 | Submission-policy PREP, replay, provenance, and audit custody foundation merged as `5a4186cc`; zero activation. |
 | `WS-AUTH-001-12F2` | Merged | `codex/ws-auth-001-12f2-manual-submission-policy` | #292 | Governed Project Manager append-only manual-draft create/update cutover merged as `81f281bd`. |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -124,14 +124,16 @@ setup-run binding findings were repaired.
 
 ## Active implementation chunk
 
-`WS-AUTH-001-12F3`; implementation and required internal reviews are complete.
-The fixed setup-service derivation cutover is ready for hosted CI and external
-review. `WS-AUTH-001-12F4` remains proposed and must not start before 12F3 is
-human-merged.
+None. Planning reconciliation is active after merged PR #295. No runtime chunk
+may start until the unified `WS-POL-003` dependency graph and remaining AUTH,
+ART, XINT, REV, and downstream contracts are reviewed and merged.
+The concise new 12I/12B2/12F4/12G/12H records are dependency skeletons, not
+implementation authority; each requires a then-current executable contract
+with explicit path scope, commands, and named reviewers before human start.
 
 ## Current review branch
 
-`codex/ws-auth-001-12f3-service-derivation`.
+`codex/ws-pol-003-auth-plan-reconciliation`.
 
 ## Chunk status
 
@@ -175,7 +177,7 @@ human-merged.
 | `WS-AUTH-001-12` | Planning repair | `codex/ws-auth-001-12-project-mutation-cutover` | - | Combined runtime contract rejected; planning parent split into 12A-12H plus 12B2/12D2 before code. |
 | `WS-AUTH-001-12A` | Merged | `codex/ws-auth-001-12a-project-mutation-catalogue` | #226 | Exact 18-action planned catalogue, typed resource/PREP scope, and migration `0041`; merged as `64dd9c98` with zero activation. |
 | `WS-AUTH-001-12B` | Merged | `codex/ws-auth-001-12b-project-setup-service` | #227 | Fixed project-setup service identity and planned matrix only; zero activation and no actor/link seed. |
-| `WS-AUTH-001-12B2` | Proposed | - | - | Final Celery call-graph cutover after 12E, 12F4, and 12G activate the exact product actions. |
+| `WS-AUTH-001-12B2` | Proposed | - | - | Setup-ledger activation after hidden POL-04A; POL-04B owns the live worker cutover. |
 | `WS-AUTH-001-12C` | Merged | `codex/ws-auth-001-12c-project-create` | #229 | System-scoped project creation cutover merged as `67f2c14b`. |
 | `WS-AUTH-001-12D` | Merged | `codex/ws-auth-001-12d-guide-draft-source` | #232 | Draft guide and source metadata mutation cutover merged as `99dc0b34`. |
 | `WS-AUTH-001-12D2` | Superseded | - | #248 | XINT-003-02A/02B own immutable review/revision policy lineage and the sole authorized mutation path; 02B merged as `25fc27c4`. |
@@ -183,10 +185,11 @@ human-merged.
 | `WS-AUTH-001-12F` | Planning split | `codex/ws-auth-001-12f-submission-artifact-policy` | - | Combined contract failed required L1 pre-start review; parent now activates nothing and delegates to 12F1-12F4. |
 | `WS-AUTH-001-12F1` | Merged | `codex/ws-auth-001-12f1-submission-policy-foundation` | #286 | Submission-policy PREP, replay, provenance, and audit custody foundation merged as `5a4186cc`; zero activation. |
 | `WS-AUTH-001-12F2` | Merged | `codex/ws-auth-001-12f2-manual-submission-policy` | #292 | Governed Project Manager append-only manual-draft create/update cutover merged as `81f281bd`. |
-| `WS-AUTH-001-12F3` | External checks | `codex/ws-auth-001-12f3-service-derivation` | #295 | Fixed setup-service derivation and asynchronous executor cutover; internal L1 reviews passed. |
-| `WS-AUTH-001-12F4` | Proposed | - | - | Project Manager approval and atomic effective/pre-submit policy chain. |
-| `WS-AUTH-001-12G` | Proposed | - | - | Post-submit checker policy approval/correction cutover after 12F4. |
-| `WS-AUTH-001-12H` | Proposed | - | - | Terminal guide activation after 12B2 and the owning CON clean cut. |
+| `WS-AUTH-001-12F3` | Merged; transitional | `codex/ws-auth-001-12f3-service-derivation` | #295 | Merged as `99c0aaf0`; authority/provenance is reused, while its separate inference entry point is removed at POL-04B. |
+| `WS-AUTH-001-12I` | Proposed | - | - | Activates hidden unified compilation request/execute only. |
+| `WS-AUTH-001-12F4` | Proposed | - | - | Activates approval of the stored unified pre-submit component; no inference. |
+| `WS-AUTH-001-12G` | Proposed | - | - | Activates deterministic stored post-submit projection; zero model calls. |
+| `WS-AUTH-001-12H` | Proposed | - | - | Activates only a complete approved unified guide lineage. |
 | `WS-AUTH-001-13` | Proposed | - | - | Task management and assignment cutover. |
 | `WS-AUTH-001-14` | Proposed | - | - | Submission/checker/audit visibility cutover. |
 | `WS-AUTH-001-15` | Proposed | - | - | Remaining internal service and obsolete authority removal. |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -177,7 +177,7 @@ with explicit path scope, commands, and named reviewers before human start.
 | `WS-AUTH-001-12` | Planning repair | `codex/ws-auth-001-12-project-mutation-cutover` | - | Combined runtime contract rejected; planning parent split into 12A-12H plus 12B2/12D2 before code. |
 | `WS-AUTH-001-12A` | Merged | `codex/ws-auth-001-12a-project-mutation-catalogue` | #226 | Exact 18-action planned catalogue, typed resource/PREP scope, and migration `0041`; merged as `64dd9c98` with zero activation. |
 | `WS-AUTH-001-12B` | Merged | `codex/ws-auth-001-12b-project-setup-service` | #227 | Fixed project-setup service identity and planned matrix only; zero activation and no actor/link seed. |
-| `WS-AUTH-001-12B2` | Proposed | - | - | Setup-ledger activation after hidden POL-04A; POL-04B owns the live worker cutover. |
+| `WS-AUTH-001-12B2` | Proposed | - | - | Setup-ledger activation after hidden POL-04A; POL-04B owns the live setup-service cutover. |
 | `WS-AUTH-001-12C` | Merged | `codex/ws-auth-001-12c-project-create` | #229 | System-scoped project creation cutover merged as `67f2c14b`. |
 | `WS-AUTH-001-12D` | Merged | `codex/ws-auth-001-12d-guide-draft-source` | #232 | Draft guide and source metadata mutation cutover merged as `99dc0b34`. |
 | `WS-AUTH-001-12D2` | Superseded | - | #248 | XINT-003-02A/02B own immutable review/revision policy lineage and the sole authorized mutation path; 02B merged as `25fc27c4`. |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12-project-mutation-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12-project-mutation-cutover.md
@@ -37,12 +37,16 @@ P1
 
 The current unified-compilation delta is owned by 12I:
 
-| Surface | ActionId | Principal |
-|---|---|---|
-| asynchronous request/recovery | `project.guide_compilation.request` | covered Project Manager |
-| fixed-service execution/persistence | `project.guide_compilation.execute` | `workstream.project.setup` |
+| Surface | ActionId | PermissionId | ActionOwner | Principal | Resource/PREP and proof | Child |
+|---|---|---|---|---|---|---|
+| asynchronous request/recovery | `project.guide_compilation.request` | `project.guide_compilation.request` | `WS-AUTH-001-12I` | covered Project Manager | Exact actor/link/grant, project/guide/source, setup generation, operation/request/idempotency; dispatch-only evidence | 12I |
+| fixed-service execution/persistence | `project.guide_compilation.execute` | `project.guide_compilation.execute` | `WS-AUTH-001-12I` | `workstream.project.setup` | Exact service profile/link/matrix, canonical input/catalogues, setup generation, attempt/provider key, result-bound two-stage PREP; no handle/transaction across I/O | 12I |
 
-Rows below for 12E/12F3/legacy 12G derivation are transitional history.
+## Historical and transitional inventory
+
+The table below records the original AUTH-12 split; it is not the active
+future inventory. Rows for 12E, 12F3, and legacy 12G derivation are
+non-activatable transitional history.
 POL-04B removes their inference entry points from live reachability; POL-08
 deletes them. Remaining 12G is deterministic projection/approval only.
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12-project-mutation-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12-project-mutation-cutover.md
@@ -4,8 +4,9 @@
 
 Planning-only parent. Required L1 review rejected the inherited combined
 runtime contract before application-code edits. Runtime work is split into
-12A through 12H plus 12B2 and 12D2, and each child requires its own reviewed
-start.
+12A through 12I plus 12B2 and 12D2. The inventory and order below record the
+original split and merged transitional actions; D38 and `CHUNK_MAP.md`
+supersede its future inference/cutover sequence. It is not executable.
 
 ## Parent initiative
 
@@ -34,6 +35,17 @@ P1
 
 ## Exact mutation inventory
 
+The current unified-compilation delta is owned by 12I:
+
+| Surface | ActionId | Principal |
+|---|---|---|
+| asynchronous request/recovery | `project.guide_compilation.request` | covered Project Manager |
+| fixed-service execution/persistence | `project.guide_compilation.execute` | `workstream.project.setup` |
+
+Rows below for 12E/12F3/legacy 12G derivation are transitional history.
+POL-04B removes their inference entry points from live reachability; POL-08
+deletes them. Remaining 12G is deterministic projection/approval only.
+
 | Surface / handler | ActionId | PermissionId | ActionOwner | Principal | Child |
 |---|---|---|---|---|---|
 | `POST /api/v1/projects` / `create_project` | `project.create` | `project.create` | `WS-AUTH-001-12C` | system-scoped Project Manager | 12C |
@@ -59,7 +71,9 @@ The hidden ART ingest route and `artifact.guide_source.ingest` are already
 active under `WS-XINT-002-04A` and are frozen outside AUTH-12. ART binding/read,
 provider access, extraction, and later ART activation remain outside AUTH-12.
 
-## Child order
+## Historical child order
+
+Superseded for all remaining work by D38 and `CHUNK_MAP.md`.
 
 1. 12A registers all eighteen actions as planned, adds exact typed resource
    contracts, and adds PostgreSQL action-evidence parity in the next revision

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12B2-project-setup-service-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12B2-project-setup-service-cutover.md
@@ -1,98 +1,41 @@
-# Chunk Contract: WS-AUTH-001-12B2 — Project Setup Service Runtime Cutover
+# Chunk Contract: WS-AUTH-001-12B2 - Unified Setup Ledger Activation
 
-## Status and prerequisite
-
-Proposed and inactive. 12B, 12E, 12F4, and 12G must be merged.
-
-## Parent initiative
-
-`WS-AUTH-001` — Workstream Authorization Service
+Status: Proposed after hidden WS-POL-003-04A; inactive. Risk: L1.
 
 ## Goal
 
-Activate `project.setup_run.update` and cut both Celery setup entry points to
-the fixed `workstream.project.setup` identity after every product action they
-invoke is active for that identity.
-
-## Why this chunk exists
-
-Registering the service identity early avoids invented authority, but switching the
-call graph early would duplicate or bypass sufficiency and policy provenance.
-
-## Risk class
-
-L1
-
-## SLA
-
-P1
+Activate only `project.setup_run.update` and its fixed-service adapter for the
+reviewed unified worker manifest. POL-04B, not AUTH, owns the live one-call
+Celery call-graph cutover.
 
 ## Allowed files
 
-```text
-backend/app/modules/authorization/catalogue.py
-backend/app/modules/authorization/kernel.py
-backend/app/modules/authorization/prepared.py
-backend/app/modules/authorization/runtime.py
-backend/app/modules/projects/authorization_reads.py
-backend/app/modules/projects/repository.py
-backend/app/modules/projects/service.py
-backend/app/modules/projects/setup_queue.py
-backend/app/workers/project_setup.py
-backend/tests/test_authorization.py
-backend/tests/test_projects.py
-backend/scripts/api_contract_e2e.py
-docs/spec_authorization_service.md
-docs/operations_authorization_service.md
-.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/**
-```
+AUTH catalogue/kernel/PREP/runtime, narrow setup-ledger authorization adapter,
+focused authorization/POL integration tests, specifications, and AUTH memory.
 
-## Not allowed changes
+## Not allowed
 
-New service identity, new product action, human route behavior, generic setup
-authority, serialized handles, ART/checker/review/contribution behavior, or
-issuer-claim compatibility.
+Worker routing, agent orchestration, model calls, policy/compiler behavior,
+human routes, generic setup authority, serialized handles, ART/checker/review/
+contribution behavior, or compatibility paths.
 
-## Acceptance criteria
+## Acceptance
 
-- 12B, 12E, 12F4, and 12G must be merged. The fixed identity has active
-  sufficiency-run, submission-policy-derive, and post-submit-policy-derive
-  memberships before either Celery entry point changes.
-- 12B2 activates `project.setup_run.update` and verifies its fixed-service
-  membership before either Celery entry point changes; no setup-ledger mutation
-  occurs before that activation.
-- `project.setup_run.update` alone covers setup context validation, task-id and
-  status changes, continuation start, output-id persistence, terminal errors,
-  and enqueue-failure persistence. Product rows retain their owning
-  12E/12F2/12F3/12F4/12G actions and provenance.
-- Celery payloads carry durable IDs/generation facts only. Each product or
-  ledger mutation resolves fresh service context and consumes fresh PREP in its
-  own root transaction after exact canonical locks.
-- No handle crosses Celery, agent calls, rollback, commit, session, or
-  transaction. Wrong/stale/cross-resource IDs, revoked service, replay, copied
-  handle, and partial failure deny or roll back without mixed provenance.
-- The fabricated human-management ActorContext is removed from the full call
-  graph, and static scanning proves no setup mutation uses it.
-- Changed authorization/project/setup-service modules remain at least 90
-  percent covered. Final pushed head SHA passes `Backend / test` and
-  `Agent Gates`.
+- Activate `project.setup_run.update` only for fixed
+  `workstream.project.setup`; no human or unrelated service receives it.
+- Bind exact project/guide/source, setup run/generation, compilation attempt,
+  canonical input/result identity, deterministic task/correlation identity,
+  expected step/transition, operation, request, session, and transaction.
+- Product projections retain their separate 12E/12F/12G actions. Setup-ledger
+  authority never authorizes a projection row or provider call.
+- The hidden POL-04A manifest proves this authority is sufficient for its exact
+  ledger transition. POL-04B alone proves live worker reachability and removal
+  of the three legacy inference calls.
+- No handle crosses Celery, commit, rollback, provider I/O, session, or
+  transaction; stale/replay/cross-resource/cross-step uses deny.
 
-## Verification commands
+## Verification and review
 
-Before start, freeze exact isolated-runner, coverage, Celery payload/rollback,
-all-pairs service denial, stale-doc, Ruff, API drill, link, and diff commands.
-
-## Required reviewers
-
-Senior engineering, QA/test, security/auth, product/ops, architecture, CI
-integrity, docs, reuse/dedup, and test delta.
-
-## Human review focus
-
-No duplicated product authority, exact setup ledger ownership, fresh per-step
-authorization, and complete removal of fabricated human authority.
-
-## Stop conditions
-
-Stop if any called product action is unavailable, a handle must cross an
-external boundary, or setup-run authority would own a product row.
+All-pairs service denial, PREP/transition binding, command manifest, POL-04A
+hidden integration, hosted coverage, and all L1 tracks. Human
+focus: ledger authority only; POL owns the cutover.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12B2-project-setup-service-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12B2-project-setup-service-cutover.md
@@ -5,7 +5,7 @@ Status: Proposed after hidden WS-POL-003-04A; inactive. Risk: L1.
 ## Goal
 
 Activate only `project.setup_run.update` and its fixed-service adapter for the
-reviewed unified worker manifest. POL-04B, not AUTH, owns the live one-call
+reviewed unified setup-service manifest. POL-04B, not AUTH, owns the live one-call
 Celery call-graph cutover.
 
 ## Allowed files
@@ -15,7 +15,7 @@ focused authorization/POL integration tests, specifications, and AUTH memory.
 
 ## Not allowed
 
-Worker routing, agent orchestration, model calls, policy/compiler behavior,
+Fixed-service routing, agent orchestration, model calls, policy/compiler behavior,
 human routes, generic setup authority, serialized handles, ART/checker/review/
 contribution behavior, or compatibility paths.
 
@@ -29,7 +29,7 @@ contribution behavior, or compatibility paths.
 - Product projections retain their separate 12E/12F/12G actions. Setup-ledger
   authority never authorizes a projection row or provider call.
 - The hidden POL-04A manifest proves this authority is sufficient for its exact
-  ledger transition. POL-04B alone proves live worker reachability and removal
+  ledger transition. POL-04B alone proves live setup-service reachability and removal
   of the three legacy inference calls.
 - No handle crosses Celery, commit, rollback, provider I/O, session, or
   transaction; stale/replay/cross-resource/cross-step uses deny.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12F4-submission-policy-approval.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12F4-submission-policy-approval.md
@@ -26,14 +26,16 @@ intake, migration of product columns, or approval of a 12F3-only draft.
   human Project Manager; every service and unrelated human denies.
 - Resource/PREP binds project/guide/source/setup generation, immutable
   compilation/result plus artifact/pre/post component hashes, both catalogue
-  snapshots, target draft, compiler/plan versions, operation, request,
+  snapshots, target draft, current approval identity/hash/provenance,
+  compiler/plan versions, operation, request,
   idempotency, actor/link/grant, session, and root transaction.
 - The complete unified result, including post-submit proposal and capability
   gaps, exists before approval can prepare or consume.
 - POL-05B alone owns product locks, compilation, writes, replay, and commit.
   AUTH evaluates and persists bounded decision evidence atomically through the
   existing participant; it does not implement a competing compiler.
-- Revocation, stale/mixed generation, changed component/catalogue, replay,
+- Revocation, stale/mixed generation, changed component/catalogue/approval
+  hash or provenance, replay,
   copied/wrong handle, or transaction/session mismatch denies with no product
   mutation or allowed evidence.
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12F4-submission-policy-approval.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12F4-submission-policy-approval.md
@@ -1,114 +1,44 @@
-# Chunk Contract: WS-AUTH-001-12F4 — Submission Policy Approval Chain
+# Chunk Contract: WS-AUTH-001-12F4 - Unified Pre-Submit Approval Activation
 
-## Status and prerequisite
-
-Proposed and inactive after merged 12F3. Risk: L1.
+Status: Proposed after hidden WS-POL-003-05A; inactive. Risk: L1.
 
 ## Goal
 
-Activate Project Manager approval and atomically persist the exact approved
-draft, effective policy and compiled pre-submit policy with authorization evidence.
+Activate only the Project Manager approval action and exact PREP/evaluator
+composition required by POL-05B to publish the approved artifact,
+effective-policy, and pre-submit chain.
 
 ## Allowed files
 
-```text
-backend/app/api/deps/authorization.py
-backend/app/modules/authorization/catalogue.py
-backend/app/modules/authorization/kernel.py
-backend/app/modules/authorization/prepared.py
-backend/app/modules/authorization/runtime.py
-backend/app/modules/checkers/catalogue.py
-backend/app/modules/checkers/compiler.py
-backend/app/modules/checkers/effective_plan.py
-backend/app/modules/projects/models.py
-backend/app/modules/projects/router.py
-backend/app/modules/projects/schemas.py
-backend/app/modules/projects/repository.py
-backend/app/modules/projects/service.py
-backend/app/modules/projects/setup_queue.py
-backend/app/modules/projects/submission_policy_mutation_service.py
-backend/app/modules/projects/submission_policy_mutation_repository.py
-backend/tests/test_authorization.py
-backend/tests/test_projects.py
-backend/tests/test_alembic.py
-backend/scripts/api_contract_e2e.py
-docs/architecture_data_model.md
-docs/spec_authorization_service.md
-docs/operations_authorization_service.md
-docs/operations_project_operating_manual.md
-.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/**
-```
-
-12F1 owns every new approval/effective/pre-submit provenance column. 12F4
-allocates no migration and may not edit a historical migration.
+AUTH catalogue/kernel/prepared/runtime/API authorization composition, narrow
+POL approval adapter/resource context, focused authorization/integration tests,
+AUTH/POL specifications, and initiative memory.
 
 ## Not allowed
 
-Post-submit derivation/compilation/approval, checker execution, agent calls,
-Celery cutover, ART, submission intake, or legacy self-committing approval.
+Agent calls, product compiler/lifecycle implementation, policy body writes,
+post-submit projection/approval, checker execution, Celery, ART, submission
+intake, migration of product columns, or approval of a 12F3-only draft.
 
 ## Acceptance
 
-- Activate only `project.submission_artifact_policy.approve` for a human Project
-  Manager with exact active project grant. Public service tokens deny.
-- Approval requires UUID `Idempotency-Key`, dedicated PREP, exact OpenAPI action
-  metadata, route-owned commit and fresh replay reauthorization.
-- Lock order is project, draft guide, latest source snapshot, setup run,
-  sufficiency report, target draft policy, current approved submission policy,
-  current effective policy, current pre-submit policy, and any existing
-  post-submit policy whose upstream lineage must be invalidated. All rows are
-  revalidated against exact IDs/statuses/hashes/generation before consume. This
-  is one total order: 12F3's post-agent relock, 12F4 approval, 12G derivation,
-  approval/correction, and every overlapping mutation must acquire their shared
-  lineage rows in this relative order with no alternate acquisition order.
-- The authoritative sufficiency report must be for the exact snapshot and
-  generation and be `passed`, or `passed_with_warnings` with that report's
-  warnings acknowledged. Missing, blocked, stale, diagnostic-only, or
-  unacknowledged-warning reports deny without mutation.
-- Approval validates the non-bypassable Workstream default submission policy
-  and compiles against one exact immutable default-catalogue snapshot. PREP,
-  replay, and row provenance bind compiler and bundle schema versions,
-  catalogue ID/version/schema, manifest SHA-256, ordered entry identities and
-  configuration hashes, disabled-catalogue startup-config digest/IDs, compiled
-  bundle hash, and downstream effective-plan hash when present. Stale compiler,
-  changed catalogue/config, missing mandatory defaults, disabled mandatory
-  definitions, or non-canonical bundles deny.
-- One root transaction consumes approval PREP and atomically records: approved
-  draft provenance, supersession of the prior upstream chain, new effective
-  policy and hash, new compiled pre-submit policy and hash, replay completion,
-  bounded allowed decision evidence, and local actor/link/grant/scope/action
-  provenance on each protected row.
-- Existing post-submit policy may only receive `lifecycle_status=superseded`,
-  `superseded_at`, and the exact upstream replacement identity because its
-  effective/pre-submit hash changed; that invalidation and its authority
-  provenance commit in the approval transaction. 12F4 does not change its body,
-  derive, compile, approve, enqueue or run post-submit/checker behavior. It may
-  stage a bounded setup continuation identity that remains unusable until 12G.
-- Exact replay returns the canonical effective result. Changed/pending/cross-
-  action/link-substitution replay, stale/concurrent approval, revocation,
-  wrong handle/session/transaction, and fault injection deny or roll back every
-  product/replay/evidence mutation. Concurrent approvals create one current chain.
-- Historical bootstrap rows remain readable and are never rewritten.
+- Activate only `project.submission_artifact_policy.approve` for the covered
+  human Project Manager; every service and unrelated human denies.
+- Resource/PREP binds project/guide/source/setup generation, immutable
+  compilation/result plus artifact/pre/post component hashes, both catalogue
+  snapshots, target draft, compiler/plan versions, operation, request,
+  idempotency, actor/link/grant, session, and root transaction.
+- The complete unified result, including post-submit proposal and capability
+  gaps, exists before approval can prepare or consume.
+- POL-05B alone owns product locks, compilation, writes, replay, and commit.
+  AUTH evaluates and persists bounded decision evidence atomically through the
+  existing participant; it does not implement a competing compiler.
+- Revocation, stale/mixed generation, changed component/catalogue, replay,
+  copied/wrong handle, or transaction/session mismatch denies with no product
+  mutation or allowed evidence.
 
-## Verification commands
+## Verification and review
 
-```bash
-cd backend
-.venv/bin/ruff check app tests scripts
-.venv/bin/pytest -q tests/test_authorization.py -k 'submission_artifact_policy and approve'
-.venv/bin/pytest -q tests/test_projects.py -k 'submission_artifact_policy and (approve or effective or pre_submit or rollback or concurrent)'
-.venv/bin/pytest -q tests/test_ci_test_lanes.py
-.venv/bin/coverage erase
-.venv/bin/coverage run --source=app.modules.projects,app.modules.authorization,app.modules.checkers --concurrency=greenlet -m pytest -q tests/test_authorization.py -k 'submission_artifact_policy and approve'
-.venv/bin/coverage run --source=app.modules.projects,app.modules.authorization,app.modules.checkers --concurrency=greenlet --append -m pytest -q tests/test_projects.py -k 'submission_artifact_policy and (approve or effective or pre_submit or rollback or concurrent)'
-.venv/bin/coverage report --include='app/modules/projects/submission_policy_mutation_*.py,app/modules/checkers/catalogue.py,app/modules/checkers/compiler.py,app/modules/checkers/effective_plan.py,app/modules/authorization/catalogue.py,app/modules/authorization/kernel.py,app/modules/authorization/prepared.py,app/modules/authorization/runtime.py' --precision=2 --fail-under=90
-.venv/bin/python scripts/api_contract_e2e.py
-cd ..
-python3 scripts/check_stale_authorization_docs.py
-python3 scripts/check_markdown_links.py
-git diff --check
-```
-
-Every selector must be non-zero; exact pushed head passes Agent Gates and full
-hosted Backend. Required reviewers: all L1 tracks. Human focus: lock order,
-single-root atomicity, exact local provenance, and zero 12G behavior.
+AUTH all-pairs, PREP integrity, full-result-before-approval, stale-hash, POL
+integration, API metadata, hosted coverage, and all L1 tracks. Human focus:
+narrow human activation over a complete immutable proposal.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12G-post-submit-checker-policy-mutations.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12G-post-submit-checker-policy-mutations.md
@@ -1,111 +1,45 @@
-# Chunk Contract: WS-AUTH-001-12G — Post-Submit Checker Policy Mutation Cutover
+# Chunk Contract: WS-AUTH-001-12G - Unified Post-Submit Projection Activation
 
-## Status and prerequisite
-
-Proposed and inactive until 12F4 is merged.
-
-## Parent initiative
-
-`WS-AUTH-001` — Workstream Authorization Service
+Status: Proposed after hidden WS-POL-003-06A; inactive. Risk: L1.
 
 ## Goal
 
-Activate post-submit checker-policy derivation for the fixed setup service and
-approval/correction request mutations for the covered Project Manager.
+Activate the exact fixed-service deterministic post-submit projection action
+and Project Manager approval/correction actions consumed by POL-06B.
 
-## Why this chunk exists
-
-These configure project policy but must not expand into checker execution,
-submission visibility, or the separately owned `WS-POL-002-03` behavior.
-
-## Risk class
-
-L1
-
-## SLA
-
-P1
+The existing `project.post_submit_checker_policy.derive` identifier means
+trusted projection/compilation of the already stored unified post component.
+It never means another guide read or model inference.
 
 ## Allowed files
 
-```text
-backend/app/modules/projects/models.py
-backend/app/modules/projects/authorization_reads.py
-backend/app/modules/projects/post_submit_policy.py
-backend/app/modules/projects/repository.py
-backend/app/modules/projects/router.py
-backend/app/modules/projects/schemas.py
-backend/app/modules/projects/service.py
-backend/app/modules/projects/setup_queue.py
-backend/app/modules/authorization/kernel.py
-backend/app/modules/authorization/prepared.py
-backend/app/modules/authorization/runtime.py
-backend/app/api/deps/authorization.py
-backend/alembic/versions/<then-current-next>_post_submit_policy_authority.py
-backend/tests/test_authorization.py
-backend/tests/test_projects.py
-backend/tests/test_alembic.py
-backend/scripts/api_contract_e2e.py
-docs/spec_authorization_service.md
-.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/**
-```
+AUTH catalogue/kernel/prepared/runtime/API composition, narrow POL post-policy
+authorization adapter/resource context, one AUTH-owned parity migration only if
+required, focused tests, specifications, and initiative memory.
 
-## Not allowed changes
+## Not allowed
 
-Checker run/trigger/retry/read behavior, submission/review lifecycle,
-`WS-POL-002-03`, ART behavior, or token-role fallback.
+Agent adapters/prompts/calls, guide material access, product compiler/body
+writes, checker execution, ART, submission/review lifecycle, new checker
+registration, or compatibility inference.
 
-## Acceptance criteria
+## Acceptance
 
-- All three actions bind the exact project, draft guide, setup run/generation,
-  compiled checker policy and current lifecycle status.
-- `project.post_submit_checker_policy.derive` is fixed-service-only for
-  `workstream.project.setup`; approval and correction remain human Project
-  Manager-only. No principal inherits the other's actions.
-- Service derivation additionally locks and binds the active setup run,
-  expected post-submit-policy step, task/correlation identity, project, guide,
-  generation, compiled-policy/output digest, and lifecycle status. It records
-  the service profile, identity link, and static-matrix membership, never a
-  fabricated human grant.
-- Every derivation, approval, and correction transaction uses the shared total
-  order for applicable rows: project, draft guide, latest source snapshot,
-  setup run, sufficiency report, target draft submission policy, current
-  approved submission policy, current effective policy, current pre-submit
-  policy, then the existing/target post-submit policy. Missing optional rows are
-  checked in that sequence; no alternate acquisition order is allowed.
-- Derivation/approval/correction record local actor/link/grant-or-service,
-  scope/action provenance and
-  commit with decision evidence atomically.
-- Missing/wrong setup run, wrong setup step/task/correlation, direct public
-  service invocation, corrected/approved/stale/replaced policy or output,
-  cross-project/guide/generation, service or human revocation, replay,
-  copied/wrong handle, and transaction/session mismatch deny before mutation
-  or continuation enqueue.
-- No checker runtime permission is registered or activated.
-- 12G owns post-submit approval/correction provenance columns and migration;
-  every new mutation records actor/link/grant-or-service/scope/action/decision event while
-  historical rows remain nullable/readable.
-- Changed authorization/project modules remain at least 90 percent covered and
-  final pushed head SHA passes `Backend / test` and `Agent Gates`.
-- Concurrency proof overlaps 12F3 derivation, 12F4 approval, and each 12G
-  mutation and shows one canonical outcome or stable denial with no deadlock,
-  partial provenance, duplicate continuation, or split policy chain.
+- Fixed `workstream.project.setup` alone receives deterministic projection;
+  covered PM alone receives approval/correction. No authority is inherited.
+- Every action binds project/guide/source/setup generation,
+  compilation/result/post component and catalogue hashes, current approved
+  upstream artifact/effective/pre chain, target lifecycle state, operation,
+  request/idempotency, principal/link/grant-or-matrix, session, and transaction.
+- POL-06B owns deterministic product behavior and performs zero model calls.
+  AUTH owns only action activation, evaluator/PREP composition, and evidence.
+- Correction requires a new unified generation or separately proven manual
+  provenance; it cannot invoke legacy post-submit derivation.
+- Replay, recovery, correction, concurrency, and all denial tests instrument
+  the provider boundary and prove zero model calls.
 
-## Verification commands
+## Verification and review
 
-Before start, freeze exact isolated-runner, seeded migration round-trip,
-coverage, Ruff, API drill, stale-doc, link, and diff commands.
-
-## Required reviewers
-
-Senior engineering, QA/test, security/auth, product/ops, architecture, CI
-integrity, docs, reuse/dedup, and test delta.
-
-## Human review focus
-
-WS-POL/checker boundary, lifecycle lineage, provenance, and enqueue atomicity.
-
-## Stop conditions
-
-Stop if checker execution/visibility or post-submit product semantics must
-change.
+AUTH all-pairs, PREP/resource integrity, zero-call reachability, stale lineage,
+POL integration, migration parity, hosted coverage, and all L1 tracks. Human
+focus: deterministic projection semantics and separation of service/human duty.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12H-guide-activation.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12H-guide-activation.md
@@ -1,95 +1,47 @@
-# Chunk Contract: WS-AUTH-001-12H — Guide Activation Cutover
+# Chunk Contract: WS-AUTH-001-12H - Unified Guide Activation Cutover
 
-## Status and prerequisite
-
-Proposed and inactive after 12B2 and the owning CON clean cut removes the
-retired guide-bound economic-policy dependency.
-
-## Parent initiative
-
-`WS-AUTH-001` — Workstream Authorization Service
+Status: Proposed after POL-07, corrected 12B2, and the owning CON clean cut;
+inactive. Risk: L1.
 
 ## Goal
 
-Activate only `project.guide.activate` after every prerequisite project policy
-mutation family is locally authorized and provenance-complete.
-
-## Why this chunk exists
-
-Guide activation is the terminal, high-value transition that publishes one
-exact immutable guide/policy bundle and must be reviewed independently.
-
-## Risk class
-
-L1
-
-## SLA
-
-P1
+Activate only `project.guide.activate` over one complete approved
+current-generation unified compilation chain.
 
 ## Allowed files
 
-```text
-backend/app/modules/projects/models.py
-backend/app/modules/projects/authorization_reads.py
-backend/app/modules/projects/repository.py
-backend/app/modules/projects/router.py
-backend/app/modules/projects/schemas.py
-backend/app/modules/projects/service.py
-backend/app/modules/authorization/kernel.py
-backend/app/modules/authorization/prepared.py
-backend/app/modules/authorization/runtime.py
-backend/app/api/deps/authorization.py
-backend/alembic/versions/<then-current-next>_guide_activation_authority.py
-backend/tests/test_authorization.py
-backend/tests/test_projects.py
-backend/tests/test_alembic.py
-backend/scripts/api_contract_e2e.py
-docs/spec_authorization_service.md
-.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/**
-```
+AUTH catalogue/kernel/PREP/runtime/API composition, project activation
+authorization adapter/resource context, one AUTH-owned parity/provenance
+migration if required, focused tests, specifications, and AUTH/POL memory.
 
-## Not allowed changes
+## Not allowed
 
-Policy derivation/approval semantics, ART provider behavior, ContributionPolicy
-or award redesign, task/submission/review activation, or issuer-claim fallback.
+Compilation, policy derivation/approval/compiler semantics, agent calls, ART
+provider behavior, CON redesign, task/submission/review activation, legacy
+chain compatibility, or issuer-role fallback.
 
-## Acceptance criteria
+## Acceptance
 
-- Entry requires 12B through 12G, 12B2, and 12D2 merged and no legacy project mutation
-  authority remaining in the activation call graph.
-- Final consume locks/revalidates exact project, draft guide, source snapshot
-  and items, setup run/generation, sufficiency, submission/effective/pre-submit
-  and post-submit policies, plus current review/revision records. Retired
-  guide-bound economic policy is neither read nor required.
-- Covered Project Manager authority, matched grant/scope, actor/link, action,
-  request digest and transaction are evidenced atomically with activation.
-- Stale/replaced/missing/cross-resource chain, concurrent activation, revoked
-  authority, replay, copied/wrong handle, and wrong session/transaction deny
-  before any state change.
-- Exactly one active guide results; no compatibility authorization path remains.
-- Activation records local actor/link/grant/scope/action and decision-event
-  provenance; historical rows remain nullable/readable. Final pushed head SHA
-  passes `Backend / test` and `Agent Gates`.
+- Entry requires exact immutable `ProjectGuideCompilation`, accepted result and
+  sufficiency/artifact/pre/post component hashes, source/setup generation, both
+  catalogue snapshots, approved effective/pre/post projections, and completed
+  unified setup custody.
+- Required capability gaps or any blocked/partial/unapproved/mixed-generation
+  component deny. Optional gaps require exact PM acknowledgement.
+- Final PREP binds the complete chain plus actor/link/grant, action, operation,
+  request/idempotency, session, and transaction. POL/project code owns product
+  locks and the one activation commit.
+- Retired guide-bound economic policy is absent after the owning CON clean cut.
+- The merged POL-07 single checker port proves both compiled pre-submit and
+  post-submit components are executable through the sole approved commands;
+  activation cannot precede that proof.
+- No old independent sufficiency/submission/post rows are sufficient without
+  compilation/component linkage; no compatibility authorization remains.
+- Concurrent activation yields one active guide. Stale/replaced/revoked/replay/
+  copied/wrong-handle/session/transaction cases deny before mutation.
 
-## Verification commands
+## Verification and review
 
-Before start, freeze exact isolated-runner, seeded migration round-trip,
-authorization/project 90% coverage, repository-wide 78% coverage baseline,
-activation/concurrency, API drill, Ruff, stale-doc, link, and diff commands.
-
-## Required reviewers
-
-Senior engineering, QA/test, security/auth, product/ops, architecture, CI
-integrity, docs, reuse/dedup, and test delta.
-
-## Human review focus
-
-Complete locked lineage, terminal transition atomicity, prerequisite-only
-legacy policy reads, and absence of fallback authority.
-
-## Stop conditions
-
-Stop if any prerequisite mutation family is not locally cut over, the owning
-CON clean cut has not removed the retired economic-policy dependency, or
-activation requires changing contribution semantics.
+Complete/partial/mixed-chain matrix, gap acknowledgement, concurrency/replay,
+AUTH all-pairs, POL-07 sole-port and activation integration, migration round trip, hosted
+coverage, and all L1 tracks. Human focus: complete unified lineage only.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12I-unified-compilation-activation.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-12I-unified-compilation-activation.md
@@ -1,0 +1,45 @@
+# Chunk Contract: WS-AUTH-001-12I - Unified Compilation Authorization Activation
+
+Status: Proposed after hidden WS-POL-003-03A; inactive. Risk: L1.
+
+## Goal
+
+Register and activate exactly two actions for immutable unified compilation:
+
+- `project.guide_compilation.request` for covered Project Manager asynchronous
+  dispatch/recovery;
+- `project.guide_compilation.execute` for fixed
+  `workstream.project.setup` execution and compilation-parent persistence.
+
+## Allowed files
+
+AUTH catalogue/permission/action owner, kernel/PREP/runtime/API composition,
+narrow POL compilation authorization adapter/resource facts, one AUTH-owned
+parity migration, focused authorization/integration tests, specifications, and
+AUTH/POL memory.
+
+## Not allowed
+
+Compilation schema/validator/product writes, agent prompts/calls, policy
+projection authority, broad compile permission, handles in Celery, ART/checker
+behavior, or human/service authority inheritance.
+
+## Acceptance
+
+- PM request binds actor/link/grant, project/guide/source, setup run/generation,
+  operation/request/idempotency and records dispatch custody only.
+- Execute binds fixed service profile/link/matrix, canonical input and both
+  catalogue hashes, setup run/generation, agent/instruction identity, prior
+  compilation when superseding, and attempt/provider-key identity.
+- Execute supports fail-closed pre-I/O admission and fresh accepted-result-bound
+  final PREP. No handle or transaction spans provider I/O.
+- Compilation authority cannot write sufficiency/artifact/pre/post canonical
+  projections; their separate actions remain mandatory.
+- Cross-principal/action/resource/generation, stale, revoked, replay, copied,
+  wrong-session, and wrong-transaction cases deny without provider/product I/O.
+
+## Verification and review
+
+Typed/SQL/catalogue/matrix parity, all-pairs human/service denial, two-stage
+PREP, POL-03A adapter integration, migration round trip, hosted coverage, and
+all L1 tracks. Human focus: narrow parent custody around external I/O.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-13-task-assignment-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-13-task-assignment-cutover.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Proposed and inactive. Exact ActionIds and its then-current migration must be
-enumerated before implementation; AUTH-PREP and the merged contributor
-foundation are required for mutations.
+Proposed and inactive. It may start only after `WS-POL-003-06B`,
+`WS-POL-003-07`, `WS-AUTH-001-12H`, and the required ART admission gates have
+merged. Exact ActionIds and the then-current migration must be frozen at start.
 
 ## Parent initiative
 
@@ -14,7 +14,8 @@ foundation are required for mutations.
 
 Move task creation/screen/release, queue visibility, contributor claim, assignment,
 and start operations to scoped manager or exact-project submitter permissions
-while preserving task lifecycle guards.
+while preserving task lifecycle guards and the exact unified-compilation
+lineage that governs the task.
 
 ## Why this chunk exists
 
@@ -69,6 +70,7 @@ docs/operations_authorization_service.md
 submission create/read/finalize
 checker trigger/read or contributor checker results
 new terminal task states or unrelated lifecycle redesign
+guide compilation, policy projection, checker selection, or checker execution
 review models or self-review implementation
 token role or legacy active-worker-profile fallback
 ```
@@ -83,6 +85,11 @@ token role or legacy active-worker-profile fallback
 - An active submitter grant for the exact project is required for
   queue/claim/start, plus existing task availability, assignment, ownership,
   and state guards.
+- A task may become claimable only under the current activated guide whose
+  immutable unified compilation has approved sufficiency, artifact,
+  pre-submit, and post-submit components. Task/assignment locks stamp the exact
+  compilation result, component hashes, catalogue hashes, and compiled checker
+  plan. AUTH validates those facts but does not compile or invoke checkers.
 - Every migrated task/assignment route or reconciliation command declares one
   primary registered action against the canonically loaded project, task, or
   assignment target. Feature-owned TaskRepository facts remain authoritative.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-14-submission-checker-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-14-submission-checker-cutover.md
@@ -12,9 +12,10 @@ ActionIds and the then-current migration must be frozen at start.
 
 ## Goal
 
-Activate only admission-backed submission authority, bounded checker
-read/repair authority, contributor projections, and task audit visibility.
-ART and POL retain all product mutation, checker orchestration, and routing.
+Verify exact admission authority and activate `submission.create`, bounded
+checker read/repair authority, contributor projections, and task audit
+visibility. ART and POL retain submission mutations, checker execution,
+findings, routing, and the sole checker-port product behavior.
 
 ## Why this chunk exists
 
@@ -69,6 +70,7 @@ docs/operations_authorization_service.md
 submission creation/finalization or artifact binding product mutations
 checker execution/routing, standalone precheck triggers, or ordinary checker triggers
 agent adapters, guide compilation, or checker-policy derivation
+checker-port implementation, checker findings, or product lifecycle behavior
 internal Celery worker authority cutover
 review queue/lease/decision implementation
 token role fallback
@@ -92,6 +94,9 @@ legacy active-worker-profile or workflow-eligibility compatibility fallback
   migrated submission/checker/audit route declares one primary registered
   action against a feature-owned canonical target and keeps artifact bytes and
   unnecessary actor data outside `ResourceContext` and authority evidence.
+- AUTH must register/evaluate/consume `submission.create` authority and commit
+  its decision evidence; feature owners alone perform the protected Submission
+  mutation.
 - Generated OpenAPI/command manifest-delta tests prove every protected
   submission/checker/audit surface migrated here has exactly one active
   `ActionId` declaration.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-14-submission-checker-cutover.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-14-submission-checker-cutover.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Proposed and inactive. Exact ActionIds and its then-current migration must be
-enumerated before implementation; AUTH-PREP and the merged contributor
-foundation are required for mutations.
+Proposed and inactive. It may start only after `WS-AUTH-001-13`,
+`WS-ART-001-05B`, `WS-POL-003-07`, and `WS-XINT-002-06B` have merged. Exact
+ActionIds and the then-current migration must be frozen at start.
 
 ## Parent initiative
 
@@ -12,9 +12,9 @@ foundation are required for mutations.
 
 ## Goal
 
-Move submission precheck/create/read/finalize, checker trigger/read, checker
-contributor projections, and task audit visibility to registered permissions and
-canonical task/project/assignment guards.
+Activate only admission-backed submission authority, bounded checker
+read/repair authority, contributor projections, and task audit visibility.
+ART and POL retain all product mutation, checker orchestration, and routing.
 
 ## Why this chunk exists
 
@@ -46,7 +46,6 @@ backend/app/modules/actors/**
 backend/app/modules/checkers/**
 backend/app/modules/projects/schemas.py
 backend/app/modules/projects/service.py
-backend/app/adapters/project_agents/openai_agent_sdk.py
 backend/alembic/versions/<then-current-next>_*.py
 backend/app/modules/authorization/**
 backend/app/modules/audit/**
@@ -67,7 +66,9 @@ docs/operations_authorization_service.md
 ## Not allowed
 
 ```text
-checker execution/routing semantics or task lifecycle redesign
+submission creation/finalization or artifact binding product mutations
+checker execution/routing, standalone precheck triggers, or ordinary checker triggers
+agent adapters, guide compilation, or checker-policy derivation
 internal Celery worker authority cutover
 review queue/lease/decision implementation
 token role fallback
@@ -85,14 +86,21 @@ legacy active-worker-profile or workflow-eligibility compatibility fallback
   direct provider access. Dedicated AUTH custodians activate the actions only
   after hidden ART behavior merges. Submission authority never implies
   artifact-storage authority.
-- Submission creation authorizes against its existing active assignment; every
+- `submission.create` authorizes only consumption of one exact verified ART
+  admission under its existing active assignment and locked unified-compilation
+  lineage; every
   migrated submission/checker/audit route declares one primary registered
   action against a feature-owned canonical target and keeps artifact bytes and
   unnecessary actor data outside `ResourceContext` and authority evidence.
 - Generated OpenAPI/command manifest-delta tests prove every protected
   submission/checker/audit surface migrated here has exactly one active
   `ActionId` declaration.
-- Manager repair/checker triggers require covered project permissions.
+- There is no caller-selectable or standalone precheck trigger. The sole POL
+  checker port consumes the compiled plan automatically at the ART scratch and
+  stored boundaries. AUTH exposes no alternate checker API.
+- Manager repair and Operator retry resume the same Submission, admission,
+  compilation, plan, checker, and run-attempt identity. They cannot select a
+  checker, change policy, or create a second business effect.
 - Project Manager repair uses covered `project.task.manage`; Operator recovery
   uses distinct `operations.submission_gate.repair` and
   `operations.checker.retry` permissions. Each path requires a reason and

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-15-worker-authority-removal.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-15-worker-authority-removal.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Proposed and inactive. Exact remaining command ActionIds, service identities,
-and then-current migration parity must be enumerated before implementation.
+Proposed cleanup-only and inactive. It follows `WS-AUTH-001-14`,
+`WS-POL-003-08`, and the applicable ART/XINT activation gates.
 
 ## Parent initiative
 
@@ -73,6 +73,7 @@ docs/operations_authorization_service.md
 
 ```text
 new product lifecycle behavior
+new action activation or compatibility aliases
 human roles on service ActorProfiles
 authorization allowlist broad enough to hide new token-role consumption
 review/contribution/compensation implementation
@@ -104,6 +105,10 @@ review/contribution/compensation implementation
 - The scanner proves the `LegacyWorkflowEligibilityCompatibility` adapter,
   allowlist, and typed-profile workflow eligibility consumers removed in chunk
   14 remain absent.
+- The scanner also rejects the three transitional guide inference entry points,
+  any model-backed post-submit derivation, standalone precheck APIs,
+  caller-selectable checker triggers, per-checker public APIs, reconstructed
+  prepared handles, and compatibility aliases for any removed path.
 - The stale scanner and route tests prove the legacy worker-profile endpoint,
   activation service/schema, token-role observation fields, and actor-service
   authority checks are absent from runtime code.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-15-worker-authority-removal.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-15-worker-authority-removal.md
@@ -106,9 +106,12 @@ review/contribution/compensation implementation
   allowlist, and typed-profile workflow eligibility consumers removed in chunk
   14 remain absent.
 - The scanner also rejects the three transitional guide inference entry points,
-  any model-backed post-submit derivation, standalone precheck APIs,
+  any legacy standalone or three-call post-submit derivation, standalone precheck APIs,
   caller-selectable checker triggers, per-checker public APIs, reconstructed
   prepared handles, and compatibility aliases for any removed path.
+- The scanner must not reject the WS-POL-003 unified provider compilation or
+  its model-produced post-submit component; only obsolete parallel inference
+  paths are forbidden.
 - The stale scanner and route tests prove the legacy worker-profile endpoint,
   activation service/schema, token-role observation fields, and actor-service
   authority checks are absent from runtime code.

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-16-evidence-live-proof.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/chunks/WS-AUTH-001-16-evidence-live-proof.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Proposed final gate. It cannot start until every protected feature surface
-already merged has its matching AUTH activation, while every registered action
-without merged feature behavior still denies as planned.
+Proposed final gate. It cannot start before `WS-POL-003-08`, corrected
+`WS-AUTH-001-12B2/12H`, `WS-AUTH-001-13/14/15`, and all applicable ART, XINT,
+REV, and CON gates have merged.
 
 ## Parent initiative
 
@@ -130,6 +130,14 @@ starting WS-POL-002-04 or another initiative automatically
 - Every activated feature action proves immutable feature-manifest-before-AUTH
   ordering, real-kernel unavailable behavior before activation, exact
   availability delta after activation, and no alternate feature writer.
+- End-to-end proof shows one logical/provider guide-compilation attempt yields
+  sufficiency plus artifact, pre-submit, and post-submit policy components;
+  approval performs no inference; post-submit projection performs zero model
+  calls; every task, admission, Submission, checker run, review, revision, and
+  audit fact retains the exact unified lineage.
+- No legacy three-call inference method, standalone precheck trigger,
+  caller-selected checker trigger, per-checker public API, serialized prepared
+  handle, or compatibility alias remains reachable.
 - When review evidence binding is registered, proof includes distinct human and
   binding-service decisions/evidence, exact lock order, and one transaction.
   When `review.decision` is active, REV plus the flush-only CON participant
@@ -155,7 +163,7 @@ starting WS-POL-002-04 or another initiative automatically
   production dependency change requires separately recorded explicit human
   approval before modification.
 - No obsolete token-role authorization remains in runtime code.
-- Initiative memory records proof and does not start `WS-POL-002-04` or another
+- Initiative memory records proof and does not start another
   initiative without a separate explicit user signal.
 
 ## Verification commands

--- a/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/PLAN.md
+++ b/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/PLAN.md
@@ -1,5 +1,10 @@
 # Plan: WS-CON-001 Contribution And Compensation
 
+Current dependency note: CON consumes accepted REV outcomes whose Submission
+lineage already binds the exact WS-POL-003 unified compilation and compiled
+checker plan. CON does not compile guides, project policies, or checker plans
+and does not invoke checker services.
+
 > Historical PLAN4 plan. Live 03A implementation state is in `STATUS.md`,
 > `SOURCE_MANIFEST.md`, and the `WS-CON-001-03A` contract.
 

--- a/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/PLAN.md
+++ b/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/PLAN.md
@@ -1,9 +1,10 @@
 # Plan: WS-CON-001 Contribution And Compensation
 
 Current dependency note: CON consumes accepted REV outcomes whose Submission
-lineage already binds the exact WS-POL-003 unified compilation and compiled
-checker plan. CON does not compile guides, project policies, or checker plans
-and does not invoke checker services.
+lineage already binds the exact WS-POL-003 compilation, accepted result,
+post-submit component, pre/post catalogue hashes, compiled-plan identity/hash,
+and current approval identity/hash/provenance. CON does not compile guides,
+project policies, or checker plans and does not invoke checker services.
 
 > Historical PLAN4 plan. Live 03A implementation state is in `STATUS.md`,
 > `SOURCE_MANIFEST.md`, and the `WS-CON-001-03A` contract.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/CHUNK_MAP.md
@@ -14,7 +14,7 @@ reviewed, merged by explicit human approval, and followed by a memory update.
 | `WS-POL-002-02` | Post-Submit Derivation Agent And Resumable Setup Integration | L1 | Merged |
 | `WS-POL-002-03` | Server-Owned Policy Approval And Visibility APIs | L1 | Merged through PR #90 as `a7aa474` |
 | `WS-POL-002-04` | Locked Runtime Execution And Routing Hardening | L1 | Inactive pending auth proof and explicit start |
-| `WS-POL-002-05` | Terminal Benchmark Post-Submit Live API Proof | L1 | Proposed |
+| `WS-POL-002-05` | Unified Post-Submit Live Proof | L1 | Non-executable planning skeleton pending then-current contract expansion |
 
 ## Dependency Order
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/DECISIONS.md
@@ -5,7 +5,10 @@
 `WS-POL-003` supersedes the standalone derivation decisions below for all
 future work. The post-submit proposal comes from the one unified compilation
 result and is deterministically projected/approved/executed with zero further
-model calls. The original decisions remain historical evidence only.
+model calls. D1-D8 below are historical evidence only and are not active
+implementation guidance.
+
+## Historical decisions D1-D8
 
 ## D1. Post-Submit Policy Is Project-Scoped
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/DECISIONS.md
@@ -1,5 +1,12 @@
 # Decisions: WS-POL-002 - Post-Submit Checker Foundation
 
+## Current authority
+
+`WS-POL-003` supersedes the standalone derivation decisions below for all
+future work. The post-submit proposal comes from the one unified compilation
+result and is deterministically projected/approved/executed with zero further
+model calls. The original decisions remain historical evidence only.
+
 ## D1. Post-Submit Policy Is Project-Scoped
 
 `PostSubmitCheckerPolicy` remains attached to the project guide/source snapshot

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/INTENT.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/INTENT.md
@@ -8,6 +8,12 @@ remaining WS-POL-002 work deterministically projects and executes it with zero
 additional model calls. The older agent-derivation narrative is retained only
 as historical rationale and is not implementation authority.
 
+## Historical intent below
+
+Every remaining section in this file describes the original POL-002 intent and
+must be read only as historical context. The current executable direction is
+the unified, zero-additional-model-call authority above.
+
 ## Human Intent
 
 Make post-submit checkers work with the same discipline as the pre-submit

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/INTENT.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/INTENT.md
@@ -1,5 +1,13 @@
 # Intent: WS-POL-002 - Post-Submit Checker Foundation
 
+## Current authority
+
+`WS-POL-003` supersedes every future setup-time derivation described below.
+One unified guide-compilation attempt stores the post-submit component;
+remaining WS-POL-002 work deterministically projects and executes it with zero
+additional model calls. The older agent-derivation narrative is retained only
+as historical rationale and is not implementation authority.
+
 ## Human Intent
 
 Make post-submit checkers work with the same discipline as the pre-submit

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/PLAN.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/PLAN.md
@@ -1,231 +1,34 @@
 # Plan: WS-POL-002 - Post-Submit Checker Foundation
 
-## Goal
+## Current authority
 
-Make post-submit checker setup match the quality of the pre-submit checker
-pipeline without changing the product review decision contract.
+Merged chunks 01-03 established useful compiler, persistence, approval, and
+visibility foundations. Their standalone `PostSubmitCheckerPolicyDerivationAgent`
+call graph is historical and must not be invoked by any remaining work.
 
-The final architecture should be:
+`WS-POL-003` now owns all future guide inference. One logical/provider guide
+compilation produces the post-submit proposal together with sufficiency,
+artifact, and pre-submit proposals. The stored post-submit component is
+deterministically validated, projected, approved, locked, and executed without
+another model call.
 
-```text
-ProjectGuide
--> GuideSourceSnapshot
--> GuideSufficiencyReport
--> SubmissionArtifactPolicy
--> EffectiveProjectSubmissionArtifactPolicy
--> project PreSubmitCheckerPolicy
--> PostSubmitCheckerPolicyDerivationAgent
--> constrained PostSubmitCheckerPolicySpec
--> trusted Workstream compiler
--> project PostSubmitCheckerPolicy
--> tasks lock references
--> finalized submissions execute deterministic post-submit checkers
-```
+## Remaining work
 
-## Current Baseline
+`WS-POL-002-04` may harden locked runtime execution only after reconciliation
+with `WS-POL-003-06B/07`, ART-06A/06B, and XINT-06B. It consumes the exact
+unified compilation/component/catalogue/compiled-plan lineage through the sole
+checker service port. It cannot infer policy, select an out-of-plan checker, or
+expose a standalone/caller-selectable trigger.
 
-The runtime gate exists, but this initiative tightened the happy path during
-`WS-POL-002-02` so manager action is not required after a contributor submits:
+`WS-POL-002-05` is proof-only. It proves automatic Submission-bound execution,
+default-plus-project compiled checker coverage, deterministic retry, safe
+visibility, review/revision handoff, and zero post-submit model calls.
 
-```text
-contributor creates submission
--> Workstream reruns pre-submit against the exact payload
--> Workstream locks the submission packet
--> automatic Celery pre-review gate
--> evaluation_pending
--> review_pending | needs_revision | internal repair route
-```
+## Ownership
 
-This initiative strengthens the project setup side so the policy feeding that
-gate is no longer manually assembled in guide create/update payloads. The
-`finalize` route is a repair/requeue surface for locked submissions only; it is
-not the normal contributor submission handoff.
+- POL owns deterministic policy validation/projection and checker orchestration.
+- ART owns immutable input/output bytes, materialization, and bindings.
+- AUTH/XINT own exact service/human authorization activation and evidence.
+- REV owns human review and revision lifecycle decisions.
 
-## Design
-
-### Setup Pipeline
-
-The project setup pipeline becomes a resumable setup flow. The current Celery
-pipeline stops when it produces a draft `SubmissionArtifactPolicy`; it does not
-already have an effective policy or compiled pre-submit bundle at that point.
-WS-POL-002 must preserve that reality.
-
-Phase 1:
-
-```text
-Guide/source capture
--> GuideSufficiencyAgent
--> SubmissionArtifactPolicyDerivationAgent
--> policy_draft_ready
--> v0.1 setup-authorized admin/project_manager approval of SubmissionArtifactPolicy
--> EffectiveProjectSubmissionArtifactPolicy
--> trusted pre-submit compiler
-```
-
-Phase 2:
-
-```text
-pre-submit compile success
--> PostSubmitCheckerPolicyDerivationAgent
--> trusted post-submit compiler
--> compiled post-submit policy pending setup approval
--> v0.1 setup-authorized admin/project_manager approval of PostSubmitCheckerPolicy
--> guide activation
-```
-
-The post-submit derivation agent runs after the effective project submission
-artifact policy and pre-submit checker bundle exist, because durable
-post-submit checks often depend on the same artifact and evidence contract.
-The trigger is the server-owned continuation after pre-submit approval/compile,
-not the initial source-capture enqueue.
-
-### Agent Contract
-
-`PostSubmitCheckerPolicyDerivationAgent` receives:
-
-- project id and guide version
-- guide source snapshot id and bundle hash
-- guide content/source excerpts
-- guide sufficiency report summary
-- submission artifact policy summary
-- effective project submission artifact policy hash and summary
-- compiled pre-submit checker bundle summary
-- current registered post-submit checker catalog
-
-The agent returns a constrained `PostSubmitCheckerPolicySpec`:
-
-- required registered checker names
-- warning registered checker names
-- severity/routing requirements
-- reasons tied to guide/source evidence
-- unsupported required-check gaps
-- human-readable setup notes
-
-The agent must not return executable runtime code in v0.1.
-
-Project source material is untrusted LLM input. The derivation adapter must
-treat guide/source excerpts as data, not instructions. Returned reasons must be
-tied to bounded source-evidence references, and server-side validation must
-reject or ignore any source text that attempts to override Workstream defaults,
-roles, checker routing, authorization, or review-decision values.
-
-### Compiler Contract
-
-The trusted Workstream post-submit compiler:
-
-- canonicalizes the spec
-- always includes default durable checkers
-- rejects unknown checker names
-- rejects attempts to remove or weaken default checkers
-- rejects duplicate or contradictory checker classifications
-- rejects blocking-severity downgrade attempts
-- requires every required checker to map to a registered deterministic checker
-- emits the canonical `PostSubmitCheckerPolicy.policy_body`
-- emits `policy_hash = sha256(canonical_json(policy_body))`
-
-The platform default checker list is authoritative at compile time.
-`policy_body.default_checkers` is stamped into the versioned locked policy body,
-and the body hash preserves that exact compiler output for future task context.
-Default-only projects are valid: the compiler represents defaults as required
-durable coverage and permits an empty project-specific addition set only when
-all platform defaults remain required in the compiled body.
-
-The compiler, not the agent, decides the executable policy body.
-
-### Runtime Contract
-
-Runtime does not run derivation. Runtime loads the locked
-`PostSubmitCheckerPolicy` id/version/hash/body from the submission and executes
-the registered deterministic checkers listed in that body.
-
-Routing remains:
-
-- all blocking checks pass: `review_pending`
-- worker-fixable blocking failure: `needs_revision`
-- setup/context defect: internal `task_setup_blocked`
-- transient trusted checker issue: internal `checker_retry`
-
-Internal repair routes must be operator-visible with a bounded reason, owner,
-next action, retry/audit provenance, and proof that reviewers only receive work
-after the task reaches `review_pending`.
-
-### Default Checkers
-
-Default durable post-submit checkers are currently:
-
-- `check_submission_packet`
-- `check_policy_context_present`
-- `check_evidence_present`
-- `check_evidence_integrity`
-- `check_required_files`
-- `check_forbidden_files`
-- `check_confidentiality_attestation`
-- `check_low_quality_generated_artifacts`
-
-These remain platform-owned and cannot be removed by project policy.
-
-### Project-Specific Checkers
-
-Project-specific post-submit policy may add registered deterministic checkers.
-For example, a project can require `check_acceptance_criteria_present` when it
-needs task setup reviewability enforced before human review.
-
-If the guide implies a check that does not exist in the registered catalog, the
-setup output must say that clearly and block activation until Workstream adds a
-checker or the project guide expectation is corrected.
-
-### API Visibility
-
-Setup-authorized admins and project_managers need API-visible state for:
-
-- post-submit derivation input summary
-- derivation result
-- unsupported checker gaps
-- compiled policy body summary
-- compiled policy hash
-- approval status
-- activation readiness
-
-Setup visibility and approval endpoints use the current v0.1 bootstrap
-authorization boundary: verified `admin` or `project_manager` roles. Workers,
-reviewers, finance actors, and auditors remain denied. Project-scoped
-project-manager authorization requires the future Workstream role-assignment
-source of truth and is out of scope for WS-POL-002.
-
-Persisted derivation output and API summaries must be bounded and redacted by
-default. They must not echo raw guide/source text, local paths, secrets,
-credential-shaped values, replayable signed refs, or exact source hashes unless
-an explicit future secure evidence surface is designed for that purpose.
-
-Workers should only see post-submit results that are safe and relevant to their
-fix path. Internal setup defects remain hidden.
-
-## Non-Scope
-
-- Human review packet assignment.
-- Reviewer decision APIs.
-- Revision replay APIs beyond existing checker-caused `needs_revision` routing.
-- Payment, reputation, blockchain, x402, ERC standards, or settlement.
-- Frontend product work.
-- Arbitrary generated checker code execution.
-- Per-task checker derivation.
-- Backward compatibility aliases for removed guide request fields.
-
-## Proof Strategy
-
-Each implementation chunk must include deterministic tests. The final chunk must
-run a Terminal Benchmark-style live API drill that shows:
-
-- source snapshot capture
-- setup-run progression
-- post-submit policy derivation input/output
-- compiled post-submit policy visibility
-- activation gate
-- task locked context
-- submission finalization
-- durable checker run
-- worker-fixable `needs_revision`
-- fixed resubmission returning to `review_pending`
-
-The drill must be API-visible and privacy-safe. Database inspection is not
-accepted as proof.
+No remaining WS-POL-002 chunk starts automatically.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/STATUS.md
@@ -1,5 +1,9 @@
 # Status: WS-POL-002 - Post-Submit Checker Foundation
 
+`WS-POL-003` is authoritative for future guide inference. Remaining runtime
+work consumes its stored post-submit component and performs no standalone
+derivation.
+
 ## Current Status
 
 Planning completed and merged through PR #85 as
@@ -49,7 +53,7 @@ None for implementation. Post-merge memory is complete through PR #94.
 | `WS-POL-002-02` | Merged | `codex/ws-pol-002-02-post-submit-derivation` | #88 | Post-submit derivation agent and resumable setup integration; merged as `32af6a7`. |
 | `WS-POL-002-03` | Merged | `codex/ws-pol-002-03-post-submit-approval-visibility` | #90 | Server-owned approval, correction audit history, and setup visibility APIs; merged as `a7aa474`. |
 | `WS-POL-002-04` | Inactive | - | - | Runtime hardening remains gated by authorization proof and a separate user start. |
-| `WS-POL-002-05` | Proposed | - | - | Terminal Benchmark-style live API proof and report. |
+| `WS-POL-002-05` | Planning skeleton | - | - | Unified zero-model-call live proof; not executable until its full contract is expanded and reviewed. |
 
 ## Blockers
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-04-post-submit-runtime-hardening.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-04-post-submit-runtime-hardening.md
@@ -1,8 +1,11 @@
 # Chunk Contract: WS-POL-002-04 - Locked Runtime Execution And Routing Hardening
 
-This proposed contract must first reconcile with `WS-POL-003-06B/07`. It
-consumes the stored unified post-submit component through the single checker
-service port and performs no inference or out-of-plan checker selection.
+This proposed contract must first reconcile with `WS-POL-003-06B/07`. It binds
+the exact compilation, accepted result, post-submit component, pre/post
+catalogue hashes, compiled-plan identity/hash, and current approval
+identity/hash/provenance. It consumes that lineage only through the POL-07
+single checker-service port, performs no inference, and permits no caller or
+runtime checker selection outside the compiled plan.
 
 ## Parent Initiative
 

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-04-post-submit-runtime-hardening.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-04-post-submit-runtime-hardening.md
@@ -1,5 +1,9 @@
 # Chunk Contract: WS-POL-002-04 - Locked Runtime Execution And Routing Hardening
 
+This proposed contract must first reconcile with `WS-POL-003-06B/07`. It
+consumes the stored unified post-submit component through the single checker
+service port and performs no inference or out-of-plan checker selection.
+
 ## Parent Initiative
 
 `WS-POL-002` - Post-Submit Checker Foundation

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-05-post-submit-live-api-proof.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-05-post-submit-live-api-proof.md
@@ -1,163 +1,47 @@
-# Chunk Contract: WS-POL-002-05 - Terminal Benchmark Post-Submit Live API Proof
+# Planning Skeleton: WS-POL-002-05 - Unified Post-Submit Live Proof
 
-## Parent Initiative
-
-`WS-POL-002` - Post-Submit Checker Foundation
-
-## Approved Plan Reference
-
-- INTENT: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/INTENT.md`
-- PLAN: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/PLAN.md`
-- CHUNK_MAP: `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/CHUNK_MAP.md`
-
-## Risk class
-
-L1
-
-## SLA
-
-P1
-
-## Problem Being Solved
-
-The implementation must be proven as a real operator/worker flow, not only by
-unit tests. The proof must show the generated post-submit policy setup and the
-runtime checker gate through APIs.
+Status: Non-executable planning skeleton after reconciled WS-POL-002-04,
+WS-POL-003-07, ART-06A/06B, and XINT-06B. Risk: L1. Before human start it must
+be expanded on then-current main with explicit allowed/not-allowed file paths,
+runnable verification commands, and named reviewer tracks.
 
 ## Goal
 
-Run a privacy-safe Terminal Benchmark-style live API drill that proves
-post-submit policy derivation, approval, task locking, finalization, checker
-routing, `needs_revision`, fixed resubmission, and `review_pending`.
+Prove the sole automatic post-submit checker path end to end without policy
+inference or caller-selected execution.
 
-## Target Behavior
+## Allowed
 
-- Project setup captures sanitized source material.
-- Sufficiency passes or blocks before post-submit derivation.
-- Post-submit derivation input/output is visible through setup APIs.
-- Compiled post-submit policy hash is visible before activation.
-- Activation requires the approved compiled post-submit policy.
-- Task locks that policy context.
-- Submission finalization runs the locked policy.
-- A clean path reaches `review_pending`.
-- A worker-fixable post-submit failure reaches `needs_revision`.
-- A fixed resubmission returns to `review_pending`.
+Focused tests/drills, bounded observability and visibility repairs, docs,
+evidence, and planning memory.
 
-## Allowed Files
+## Not allowed
 
-```text
-.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/**
-.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/**
-.agent-loop/LOOP_STATE.md
-.agent-loop/WORK_QUEUE.md
-.agent-loop/REVIEW_LOG.md
-docs/roadmap_status.md
-examples/terminal_benchmark/**
-scripts/privacy_scan_evidence.py
-```
+Model/agent calls, policy derivation, checker selection, standalone or
+per-checker public triggers, alternate submission finalization, review decision
+changes, ART provider behavior, or authorization widening.
 
-The exact `scripts/privacy_scan_evidence.py` path is allowed so this chunk can
-add the committed privacy scan used by the verification command. Broader
-`scripts/**` edits remain out of scope.
+## Acceptance
 
-## Not Allowed
+- A verified admission becomes exactly one Submission and automatically enters
+  post-submit checks under its locked unified compilation lineage.
+- The run binds exact Submission/version, compilation/result/post component,
+  catalogue hashes, compiled plan, checker versions, ART materialization, and
+  attempt/idempotency identities.
+- Platform defaults cannot be weakened; project checks can only add registered
+  capabilities from the stored compiled plan.
+- Retry resumes the same run/plan and cannot choose a checker or duplicate a
+  business effect.
+- Failures route deterministically to the existing checker/review/revision
+  lifecycle without inventing product decision values.
+- Contributor, Project Manager, Operator, Audit, and reviewer views remain
+  bounded and authorized.
+- Instrumented proof records zero post-submit model/provider calls and rejects
+  every legacy derivation or alternate trigger path.
+- Focused and full hosted tests, stale scans, links, diff integrity, and all L1
+  reviewer tracks pass.
 
-```text
-backend/app/**
-backend/alembic/versions/**
-backend/tests/**
-backend/scripts/**
-frontend or demo UI work
-payment/reputation/blockchain settlement
-private source identifiers in committed evidence
-database inspection as lifecycle proof
-```
+## Human review focus
 
-## Acceptance Criteria
-
-- Evidence shows every lifecycle step through API-visible request/response
-  facts.
-- Evidence includes post-submit derivation input and output summaries.
-- Evidence includes compiled post-submit policy hash and approved status.
-- Evidence reads back approval provenance, setup context, source snapshot id,
-  source snapshot hash field presence/shape, and compiled policy hash field
-  presence/shape through APIs. Committed evidence must show field presence/shape
-  or approved redacted placeholders for actor/source/setup identifiers, and must
-  redact exact source and policy hash values as `sha256:<redacted>`.
-- Evidence proves clean finalization to `review_pending`.
-- Evidence proves worker-fixable post-submit failure to `needs_revision`.
-- Evidence proves checker-caused `needs_revision` has
-  `outcome_source = auto_checker` and no human review decision id.
-- Evidence proves fixed resubmission back to `review_pending`.
-- Evidence proves internal setup/retry routes remain hidden from workers.
-- Evidence proves operator-visible internal repair routes include bounded
-  reason, owner, next action, retry eligibility, and audit event id.
-- Evidence is privacy-safe and contains no raw local paths, source-specific task
-  identifiers, raw source hashes, raw policy hashes, credentials, or replayable
-  private refs.
-- Privacy scan rejects exact source and policy hashes while allowing approved
-  redacted provenance placeholders such as `sha256:<redacted>`.
-- A professional PDF report is generated when evidence volume exceeds a concise
-  Markdown review packet.
-
-## Verification Commands
-
-```bash
-python3 scripts/check_stale_workstream_wording.py
-python3 scripts/check_markdown_links.py
-(cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/api_contract_e2e.py)
-(cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test .venv/bin/python scripts/week2_api_e2e.py)
-(cd backend && WORKSTREAM_DATABASE_URL=postgresql+asyncpg://workstream:workstream@localhost:5433/workstream_test OPENAI_API_KEY=\"${OPENAI_API_KEY:?set OpenAI key}\" WORKSTREAM_PROJECT_AGENT_OPENAI_AGENT_SDK_MODEL=\"${WORKSTREAM_PROJECT_AGENT_OPENAI_AGENT_SDK_MODEL:?set model}\" WORKSTREAM_TERMINAL_BENCH_FIXTURE=\"${WORKSTREAM_TERMINAL_BENCH_FIXTURE:?set fixture}\" WORKSTREAM_TERMINAL_BENCH_GUIDE_ROOT=\"${WORKSTREAM_TERMINAL_BENCH_GUIDE_ROOT:-}\" .venv/bin/python ../examples/terminal_benchmark/terminal_benchmark_api_e2e.py)
-python3 -m py_compile scripts/privacy_scan_evidence.py
-(cd backend && .venv/bin/python -m ruff check ../scripts/privacy_scan_evidence.py)
-python3 scripts/privacy_scan_evidence.py .agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews
-git diff --check
-```
-
-Prerequisites:
-
-- local Postgres test database `workstream_test`
-- backend dependencies installed in `backend/.venv`
-- `OPENAI_API_KEY` set in local shell only; never committed
-- `WORKSTREAM_PROJECT_AGENT_OPENAI_AGENT_SDK_MODEL` set to the approved local
-  OpenAI Agents SDK model for the drill
-- `WORKSTREAM_TERMINAL_BENCH_FIXTURE` set to the sanitized local fixture path
-- `WORKSTREAM_TERMINAL_BENCH_GUIDE_ROOT` set when the fixture needs a separate
-  guide-material root
-- local API/worker execution configured exactly as the drill command requires
-- only redacted evidence committed under
-  `.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/reviews/`
-
-If `scripts/privacy_scan_evidence.py` does not exist when this chunk starts,
-the chunk must add it or replace it with an equivalent committed privacy scan
-script before evidence is accepted.
-
-## Required Reviewers
-
-- senior engineering
-- QA/test
-- security/auth
-- product/ops
-- architecture
-- docs
-- reuse/dedup
-- test delta
-- CI integrity
-
-## Human Review Focus
-
-- Confirm the report proves behavior through APIs without DB inspection.
-- Confirm Terminal Benchmark material is used only as a sanitized example.
-- Confirm post-submit checker policy is project-scoped and deterministic.
-- Confirm worker-facing lifecycle remains clear.
-
-## Stop conditions
-
-Stop and escalate if:
-
-- scope must expand beyond allowed files
-- architecture direction changes
-- auth/payment/policy/data boundary changes beyond this contract
-- CI/test weakening is required to pass
-- the same blocker remains after 2 repair attempts
-- secrets or production data are needed
+Confirm one automatic checker port, immutable lineage, default-checker
+preservation, zero inference, and no alternate trigger.

--- a/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-05-post-submit-live-api-proof.md
+++ b/.agent-loop/initiatives/WS-POL-002-post-submit-checker-foundation/chunks/WS-POL-002-05-post-submit-live-api-proof.md
@@ -7,7 +7,7 @@ runnable verification commands, and named reviewer tracks.
 
 ## Goal
 
-Prove the sole automatic post-submit checker path end to end without policy
+Prove the sole automatic post-submit checker path end-to-end without policy
 inference or caller-selected execution.
 
 ## Allowed

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/CHUNK_MAP.md
@@ -1,17 +1,47 @@
 # Chunk Map: WS-POL-003 - Unified Project Guide Compilation
 
-All chunks are L1, one PR each, proposed, and inactive.
+All chunks are L1, one PR each, proposed, and inactive. Product behavior is
+built hidden before AUTH activation; only a later live-cutover chunk exposes
+it. No chunk starts automatically.
 
 | Chunk | Purpose | Hard dependency |
 |---|---|---|
-| WS-POL-003-01 | Strict unified contracts, safe evidence references, merged ART-04B1 pre-submit projection, and durable CHECKER/POL post-submit projection | AUTH-12B2 merged; consume ART-04B1 PR #276 exact contract |
-| WS-POL-003-02 | One OpenAI Agents SDK unified adapter method and fake-runtime tests | 01 |
-| WS-POL-003-03 | Immutable compilation persistence, trusted validator, and action-specific service provenance | 02; AUTH-12F/12G and exact XINT/AUTH compilation request+execute activation merged |
-| WS-POL-003-04 | Initial setup cutover from sufficiency + artifact-policy calls to one compilation | 03 |
-| WS-POL-003-05 | Project Manager approval and trusted project pre-submit policy compilation | 04 |
-| WS-POL-003-06 | Deterministic post-submit projection compilation with zero second model call | 05; AUTH-12G merged |
-| WS-POL-003-07 | One typed checker service port with one complete pre and one complete post command | 06; ART-04B1-04B3 pre-submit executor/evidence-writer contract merged and callable |
-| WS-POL-003-08 | Visibility, generation-safe correction, activation compatibility, checker-route clean cut, and legacy inference cleanup | 07; AUTH-12H/14 and ART-05B merged |
+| `WS-POL-003-01` | Strict unified contracts and read-only pre/post capability projections. | Merged ART-04B1 and canonical CHECKER/POL post-submit registry |
+| `WS-POL-003-02` | One `compile_project_guide` adapter method and fake-runtime proof. | 01 |
+| `WS-POL-003-03A` | Hidden immutable attempt/compilation schema, validator, repository, crash fence, and deny-by-default authorization seams. | 02 |
+| `WS-AUTH-001-12I` | Register and activate exact PM compilation request/recovery plus fixed-service compilation execute authority. | 03A exact resource/action manifest |
+| `WS-POL-003-03B` | Consume 12I to make immutable compilation parent/result persistence usable; no policy projection or worker cutover. | 03A + AUTH-12I |
+| `WS-POL-003-04A` | Hidden one-attempt setup orchestrator over the complete result, with all three legacy inference methods denied/unreachable in the candidate call graph. | 03B |
+| `WS-AUTH-001-12B2` | Activate only setup-ledger mutation and its fixed-service adapter for the reviewed unified worker manifest. | 04A |
+| `WS-POL-003-04B` | Live one-call setup cutover; persist complete result, sufficiency, and artifact-policy projections; remove every legacy inference call from live reachability. | 04A + AUTH-12B2 |
+| `WS-POL-003-05A` | Hidden approval/effective/pre-submit projection behavior over the complete immutable result. | 04B |
+| `WS-AUTH-001-12F4` | Activate exact PM approval authority and PREP composition for the hidden 05A manifest. | 05A |
+| `WS-POL-003-05B` | Live PM approval and trusted effective/pre-submit projection cutover. | 05A + AUTH-12F4 |
+| `WS-POL-003-06A` | Hidden deterministic post-submit projection and separate approval behavior; zero model calls. | 05B |
+| `WS-AUTH-001-12G` | Activate exact fixed-service projection plus PM approval/correction authority for the hidden 06A manifest. | 06A |
+| `WS-POL-003-06B` | Live deterministic post-submit projection/approval cutover with zero additional inference. | 06A + AUTH-12G |
+| `WS-POL-003-07` | One typed checker-service port with one complete pre and one complete post command. | 06B + merged ART-04B1-04B3 execution/evidence contract |
+| `WS-AUTH-001-12H` | Activate guide publication only over the complete approved current-generation unified chain and CON clean cut. | 07 + corrected 12B2 + owning CON clean cut |
+| `WS-POL-003-08` | Visibility, generation-safe correction, physical legacy inference/parallel-route cleanup, and activation compatibility proof. | 07 + AUTH-12H + ART-05B |
 
-No chunk starts automatically. Each contract must be reconciled against the
-then-current main and dependency merge before human start.
+## Parallel ART admission path
+
+The ART admission sequence remains independent and may proceed concurrently:
+
+```text
+merged ART-04B3
+-> merged XINT-06A
+-> ART-04C1 -> ART-04C2
+-> XINT-05A -> ART-05A -> XINT-05B -> ART-05B
+```
+
+Once a unified guide generation is active, ART admission must bind only that
+generation's approved compilation-derived policy hashes; stale pre-unified or
+mixed-generation chains deny through the existing locked-lineage checks.
+
+## Post-submit execution gate
+
+ART-06A/06B may build hidden materialization/output behavior after ART-05B,
+but XINT-06B must not activate it until POL-06B and POL-07 have merged. AUTH-14
+then owns only bounded live authorization/visibility over the sole
+admission-backed Submission and checker paths.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/CHUNK_MAP.md
@@ -10,9 +10,9 @@ it. No chunk starts automatically.
 | `WS-POL-003-02` | One `compile_project_guide` adapter method and fake-runtime proof. | 01 |
 | `WS-POL-003-03A` | Hidden immutable attempt/compilation schema, validator, repository, crash fence, and deny-by-default authorization seams. | 02 |
 | `WS-AUTH-001-12I` | Register and activate exact PM compilation request/recovery plus fixed-service compilation execute authority. | 03A exact resource/action manifest |
-| `WS-POL-003-03B` | Consume 12I to make immutable compilation parent/result persistence usable; no policy projection or worker cutover. | 03A + AUTH-12I |
+| `WS-POL-003-03B` | Consume 12I to make immutable compilation parent/result persistence usable; no policy projection or setup-service cutover. | 03A + AUTH-12I |
 | `WS-POL-003-04A` | Hidden one-attempt setup orchestrator over the complete result, with all three legacy inference methods denied/unreachable in the candidate call graph. | 03B |
-| `WS-AUTH-001-12B2` | Activate only setup-ledger mutation and its fixed-service adapter for the reviewed unified worker manifest. | 04A |
+| `WS-AUTH-001-12B2` | Activate only setup-ledger mutation and its fixed-service adapter for the reviewed unified setup-service manifest. | 04A |
 | `WS-POL-003-04B` | Live one-call setup cutover; persist complete result, sufficiency, and artifact-policy projections; remove every legacy inference call from live reachability. | 04A + AUTH-12B2 |
 | `WS-POL-003-05A` | Hidden approval/effective/pre-submit projection behavior over the complete immutable result. | 04B |
 | `WS-AUTH-001-12F4` | Activate exact PM approval authority and PREP composition for the hidden 05A manifest. | 05A |

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/DECISIONS.md
@@ -61,3 +61,16 @@
     attempt, result, and evidence writer. The post command uses CHECKER's sole
     durable executor/repository. The facade creates no duplicate member rows or
     evidence and returns only the canonical phase result/reference.
+20. Feature behavior is built hidden before AUTH activation, then cut live;
+    AUTH owns action/PREP/evidence custody and POL owns product behavior.
+21. The complete unified result, including the post-submit proposal, exists
+    before any approval. Separate approval gates never cause inference.
+22. Compilation execution uses pre-I/O authorization, a committed durable
+    attempt/idempotency reservation, external I/O without held DB locks, and
+    fresh result-bound PREP for final persistence.
+23. AUTH-12E/12F3 are transitional separate-call implementations. POL-04B
+    removes all three legacy inference methods from live reachability; POL-08
+    later deletes the retired code without compatibility aliases.
+24. Post-submit projection is deterministic from the stored unified component
+    and performs zero model calls in projection, approval, correction, replay,
+    or recovery.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/DISCOVERY.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/DISCOVERY.md
@@ -44,7 +44,7 @@ on 2026-08-08.
 ## Canonical dependencies
 
 - AUTH-12I: hidden unified compilation request/execute activation after POL-03A.
-- AUTH-12B2: setup-ledger-only activation after hidden POL-04A; POL-04B owns the live worker cutover.
+- AUTH-12B2: setup-ledger-only activation after hidden POL-04A; POL-04B owns the live setup-service cutover.
 - AUTH-12F4: stored unified pre-submit component approval after hidden POL-05A; no inference.
 - AUTH-12G: deterministic stored post-submit projection/approval after hidden POL-06A; zero model calls.
 - AUTH-12H: terminal guide activation after POL-07 and the CON clean cut.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/DISCOVERY.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/DISCOVERY.md
@@ -1,13 +1,17 @@
 # Discovery: WS-POL-003 - Unified Project Guide Compilation
 
-Baseline inspected: `origin/main` `bb77ff4a0ab61120b94d6d4763934b444c39207d`
-on 2026-08-05.
+Baseline refreshed: `origin/main` `99c0aaf04efd36c7ac4af4aeec2e9d810f012305`
+on 2026-08-08.
 
 ## Current behavior
 
 - `backend/app/interfaces/project_agents.py` exposes separate
   `analyze_guide_sufficiency`, `derive_submission_artifact_policy`, and
   `derive_post_submit_checker_policy` contracts.
+- AUTH-12E and AUTH-12F3 are merged transitional implementations of the first
+  two separate calls. Their action-specific authorization/projection custody
+  remains reusable, but their independent invocation paths are not the final
+  orchestration and must become unreachable at the unified cutover.
 - `backend/app/adapters/project_agents/openai_agent_sdk.py` implements three
   prompts/model calls behind `ProjectGuideAgentRuntime`.
 - `backend/app/modules/projects/sufficiency_mutation_service.py` now performs
@@ -39,10 +43,11 @@ on 2026-08-05.
 
 ## Canonical dependencies
 
-- AUTH-12F: submission-artifact policy mutation/provenance authority.
-- AUTH-12G: post-submit policy mutation/provenance authority.
-- AUTH-12B2: fixed setup-service worker call-graph cutover.
-- AUTH-12H: terminal guide activation authority.
+- AUTH-12I: hidden unified compilation request/execute activation after POL-03A.
+- AUTH-12B2: setup-ledger-only activation after hidden POL-04A; POL-04B owns the live worker cutover.
+- AUTH-12F4: stored unified pre-submit component approval after hidden POL-05A; no inference.
+- AUTH-12G: deterministic stored post-submit projection/approval after hidden POL-06A; zero model calls.
+- AUTH-12H: terminal guide activation after POL-07 and the CON clean cut.
 - ART-04B1: merged PR #276. The immutable catalogue is exactly
   `workstream.pre_submission_checkers` `v0.1` with schema
   `pre_submission_checker_catalogue.v1`; the pure effective plan is
@@ -50,6 +55,9 @@ on 2026-08-05.
   source/effective/pre-submit policy lineage.
 - ART-04B2/04B3: sealed scratch/default execution facts consumed through a
   typed boundary; WS-POL-003 does not change those ART behaviors.
+- ART-04B2, ART-04B3, and XINT-06A pre-submit materialization activation are
+  merged. ART-04C1 is the next admission-path implementation and may proceed
+  independently of unified compilation.
 - CHECKER/POL: canonical durable post-submit defaults/selectable rules and one
   typed evaluation service with a complete pre and complete post command.
 - Artifact-flow orchestration invokes the pre command once while material is

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/INTENT.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/INTENT.md
@@ -22,6 +22,9 @@ approval authority.
   blocks that generation. Correction or another genuine evaluation requires a
   new setup generation; transport uncertainty is reconciled under the original
   key and can only reuse an already accepted result.
+- The accepted result contains sufficiency, submission-artifact, pre-submit,
+  and post-submit proposals together before any Project Manager approval can
+  occur. Approval never triggers another guide-reading inference.
 - Trusted server validation projects the immutable result into the existing
   canonical policy objects; `ProjectGuideCompilation` does not replace them.
 - Platform checks remain mandatory and non-selectable.
@@ -58,6 +61,8 @@ approval authority.
 
 - Prefer one unified inference over three complete guide-reading inferences.
 - Keep durable policy lifecycles and approval gates separate.
+- Separate approval gates operate on components of the already complete
+  immutable result; they do not divide model generation into stages.
 - Treat the model as an untrusted proposal generator.
 - Preserve async-first execution and fixed-service authorization custody.
 - Do not preserve compatibility aliases or dual inference paths in v0.1.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/PLAN.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/PLAN.md
@@ -22,12 +22,29 @@ The invocation proposes:
 The model is untrusted. Trusted server code validates, canonicalizes, hashes,
 persists, compiles, and submits separate canonical policies for approval.
 
-## Prerequisite sequence
+## Prerequisite and activation sequence
 
-AUTH-12F, 12G, 12B2, and 12H complete the existing policy mutation,
-fixed-service worker, and activation authorization boundaries. WS-POL-003 must
-reuse those action-specific boundaries rather than create a broad
-`project.guide.compile_everything` permission.
+The mandatory order is:
+
+```text
+typed contract and hidden feature behavior
+-> narrow AUTH/XINT registration and activation
+-> live feature cutover
+-> legacy-path deletion
+```
+
+AUTH owns action registration, evaluator/PREP composition, availability, and
+authorization evidence. POL owns unified compilation, trusted projections,
+approval lifecycle behavior, and one-call orchestration. AUTH must not
+implement a second compiler or agent lifecycle; POL must not create broad
+`project.guide.compile_everything` authority.
+
+AUTH-12E and AUTH-12F3 are merged transitional separate-inference paths. Their
+action-specific projection custody remains reusable, but POL-04B makes their
+independent model calls unreachable without aliases or fallbacks. Remaining
+AUTH-12F4, 12G, 12B2, and 12H are narrow authorization/activation gates placed
+after the corresponding hidden POL behavior and before its live cutover. They
+are not blanket prerequisites for POL-01.
 
 ART-04B1 supplies the complete typed pre-submit catalogue and effective-plan
 compiler: mandatory/non-selectable platform coverage plus its closed selectable
@@ -54,7 +71,8 @@ selectable project rules. WS-POL-003 creates no pre-submit or post-submit
 dispatch registry; the unified agent sees read-only projections from both
 canonical phase owners.
 
-Before persistence/runtime cutover, an XINT/AUTH amendment must activate:
+After strict contracts, the unified adapter, and the hidden persistence
+manifest exist, a bounded XINT/AUTH amendment must register and activate:
 
 - `project.guide_compilation.request`: Project Manager dispatch/recovery bound
   to exact actor/link/grant, project, draft guide, snapshot, setup
@@ -63,6 +81,12 @@ Before persistence/runtime cutover, an XINT/AUTH amendment must activate:
   authority bound to exact canonical input hash, source and phase-owned
   capability snapshot hashes, setup run/generation, instruction/agent version,
   prior compilation when superseding, session/root transaction, and result.
+
+Execute has two fresh authorization points around external I/O: fail-closed
+preflight over the exact canonical input before the provider call, then fresh
+transaction-bound PREP over the exact accepted-result digest before immutable
+persistence. A durable attempt reservation and provider idempotency key commit
+before I/O; no database transaction or row lock is held across the model call.
 
 Execute authorizes only the model call plus immutable compilation parent
 creation/supersession. It does not authorize canonical projections: 12E owns
@@ -237,11 +261,11 @@ Validation must, in order:
    timeout/budget fields only when their canonical source defines them;
 9. sanitize every persisted text field;
 10. canonicalize and hash the result and each projection; and
-11. prepare every required action-specific fixed-service PREP, consume all of
-    them inside the one root database transaction owning compilation and
-    projection persistence, then commit mutations and authorization evidence
-    together; any validation, consumption, or write failure rolls back the
-    entire unit without borrowing authority between actions.
+11. consume fresh action-specific fixed-service PREP inside each protected
+    projection transaction and commit that projection with its authorization
+    evidence atomically, without borrowing authority between actions. The
+    already committed pre-I/O attempt reservation is a separate crash fence;
+    no transaction spans provider I/O and no plan promises to roll it back.
 
 The agent cannot order platform execution. Catalogue phases, dependencies, and
 the trusted compiler determine order.
@@ -270,13 +294,17 @@ ART verified extraction
 -> canonical platform/capability projections
 -> one unified model invocation
 -> trusted validation and immutable compilation
--> separate sufficiency/policy proposals
--> Project Manager review/approval
+-> complete sufficiency/artifact/pre/post proposal visible for review
+-> Project Manager submission/effective/pre approval
 -> trusted effective + pre-submit compilation
 -> deterministic post-submit proposal compilation (zero model calls)
 -> separate PostSubmitCheckerPolicy approval
 -> existing authorized guide activation
 ```
+
+No approval may occur before the complete immutable result, including its
+post-submit proposal, exists. Separate approvals preserve canonical policy
+lifecycles; they never trigger another inference.
 
 Blocked compilation creates no policy projections. A required capability gap
 blocks activation with an exact operator-visible setup status/error. The setup

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/RISKS.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/RISKS.md
@@ -3,7 +3,7 @@
 | Risk | Severity | Mitigation |
 |---|---|---|
 | Unified model result is trusted as policy | Critical | Strict schemas, canonical registry lookup, trusted validation, separate approvals, and final locked revalidation. |
-| Setup service borrows PM/admin authority | Critical | Finish AUTH-12F/12G/12B2/12H; use fresh fixed-service PREP per protected transaction. |
+| Setup service borrows PM/admin authority | Critical | Use 12I/12B2/12F4/12G/12H narrow gates and fresh fixed-service PREP per protected transaction. |
 | Pre-submit capability dispatch is duplicated | Critical | Consume ART-04B1's complete platform-plus-project catalogue read-only; add no POL pre-submit registry or primitive map. |
 | Manual correction breaks compilation provenance | Critical | Immutable agent projections; new generation or independent manual replacement provenance. |
 | Model echoes secrets or injected guide instructions | High | Closed evidence references, safe-text validation/redaction, strict limits, no tools/network, and prompt-injection tests. |
@@ -16,4 +16,9 @@
 | ART is forced to own post-submit policy | Critical | ART retains only its current pre-submit catalogue/material custody; durable CHECKER/POL ownership remains post-submit. |
 | Individual checker calls bypass the effective plan | Critical | One checker-service port exposes one pre and one post command; artifact-flow orchestration invokes once per material boundary and cannot select checkers. |
 | Facade duplicates ART pre-submit execution/evidence | Critical | Pre command delegates once to ART-04B1-04B3 and returns its canonical result/reference; ART remains the sole pre attempt/evidence writer. |
-| Compilation parent lacks exact AUTH custody | Critical | Merge narrow XINT/AUTH request+execute activation before chunk 03; projections retain separate 12E/12F/12G PREP. |
+| Compilation parent lacks exact AUTH custody | Critical | Build hidden POL-03A, merge AUTH-12I, then enable POL-03B persistence; projections retain action-specific PREP. |
+| AUTH activates before hidden behavior exists | Critical | Require exact hidden manifest, then narrow activation, then live cutover. |
+| Legacy post-submit model call survives unified cutover | Critical | POL-04B makes all three old inference methods unreachable; static and runtime zero-call tests fail on any fallback. |
+| Approval occurs before the complete result | Critical | Bind approval to the immutable full result and all component hashes, including post-submit. |
+| A transaction or lock spans provider I/O | Critical | Commit reservation before I/O and use fresh final PREP; represent uncertainty durably under the same provider key. |
+| Partial projection is mistaken for global atomicity | High | Compilation and each canonical projection use separate owning transactions with exact hashes and action-specific PREP. |

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/STATUS.md
@@ -1,27 +1,49 @@
 # Status: WS-POL-003 - Unified Project Guide Compilation
 
-Status: planning candidate under review; no implementation is active.
+Status: planning reconciliation active; no implementation chunk is active.
 
-Baseline: `origin/main` `bb77ff4a0ab61120b94d6d4763934b444c39207d`.
+Baseline: `origin/main` `99c0aaf04efd36c7ac4af4aeec2e9d810f012305`
+after merged AUTH-12F3 PR #295.
+
+## Current delivery truth
+
+- One logical model attempt per immutable guide/catalogue/setup generation is
+  the sole target design.
+- The complete accepted result contains sufficiency, artifact, pre-submit, and
+  post-submit proposals before any approval.
+- AUTH-12E and AUTH-12F3 are merged transitional separate-call
+  implementations. Their action-specific projection custody is reusable; their
+  independent inference paths must not survive POL-04B.
+- ART-04B1, 04B2, 04B3, and XINT-06A are merged. ART-04C1 is ready to proceed
+  independently through the admission sequence.
+- Remaining AUTH-12F4, 12G, 12B2, and 12H contracts require reconciliation as
+  narrow activation gates around hidden POL behavior. They are not authority
+  for another inference pipeline.
 
 ## Dependency gates
 
-| Dependency | Required before | Current status at baseline |
+| Dependency | Required before | Current status |
 |---|---|---|
-| AUTH-12F | service submission-policy projection writes | Proposed after merged 12E |
-| AUTH-12G | service post-submit projection writes | Proposed after 12F |
-| AUTH-12B2 | unified Celery call-graph cutover | Proposed after 12F/12G |
-| AUTH-12H | terminal activation integration | Proposed after 12B2 |
-| ART PLAN5 / 04A4 | 04A4 superseded; standalone precheck clean cut moved to ART-05B | PLAN5 merged through PR #273 |
-| ART-04B1 complete pre-submit catalogue/effective-plan contract | exact immutable platform plus closed project-rule projection consumed read-only | Merged through PR #276 |
-| ART-04B2/04B3 | sealed execution and immutable evidence writer used behind the pre facade | Proposed after merged ART-04B1 |
-| ART-05B | standalone precheck and legacy Submission path clean cut | Proposed after ART/XINT admission sequence |
-| CHECKER/POL post-submit catalogue | durable defaults plus registered selectable project rules | Consumed read-only/hardened by POL work |
-| CHECKER typed evaluation port | one pre call in scratch and one post call after verified storage/binding | Owned by WS-POL-003-07 |
-| XINT/AUTH compilation activation | exact PM request and fixed-service execute actions for immutable compilation custody | Not yet planned/merged |
+| ART-04B1 complete pre-submit catalogue/effective plan | POL-01 | Merged PR #276 |
+| Canonical CHECKER/POL post-submit registry | POL-01 | Present; remaining POL-002 work must be reframed as executor ownership, not inference |
+| POL-01/02 strict manifest and adapter | POL-03A | Proposed |
+| Hidden POL-03A compilation manifest | AUTH-12I compilation request/execute activation | Proposed |
+| AUTH-12I | POL-03B authorized persistence | Not yet implemented |
+| Hidden POL-04A unified worker manifest | AUTH-12B2 setup-ledger activation | Not yet implemented |
+| Hidden POL-05A approval manifest | AUTH-12F4 approval activation | Not yet implemented |
+| Hidden POL-06A deterministic post manifest | AUTH-12G projection/approval activation | Not yet implemented |
+| Complete POL-07 single checker port + corrected 12B2 + CON clean cut | AUTH-12H | Not yet implemented |
+| ART-05B + POL-07 + ART-06A/06B evidence | XINT-06B and AUTH-14 | Not yet implemented |
 
 ## Chunk state
 
-All WS-POL-003 chunks are proposed and inactive. Planning does not authorize
-implementation. The first implementation chunk requires explicit human start
-after this plan and its applicable dependencies are merged.
+POL-01 and POL-02 retain their full executable contracts. The newly split
+03A-06B and corresponding AUTH gates are reviewed planning skeletons only:
+before any is started, its contract must be expanded on then-current main with
+explicit allowed/not-allowed paths, runnable verification commands, and named
+reviewer tracks. They cannot authorize implementation in their current form.
+
+All WS-POL-003 chunks and corresponding AUTH gates are proposed and inactive.
+The current work is planning-only. The first executable candidate after this
+planning PR merges is `WS-POL-003-01`, subject to a separate explicit start and
+fresh preimplementation review.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/STATUS.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/STATUS.md
@@ -29,7 +29,7 @@ after merged AUTH-12F3 PR #295.
 | POL-01/02 strict manifest and adapter | POL-03A | Proposed |
 | Hidden POL-03A compilation manifest | AUTH-12I compilation request/execute activation | Proposed |
 | AUTH-12I | POL-03B authorized persistence | Not yet implemented |
-| Hidden POL-04A unified worker manifest | AUTH-12B2 setup-ledger activation | Not yet implemented |
+| Hidden POL-04A unified setup-service manifest | AUTH-12B2 setup-ledger activation | Not yet implemented |
 | Hidden POL-05A approval manifest | AUTH-12F4 approval activation | Not yet implemented |
 | Hidden POL-06A deterministic post manifest | AUTH-12G projection/approval activation | Not yet implemented |
 | Complete POL-07 single checker port + corrected 12B2 + CON clean cut | AUTH-12H | Not yet implemented |

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03-compilation-persistence-validator.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03-compilation-persistence-validator.md
@@ -1,51 +1,13 @@
-# Chunk Contract: WS-POL-003-03 - Compilation Persistence and Validator
+# Planning Parent: WS-POL-003-03 - Compilation Persistence and Validator
 
-Status: Proposed after 02 and required AUTH dependencies. Risk: L1.
+Status: Split into `03A` and `03B`; this file is not executable. Risk: L1.
 
-Hard gate: the exact XINT/AUTH registration and activation for
-`project.guide_compilation.request` and
-`project.guide_compilation.execute` is merged. Generic fixed-service authority
-or 12E/12F/12G projection authority cannot substitute for it.
+`03A` builds hidden schema, validator, repository, attempt crash fencing, and
+deny-by-default authorization seams. AUTH-12I then activates the exact request
+and execute actions. `03B` consumes that authority to make compilation-parent
+persistence usable. Policy projections remain owned by 04B, 05B, and 06B in
+their separate protected transactions.
 
-## Goal
-
-Add immutable compilation provenance, trusted validation, component hashes,
-append-only supersession, and action-specific fixed-service mutation custody.
-
-## Allowed files
-
-Project models/schemas/repository/validator/composition, AUTH prepared-resource
-composition only where exact existing actions require it, one then-current
-Alembic migration, focused tests, and WS-POL-003/AUTH specification docs.
-
-## Not allowed
-
-Celery call-graph cutover, approval behavior, checker execution, broad compilation
-permission, synthetic human authority, compatibility path, or ART semantics.
-
-## Acceptance
-
-- A database `UNIQUE` constraint covers exact `project_id`, `guide_id`, source
-  snapshot ID, pre- and post-catalogue snapshot hashes, setup run ID, and setup
-  generation. The setup-run current-compilation pointer advances only by
-  compare-and-swap against its locked expected generation/current ID. Concurrent
-  requests therefore converge on one immutable compilation rather than two
-  current rows.
-- Strict validation and sanitization precede atomic persistence.
-- Existing policy projections bind exact compilation/component hashes.
-- Fresh action-specific fixed-service PREPs are prepared separately, but all
-  required handles are consumed in the single root database transaction that
-  owns compilation, projection links, and authorization evidence. Replay,
-  copied/wrong handle, stale context, or any partial failure rolls back the
-  whole unit and creates no durable effect.
-- Agent-derived projections cannot be updated in place.
-- Compilation creation/supersession consumes the exact fixed-service execute
-  action; PM recovery consumes the exact request action. Projection writes each
-  consume their separate 12E/12F/12G PREP in that same root transaction and
-  cannot borrow compilation authority.
-
-## Verification and review
-
-Postgres unique-key, compare-and-swap, concurrent-insert, PREP atomicity, and
-rollback tests plus AUTH all-pairs denials and 90% changed-subsystem coverage.
-Required reviewers: all L1 tracks.
+No transaction or lock spans provider I/O. PM request/recovery records only
+dispatch custody; the worker later authenticates independently as
+`workstream.project.setup`. No handle crosses Celery.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03-compilation-persistence-validator.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03-compilation-persistence-validator.md
@@ -9,5 +9,5 @@ persistence usable. Policy projections remain owned by 04B, 05B, and 06B in
 their separate protected transactions.
 
 No transaction or lock spans provider I/O. PM request/recovery records only
-dispatch custody; the worker later authenticates independently as
+dispatch custody; the setup service later authenticates independently as
 `workstream.project.setup`. No handle crosses Celery.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03A-hidden-compilation-foundation.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03A-hidden-compilation-foundation.md
@@ -1,0 +1,37 @@
+# Chunk Contract: WS-POL-003-03A - Hidden Compilation Foundation
+
+Status: Proposed after 02; inactive. Risk: L1.
+
+## Goal
+
+Add immutable attempt/compilation persistence, trusted validation, append-only
+supersession, and deny-by-default request/execute seams without making a model
+call or a live product mutation.
+
+## Allowed files
+
+Project compilation models, schemas, validator, repository, composition seam,
+one then-current Alembic migration, focused tests, and WS-POL-003 docs.
+
+## Not allowed
+
+Action activation, provider calls, Celery cutover, policy projections,
+approval, checker execution, compatibility paths, or ART changes.
+
+## Acceptance
+
+- One durable attempt is uniquely bound to canonical input hash, project,
+  guide/source, both catalogue snapshots, setup run/generation, agent identity,
+  and instruction version; compare-and-swap selects one current compilation.
+- States distinguish reserved, provider-uncertain, accepted, invalid-terminal,
+  persisted, and superseded. Invalid/unsafe output terminally consumes the
+  generation; transport uncertainty alone is reconciled under the same key.
+- Reservation commits before provider I/O. No transaction/lock spans I/O.
+- Strict validation, safe text, evidence grammar, component hashes, and
+  append-only invariants are proven while every runtime seam denies.
+
+## Verification and review
+
+PostgreSQL migration/uniqueness/CAS/crash-state tests, validator/security tests,
+Ruff, hosted CI, and all L1 reviewer tracks. Human focus: durable cardinality
+and fail-closed hidden state.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03B-authorized-compilation-persistence.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03B-authorized-compilation-persistence.md
@@ -9,18 +9,18 @@ dispatch custody and fixed-service immutable compilation persistence are usable.
 
 ## Allowed files
 
-Compilation request/service/repository/router/worker composition, AUTH resource
+Compilation request/service/repository/fixed-service execution composition, AUTH resource
 adapter consumption, focused tests, specifications, and WS-POL-003 docs.
 
 ## Not allowed
 
-Policy projection writes, approval, live unified worker cutover, checker
+Policy projection writes, approval, live setup-service cutover, checker
 execution, broad authority, handles in Celery, or transactions across I/O.
 
 ## Acceptance
 
 - PM request records only authorized dispatch/recovery custody and identifiers.
-- Worker independently authenticates the fixed service and performs exact
+- `workstream.project.setup` independently authenticates as the fixed service and performs exact
   pre-I/O admission, committed attempt reservation, same-key provider recovery,
   and fresh final result-bound PREP before immutable persistence.
 - Compilation/result/evidence commit atomically in the final transaction;

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03B-authorized-compilation-persistence.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-03B-authorized-compilation-persistence.md
@@ -1,0 +1,34 @@
+# Chunk Contract: WS-POL-003-03B - Authorized Compilation Persistence
+
+Status: Proposed after 03A and AUTH-12I; inactive. Risk: L1.
+
+## Goal
+
+Consume the exact compilation request/execute authorization adapters so PM
+dispatch custody and fixed-service immutable compilation persistence are usable.
+
+## Allowed files
+
+Compilation request/service/repository/router/worker composition, AUTH resource
+adapter consumption, focused tests, specifications, and WS-POL-003 docs.
+
+## Not allowed
+
+Policy projection writes, approval, live unified worker cutover, checker
+execution, broad authority, handles in Celery, or transactions across I/O.
+
+## Acceptance
+
+- PM request records only authorized dispatch/recovery custody and identifiers.
+- Worker independently authenticates the fixed service and performs exact
+  pre-I/O admission, committed attempt reservation, same-key provider recovery,
+  and fresh final result-bound PREP before immutable persistence.
+- Compilation/result/evidence commit atomically in the final transaction;
+  already-issued provider I/O is represented by durable recovery state.
+- Replay/copy/stale/session/transaction/service/resource mismatches fail closed.
+
+## Verification and review
+
+PREP all-pairs, provider uncertainty/recovery, crash, replay, rollback, and 90%
+changed-subsystem coverage; all L1 tracks. Human focus: authorization around,
+never across, external I/O.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04-initial-setup-cutover.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04-initial-setup-cutover.md
@@ -5,6 +5,6 @@ Status: Split into `04A` and `04B`; this file is not executable. Risk: L1.
 `04A` builds the hidden one-attempt orchestrator and proves the complete
 sufficiency/artifact/pre/post proposal is one atomic structured result.
 AUTH-12B2 then activates only setup-ledger authority. `04B` makes the unified
-worker live and removes all three legacy inference calls from live
+setup service live and removes all three legacy inference calls from live
 reachability. It is forbidden to retain a fallback or defer the old post-submit
 model call to another continuation.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04-initial-setup-cutover.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04-initial-setup-cutover.md
@@ -1,41 +1,10 @@
-# Chunk Contract: WS-POL-003-04 - Initial Setup Pipeline Cutover
+# Planning Parent: WS-POL-003-04 - Initial Setup Pipeline Cutover
 
-Status: Proposed after 03. Risk: L1.
+Status: Split into `04A` and `04B`; this file is not executable. Risk: L1.
 
-## Goal
-
-Replace the separate sufficiency and submission-policy inference calls with one
-unified compilation, while producing the existing canonical report and draft
-policy projections.
-
-## Allowed files
-
-Project setup worker/service/queue/composition, unified compilation services,
-focused project/authorization/ART-boundary tests, and WS-POL-003 docs.
-
-## Not allowed
-
-Post-submit continuation cutover, approval semantics, checker execution,
-serialized handles/material, or fallback to legacy guide excerpts.
-
-## Acceptance
-
-- Automatic and manual recovery converge on one deterministic setup run/task.
-- Each generation persists one model-attempt row and provider idempotency key
-  derived from the exact setup run/generation and compilation input identity.
-  Dispatch and recovery atomically claim that row; retries use the same key.
-- Provider acceptance must be recoverable by idempotent replay/result lookup,
-  and the accepted result is persisted before downstream continuation. A
-  timeout-after-acceptance retry reuses that result without another invocation.
-- Invalid or unsafe output terminally consumes the generation's attempt;
-  another evaluation requires a new setup generation.
-- Blocked output creates no policy projection.
-- Ready output atomically links sufficiency and draft artifact policy to one
-  compilation.
-- Stale/revoked/wrong-service/output failures occur before protected mutation.
-
-## Verification and review
-
-Celery concurrent-claim, retry/replay, timeout-after-acceptance, accepted-result
-reuse, terminal-invalid-output, stale-generation, provider-failure, and rollback
-tests plus hosted full coverage. Required reviewers: all L1 tracks.
+`04A` builds the hidden one-attempt orchestrator and proves the complete
+sufficiency/artifact/pre/post proposal is one atomic structured result.
+AUTH-12B2 then activates only setup-ledger authority. `04B` makes the unified
+worker live and removes all three legacy inference calls from live
+reachability. It is forbidden to retain a fallback or defer the old post-submit
+model call to another continuation.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04A-hidden-unified-setup.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04A-hidden-unified-setup.md
@@ -1,0 +1,33 @@
+# Chunk Contract: WS-POL-003-04A - Hidden Unified Setup
+
+Status: Proposed after 03B; inactive. Risk: L1.
+
+## Goal
+
+Build the hidden one-attempt setup orchestrator and prove one complete result
+contains sufficiency, artifact, pre-submit, and post-submit proposals together.
+
+## Allowed files
+
+Project setup worker/service/queue composition, unified compilation services,
+focused project/authorization tests, and WS-POL-003 docs.
+
+## Not allowed
+
+Live worker routing, setup-ledger activation, approval, checker execution,
+serialized handles/material, or any legacy inference fallback.
+
+## Acceptance
+
+- Automatic and manual recovery converge on one attempt/key/provider effect.
+- Partial/malformed/unsafe output creates no component projection and
+  terminally consumes the generation.
+- Candidate call-graph tests prove all three legacy inference methods are
+  unreachable and post-submit is already present in the unified result.
+- No approval, continuation, replay, or recovery causes a second model call.
+
+## Verification and review
+
+Concurrent dispatch/recovery, same-key uncertainty, partial-result, static
+reachability, and zero-second-call tests plus all L1 tracks. Human focus: one
+complete result before any approval.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04A-hidden-unified-setup.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04A-hidden-unified-setup.md
@@ -14,7 +14,7 @@ focused project/authorization tests, and WS-POL-003 docs.
 
 ## Not allowed
 
-Live worker routing, setup-ledger activation, approval, checker execution,
+Live fixed-service routing, setup-ledger activation, approval, checker execution,
 serialized handles/material, or any legacy inference fallback.
 
 ## Acceptance

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04A-hidden-unified-setup.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04A-hidden-unified-setup.md
@@ -9,7 +9,7 @@ contains sufficiency, artifact, pre-submit, and post-submit proposals together.
 
 ## Allowed files
 
-Project setup worker/service/queue composition, unified compilation services,
+Project setup-service/queue composition, unified compilation services,
 focused project/authorization tests, and WS-POL-003 docs.
 
 ## Not allowed

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04B-live-unified-setup-cutover.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04B-live-unified-setup-cutover.md
@@ -21,7 +21,9 @@ compatibility routing, or a second provider attempt/key.
 
 - Live orchestration invokes only `compile_project_guide`.
 - Sufficiency and artifact-policy projections each consume fresh action-bound
-  PREP in their own atomic transaction and bind the compilation/component hash.
+  PREP in their own atomic transaction. Each PREP binds the immutable
+  compilation and accepted-result hashes plus its exact sufficiency or
+  artifact-policy component hash.
 - All three old model methods/prompts are unreachable for unified generations;
   no deferred legacy post call or fallback exists.
 - Complete replay returns canonical outputs with zero provider calls.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04B-live-unified-setup-cutover.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04B-live-unified-setup-cutover.md
@@ -4,12 +4,12 @@ Status: Proposed after 04A and AUTH-12B2; inactive. Risk: L1.
 
 ## Goal
 
-Make the unified setup worker the sole live inference path and persist the
+Make the unified setup service the sole live inference path and persist the
 complete compilation plus canonical sufficiency/artifact-policy projections.
 
 ## Allowed files
 
-Project setup worker/service/queue/composition, projection repositories, exact
+Project setup-service/queue/composition, projection repositories, exact
 12E/12F action adapters, focused tests, specifications, and WS-POL-003 docs.
 
 ## Not allowed

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04B-live-unified-setup-cutover.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-04B-live-unified-setup-cutover.md
@@ -1,0 +1,33 @@
+# Chunk Contract: WS-POL-003-04B - Live Unified Setup Cutover
+
+Status: Proposed after 04A and AUTH-12B2; inactive. Risk: L1.
+
+## Goal
+
+Make the unified setup worker the sole live inference path and persist the
+complete compilation plus canonical sufficiency/artifact-policy projections.
+
+## Allowed files
+
+Project setup worker/service/queue/composition, projection repositories, exact
+12E/12F action adapters, focused tests, specifications, and WS-POL-003 docs.
+
+## Not allowed
+
+Approval/pre effective mutation, post canonical projection, checker execution,
+compatibility routing, or a second provider attempt/key.
+
+## Acceptance
+
+- Live orchestration invokes only `compile_project_guide`.
+- Sufficiency and artifact-policy projections each consume fresh action-bound
+  PREP in their own atomic transaction and bind the compilation/component hash.
+- All three old model methods/prompts are unreachable for unified generations;
+  no deferred legacy post call or fallback exists.
+- Complete replay returns canonical outputs with zero provider calls.
+
+## Verification and review
+
+Real PostgreSQL/Celery/API cutover, static reachability, one-attempt replay,
+projection atomicity, hosted coverage, and all L1 tracks. Human focus: clean
+one-call cutover with reusable, not borrowed, projection authority.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-05-approval-pre-submit-integration.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-05-approval-pre-submit-integration.md
@@ -1,40 +1,8 @@
-# Chunk Contract: WS-POL-003-05 - Approval and Pre-Submit Integration
+# Planning Parent: WS-POL-003-05 - Approval and Pre-Submit Integration
 
-Status: Proposed after 04. Risk: L1.
+Status: Split into `05A` and `05B`; this file is not executable. Risk: L1.
 
-## Goal
-
-Bind Project Manager approval to the exact immutable compilation and compile
-approved project pre-submit bindings through ART-04B1's effective-plan
-compiler while preserving its platform entries as mandatory and non-selectable.
-
-## Allowed files
-
-Project policy approval/service/repository/router/schema surfaces,
-ART-04B1 catalogue/compiler integration,
-authorization resource composition, focused tests, and specifications.
-
-## Not allowed
-
-Second registry/compiler, platform-default selection, checker execution,
-post-submit compilation, unrelated approval semantics, task/review/payment
-behavior, or in-place agent edits. This chunk does own Project Manager approval
-binding to the exact compilation, including hash binding, stale invalidation,
-and activation blocking.
-
-## Acceptance
-
-- Approval locks exact compilation/result/artifact/pre-submit hashes.
-- Platform defaults are composed only by ART and cannot be selected, repeated,
-  weakened, reordered, or downgraded.
-- Required capability gaps block approval/activation with exact operator code.
-- Catalogue/source/generation/projection changes stale prior approval.
-- Effective and pre-submit outputs commit atomically with authorization evidence.
-- The approved project plan and mandatory ART platform entries compose only
-  through the later single checker-service pre-submit command; this chunk does
-  not change ART or expose an execution route.
-
-## Verification and review
-
-Postgres approval races, stale hashes, default isolation, compiler parity,
-AUTH denial, and task-lock regression tests. Required reviewers: all L1 tracks.
+`05A` builds hidden approval/effective/pre-submit behavior over an already
+complete immutable unified result. AUTH-12F4 then activates the exact human
+approval boundary. `05B` exposes it. The post-submit proposal already exists
+before approval; approval causes no model call.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-05A-hidden-pre-submit-approval.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-05A-hidden-pre-submit-approval.md
@@ -1,0 +1,33 @@
+# Chunk Contract: WS-POL-003-05A - Hidden Pre-Submit Approval
+
+Status: Proposed after 04B; inactive. Risk: L1.
+
+## Goal
+
+Build hidden PM approval and trusted effective/pre-submit projection behavior
+over the complete immutable unified result.
+
+## Allowed files
+
+Project approval/policy service/repository/schema, ART catalogue/compiler
+integration, deny-by-default AUTH seam, focused tests, and WS-POL-003 docs.
+
+## Not allowed
+
+Action activation, public live approval, model calls, post projection,
+checker execution, second compiler/registry, or in-place proposal edits.
+
+## Acceptance
+
+- Approval input binds compilation/result/artifact/pre/post component hashes,
+  source/setup generation, and both catalogue snapshots.
+- The full proposal is reviewable before approval; required gaps block and
+  optional gaps require acknowledgement.
+- Mandatory platform entries cannot be selected, repeated, weakened, or
+  reordered; stale lineage denies.
+- Candidate effective/pre writes remain hidden and denied until AUTH-12F4.
+
+## Verification and review
+
+Compiler parity, full-result-before-approval, gap, stale-hash, and denial tests;
+all L1 tracks. Human focus: complete proposal and no inference at approval.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-05B-live-pre-submit-approval.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-05B-live-pre-submit-approval.md
@@ -1,0 +1,31 @@
+# Chunk Contract: WS-POL-003-05B - Live Pre-Submit Approval
+
+Status: Proposed after 05A and AUTH-12F4; inactive. Risk: L1.
+
+## Goal
+
+Expose PM approval and atomically publish the exact approved artifact,
+effective, and compiled pre-submit chain under the narrow AUTH adapter.
+
+## Allowed files
+
+Project approval router/service/repository, AUTH adapter consumption, ART
+compiler integration, focused tests, specifications, and WS-POL-003 docs.
+
+## Not allowed
+
+Model calls, post canonical projection/approval, checker execution, broad
+authority, legacy 12F3-only approval, or partial effective state.
+
+## Acceptance
+
+- Fresh PM PREP and final locked revalidation bind the complete compilation and
+  exact component/catalogue hashes.
+- Approved artifact/effective/pre outputs, replay, and decision evidence commit
+  atomically; concurrent approval yields one current chain.
+- Approval performs zero model calls and never precedes post-proposal creation.
+
+## Verification and review
+
+PostgreSQL approval races, replay/revocation/stale facts, default isolation,
+zero-call proof, hosted coverage, and all L1 tracks.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06-post-submit-deterministic-cutover.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06-post-submit-deterministic-cutover.md
@@ -4,5 +4,8 @@ Status: Split into `06A` and `06B`; this file is not executable. Risk: L1.
 
 `06A` builds hidden trusted projection/approval behavior from the post-submit
 component already stored in the unified result. AUTH-12G activates the exact
-service and human boundaries. `06B` exposes them. Every path, including replay,
-correction, and recovery, performs zero additional model calls.
+service and human boundaries. `06B` exposes them. Replay, recovery, and a
+correction request against existing compilation provenance perform zero
+additional model calls. A correction that requires a new unified generation is
+a separate compilation attempt with its own idempotency key; it is not replay
+or recovery of the prior attempt.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06-post-submit-deterministic-cutover.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06-post-submit-deterministic-cutover.md
@@ -1,42 +1,8 @@
-# Chunk Contract: WS-POL-003-06 - Deterministic Post-Submit Cutover
+# Planning Parent: WS-POL-003-06 - Deterministic Post-Submit Cutover
 
-Status: Proposed after 05. Risk: L1.
+Status: Split into `06A` and `06B`; this file is not executable. Risk: L1.
 
-## Goal
-
-Compile the stored unified post-submit proposal after effective/pre-submit
-approval without rereading the guide or invoking a second model.
-
-## Allowed files
-
-Project post-submit policy/compiler/Celery/repository surfaces, exact AUTH-12G
-composition, the canonical durable CHECKER/POL post-submit capability source,
-focused tests, and WS-POL-003 docs.
-
-## Not allowed
-
-Checker execution, review/revision behavior, new checker registration, default
-checker repetition, manual reuse of agent provenance, or ART changes.
-
-## Acceptance
-
-- Continuation performs zero model invocations.
-- Exact compilation, effective policy, pre-submit plan, catalogue, setup
-  generation, approval record ID, approval actor identity, and approval hash are
-  locked and revalidated.
-- Any correction, replacement, catalogue change, or change to the stored
-  approval record/actor/hash invalidates the proposal.
-- Platform-default repetition and unknown/wrong-stage checkers fail closed.
-- Only registered project entries from the canonical durable CHECKER/POL
-  post-submit source are selectable; ART pre-submit entries cannot be selected.
-- Tests explicitly reject current legacy behavior that repeats any durable
-  default in either required or warning project bindings.
-- Compiled post-submit policy retains separate PM approval; that later approver
-  may differ, but cannot substitute for or alter the exact approval identity
-  authorizing selection of the stored proposal.
-
-## Verification and review
-
-Zero-call, invalidation, replay, approval-race, default-isolation, and atomic
-evidence tests. Runtime dispatch is owned by later consumers of the chunk-07
-port. Required reviewers: all L1 tracks.
+`06A` builds hidden trusted projection/approval behavior from the post-submit
+component already stored in the unified result. AUTH-12G activates the exact
+service and human boundaries. `06B` exposes them. Every path, including replay,
+correction, and recovery, performs zero additional model calls.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06A-hidden-post-submit-projection.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06A-hidden-post-submit-projection.md
@@ -1,0 +1,32 @@
+# Chunk Contract: WS-POL-003-06A - Hidden Post-Submit Projection
+
+Status: Proposed after 05B; inactive. Risk: L1.
+
+## Goal
+
+Build hidden deterministic projection and separate approval/correction behavior
+from the post-submit component already stored in the unified result.
+
+## Allowed files
+
+Project post-submit compiler/service/repository/schema, canonical CHECKER/POL
+catalogue projection, deny-by-default AUTH seam, focused tests, and POL docs.
+
+## Not allowed
+
+Action activation, live routes, guide rereads, any model call, checker
+execution, new registrations, or reuse of agent provenance by manual policy.
+
+## Acceptance
+
+- Projection binds compilation/result/post component, approved upstream chain,
+  catalogue snapshot, setup generation, and deterministic output hash.
+- Unknown/wrong-stage/default-repeating entries fail closed.
+- Correction requires new unified generation or separately proven manual
+  provenance; it cannot rederive from the guide.
+- Candidate mutations remain denied until AUTH-12G.
+
+## Verification and review
+
+Zero-call, stale/replacement, catalogue/default, correction, denial, and race
+tests; all L1 tracks. Human focus: deterministic projection only.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06A-hidden-post-submit-projection.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06A-hidden-post-submit-projection.md
@@ -22,8 +22,10 @@ execution, new registrations, or reuse of agent provenance by manual policy.
 - Projection binds compilation/result/post component, approved upstream chain,
   catalogue snapshot, setup generation, and deterministic output hash.
 - Unknown/wrong-stage/default-repeating entries fail closed.
-- Correction requires new unified generation or separately proven manual
-  provenance; it cannot rederive from the guide.
+- A correction request against existing provenance performs no model call. A
+  correction requiring new unified generation is a separate compilation
+  attempt with its own idempotency key. Separately proven manual provenance
+  remains distinct; neither path may silently rederive from the guide.
 - Candidate mutations remain denied until AUTH-12G.
 
 ## Verification and review

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06B-live-post-submit-projection.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-06B-live-post-submit-projection.md
@@ -1,0 +1,33 @@
+# Chunk Contract: WS-POL-003-06B - Live Post-Submit Projection
+
+Status: Proposed after 06A and AUTH-12G; inactive. Risk: L1.
+
+## Goal
+
+Expose deterministic fixed-service projection plus separate PM
+approval/correction under the exact AUTH adapters, with zero additional model
+calls.
+
+## Allowed files
+
+Project post-submit service/repository/router, AUTH adapter consumption,
+canonical compiler integration, focused tests, specifications, and POL docs.
+
+## Not allowed
+
+Guide/model invocation, checker execution, ART behavior, caller-selected
+checkers, legacy post-submit agent method, or partial activation.
+
+## Acceptance
+
+- Projection, approval, and correction each consume their own exact fresh PREP
+  and commit product/replay/evidence atomically.
+- Every path binds compilation/result/post component and current upstream
+  approval hashes; stale or mixed generation denies.
+- Continuation, replay, correction, and recovery prove zero provider/model
+  calls and no reachable legacy post-submit inference.
+
+## Verification and review
+
+PostgreSQL atomicity/races, all-pairs authorization, zero-call reachability,
+hosted coverage, and all L1 tracks.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-07-single-checker-service-port.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-07-single-checker-service-port.md
@@ -1,6 +1,6 @@
 # Chunk Contract: WS-POL-003-07 - Single Checker Service Port
 
-Status: Proposed after 06. Risk: L1.
+Status: Proposed after 06B and merged ART-04B1-04B3. Risk: L1.
 
 ## Goal
 
@@ -42,7 +42,8 @@ plugins, arbitrary code/network execution, or prepared handles in payloads.
 - Post composes durable defaults with exact task-locked project post-submit
   entries and evaluates them against one verified stored/bound content lineage.
 - Both commands bind exact project/task/assignment, guide/policy, artifact,
-  manifest, generation, attempt, action, service identity, and transaction
+  compilation/result/component/catalogue hashes, manifest, generation,
+  attempt, action, service identity, and transaction
   facts; stale/replay/cross-phase/cross-resource calls fail closed.
 - The port requires a deterministic attempt identity. Bounded retry/repair may
   call the command again for that same logical attempt, but replay returns the

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-08-visibility-correction-cleanup.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-08-visibility-correction-cleanup.md
@@ -1,6 +1,6 @@
 # Chunk Contract: WS-POL-003-08 - Visibility, Correction, and Cleanup
 
-Status: Proposed after 07 and AUTH-12H. Risk: L1.
+Status: Proposed after 07, AUTH-12H, and ART-05B. Risk: L1.
 
 ## Goal
 
@@ -27,7 +27,7 @@ aliases.
 - Correction creates a new setup generation and compilation; immutable history
   remains linked and superseded.
 - Existing authorized activation consumes only the complete current approved
-  chain.
+  unified chain with exact compilation/result/component/catalogue hashes.
 - Three retired runtime methods/prompts and the second post-submit model call
   are deleted; the canonical ART-04B1 pre-submit catalogue, canonical
   CHECKER/POL post-submit catalogue, and one checker service port remain.
@@ -39,6 +39,9 @@ aliases.
 - Static/import tests find no per-checker product entry, caller-selected
   checker names, dual project registry, stale terminology, or compatibility
   inference path.
+- The live call graph was already clean-cut in 04B; this chunk physically
+  deletes retired code and cannot temporarily restore it for migration or
+  compatibility.
 - Failures/gaps create no contribution, payment, or reputation evidence.
 
 ## Verification and review

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-08-visibility-correction-cleanup.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/chunks/WS-POL-003-08-visibility-correction-cleanup.md
@@ -10,7 +10,7 @@ paths and parallel project-checker maps.
 
 ## Allowed files
 
-Project setup visibility/correction/API/service/worker surfaces, agent
+Project setup visibility/correction/API/fixed-service surfaces, agent
 interfaces/adapters cleanup, checker project-catalogue and ordinary trigger
 route cleanup, task/activation regression tests, docs, and WS-POL-003 memory.
 

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-PLAN-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-PLAN-pr-trust-bundle.md
@@ -1,5 +1,8 @@
 # WS-POL-003 Planning PR Trust Bundle
 
+Historical evidence for the original planning PR. The current authoritative
+split and dependency graph is `../CHUNK_MAP.md`; this file is not executable.
+
 ## Chunk
 
 `WS-POL-003-PLAN` — Unified Project Guide Compilation planning.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-external-review-response.md
@@ -1,0 +1,47 @@
+# WS-POL-003 Planning Reconciliation External Review Response
+
+Date: 2026-08-08
+PR: #298
+
+## Comments addressed
+
+- Separated 12I's complete active inventory from explicitly historical and
+  non-activatable 12E/12F3/legacy-12G inference rows.
+- Added exact 12I permission, owner, principal, resource/PREP, and proof custody.
+- Bound 12F4, POL-002 runtime, and CON consumption to complete compilation,
+  result, component, catalogue, compiled-plan, and approval provenance.
+- Clarified AUTH-14 owns `submission.create` authorization/evidence while ART
+  and POL own Submission/checker product behavior.
+- Narrowed the cleanup scanner to legacy standalone inference without blocking
+  WS-POL-003 unified provider compilation.
+- Marked POL-002 D1-D8 and remaining intent text explicitly historical.
+- Replaced stale human-worker terminology with fixed setup-service terminology.
+- Bound each POL-04B projection PREP to compilation, accepted result, and the
+  matching component hash.
+- Distinguished zero-call correction/recovery from a new-generation attempt
+  with a new idempotency key.
+- Applied the requested `end-to-end` wording correction.
+- Expanded the PR description to the complete trust-bundle structure.
+
+## Comments deferred
+
+None.
+
+## Human decisions needed
+
+None. All comments reinforce the already approved unified-compilation design.
+
+## Commands rerun
+
+```text
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+python3 scripts/test_agent_gates.py
+git diff --check
+```
+
+## Remaining risks
+
+Future planning skeletons still require then-current executable contracts
+before implementation. This PR activates nothing.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-external-review-response.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-external-review-response.md
@@ -15,7 +15,7 @@ PR: #298
 - Narrowed the cleanup scanner to legacy standalone inference without blocking
   WS-POL-003 unified provider compilation.
 - Marked POL-002 D1-D8 and remaining intent text explicitly historical.
-- Replaced stale human-worker terminology with fixed setup-service terminology.
+- Replaced stale human-principal terminology with fixed setup-service terminology.
 - Bound each POL-04B projection PREP to compilation, accepted result, and the
   matching component hash.
 - Distinguished zero-call correction/recovery from a new-generation attempt

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-internal-review-evidence.md
@@ -1,0 +1,37 @@
+# WS-POL-003 Planning Reconciliation Review Evidence
+
+Date: 2026-08-08
+
+## Scope
+
+Reconcile all remaining POL, AUTH, ART, XINT, REV, CON, and POL-002 planning
+with one unified Project Guide compilation attempt and the ordering rule:
+
+```text
+hidden product behavior -> narrow AUTH activation -> live product cutover -> cleanup
+```
+
+## Internal review
+
+- Architecture: pass with low risk after making POL-07 a universal AUTH-12H prerequisite.
+- Security: pass with low risk after the same terminal-activation repair; the
+  two-stage PREP/provider-I/O boundary is fail closed.
+- Product/operations: pass after removing future standalone post-submit
+  derivation authority and moving live-worker proof out of AUTH-12B2.
+- QA: pass with low risk after aligning ART-06A/06B and XINT-06B executable
+  contracts and every cross-initiative order table with POL-06B/07.
+- Senior engineering: pass with low risk after marking concise future records
+  non-executable until expanded and superseding the old AUTH-12 parent order.
+- Documentation: pass with low risk after marking POL-002-05 a non-executable
+  planning skeleton and aligning its map/status wording.
+
+## Deterministic evidence
+
+```text
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+All passed on the reconciled planning diff. No runtime code, migration, CI
+threshold, permission availability, or product data was changed.

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-internal-review-evidence.md
@@ -17,7 +17,7 @@ hidden product behavior -> narrow AUTH activation -> live product cutover -> cle
 - Security: pass with low risk after the same terminal-activation repair; the
   two-stage PREP/provider-I/O boundary is fail closed.
 - Product/operations: pass after removing future standalone post-submit
-  derivation authority and moving live-worker proof out of AUTH-12B2.
+  derivation authority and moving live setup-service proof out of AUTH-12B2.
 - QA: pass with low risk after aligning ART-06A/06B and XINT-06B executable
   contracts and every cross-initiative order table with POL-06B/07.
 - Senior engineering: pass with low risk after marking concise future records

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-pr-trust-bundle.md
@@ -24,6 +24,8 @@ runtime work resumes.
 Architecture, security, product/operations, QA, senior engineering, and docs
 review passed after resolving dependency and stale-authority findings. Details
 are in `WS-POL-003-RECONCILIATION-internal-review-evidence.md`.
+All ten CodeRabbit inline findings were addressed; the external response is in
+`WS-POL-003-RECONCILIATION-external-review-response.md`.
 
 The following deterministic checks pass:
 

--- a/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-POL-003-unified-project-guide-compilation/reviews/WS-POL-003-RECONCILIATION-pr-trust-bundle.md
@@ -1,0 +1,46 @@
+# WS-POL-003 Planning Reconciliation PR Trust Bundle
+
+## Intent
+
+Make one unified Project Guide compilation the sole future inference path and
+reconcile every remaining AUTH, ART, XINT, POL, REV, and CON dependency before
+runtime work resumes.
+
+## Design and scope
+
+- One logical/provider attempt returns sufficiency plus artifact, pre-submit,
+  and post-submit proposals before approval.
+- Product chunks build hidden behavior; AUTH activates the exact reviewed
+  boundary; product owners then perform the live cutover; cleanup deletes old
+  paths.
+- No database transaction or prepared handle spans provider I/O.
+- Tasks, admissions, Submissions, checker runs, reviews, revisions, and
+  contribution consumption retain exact unified compilation lineage.
+- This PR changes planning and review evidence only. It changes no runtime
+  code, migration, action availability, permission, CI threshold, or data.
+
+## Review and evidence
+
+Architecture, security, product/operations, QA, senior engineering, and docs
+review passed after resolving dependency and stale-authority findings. Details
+are in `WS-POL-003-RECONCILIATION-internal-review-evidence.md`.
+
+The following deterministic checks pass:
+
+```text
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_markdown_links.py
+git diff --check
+```
+
+## Remaining risk and human focus
+
+The split POL-03A-06B and AUTH activation records are deliberately
+non-executable planning skeletons. Before each starts, it must be expanded on
+then-current main with exact paths, commands, and named reviewers. Human review
+should confirm the dependency order and that no document restores standalone
+guide inference, caller-selected checker execution, or cross-boundary product
+ownership.
+
+After merge, the first executable candidate is WS-POL-003-01, subject to a
+separate explicit start.

--- a/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/CHUNK_MAP.md
@@ -1,5 +1,9 @@
 # Chunk Map: WS-REV-001 Review And Revision Lifecycle
 
+REV owns review/revision lifecycle behavior, not guide compilation or checker
+orchestration. Every eligible Submission and packet retains the exact
+`WS-POL-003` compilation, component, catalogue, and compiled-plan lineage.
+
 ## Live sequence
 
 Historical PLAN through PLAN3 and retired 02-family records remain evidence.

--- a/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/PLAN.md
+++ b/.agent-loop/initiatives/WS-REV-001-review-revision-lifecycle/PLAN.md
@@ -2,6 +2,11 @@
 
 ## Current authority
 
+REV owns review/revision lifecycle behavior only. Eligible Submissions and
+packets must carry the exact WS-POL-003 compilation/component/catalogue/plan
+lineage admitted by ART/AUTH/XINT; REV neither compiles guides nor selects or
+invokes checkers.
+
 This PLAN4 refresh supersedes PLAN2/PLAN3 implementation sequencing while
 preserving their boundary correction: REV begins only at a final current
 CheckerRun `allow_review`. Historical files remain evidence, not executable

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/CHUNK_MAP.md
@@ -7,12 +7,12 @@
 | `03` | Activate verifier, scheduler scan, and put resolver. | L1 | Merged |
 | `04A` | Activate Project Manager guide ingest. | L1 | Merged/active |
 | `04B` | Activate fixed-service guide binding and read. | L1 | Merged/active in PR #245 (`6babf81b`) |
-| `06A` | Activate only pre-submit checker-input materialization. | L1 | Merged ART-04B3/AUTH-12F2 evidence; must precede ART-04C1 and 05A |
-| `05A` | Activate initial contributor preparation and durable ready admission. | L1 | 06A plus ART-04A1-04C2 evidence |
-| `05B` | Activate fresh human Submission creation plus fixed binding/consumption. | L1 | 05A plus ART-05A/TASK evidence |
+| `06A` | Activate only pre-submit checker-input materialization. | L1 | Merged through PR #293; precedes ART-04C1 and 05A |
+| `05A` | Activate initial contributor preparation only over hidden ART ready-admission behavior. | L1 | 06A plus ART-04A1-04C2 evidence |
+| `05B` | Activate fresh human Submission creation plus fixed binding/consumption; ART owns the mutations. | L1 | 05A plus ART-05A/TASK evidence |
 | `05C` | Activate checker-remediation submission context. | L1 | 05B plus checker remediation evidence |
 | `05D` | Activate human-review revision context. | L1 | 05B plus REV revision-obligation evidence |
-| `06B` | Activate post-submit materialization and checker output write/binding. | L1 | ART-06A/06B evidence |
+| `06B` | Activate post-submit materialization and checker output write/binding. | L1 | POL-06B/07 unified-plan plus ART-06A/06B evidence |
 | `07A` | Activate lease-scoped reviewer packet materialization only. | L1 | ART-07A plus REV lease/packet evidence |
 | `07B` | Reserved review-evidence binding gate; keep unavailable absent new approved REV intent. | L1 | Future approved REV evidence-upload contract, if any |
 | `08` | Prove complete catalogue, least privilege, revocation, replay, concurrency, audit, and lifecycle conformance. | L1 | All activated v0.1 waves |

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/STATUS.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/STATUS.md
@@ -31,7 +31,7 @@ merge.
 
 04A is merged and active. 04B production implementation merged in PR #245 at
 `6babf81b`; guide read and binding are active for their fixed services.
-Future chunk 06 must split: 06A activates pre-submit materialization before
+Chunk 06 is split: merged 06A activates pre-submit materialization before
 05A, and 06B later activates post-submit materialization plus checker output
 write/binding. Reviewer packet activation is independent; review-evidence
 binding remains planned without approved reviewer-upload intent.

--- a/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-06B-post-submit-checker-activation.md
+++ b/.agent-loop/initiatives/WS-XINT-002-art-auth-end-to-end/chunks/WS-XINT-002-06B-post-submit-checker-activation.md
@@ -1,6 +1,6 @@
 # Chunk Contract: WS-XINT-002-06B — Post-Submit Checker Activation
 
-Parent initiative: `WS-XINT-002` | Risk: L1 | Status: Proposed after ART-06B
+Parent initiative: `WS-XINT-002` | Risk: L1 | Status: Proposed after POL-06B/07 and ART-06A/06B
 
 ## Goal
 
@@ -23,7 +23,10 @@ reads, Submission consumption, or new ActionIds.
   change availability;
 - fixed identities are distinct and cannot substitute for each other;
 - facts bind Submission, binding/content/manifest, CheckerRun, checker role,
-  generated commitment, request, session, and transaction;
+  unified compilation/result/post component, both catalogue hashes, compiled
+  checker plan, generated commitment, request, session, and transaction;
+- no action activates for pre-unified, mixed-generation, missing-plan, stale,
+  or non-POL-07 lineage;
 - denial/replay/stale/cross-resource cases precede byte exposure or mutation;
 - no prepared handle is serialized.
 
@@ -39,4 +42,5 @@ reuse/dedup, test delta, and docs.
 
 ## Human Review Focus And Stop Conditions
 
-Confirm service separation and exact facts. Stop before reviewer activation.
+Confirm service separation, exact unified facts, and the sole POL-07 port. Stop
+before reviewer activation.


### PR DESCRIPTION
## Chunk

WS-POL-003 planning reconciliation across remaining POL, AUTH, ART, XINT, REV, CON, and POL-002 work.

## Goal

Make one unified Project Guide compilation attempt the sole future inference path and eliminate planning that could restore repeated model calls, mixed-generation policy lineage, or cross-boundary ownership.

## Scope

- Reconcile the end-to-end dependency graph.
- Split future work into hidden product behavior, narrow AUTH activation, live product cutover, and legacy cleanup.
- Define AUTH-12I compilation request/execute custody.
- Bind downstream tasks, admissions, Submissions, checker runs, reviews, revisions, and contribution consumption to exact unified lineage.
- Mark future concise records non-executable until expanded on then-current main.

No runtime code, migration, action availability, permission, CI threshold, or product data changes.

## Design

One logical/provider attempt produces sufficiency, artifact, pre-submit, and post-submit proposals before approval. Approvals perform no inference. Post-submit projection is deterministic and performs zero additional model calls. No database transaction or prepared handle spans provider I/O.

POL owns compilation, projections, and checker orchestration. AUTH owns catalogue/evaluator/PREP activation and decision evidence. ART owns immutable materialization and bindings. REV and CON retain their lifecycle ownership.

## Alternatives rejected

- Three independent guide-reading inference calls.
- AUTH-owned product orchestration.
- A prepared handle or open database transaction spanning provider I/O.
- Standalone or caller-selected checker triggers.
- Compatibility paths preserving transitional inference entry points.

## Acceptance proof

- Transitional AUTH-12E/12F3/legacy-12G inference is explicitly non-activatable and removed by POL-04B/POL-08.
- AUTH-12H waits for POL-07 sole checker-port proof.
- ART-06A/06B and XINT-06B require exact compilation/result/component/catalogue/compiled-plan lineage.
- POL-002 future work performs zero standalone post-submit inference.
- Future skeletons cannot authorize implementation until expanded and reviewed.

## Test and documentation delta

Planning/docs only. No production or test code changed.

Commands passed:

- `python3 scripts/check_stale_authorization_docs.py`
- `python3 scripts/check_stale_workstream_wording.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/test_agent_gates.py`
- `git diff --check`

## Reviewer results

Architecture, security, product/operations, QA, senior engineering, and documentation internal reviews passed. All ten CodeRabbit inline findings were addressed and architecture/security re-review passed on the repair diff.

## CI integrity

No workflow, dependency, test, lint, coverage, or configuration gate was weakened. Hosted Agent Gates and Backend run on the exact pushed head.

## Risks

Future planning skeletons require exact allowed paths, forbidden changes, runnable commands, and named reviewers before implementation. This PR activates nothing.

## Ownership and next action

After human merge, WS-POL-003-01 is the first executable candidate and requires a separate explicit start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Planning Updates**
  * Reconciled initiative sequencing and dependencies for unified guide compilation, authorization, artifact storage, and checker workflows.
  * Defined a staged rollout for unified compilation, approval, post-submit projection, and checker routing.
  * Clarified ownership boundaries and activation prerequisites across project setup, submissions, reviews, and contributions.

* **Reliability and Security**
  * Added requirements for immutable lineage, hash validation, stale-data rejection, idempotency, and fail-closed authorization.
  * Ensured post-submit processing, replay, recovery, and corrections require no additional model calls.

* **Documentation**
  * Added planning contracts, decision records, risk updates, and reconciliation evidence.
  * Confirmed the changes activate no runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->