### PR TITLE
feat(quality): add local context evidence

### DIFF
--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/CHUNK_MAP.md
@@ -3,7 +3,7 @@
 | Chunk | Purpose | Dependency | Risk | State |
 |---|---|---|---|---|
 | `WS-QUAL-002-01` | Catalogue schema, inventory, generator, validation foundation | none | L1 | merged PR #297 |
-| `WS-QUAL-002-02` | Coverage-context candidate evidence and runtime calibration | 01 | L1 | pending |
+| `WS-QUAL-002-02` | Coverage-context candidate evidence and runtime calibration | 01 | L1 | implemented; GitHub is authoritative for merge state |
 | `WS-QUAL-002-03A` | AUTH, actors, API controls, audit ownership | 01, 02 | L1 | pending |
 | `WS-QUAL-002-03B` | Artifacts, storage, extraction, external adapters ownership | 01, 02 | L1 | pending |
 | `WS-QUAL-002-03C` | Projects, tasks, checkers, reviews, contribution ownership | 01, 02 | L1 | pending |

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
@@ -17,11 +17,13 @@ is authoritative for its transient review and merge state.
 
 Current focused evidence:
 
-- 49 focused tests pass.
-- `scripts.behavior_ownership` coverage is 91.30 percent.
+- 72 behavior-ownership tests pass.
+- `scripts.behavior_ownership` coverage is 90.11 percent.
 - 33 semantic-lane contract tests pass, including exact assignment of the new
   focused test module to `shared_foundations` under the human-approved scope
   correction.
+- The real local context probe completed 72 exact nodes in 27 seconds and
+  emitted a 96,535-byte digest-bound artifact, below both adoption limits.
 - The initial catalogue is explicitly incomplete and candidate output remains
   non-authoritative while subsystem population has not started.
 

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
@@ -22,8 +22,8 @@ Current focused evidence:
 - 33 semantic-lane contract tests pass, including exact assignment of the new
   focused test module to `shared_foundations` under the human-approved scope
   correction.
-- The real local context probe completed 72 exact nodes in 27 seconds and
-  emitted a 96,535-byte digest-bound artifact, below both adoption limits.
+- The real local context probe completed 72 exact nodes in 38 seconds and
+  emitted a 96,570-byte digest-bound artifact, below both adoption limits.
 - The initial catalogue is explicitly incomplete and candidate output remains
   non-authoritative while subsystem population has not started.
 

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
@@ -23,8 +23,8 @@ Current focused evidence:
 - 33 semantic-lane contract tests pass, including exact assignment of the new
   focused test module to `shared_foundations` under the human-approved scope
   correction.
-- The real local context probe completed 83 exact nodes in 29.71 seconds and
-  emitted a 126,769-byte digest-bound artifact, below both adoption limits.
+- The real local context probe completed 90 exact nodes in 18.12 seconds and
+  emitted a 141,701-byte digest-bound artifact, below both adoption limits.
 - The initial catalogue is explicitly incomplete and candidate output remains
   non-authoritative while subsystem population has not started.
 

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
@@ -10,9 +10,10 @@ validator, examples, focused tests, and contributor documentation. It does not
 reactivate mutation or change any workflow, product behavior, coverage floor,
 lane, skip, or deselection.
 
-The next dependency-ordered boundary is `WS-QUAL-002-02` context evidence.
-Open pull requests, not this static file, determine whether that or any other
-chunk is currently under review.
+`WS-QUAL-002-02` implements local, non-authoritative coverage-context evidence
+with exact collection, completion, head, callable-line, digest, runtime, size,
+and privacy custody. It does not change catalogue records or hosted CI. GitHub
+is authoritative for its transient review and merge state.
 
 Current focused evidence:
 

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
@@ -17,13 +17,14 @@ is authoritative for its transient review and merge state.
 
 Current focused evidence:
 
-- 82 behavior-ownership tests pass.
-- `scripts.behavior_ownership` coverage remains above 90 percent.
+- 83 behavior-ownership tests pass; the combined behavior-ownership and
+  semantic-lane contract suite passes all 117 tests.
+- `scripts.behavior_ownership` coverage is 91 percent.
 - 33 semantic-lane contract tests pass, including exact assignment of the new
   focused test module to `shared_foundations` under the human-approved scope
   correction.
-- The real local context probe completed 72 exact nodes in 38 seconds and
-  emitted a 96,570-byte digest-bound artifact, below both adoption limits.
+- The real local context probe completed 83 exact nodes in 29.71 seconds and
+  emitted a 126,769-byte digest-bound artifact, below both adoption limits.
 - The initial catalogue is explicitly incomplete and candidate output remains
   non-authoritative while subsystem population has not started.
 

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
@@ -17,8 +17,8 @@ is authoritative for its transient review and merge state.
 
 Current focused evidence:
 
-- 83 behavior-ownership tests pass; the combined behavior-ownership and
-  semantic-lane contract suite passes all 117 tests.
+- 90 behavior-ownership tests pass; the combined behavior-ownership and
+  semantic-lane contract suite passes all 124 tests.
 - `scripts.behavior_ownership` coverage is 91 percent.
 - 33 semantic-lane contract tests pass, including exact assignment of the new
   focused test module to `shared_foundations` under the human-approved scope

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
@@ -17,8 +17,8 @@ is authoritative for its transient review and merge state.
 
 Current focused evidence:
 
-- 72 behavior-ownership tests pass.
-- `scripts.behavior_ownership` coverage is 90.11 percent.
+- 82 behavior-ownership tests pass.
+- `scripts.behavior_ownership` coverage remains above 90 percent.
 - 33 semantic-lane contract tests pass, including exact assignment of the new
   focused test module to `shared_foundations` under the human-approved scope
   correction.

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/chunks/WS-QUAL-002-02-context-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/chunks/WS-QUAL-002-02-context-evidence.md
@@ -23,6 +23,7 @@ backend/tests/test_ci_test_lanes.py
 backend/pyproject.toml
 docs/operations_backend_testing.md
 .agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/STATUS.md
+.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/CHUNK_MAP.md
 .agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/chunks/WS-QUAL-002-02-context-evidence.md
 .agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-*
 ```

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/chunks/WS-QUAL-002-02-context-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/chunks/WS-QUAL-002-02-context-evidence.md
@@ -61,15 +61,15 @@ nodes, skip/deselect state, line-context mappings, elapsed time, and digest.
 It contains no test output, environment values, credentials, request payloads,
 logs, or database values.
 ## Acceptance criteria
-- [ ] Context evidence binds exact head, callable lines, and collected nodes.
-- [ ] Test discovery, collection, and completion evidence reuse `run_test_lanes.py` rather than introducing a parallel collector.
-- [ ] Candidate output cannot satisfy reviewed ownership.
-- [ ] Context evidence is a separate uncommitted local artifact and cannot be
+- [x] Context evidence binds exact head, callable lines, and collected nodes.
+- [x] Test discovery, collection, and completion evidence reuse `run_test_lanes.py` rather than introducing a parallel collector.
+- [x] Candidate output cannot satisfy reviewed ownership.
+- [x] Context evidence is a separate uncommitted local artifact and cannot be
       parsed as a catalogue record or consumed by catalogue validation.
-- [ ] The prototype is a local/manual command only and adds no workflow or required check.
-- [ ] Added local runtime is at most two minutes and each generated artifact is at most 10 MiB; exceeding either limit stops adoption and triggers redesign.
-- [ ] Artifacts contain only commit SHAs, lane identity, collection/completion status, skip/deselect status, target paths, callable spans, collected node IDs, line-coverage metadata, and an artifact digest or immutable canonical-lane manifest reference; they never contain environment values, secrets, tokens, request payloads, logs, or database values.
-- [ ] Validation rejects stale-head, partial, incomplete, skipped, deselected, digest-mismatched, or overwritten evidence as candidate input.
+- [x] The prototype is a local/manual command only and adds no workflow or required check.
+- [x] Added local runtime is at most two minutes and each generated artifact is at most 10 MiB; exceeding either limit stops adoption and triggers redesign.
+- [x] Artifacts contain only commit SHAs, lane identity, collection/completion status, skip/deselect status, target paths, callable spans, collected node IDs, line-coverage metadata, and an artifact digest or immutable canonical-lane manifest reference; they never contain environment values, secrets, tokens, request payloads, logs, or database values.
+- [x] Validation rejects stale-head, partial, incomplete, skipped, deselected, digest-mismatched, or overwritten evidence as candidate input.
 ## Verification commands
 ```bash
 (cd backend && .venv/bin/python -m pytest -q tests/test_behavior_ownership.py tests/test_ci_test_lanes.py)

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/chunks/WS-QUAL-002-02-context-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/chunks/WS-QUAL-002-02-context-evidence.md
@@ -29,11 +29,42 @@ docs/operations_backend_testing.md
 ## Not allowed
 ```text
 backend/app/**; .github/workflows/**; reviewed catalogue population; mutation reactivation; coverage or test weakening; any required-check or blocking-gate change
+scripts/behavior-ownership.schema.json; .ci/behavior-ownership/**
 ```
+
+## Local command and artifact boundary
+
+The implementation adds one manual command:
+
+```bash
+cd backend
+.venv/bin/python -m scripts.behavior_ownership context-evidence \
+  --target backend/scripts/behavior_ownership.py \
+  --test-module tests/test_behavior_ownership.py \
+  --output /tmp/workstream-context-evidence.json
+```
+
+The command collects and executes the exact nodes in the named test module by
+reusing the `scripts.run_test_lanes` pytest collection/completion plugin. It
+runs coverage with per-test contexts, maps only executed callable lines to
+completed exact node IDs, and writes one new regular output file exclusively.
+The output path must not already exist.
+
+The output uses a separate
+`workstream.behavior-ownership-context-evidence.v1` envelope. It is temporary,
+local, non-catalogue evidence: it is not committed under
+`.ci/behavior-ownership/`, is not a catalogue `candidate` or `reviewed` record,
+cannot be consumed by `validate_catalogue()`, and cannot establish ownership.
+The artifact binds its exact head, target, callable spans, collected/completed
+nodes, skip/deselect state, line-context mappings, elapsed time, and digest.
+It contains no test output, environment values, credentials, request payloads,
+logs, or database values.
 ## Acceptance criteria
 - [ ] Context evidence binds exact head, callable lines, and collected nodes.
 - [ ] Test discovery, collection, and completion evidence reuse `run_test_lanes.py` rather than introducing a parallel collector.
 - [ ] Candidate output cannot satisfy reviewed ownership.
+- [ ] Context evidence is a separate uncommitted local artifact and cannot be
+      parsed as a catalogue record or consumed by catalogue validation.
 - [ ] The prototype is a local/manual command only and adds no workflow or required check.
 - [ ] Added local runtime is at most two minutes and each generated artifact is at most 10 MiB; exceeding either limit stops adoption and triggers redesign.
 - [ ] Artifacts contain only commit SHAs, lane identity, collection/completion status, skip/deselect status, target paths, callable spans, collected node IDs, line-coverage metadata, and an artifact digest or immutable canonical-lane manifest reference; they never contain environment values, secrets, tokens, request payloads, logs, or database values.
@@ -41,6 +72,13 @@ backend/app/**; .github/workflows/**; reviewed catalogue population; mutation re
 ## Verification commands
 ```bash
 (cd backend && .venv/bin/python -m pytest -q tests/test_behavior_ownership.py tests/test_ci_test_lanes.py)
+(cd backend && tmp_dir=$(mktemp -d) && trap 'rm -rf "$tmp_dir"' EXIT && \
+  .venv/bin/python -m scripts.behavior_ownership context-evidence \
+    --target backend/scripts/behavior_ownership.py \
+    --test-module tests/test_behavior_ownership.py \
+    --output "$tmp_dir/context-evidence.json" && \
+  .venv/bin/python -m scripts.behavior_ownership validate-context-evidence \
+    --input "$tmp_dir/context-evidence.json")
 git diff --check origin/main...HEAD
 ```
 ## Required reviewers

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-external-review-response.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-external-review-response.md
@@ -1,0 +1,42 @@
+# External Review Response: WS-QUAL-002-02
+
+## Comments Addressed
+
+- Enforced one shared two-minute budget across collection and execution, with
+  both timeout paths translated to `context_runtime_exceeded`.
+- Documented that fixture setup and teardown contexts are deliberately excluded
+  from callable-execution evidence.
+- Added fail-closed tests for collection and execution timeouts, non-zero test
+  exit, incomplete completion evidence, skips, deselection, and missing
+  coverage evidence.
+- Expanded the PR trust bundle to the canonical repository template sections.
+
+## Comments Deferred
+
+- CodeRabbit's generic docstring-coverage warning is not adopted. The changed
+  public evidence functions have docstrings, the focused module remains above
+  its required 90 percent test-coverage floor, and adding ceremonial docstrings
+  to private helpers would not improve this chunk's behavior contract.
+
+## Human Decisions Needed
+
+None beyond normal review and explicit merge approval.
+
+## Commands Rerun
+
+```bash
+cd backend
+.venv/bin/ruff check scripts/behavior_ownership.py scripts/run_test_lanes.py \
+  tests/test_behavior_ownership.py tests/test_ci_test_lanes.py
+.venv/bin/python -m pytest -q \
+  tests/test_behavior_ownership.py tests/test_ci_test_lanes.py
+.venv/bin/coverage erase
+.venv/bin/python -m pytest -q --cov=scripts.behavior_ownership \
+  --cov-report=term tests/test_behavior_ownership.py
+```
+
+## Remaining Risks
+
+The evidence remains local and non-authoritative. CodeRabbit's newest review
+attempt was rate-limited; earlier actionable findings were independently
+verified and addressed, while exact-head GitHub checks remain authoritative.

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-internal-review-evidence.md
@@ -11,10 +11,10 @@ behavior, or change hosted CI.
 - Architecture: PASS WITH LOW RISKS. The evidence envelope remains separate
   from authoritative catalogue data. Private lane helpers are acceptable for
   this bounded prototype; expose a public API only if more consumers appear.
-- QA: initial FAIL because a digest-valid artifact could omit a callable. The
-  validator now requires the submitted callable set to exactly equal the
-  callable set derived from committed source, with a focused negative test.
-  Final re-review is recorded in the PR trust bundle.
+- QA: initial FAIL because a digest-valid artifact could omit a callable and a
+  later re-review found validation reading callable spans from the working
+  tree. The validator now requires the complete callable set and derives exact
+  spans from the artifact-bound Git revision, with focused regression tests.
 - Security: initial FAIL because pytest collection inherited the caller's full
   environment. Collection and execution now use a minimal allowlist;
   untracked files invalidate generation; callable spans must exactly match
@@ -32,6 +32,7 @@ behavior, or change hosted CI.
 2. Rejected untracked files when binding evidence to an exact Git head.
 3. Required exact callable start and end lines from committed source.
 4. Required complete callable membership, not merely valid submitted entries.
+5. Bound validation spans to committed source rather than mutable local files.
 
 ## Accepted Low Risks
 

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-internal-review-evidence.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-internal-review-evidence.md
@@ -1,0 +1,41 @@
+# Internal Review Evidence: WS-QUAL-002-02
+
+## Reviewed Scope
+
+Local, non-authoritative coverage-context evidence for the behavior-ownership
+catalogue. The change does not populate catalogue records, alter application
+behavior, or change hosted CI.
+
+## Reviewer Results
+
+- Architecture: PASS WITH LOW RISKS. The evidence envelope remains separate
+  from authoritative catalogue data. Private lane helpers are acceptable for
+  this bounded prototype; expose a public API only if more consumers appear.
+- QA: initial FAIL because a digest-valid artifact could omit a callable. The
+  validator now requires the submitted callable set to exactly equal the
+  callable set derived from committed source, with a focused negative test.
+  Final re-review is recorded in the PR trust bundle.
+- Security: initial FAIL because pytest collection inherited the caller's full
+  environment. Collection and execution now use a minimal allowlist;
+  untracked files invalidate generation; callable spans must exactly match
+  committed source. Re-review: PASS.
+- CI integrity: PASS WITH LOW RISKS. No workflow, lane, coverage-policy,
+  package, or required-check file changed.
+- Reuse/deduplication: PASS WITH LOW RISKS. Existing lane custody, callable,
+  eligibility, and safe-path helpers are reused. No blocking duplication.
+- Test delta: PASS. Tests are additive and behavioral; no test was removed,
+  skipped, deselected, or weakened.
+
+## Resolved Findings
+
+1. Sanitized pytest collection before importing test or conftest code.
+2. Rejected untracked files when binding evidence to an exact Git head.
+3. Required exact callable start and end lines from committed source.
+4. Required complete callable membership, not merely valid submitted entries.
+
+## Accepted Low Risks
+
+The bounded prototype uses private helpers from `run_test_lanes.py`. This is
+preferable to expanding the chunk into a lane-runner API refactor. If another
+consumer needs the same custody mechanism, a later bounded chunk should expose
+one public collection/execution API.

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-pr-trust-bundle.md
@@ -88,9 +88,8 @@ scripts.behavior_ownership coverage: 91 percent.
 Ruff, Markdown links, stale wording, and diff integrity passed.
 ```
 
-The last clean-tree calibration completed 83 nodes in 29.71 seconds and emitted
-126,769 bytes. A final exact-head calibration will refresh this count after the
-external-review repair commit.
+The exact implementation-head calibration completed 90 nodes in 18.12 seconds
+and emitted 141,701 bytes, below both adoption limits.
 
 ## Acceptance Criteria Proof
 
@@ -122,7 +121,7 @@ external-review repair commit.
 
 ## Internal Reviewer Results
 
-Reviewed code SHA: pending final post-review-repair commit
+Reviewed implementation SHA: `836865b1d84d06f534c0c45f551e72f335d810aa`
 
 Reviewed at: 2026-08-09
 

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-pr-trust-bundle.md
@@ -30,10 +30,12 @@ authorization, payment, reputation, or `ContributionRecord` behavior changed.
 
 ## Verification
 
-- 82 focused behavior-ownership tests pass.
-- `scripts.behavior_ownership` remains above the required 90 percent focused
-  coverage floor.
-- 33 semantic-lane contract tests pass.
+- 83 focused behavior-ownership tests pass; the combined focused suite passes
+  all 117 tests.
+- `scripts.behavior_ownership` has 91 percent focused coverage, above the
+  required 90 percent floor.
+- The exact-head probe completed 83 nodes in 29.71 seconds and produced a
+  126,769-byte artifact, below both adoption limits.
 - Ruff, Markdown links, stale-wording checks, and diff integrity pass.
 - A real clean-tree probe remains below the 120-second and 10-MiB adoption
   limits and passes standalone validation.

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-pr-trust-bundle.md
@@ -1,0 +1,71 @@
+# PR Trust Bundle: WS-QUAL-002-02
+
+## Chunk
+
+`WS-QUAL-002-02` — Local Coverage-Context Evidence.
+
+## Intent
+
+Provide bounded local evidence showing which exact pytest nodes execute which
+callable lines, without treating inference as reviewed ownership and without
+adding hosted CI cost.
+
+## What Changed
+
+- Added manual `context-evidence` generation and validation commands.
+- Reused the semantic-lane pytest plugin for exact collection, completion,
+  skip, and deselection custody.
+- Added coverage.py per-test contexts mapped to exact callable spans.
+- Added digest, Git-head, clean-tree, runtime, size, path, overwrite, and
+  non-authoritative-schema controls.
+- Sanitized both collection and execution environments so branch-controlled
+  pytest imports cannot inherit unrelated local secrets.
+- Documented operation and recorded the chunk status and evidence limits.
+
+## Scope And Non-Goals
+
+No workflow, required check, catalogue record, application module, migration,
+coverage threshold, test selection, mutation activation, product lifecycle,
+authorization, payment, reputation, or `ContributionRecord` behavior changed.
+
+## Verification
+
+- 82 focused behavior-ownership tests pass.
+- `scripts.behavior_ownership` remains above the required 90 percent focused
+  coverage floor.
+- 33 semantic-lane contract tests pass.
+- Ruff, Markdown links, stale-wording checks, and diff integrity pass.
+- A real clean-tree probe remains below the 120-second and 10-MiB adoption
+  limits and passes standalone validation.
+
+## Internal Review
+
+- Architecture: PASS WITH LOW RISKS.
+- QA: PASS after complete-callable evidence enforcement.
+- Security: PASS after collection privacy and evidence-integrity repairs.
+- CI integrity: PASS WITH LOW RISKS.
+- Reuse/deduplication: PASS WITH LOW RISKS.
+- Test delta: PASS.
+
+Detailed review evidence is in
+`WS-QUAL-002-02-internal-review-evidence.md` in this directory.
+
+## Remaining Risk
+
+This evidence is deliberately local and candidate-only. It does not establish
+reviewed ownership and no authoritative catalogue consumer accepts it. Private
+lane-helper coupling should be revisited only if a second consumer appears.
+
+## Human Review Focus
+
+Confirm the non-authoritative boundary, secret-free pytest subprocesses,
+complete exact-head/callable custody, and absence of hosted-CI changes.
+
+## Human Merge Ownership
+
+- [x] Intent, scope, and non-goals are explicit.
+- [x] Deterministic local evidence passes.
+- [x] Required internal reviewer tracks pass.
+- [ ] External review findings are addressed.
+- [ ] Exact-head GitHub checks pass.
+- [ ] The user explicitly approves this PR for merge.

--- a/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-QUAL-002-behavior-ownership-catalogue/reviews/WS-QUAL-002-02-pr-trust-bundle.md
@@ -1,73 +1,181 @@
-# PR Trust Bundle: WS-QUAL-002-02
+# Workstream PR Trust Bundle
 
 ## Chunk
 
-`WS-QUAL-002-02` — Local Coverage-Context Evidence.
+`WS-QUAL-002-02` - Local Coverage-Context Evidence
 
-## Intent
+## Goal
 
-Provide bounded local evidence showing which exact pytest nodes execute which
-callable lines, without treating inference as reviewed ownership and without
-adding hosted CI cost.
+Emit bounded, non-authoritative callable-to-test candidate evidence from exact
+local coverage contexts without adding hosted CI infrastructure.
+
+## Intent And Planning Context
+
+- Intent: `../INTENT.md`
+- Chunk contract: `../chunks/WS-QUAL-002-02-context-evidence.md`
 
 ## What Changed
 
 - Added manual `context-evidence` generation and validation commands.
-- Reused the semantic-lane pytest plugin for exact collection, completion,
-  skip, and deselection custody.
-- Added coverage.py per-test contexts mapped to exact callable spans.
-- Added digest, Git-head, clean-tree, runtime, size, path, overwrite, and
-  non-authoritative-schema controls.
-- Sanitized both collection and execution environments so branch-controlled
-  pytest imports cannot inherit unrelated local secrets.
-- Documented operation and recorded the chunk status and evidence limits.
+- Reused semantic-lane collection and completion custody.
+- Mapped per-test coverage contexts to exact callable spans.
+- Added digest, exact-head, clean-tree, runtime, size, path, overwrite, privacy,
+  and non-authoritative-schema controls.
+- Added focused fail-closed tests and operational documentation.
 
-## Scope And Non-Goals
+## Why It Changed
 
-No workflow, required check, catalogue record, application module, migration,
-coverage threshold, test selection, mutation activation, product lifecycle,
-authorization, payment, reputation, or `ContributionRecord` behavior changed.
+Imports and coverage totals do not show which exact tests execute a callable.
+This bounded evidence makes later ownership review better informed without
+claiming that inferred execution proves assertions or reviewed ownership.
 
-## Verification
+## Design Chosen
 
-- 83 focused behavior-ownership tests pass; the combined focused suite passes
-  all 117 tests.
-- `scripts.behavior_ownership` has 91 percent focused coverage, above the
-  required 90 percent floor.
-- The exact-head probe completed 83 nodes in 29.71 seconds and produced a
-  126,769-byte artifact, below both adoption limits.
-- Ruff, Markdown links, stale-wording checks, and diff integrity pass.
-- A real clean-tree probe remains below the 120-second and 10-MiB adoption
-  limits and passes standalone validation.
+One local-only artifact uses the existing lane plugin for collection and
+completion, coverage.py test contexts for line evidence, and an independent
+schema that catalogue validation cannot consume.
 
-## Internal Review
+## Alternatives Rejected
 
-- Architecture: PASS WITH LOW RISKS.
-- QA: PASS after complete-callable evidence enforcement.
-- Security: PASS after collection privacy and evidence-integrity repairs.
-- CI integrity: PASS WITH LOW RISKS.
-- Reuse/deduplication: PASS WITH LOW RISKS.
-- Test delta: PASS.
+- Hosted collection was rejected because this calibration chunk must add no CI
+  cost or required gate.
+- Import-based inference was rejected because importing code does not prove
+  behavior execution.
+- Automatic catalogue population was rejected because candidate evidence is
+  not reviewed ownership.
 
-Detailed review evidence is in
-`WS-QUAL-002-02-internal-review-evidence.md` in this directory.
+## Scope Control
 
-## Remaining Risk
+### Allowed Files Changed
 
-This evidence is deliberately local and candidate-only. It does not establish
-reviewed ownership and no authoritative catalogue consumer accepts it. Private
-lane-helper coupling should be revisited only if a second consumer appears.
+- WS-QUAL-002 plan, status, contract, and review evidence.
+- `backend/scripts/behavior_ownership.py` and `run_test_lanes.py`.
+- Their focused tests and backend testing operations documentation.
+
+### Files Outside Stated Scope
+
+- None.
+
+## Product Behavior
+
+- [x] No Workstream product behavior changed.
+- [ ] Product behavior changed and is explained here.
+
+## Evidence
+
+### Commands Run
+
+```bash
+cd backend
+.venv/bin/ruff check scripts/behavior_ownership.py scripts/run_test_lanes.py \
+  tests/test_behavior_ownership.py tests/test_ci_test_lanes.py
+.venv/bin/python -m pytest -q \
+  tests/test_behavior_ownership.py tests/test_ci_test_lanes.py
+.venv/bin/coverage erase
+.venv/bin/python -m pytest -q --cov=scripts.behavior_ownership \
+  --cov-report=term tests/test_behavior_ownership.py
+python3 ../scripts/check_markdown_links.py
+python3 ../scripts/check_stale_workstream_wording.py
+git diff --check origin/main...HEAD
+```
+
+### Result Summary
+
+```text
+124 focused tests passed.
+90 behavior-ownership tests passed.
+scripts.behavior_ownership coverage: 91 percent.
+Ruff, Markdown links, stale wording, and diff integrity passed.
+```
+
+The last clean-tree calibration completed 83 nodes in 29.71 seconds and emitted
+126,769 bytes. A final exact-head calibration will refresh this count after the
+external-review repair commit.
+
+## Acceptance Criteria Proof
+
+- [x] Exact head, callable lines, and collected nodes are bound and validated.
+- [x] Collection and completion reuse `run_test_lanes.py`.
+- [x] Candidate evidence cannot satisfy reviewed catalogue ownership.
+- [x] The artifact is local, separate, non-catalogue, and never committed.
+- [x] No workflow or required check invokes the command.
+- [x] Runtime and artifact size remain below two minutes and 10 MiB.
+- [x] Artifact fields exclude environment values, secrets, payloads, and logs.
+- [x] Validation fails closed on stale, partial, skipped, deselected,
+  digest-mismatched, overwritten, or timeout evidence.
+
+## Test Delta
+
+### Tests Added
+
+- Context artifact identity, digest, exact-head, callable, path, size, runtime,
+  collection, completion, skip/deselect, coverage, and privacy behavior.
+- Minimal sanitized collection environment and timeout forwarding.
+
+### Tests Modified
+
+- Existing collection mocks accept the canonical optional timeout contract.
+
+### Tests Removed Or Skipped
+
+- None.
+
+## Internal Reviewer Results
+
+Reviewed code SHA: pending final post-review-repair commit
+
+Reviewed at: 2026-08-09
+
+Reviewer run IDs: `qual002_02_{arch,qa,security,ci,reuse,test_delta}`
+
+| Reviewer | Result | Blocking Findings | Notes |
+|---|---:|---|---|
+| Senior engineering | N/A - proportionate L1 review | None | Required focused tracks cover this bounded tool |
+| QA/test | PASS AFTER FIXES | None | Exact-head and fail-closed custody repaired |
+| Security/auth | PASS AFTER FIXES | None | Environment, path, digest, and Git custody reviewed |
+| Product/ops | N/A - no product behavior | None | Local engineering evidence only |
+| Architecture | PASS | None | Non-authoritative boundary preserved |
+| CI integrity | PASS | None | No workflow or gate weakening |
+| Docs | N/A - focused operational update | None | Links and stale wording pass |
+| Reuse/dedup | PASS | None | Canonical collector reused |
+| Test delta | PASS | None | Additive tests; none skipped or weakened |
+
+## External Review
+
+| Source | Status | Notes |
+|---|---:|---|
+| CodeRabbit | PASS AFTER FIXES | Valid earlier findings addressed; newest run rate-limited |
+| GitHub checks | Pending | Exact-head checks are running |
+
+## CI And Gate Integrity
+
+- [x] No workflow weakening.
+- [x] No lint/test/docstring gate weakening.
+- [x] No coverage threshold weakening.
+- [x] No package script weakening.
+- [x] No unpinned new GitHub Action.
+- [x] Checkout credential persistence disabled where checkout is used.
+
+## Remaining Risks
+
+The artifact is candidate evidence only. It cannot establish reviewed ownership
+and no authoritative catalogue consumer accepts it.
+
+## Follow-Up Work
+
+Use this evidence during later bounded catalogue-population chunks. Promote a
+public lane-runner API only if a second consumer needs the same custody path.
 
 ## Human Review Focus
 
-Confirm the non-authoritative boundary, secret-free pytest subprocesses,
-complete exact-head/callable custody, and absence of hosted-CI changes.
+Please inspect the non-authoritative boundary, shared runtime budget,
+secret-free subprocesses, exact-head callable custody, and lack of hosted-CI
+changes.
 
 ## Human Merge Ownership
 
-- [x] Intent, scope, and non-goals are explicit.
-- [x] Deterministic local evidence passes.
-- [x] Required internal reviewer tracks pass.
-- [ ] External review findings are addressed.
-- [ ] Exact-head GitHub checks pass.
-- [ ] The user explicitly approves this PR for merge.
+- [x] I can explain what changed.
+- [x] I can explain why it changed.
+- [x] I know what could break.
+- [x] I accept the remaining risks.
+- [ ] The user explicitly approved this specific PR for merge.

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -802,7 +802,9 @@ def validate_context_evidence(
         raise BehaviorOwnershipError("invalid_context_elapsed")
     if not isinstance(value["callables"], list):
         raise BehaviorOwnershipError("invalid_context_callables")
-    source = (root / target).read_text(encoding="utf-8")
+    source = _git_show_optional(root, head_revision, target)
+    if source is None:
+        raise BehaviorOwnershipError("invalid_context_identity")
     actual_spans = {
         name: (start_line, end_line)
         for start_line, end_line, name in _callable_spans(

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -7,13 +7,19 @@ import argparse
 import ast
 import hashlib
 import json
+import os
 from pathlib import Path
+import re
 import subprocess
 import sys
+import tempfile
+import time
 from typing import Any, Iterable
 
+from coverage import CoverageData
 from jsonschema import Draft202012Validator
 
+from scripts import run_test_lanes as test_lanes
 from scripts.mutation_policy import CALLABLE_RE
 from scripts.mutation_policy import OBSERVABLE_OUTCOMES
 from scripts.mutation_policy import REAL_BOUNDARIES
@@ -30,7 +36,27 @@ SCHEMA_PATH = "scripts/behavior-ownership.schema.json"
 PARTITION_PATH = ".ci/behavior-ownership/partition.v1.json"
 PARTITION_SCHEMA = "workstream.behavior-ownership-partition.v1"
 CATALOGUE_SCHEMA = "workstream.behavior-ownership.v1"
+CONTEXT_EVIDENCE_SCHEMA = "workstream.behavior-ownership-context-evidence.v1"
 GROUPS = ("auth", "artifacts", "lifecycle", "shared")
+CONTEXT_RUNTIME_LIMIT_SECONDS = 120.0
+CONTEXT_ARTIFACT_LIMIT_BYTES = 10 * 1024 * 1024
+CONTEXT_EVIDENCE_KEYS = {
+    "schema",
+    "authoritative",
+    "head_sha",
+    "lane",
+    "target",
+    "test_module",
+    "collection_complete",
+    "execution_complete",
+    "collected_nodes",
+    "completed_nodes",
+    "skipped_nodes",
+    "deselected_nodes",
+    "callables",
+    "elapsed_seconds",
+    "artifact_digest",
+}
 
 
 class BehaviorOwnershipError(RuntimeError):
@@ -457,6 +483,261 @@ def generate_candidates(root: Path = ROOT, *, group: str | None = None) -> dict[
     }
 
 
+def _write_exclusive(path: Path, data: bytes) -> None:
+    """Write one private regular artifact without overwrite or symlink following."""
+    if len(data) > CONTEXT_ARTIFACT_LIMIT_BYTES:
+        raise BehaviorOwnershipError("context_evidence_too_large")
+    if not path.parent.is_dir():
+        raise BehaviorOwnershipError("invalid_context_output_parent")
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except OSError as exc:
+        raise BehaviorOwnershipError("context_output_exists_or_unsafe") from exc
+    try:
+        with os.fdopen(descriptor, "wb") as destination:
+            destination.write(data)
+    except OSError:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _coverage_lines_by_context(
+    coverage_path: Path, target_path: Path, completed_nodes: set[str]
+) -> dict[str, set[int]]:
+    """Read exact pytest contexts without exposing unrelated coverage metadata."""
+    data = CoverageData(basename=str(coverage_path))
+    try:
+        data.read()
+    except Exception as exc:
+        raise BehaviorOwnershipError("invalid_context_coverage") from exc
+    result: dict[str, set[int]] = {}
+    for context in sorted(data.measured_contexts()):
+        node = context.removesuffix("|run")
+        if node not in completed_nodes:
+            continue
+        data.set_query_contexts([f"^{re.escape(context)}$"])
+        lines = data.lines(str(target_path.resolve())) or []
+        result.setdefault(node, set()).update(lines)
+    data.set_query_contexts(None)
+    if set(result) != completed_nodes:
+        raise BehaviorOwnershipError("missing_test_context")
+    return result
+
+
+def build_context_evidence(
+    root: Path,
+    *,
+    target: str,
+    test_module: str,
+    output: Path,
+    runtime_limit_seconds: float = CONTEXT_RUNTIME_LIMIT_SECONDS,
+) -> dict[str, Any]:
+    """Run one local context probe and emit non-authoritative evidence."""
+    started = time.monotonic()
+    if runtime_limit_seconds <= 0 or runtime_limit_seconds > CONTEXT_RUNTIME_LIMIT_SECONDS:
+        raise BehaviorOwnershipError("invalid_context_runtime_limit")
+    if not _regular_repository_file(root, target) or not _eligible_target(target):
+        raise BehaviorOwnershipError("unsafe_or_missing_target")
+    backend_root = root / "backend"
+    if not test_lanes._safe_module_path(test_module):
+        raise BehaviorOwnershipError("invalid_context_test_module")
+    if test_module not in test_lanes.discover_test_modules(backend_root / "tests", backend_root):
+        raise BehaviorOwnershipError("missing_context_test_module")
+    head_sha = _git(root, "rev-parse", "HEAD")
+    if _git(root, "status", "--porcelain", "--untracked-files=no"):
+        raise BehaviorOwnershipError("dirty_context_tree")
+    try:
+        output = output.resolve(strict=False)
+    except OSError as exc:
+        raise BehaviorOwnershipError("invalid_context_output") from exc
+    if output.exists() or output.is_symlink():
+        raise BehaviorOwnershipError("context_output_exists_or_unsafe")
+
+    with tempfile.TemporaryDirectory(prefix="workstream-context-evidence-") as directory:
+        metadata = Path(directory)
+        collection_code, nodes, collection_deselected = test_lanes.collect_nodes(
+            (test_module,), metadata, head_sha
+        )
+        if collection_code != 0 or collection_deselected or not nodes:
+            raise BehaviorOwnershipError("invalid_context_collection")
+        coverage_path = metadata / ".coverage.context"
+        lane = test_lanes.TestLane("context_evidence", (test_module,), requires_postgres=False)
+        for suffix in ("collected", "completed", "skipped", "deselected"):
+            test_lanes._exclusive_file(metadata / f"context.{suffix}.jsonl")
+        environment = test_lanes.lane_environment(
+            lane, metadata, coverage_path, "context", head_sha
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-q",
+            *test_lanes._plugin_args(),
+            f"--cov={module_name(target)}",
+            "--cov-report=",
+            "--cov-context=test",
+            *nodes,
+        ]
+        try:
+            run = subprocess.run(
+                command,
+                cwd=backend_root,
+                env=environment,
+                check=False,
+                timeout=runtime_limit_seconds,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise BehaviorOwnershipError("context_runtime_exceeded") from exc
+        if run.returncode:
+            raise BehaviorOwnershipError("context_test_failure")
+        collected = test_lanes._read_nodes(metadata / "context.collected.jsonl")
+        completed = test_lanes._read_nodes(metadata / "context.completed.jsonl")
+        skipped = test_lanes._read_nodes(
+            metadata / "context.skipped.jsonl", allow_empty=True
+        )
+        deselected = test_lanes._read_nodes(
+            metadata / "context.deselected.jsonl", allow_empty=True
+        )
+        if collected != nodes or completed != nodes:
+            raise BehaviorOwnershipError("incomplete_context_execution")
+        if skipped or deselected:
+            raise BehaviorOwnershipError("weakened_context_execution")
+        if not coverage_path.is_file() or coverage_path.is_symlink():
+            raise BehaviorOwnershipError("missing_context_coverage")
+        lines_by_node = _coverage_lines_by_context(
+            coverage_path, root / target, set(completed)
+        )
+
+    elapsed = time.monotonic() - started
+    if elapsed > runtime_limit_seconds:
+        raise BehaviorOwnershipError("context_runtime_exceeded")
+    source = (root / target).read_text(encoding="utf-8")
+    spans = _callable_spans(source, module_name(target))[0]
+    callables = []
+    for start_line, end_line, name in sorted(spans, key=lambda item: item[2]):
+        node_lines = {
+            node: sorted(line for line in lines if start_line <= line <= end_line)
+            for node, lines in lines_by_node.items()
+        }
+        callables.append(
+            {
+                "callable": name,
+                "start_line": start_line,
+                "end_line": end_line,
+                "contexts": [
+                    {"nodeid": node, "lines": lines}
+                    for node, lines in sorted(node_lines.items())
+                    if lines
+                ],
+            }
+        )
+    authority = {
+        "schema": CONTEXT_EVIDENCE_SCHEMA,
+        "authoritative": False,
+        "head_sha": head_sha,
+        "lane": "context_evidence",
+        "target": target,
+        "test_module": test_module,
+        "collection_complete": True,
+        "execution_complete": True,
+        "collected_nodes": nodes,
+        "completed_nodes": completed,
+        "skipped_nodes": skipped,
+        "deselected_nodes": deselected,
+        "callables": callables,
+        "elapsed_seconds": round(elapsed, 3),
+    }
+    artifact = {**authority, "artifact_digest": _digest(authority)}
+    _write_exclusive(output, _json_bytes(artifact))
+    return artifact
+
+
+def validate_context_evidence(
+    root: Path, path: Path, *, head_revision: str = "HEAD"
+) -> dict[str, Any]:
+    """Validate one local context artifact as non-authoritative candidate input."""
+    try:
+        if not path.is_file() or path.is_symlink():
+            raise BehaviorOwnershipError("unsafe_context_evidence")
+        if path.stat().st_size > CONTEXT_ARTIFACT_LIMIT_BYTES:
+            raise BehaviorOwnershipError("context_evidence_too_large")
+    except OSError as exc:
+        raise BehaviorOwnershipError("unsafe_context_evidence") from exc
+    value = _read_json(path, "invalid_context_evidence_json")
+    if not isinstance(value, dict) or set(value) != CONTEXT_EVIDENCE_KEYS:
+        raise BehaviorOwnershipError("invalid_context_evidence_shape")
+    if value["schema"] != CONTEXT_EVIDENCE_SCHEMA or value["authoritative"] is not False:
+        raise BehaviorOwnershipError("invalid_context_evidence_schema")
+    authority = {key: value[key] for key in value if key != "artifact_digest"}
+    if value["artifact_digest"] != _digest(authority):
+        raise BehaviorOwnershipError("context_evidence_digest_mismatch")
+    if value["head_sha"] != _git(root, "rev-parse", head_revision):
+        raise BehaviorOwnershipError("stale_context_evidence")
+    collected = value["collected_nodes"]
+    completed = value["completed_nodes"]
+    if (
+        value["lane"] != "context_evidence"
+        or value["collection_complete"] is not True
+        or value["execution_complete"] is not True
+        or not isinstance(collected, list)
+        or not collected
+        or collected != completed
+        or len(collected) != len(set(collected))
+    ):
+        raise BehaviorOwnershipError("incomplete_context_evidence")
+    if value["skipped_nodes"] or value["deselected_nodes"]:
+        raise BehaviorOwnershipError("weakened_context_evidence")
+    if (
+        not isinstance(value["elapsed_seconds"], (int, float))
+        or isinstance(value["elapsed_seconds"], bool)
+        or value["elapsed_seconds"] < 0
+        or value["elapsed_seconds"] > CONTEXT_RUNTIME_LIMIT_SECONDS
+    ):
+        raise BehaviorOwnershipError("invalid_context_elapsed")
+    if not isinstance(value["callables"], list):
+        raise BehaviorOwnershipError("invalid_context_callables")
+    for item in value["callables"]:
+        if (
+            not isinstance(item, dict)
+            or set(item) != {"callable", "start_line", "end_line", "contexts"}
+            or not isinstance(item["callable"], str)
+            or not isinstance(item["start_line"], int)
+            or not isinstance(item["end_line"], int)
+            or item["start_line"] > item["end_line"]
+            or not isinstance(item["contexts"], list)
+        ):
+            raise BehaviorOwnershipError("invalid_context_callables")
+        for context in item["contexts"]:
+            if (
+                not isinstance(context, dict)
+                or set(context) != {"nodeid", "lines"}
+                or context["nodeid"] not in completed
+                or not isinstance(context["lines"], list)
+                or not context["lines"]
+                or any(
+                    not isinstance(line, int)
+                    or isinstance(line, bool)
+                    or line < item["start_line"]
+                    or line > item["end_line"]
+                    for line in context["lines"]
+                )
+            ):
+                raise BehaviorOwnershipError("invalid_context_callables")
+    return {
+        "schema": CONTEXT_EVIDENCE_SCHEMA,
+        "authoritative": False,
+        "head_sha": value["head_sha"],
+        "target": value["target"],
+        "test_module": value["test_module"],
+        "callable_count": len(value["callables"]),
+        "node_count": len(collected),
+        "artifact_digest": value["artifact_digest"],
+    }
+
+
 def _run_test_nodes(
     root: Path, records: Iterable[dict[str, Any]], *, collect_only: bool
 ) -> int:
@@ -494,6 +775,13 @@ def _main() -> int:
     validate_parser.add_argument("--run-owned-tests", action="store_true")
     partition_parser = subparsers.add_parser("partition")
     partition_parser.add_argument("--base-commit")
+    context_parser = subparsers.add_parser("context-evidence")
+    context_parser.add_argument("--target", required=True)
+    context_parser.add_argument("--test-module", required=True)
+    context_parser.add_argument("--output", required=True, type=Path)
+    context_validate_parser = subparsers.add_parser("validate-context-evidence")
+    context_validate_parser.add_argument("--input", required=True, type=Path)
+    context_validate_parser.add_argument("--head-revision", default="HEAD")
     args = parser.parse_args()
     try:
         if args.command == "inventory":
@@ -502,6 +790,17 @@ def _main() -> int:
             result = generate_candidates(group=args.group)
         elif args.command == "partition":
             result = build_partition(base_commit=args.base_commit)
+        elif args.command == "context-evidence":
+            result = build_context_evidence(
+                ROOT,
+                target=args.target,
+                test_module=args.test_module,
+                output=args.output,
+            )
+        elif args.command == "validate-context-evidence":
+            result = validate_context_evidence(
+                ROOT, args.input, head_revision=args.head_revision
+            )
         else:
             result = validate_catalogue(
                 group=args.group,

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -555,6 +555,8 @@ def _coverage_lines_by_context(
         raise BehaviorOwnershipError("invalid_context_coverage") from exc
     result: dict[str, set[int]] = {}
     for context in sorted(data.measured_contexts()):
+        # Fixture setup/teardown contexts are deliberately excluded: they do
+        # not prove that the test body executed the callable behavior.
         node = context.removesuffix("|run")
         if node not in completed_nodes:
             continue
@@ -630,12 +632,19 @@ def build_context_evidence(
 
     with tempfile.TemporaryDirectory(prefix="workstream-context-evidence-") as directory:
         metadata = Path(directory)
-        collection_code, nodes, collection_deselected = test_lanes.collect_nodes(
-            (test_module,),
-            metadata,
-            head_sha,
-            base_environment=_sanitize_context_environment(os.environ, backend_root),
-        )
+        remaining = runtime_limit_seconds - (time.monotonic() - started)
+        if remaining <= 0:
+            raise BehaviorOwnershipError("context_runtime_exceeded")
+        try:
+            collection_code, nodes, collection_deselected = test_lanes.collect_nodes(
+                (test_module,),
+                metadata,
+                head_sha,
+                base_environment=_sanitize_context_environment(os.environ, backend_root),
+                timeout_seconds=remaining,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise BehaviorOwnershipError("context_runtime_exceeded") from exc
         if collection_code != 0 or collection_deselected or not nodes:
             raise BehaviorOwnershipError("invalid_context_collection")
         coverage_path = metadata / ".coverage.context"
@@ -657,13 +666,16 @@ def build_context_evidence(
             "--cov-context=test",
             *nodes,
         ]
+        remaining = runtime_limit_seconds - (time.monotonic() - started)
+        if remaining <= 0:
+            raise BehaviorOwnershipError("context_runtime_exceeded")
         try:
             run = subprocess.run(
                 command,
                 cwd=backend_root,
                 env=environment,
                 check=False,
-                timeout=runtime_limit_seconds,
+                timeout=remaining,
             )
         except subprocess.TimeoutExpired as exc:
             raise BehaviorOwnershipError("context_runtime_exceeded") from exc

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -630,52 +630,13 @@ def build_context_evidence(
 
     with tempfile.TemporaryDirectory(prefix="workstream-context-evidence-") as directory:
         metadata = Path(directory)
-        collection_files = {
-            test_lanes.COLLECTED_ENV: metadata / "collection.nodes.jsonl",
-            test_lanes.DESELECTED_ENV: metadata / "collection.deselected.jsonl",
-        }
-        for evidence_path in collection_files.values():
-            test_lanes._exclusive_file(evidence_path)
-        collection_environment = _sanitize_context_environment(
-            {
-                **os.environ,
-                "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
-                "PYTHONPATH": str(backend_root),
-                test_lanes.HEAD_ENV: head_sha,
-                **{key: str(path.resolve()) for key, path in collection_files.items()},
-            },
-            backend_root,
+        collection_code, nodes, collection_deselected = test_lanes.collect_nodes(
+            (test_module,),
+            metadata,
+            head_sha,
+            base_environment=_sanitize_context_environment(os.environ, backend_root),
         )
-        collection = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pytest",
-                "--collect-only",
-                "-q",
-                *test_lanes._plugin_args(),
-                test_module,
-            ],
-            cwd=backend_root,
-            env=collection_environment,
-            check=False,
-            timeout=runtime_limit_seconds,
-        )
-        nodes = (
-            test_lanes._read_nodes(collection_files[test_lanes.COLLECTED_ENV])
-            if collection.returncode == 0
-            else []
-        )
-        collection_deselected = test_lanes._read_nodes(
-            collection_files[test_lanes.DESELECTED_ENV], allow_empty=True
-        )
-        if (
-            collection.returncode != 0
-            or collection_deselected
-            or not nodes
-            or len(nodes) != len(set(nodes))
-            or any(test_lanes._module_from_node(node) != test_module for node in nodes)
-        ):
+        if collection_code != 0 or collection_deselected or not nodes:
             raise BehaviorOwnershipError("invalid_context_collection")
         coverage_path = metadata / ".coverage.context"
         lane = test_lanes.TestLane("context_evidence", (test_module,), requires_postgres=False)

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -630,13 +630,52 @@ def build_context_evidence(
 
     with tempfile.TemporaryDirectory(prefix="workstream-context-evidence-") as directory:
         metadata = Path(directory)
-        collection_code, nodes, collection_deselected = test_lanes.collect_nodes(
-            (test_module,),
-            metadata,
-            head_sha,
-            base_environment=_sanitize_context_environment(os.environ, backend_root),
+        collection_files = {
+            test_lanes.COLLECTED_ENV: metadata / "collection.nodes.jsonl",
+            test_lanes.DESELECTED_ENV: metadata / "collection.deselected.jsonl",
+        }
+        for evidence_path in collection_files.values():
+            test_lanes._exclusive_file(evidence_path)
+        collection_environment = _sanitize_context_environment(
+            {
+                **os.environ,
+                "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+                "PYTHONPATH": str(backend_root),
+                test_lanes.HEAD_ENV: head_sha,
+                **{key: str(path.resolve()) for key, path in collection_files.items()},
+            },
+            backend_root,
         )
-        if collection_code != 0 or collection_deselected or not nodes:
+        collection = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "--collect-only",
+                "-q",
+                *test_lanes._plugin_args(),
+                test_module,
+            ],
+            cwd=backend_root,
+            env=collection_environment,
+            check=False,
+            timeout=runtime_limit_seconds,
+        )
+        nodes = (
+            test_lanes._read_nodes(collection_files[test_lanes.COLLECTED_ENV])
+            if collection.returncode == 0
+            else []
+        )
+        collection_deselected = test_lanes._read_nodes(
+            collection_files[test_lanes.DESELECTED_ENV], allow_empty=True
+        )
+        if (
+            collection.returncode != 0
+            or collection_deselected
+            or not nodes
+            or len(nodes) != len(set(nodes))
+            or any(test_lanes._module_from_node(node) != test_module for node in nodes)
+        ):
             raise BehaviorOwnershipError("invalid_context_collection")
         coverage_path = metadata / ".coverage.context"
         lane = test_lanes.TestLane("context_evidence", (test_module,), requires_postgres=False)

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -567,6 +567,30 @@ def _coverage_lines_by_context(
     return result
 
 
+def _sanitize_context_environment(
+    environment: dict[str, str], backend_root: Path
+) -> dict[str, str]:
+    """Retain only non-secret runtime and lane-custody environment values."""
+    allowed = {
+        "PATH",
+        "VIRTUAL_ENV",
+        "LANG",
+        "LC_ALL",
+        "TZ",
+        "TMPDIR",
+        test_lanes.COLLECTED_ENV,
+        test_lanes.COMPLETED_ENV,
+        test_lanes.SKIPPED_ENV,
+        test_lanes.DESELECTED_ENV,
+        test_lanes.HEAD_ENV,
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+        "COVERAGE_FILE",
+    }
+    sanitized = {key: value for key, value in environment.items() if key in allowed}
+    sanitized["PYTHONPATH"] = str(backend_root)
+    return sanitized
+
+
 def build_context_evidence(
     root: Path,
     *,
@@ -591,7 +615,7 @@ def build_context_evidence(
         root, head_sha, f"backend/{test_module}"
     ):
         raise BehaviorOwnershipError("untracked_context_input")
-    if _git(root, "status", "--porcelain", "--untracked-files=no"):
+    if _git(root, "status", "--porcelain", "--untracked-files=all"):
         raise BehaviorOwnershipError("dirty_context_tree")
     if output.is_symlink() or any(
         parent.is_symlink() for parent in output.parents if parent.exists()
@@ -606,10 +630,45 @@ def build_context_evidence(
 
     with tempfile.TemporaryDirectory(prefix="workstream-context-evidence-") as directory:
         metadata = Path(directory)
-        collection_code, nodes, collection_deselected = test_lanes.collect_nodes(
-            (test_module,), metadata, head_sha
+        collection_files = {
+            test_lanes.COLLECTED_ENV: metadata / "collection.nodes.jsonl",
+            test_lanes.DESELECTED_ENV: metadata / "collection.deselected.jsonl",
+        }
+        for evidence_path in collection_files.values():
+            test_lanes._exclusive_file(evidence_path)
+        collection_environment = _sanitize_context_environment(
+            {
+                **os.environ,
+                "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+                "PYTHONPATH": str(backend_root),
+                test_lanes.HEAD_ENV: head_sha,
+                **{key: str(path.resolve()) for key, path in collection_files.items()},
+            },
+            backend_root,
         )
-        if collection_code != 0 or collection_deselected or not nodes:
+        collection = subprocess.run(
+            [sys.executable, "-m", "pytest", "--collect-only", "-q",
+             *test_lanes._plugin_args(), test_module],
+            cwd=backend_root,
+            env=collection_environment,
+            check=False,
+            timeout=runtime_limit_seconds,
+        )
+        nodes = (
+            test_lanes._read_nodes(collection_files[test_lanes.COLLECTED_ENV])
+            if collection.returncode == 0
+            else []
+        )
+        collection_deselected = test_lanes._read_nodes(
+            collection_files[test_lanes.DESELECTED_ENV], allow_empty=True
+        )
+        if (
+            collection.returncode != 0
+            or collection_deselected
+            or not nodes
+            or len(nodes) != len(set(nodes))
+            or any(test_lanes._module_from_node(node) != test_module for node in nodes)
+        ):
             raise BehaviorOwnershipError("invalid_context_collection")
         coverage_path = metadata / ".coverage.context"
         lane = test_lanes.TestLane("context_evidence", (test_module,), requires_postgres=False)
@@ -618,30 +677,7 @@ def build_context_evidence(
         environment = test_lanes.lane_environment(
             lane, metadata, coverage_path, "context", head_sha
         )
-        allowed_environment = {
-            "PATH",
-            "PYTHONPATH",
-            "VIRTUAL_ENV",
-            "LANG",
-            "LC_ALL",
-            "TZ",
-            "TMPDIR",
-        }
-        environment = {
-            key: value
-            for key, value in environment.items()
-            if key in allowed_environment
-            or key
-            in {
-                test_lanes.COLLECTED_ENV,
-                test_lanes.COMPLETED_ENV,
-                test_lanes.SKIPPED_ENV,
-                test_lanes.DESELECTED_ENV,
-                test_lanes.HEAD_ENV,
-                "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
-            }
-            or key == "COVERAGE_FILE"
-        }
+        environment = _sanitize_context_environment(environment, backend_root)
         command = [
             sys.executable,
             "-m",
@@ -798,7 +834,14 @@ def validate_context_evidence(
         raise BehaviorOwnershipError("invalid_context_elapsed")
     if not isinstance(value["callables"], list):
         raise BehaviorOwnershipError("invalid_context_callables")
-    actual_callables = set(callable_names(root, target))
+    source = (root / target).read_text(encoding="utf-8")
+    actual_spans = {
+        name: (start_line, end_line)
+        for start_line, end_line, name in _callable_spans(
+            source, module_name(target)
+        )[0]
+    }
+    actual_callables = set(actual_spans)
     seen_callables: set[str] = set()
     for item in value["callables"]:
         if (
@@ -809,8 +852,12 @@ def validate_context_evidence(
             or item["callable"] not in actual_callables
             or item["callable"] in seen_callables
             or not isinstance(item["start_line"], int)
+            or isinstance(item["start_line"], bool)
             or not isinstance(item["end_line"], int)
+            or isinstance(item["end_line"], bool)
             or item["start_line"] > item["end_line"]
+            or (item["start_line"], item["end_line"])
+            != actual_spans[item["callable"]]
             or not isinstance(item["contexts"], list)
         ):
             raise BehaviorOwnershipError("invalid_context_callables")

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -21,6 +21,7 @@ from jsonschema import Draft202012Validator
 
 from scripts import run_test_lanes as test_lanes
 from scripts.mutation_policy import CALLABLE_RE
+from scripts.mutation_policy import MutationPolicyError
 from scripts.mutation_policy import OBSERVABLE_OUTCOMES
 from scripts.mutation_policy import REAL_BOUNDARIES
 from scripts.mutation_policy import TEST_NODE_RE
@@ -489,8 +490,11 @@ def _write_exclusive(path: Path, data: bytes) -> None:
         raise BehaviorOwnershipError("context_evidence_too_large")
     if not path.parent.is_dir():
         raise BehaviorOwnershipError("invalid_context_output_parent")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
     try:
-        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        descriptor = os.open(path, flags, 0o600)
     except OSError as exc:
         raise BehaviorOwnershipError("context_output_exists_or_unsafe") from exc
     try:
@@ -502,6 +506,42 @@ def _write_exclusive(path: Path, data: bytes) -> None:
         except OSError:
             pass
         raise
+
+
+def _tracked_at_revision(root: Path, revision: str, path: str) -> bool:
+    """Return whether one safe repository path is tracked at the revision."""
+    try:
+        _safe_path(path)
+    except MutationPolicyError:
+        return False
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{revision}:{path}"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _context_node_is_valid(node: object, test_module: str) -> bool:
+    """Validate one backend-relative pytest node against the selected module."""
+    if not isinstance(node, str) or any(character in node for character in "\x00\r\n"):
+        return False
+    try:
+        return test_lanes._module_from_node(node) == test_module
+    except test_lanes.LaneError:
+        return False
+
+
+def _context_target_is_valid(root: Path, target: object) -> bool:
+    """Validate an eligible regular target without leaking policy exceptions."""
+    if not isinstance(target, str):
+        return False
+    try:
+        return _eligible_target(target) and _regular_repository_file(root, target)
+    except MutationPolicyError:
+        return False
 
 
 def _coverage_lines_by_context(
@@ -547,8 +587,16 @@ def build_context_evidence(
     if test_module not in test_lanes.discover_test_modules(backend_root / "tests", backend_root):
         raise BehaviorOwnershipError("missing_context_test_module")
     head_sha = _git(root, "rev-parse", "HEAD")
+    if not _tracked_at_revision(root, head_sha, target) or not _tracked_at_revision(
+        root, head_sha, f"backend/{test_module}"
+    ):
+        raise BehaviorOwnershipError("untracked_context_input")
     if _git(root, "status", "--porcelain", "--untracked-files=no"):
         raise BehaviorOwnershipError("dirty_context_tree")
+    if output.is_symlink() or any(
+        parent.is_symlink() for parent in output.parents if parent.exists()
+    ):
+        raise BehaviorOwnershipError("context_output_exists_or_unsafe")
     try:
         output = output.resolve(strict=False)
     except OSError as exc:
@@ -570,6 +618,30 @@ def build_context_evidence(
         environment = test_lanes.lane_environment(
             lane, metadata, coverage_path, "context", head_sha
         )
+        allowed_environment = {
+            "PATH",
+            "PYTHONPATH",
+            "VIRTUAL_ENV",
+            "LANG",
+            "LC_ALL",
+            "TZ",
+            "TMPDIR",
+        }
+        environment = {
+            key: value
+            for key, value in environment.items()
+            if key in allowed_environment
+            or key
+            in {
+                test_lanes.COLLECTED_ENV,
+                test_lanes.COMPLETED_ENV,
+                test_lanes.SKIPPED_ENV,
+                test_lanes.DESELECTED_ENV,
+                test_lanes.HEAD_ENV,
+                "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+            }
+            or key == "COVERAGE_FILE"
+        }
         command = [
             sys.executable,
             "-m",
@@ -676,6 +748,21 @@ def validate_context_evidence(
         raise BehaviorOwnershipError("context_evidence_digest_mismatch")
     if value["head_sha"] != _git(root, "rev-parse", head_revision):
         raise BehaviorOwnershipError("stale_context_evidence")
+    head_sha = value["head_sha"]
+    target = value["target"]
+    test_module = value["test_module"]
+    if (
+        not isinstance(head_sha, str)
+        or re.fullmatch(r"[0-9a-f]{40}", head_sha) is None
+        or not _context_target_is_valid(root, target)
+        or not _tracked_at_revision(root, head_revision, target)
+        or not isinstance(test_module, str)
+        or not test_lanes._safe_module_path(test_module)
+        or test_module
+        not in test_lanes.discover_test_modules(root / "backend/tests", root / "backend")
+        or not _tracked_at_revision(root, head_revision, f"backend/{test_module}")
+    ):
+        raise BehaviorOwnershipError("invalid_context_identity")
     collected = value["collected_nodes"]
     completed = value["completed_nodes"]
     if (
@@ -684,11 +771,23 @@ def validate_context_evidence(
         or value["execution_complete"] is not True
         or not isinstance(collected, list)
         or not collected
+        or any(not _context_node_is_valid(node, test_module) for node in collected)
+        or not isinstance(completed, list)
+        or any(not _context_node_is_valid(node, test_module) for node in completed)
         or collected != completed
         or len(collected) != len(set(collected))
     ):
         raise BehaviorOwnershipError("incomplete_context_evidence")
-    if value["skipped_nodes"] or value["deselected_nodes"]:
+    skipped = value["skipped_nodes"]
+    deselected = value["deselected_nodes"]
+    if (
+        not isinstance(skipped, list)
+        or not isinstance(deselected, list)
+        or any(not _context_node_is_valid(node, test_module) for node in skipped)
+        or any(not _context_node_is_valid(node, test_module) for node in deselected)
+        or skipped
+        or deselected
+    ):
         raise BehaviorOwnershipError("weakened_context_evidence")
     if (
         not isinstance(value["elapsed_seconds"], (int, float))
@@ -699,17 +798,23 @@ def validate_context_evidence(
         raise BehaviorOwnershipError("invalid_context_elapsed")
     if not isinstance(value["callables"], list):
         raise BehaviorOwnershipError("invalid_context_callables")
+    actual_callables = set(callable_names(root, target))
+    seen_callables: set[str] = set()
     for item in value["callables"]:
         if (
             not isinstance(item, dict)
             or set(item) != {"callable", "start_line", "end_line", "contexts"}
             or not isinstance(item["callable"], str)
+            or CALLABLE_RE.fullmatch(item["callable"]) is None
+            or item["callable"] not in actual_callables
+            or item["callable"] in seen_callables
             or not isinstance(item["start_line"], int)
             or not isinstance(item["end_line"], int)
             or item["start_line"] > item["end_line"]
             or not isinstance(item["contexts"], list)
         ):
             raise BehaviorOwnershipError("invalid_context_callables")
+        seen_callables.add(item["callable"])
         for context in item["contexts"]:
             if (
                 not isinstance(context, dict)

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -647,8 +647,15 @@ def build_context_evidence(
             backend_root,
         )
         collection = subprocess.run(
-            [sys.executable, "-m", "pytest", "--collect-only", "-q",
-             *test_lanes._plugin_args(), test_module],
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "--collect-only",
+                "-q",
+                *test_lanes._plugin_args(),
+                test_module,
+            ],
             cwd=backend_root,
             env=collection_environment,
             check=False,
@@ -878,6 +885,8 @@ def validate_context_evidence(
                 )
             ):
                 raise BehaviorOwnershipError("invalid_context_callables")
+    if seen_callables != actual_callables:
+        raise BehaviorOwnershipError("incomplete_context_evidence")
     return {
         "schema": CONTEXT_EVIDENCE_SCHEMA,
         "authoritative": False,

--- a/backend/scripts/run_test_lanes.py
+++ b/backend/scripts/run_test_lanes.py
@@ -430,17 +430,12 @@ def _plugin_args() -> list[str]:
     return ["-p", "pytest_asyncio.plugin", "-p", "pytest_cov.plugin", "-p", "scripts.run_test_lanes"]
 
 
-def _collection_environment(
-    collected: Path,
-    deselected: Path,
-    tree_sha: str,
-    *,
-    base_environment: dict[str, str] | None = None,
-) -> dict[str, str]:
-    env = (base_environment if base_environment is not None else os.environ).copy()
+def _collection_environment(collected: Path, deselected: Path, tree_sha: str) -> dict[str, str]:
+    env = os.environ.copy()
     env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
-    python_paths = (str(ROOT), *env.get("PYTHONPATH", "").split(os.pathsep))
-    env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(value for value in python_paths if value))
+    env["PYTHONPATH"] = os.pathsep.join(
+        value for value in (str(ROOT), env.get("PYTHONPATH", "")) if value
+    )
     env[COLLECTED_ENV] = str(collected.resolve())
     env[DESELECTED_ENV] = str(deselected.resolve())
     env[HEAD_ENV] = tree_sha
@@ -448,11 +443,7 @@ def _collection_environment(
 
 
 def collect_nodes(
-    modules: tuple[str, ...],
-    metadata_dir: Path,
-    tree_sha: str,
-    *,
-    base_environment: dict[str, str] | None = None,
+    modules: tuple[str, ...], metadata_dir: Path, tree_sha: str
 ) -> tuple[int, list[str], list[str]]:
     collected = metadata_dir / "collection.nodes.jsonl"
     deselected = metadata_dir / "collection.deselected.jsonl"
@@ -460,14 +451,7 @@ def collect_nodes(
     _exclusive_file(deselected)
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "--collect-only", "-q", *_plugin_args(), *modules],
-        cwd=ROOT,
-        env=_collection_environment(
-            collected,
-            deselected,
-            tree_sha,
-            base_environment=base_environment,
-        ),
-        check=False,
+        cwd=ROOT, env=_collection_environment(collected, deselected, tree_sha), check=False,
     )
     nodes = _read_nodes(collected) if result.returncode == 0 else []
     deselected_nodes = _read_nodes(deselected, allow_empty=True)

--- a/backend/scripts/run_test_lanes.py
+++ b/backend/scripts/run_test_lanes.py
@@ -430,12 +430,17 @@ def _plugin_args() -> list[str]:
     return ["-p", "pytest_asyncio.plugin", "-p", "pytest_cov.plugin", "-p", "scripts.run_test_lanes"]
 
 
-def _collection_environment(collected: Path, deselected: Path, tree_sha: str) -> dict[str, str]:
-    env = os.environ.copy()
+def _collection_environment(
+    collected: Path,
+    deselected: Path,
+    tree_sha: str,
+    *,
+    base_environment: dict[str, str] | None = None,
+) -> dict[str, str]:
+    env = (base_environment if base_environment is not None else os.environ).copy()
     env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
-    env["PYTHONPATH"] = os.pathsep.join(
-        value for value in (str(ROOT), env.get("PYTHONPATH", "")) if value
-    )
+    python_paths = (str(ROOT), *env.get("PYTHONPATH", "").split(os.pathsep))
+    env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(value for value in python_paths if value))
     env[COLLECTED_ENV] = str(collected.resolve())
     env[DESELECTED_ENV] = str(deselected.resolve())
     env[HEAD_ENV] = tree_sha
@@ -443,7 +448,11 @@ def _collection_environment(collected: Path, deselected: Path, tree_sha: str) ->
 
 
 def collect_nodes(
-    modules: tuple[str, ...], metadata_dir: Path, tree_sha: str
+    modules: tuple[str, ...],
+    metadata_dir: Path,
+    tree_sha: str,
+    *,
+    base_environment: dict[str, str] | None = None,
 ) -> tuple[int, list[str], list[str]]:
     collected = metadata_dir / "collection.nodes.jsonl"
     deselected = metadata_dir / "collection.deselected.jsonl"
@@ -451,7 +460,14 @@ def collect_nodes(
     _exclusive_file(deselected)
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "--collect-only", "-q", *_plugin_args(), *modules],
-        cwd=ROOT, env=_collection_environment(collected, deselected, tree_sha), check=False,
+        cwd=ROOT,
+        env=_collection_environment(
+            collected,
+            deselected,
+            tree_sha,
+            base_environment=base_environment,
+        ),
+        check=False,
     )
     nodes = _read_nodes(collected) if result.returncode == 0 else []
     deselected_nodes = _read_nodes(deselected, allow_empty=True)

--- a/backend/scripts/run_test_lanes.py
+++ b/backend/scripts/run_test_lanes.py
@@ -453,6 +453,7 @@ def collect_nodes(
     tree_sha: str,
     *,
     base_environment: dict[str, str] | None = None,
+    timeout_seconds: float | None = None,
 ) -> tuple[int, list[str], list[str]]:
     collected = metadata_dir / "collection.nodes.jsonl"
     deselected = metadata_dir / "collection.deselected.jsonl"
@@ -468,6 +469,7 @@ def collect_nodes(
             base_environment=base_environment,
         ),
         check=False,
+        timeout=timeout_seconds,
     )
     nodes = _read_nodes(collected) if result.returncode == 0 else []
     deselected_nodes = _read_nodes(deselected, allow_empty=True)

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -641,14 +641,19 @@ def test_build_context_evidence_reuses_lane_collection_and_completion(
         "discover_test_modules",
         lambda *args: ("tests/test_example.py",),
     )
-    monkeypatch.setattr(
-        ownership.test_lanes,
-        "collect_nodes",
-        lambda *args: (0, [node], []),
-    )
     monkeypatch.setattr(ownership, "_tracked_at_revision", lambda *args: True)
 
     def fake_run(arguments, *, cwd, env, check, timeout):
+        assert env["PYTHONPATH"] == str(tmp_path / "backend")
+        assert "UNRELATED_SECRET" not in env
+        if "--collect-only" in arguments:
+            Path(env[ownership.test_lanes.COLLECTED_ENV]).write_text(
+                json.dumps(node) + "\n", encoding="utf-8"
+            )
+            Path(env[ownership.test_lanes.DESELECTED_ENV]).write_text(
+                "", encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(arguments, 0)
         metadata = Path(env[ownership.test_lanes.COLLECTED_ENV]).parent
         for suffix in ("collected", "completed"):
             (metadata / f"context.{suffix}.jsonl").write_text(
@@ -790,6 +795,19 @@ def test_coverage_context_reader_rejects_invalid_data(
             },
             "invalid_context_callables",
         ),
+        (
+            {
+                "callables": [
+                    {
+                        "callable": "scripts.example.run",
+                        "start_line": 1,
+                        "end_line": 3,
+                        "contexts": [],
+                    }
+                ]
+            },
+            "invalid_context_callables",
+        ),
         ({"target": "../unsafe.py"}, "invalid_context_identity"),
         ({"test_module": "../unsafe.py"}, "invalid_context_identity"),
         ({"head_sha": "not-a-sha"}, "stale_context_evidence"),
@@ -894,11 +912,15 @@ def test_context_builder_fails_closed_before_execution(
         "_tracked_at_revision",
         lambda *args: case != "untracked",
     )
-    monkeypatch.setattr(
-        ownership.test_lanes,
-        "collect_nodes",
-        lambda *args: (1, [], []) if case == "collection" else (0, ["node::id"], []),
-    )
+    def fake_collection(arguments, *, cwd, env, check, timeout):
+        if case != "collection":
+            Path(env[ownership.test_lanes.COLLECTED_ENV]).write_text(
+                json.dumps("tests/test_example.py::test_run") + "\n", encoding="utf-8"
+            )
+        Path(env[ownership.test_lanes.DESELECTED_ENV]).write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(arguments, 1 if case == "collection" else 0)
+
+    monkeypatch.setattr(ownership.subprocess, "run", fake_collection)
     if case == "output":
         output.write_text("existing", encoding="utf-8")
     if case == "symlink_output":

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -655,16 +655,19 @@ def test_build_context_evidence_reuses_lane_collection_and_completion(
         "discover_test_modules",
         lambda *args: ("tests/test_example.py",),
     )
-    monkeypatch.setattr(
-        ownership.test_lanes,
-        "collect_nodes",
-        lambda *args, **kwargs: (0, [node], []),
-    )
     monkeypatch.setattr(ownership, "_tracked_at_revision", lambda *args: True)
 
     def fake_run(arguments, *, cwd, env, check, timeout):
         assert env["PYTHONPATH"] == str(tmp_path / "backend")
         assert "UNRELATED_SECRET" not in env
+        if "--collect-only" in arguments:
+            Path(env[ownership.test_lanes.COLLECTED_ENV]).write_text(
+                json.dumps(node) + "\n", encoding="utf-8"
+            )
+            Path(env[ownership.test_lanes.DESELECTED_ENV]).write_text(
+                "", encoding="utf-8"
+            )
+            return subprocess.CompletedProcess(arguments, 0)
         metadata = Path(env[ownership.test_lanes.COLLECTED_ENV]).parent
         for suffix in ("collected", "completed"):
             (metadata / f"context.{suffix}.jsonl").write_text(

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -664,6 +664,16 @@ def test_build_context_evidence_reuses_lane_collection_and_completion(
     assert artifact["completed_nodes"] == [node]
     assert artifact["callables"][0]["contexts"] == [{"nodeid": node, "lines": [1, 2]}]
 
+    ticks = iter((0.0, ownership.CONTEXT_RUNTIME_LIMIT_SECONDS + 1.0))
+    monkeypatch.setattr(ownership.time, "monotonic", lambda: next(ticks))
+    with pytest.raises(ownership.BehaviorOwnershipError, match="context_runtime_exceeded"):
+        ownership.build_context_evidence(
+            tmp_path,
+            target=target,
+            test_module="tests/test_example.py",
+            output=tmp_path / "late-context.json",
+        )
+
 
 def test_context_output_rejects_size_and_missing_parent(tmp_path: Path) -> None:
     with pytest.raises(ownership.BehaviorOwnershipError, match="too_large"):
@@ -775,6 +785,15 @@ def test_context_validator_rejects_invalid_shapes(
 def test_context_validator_rejects_unsafe_and_unknown_shape(tmp_path: Path) -> None:
     with pytest.raises(ownership.BehaviorOwnershipError, match="unsafe_context_evidence"):
         ownership.validate_context_evidence(tmp_path, tmp_path / "missing.json")
+    symlink = tmp_path / "symlink.json"
+    symlink.symlink_to(tmp_path / "missing-target.json")
+    with pytest.raises(ownership.BehaviorOwnershipError, match="unsafe_context_evidence"):
+        ownership.validate_context_evidence(tmp_path, symlink)
+    oversized = tmp_path / "oversized.json"
+    with oversized.open("wb") as destination:
+        destination.truncate(ownership.CONTEXT_ARTIFACT_LIMIT_BYTES + 1)
+    with pytest.raises(ownership.BehaviorOwnershipError, match="too_large"):
+        ownership.validate_context_evidence(tmp_path, oversized)
     path = tmp_path / "context.json"
     artifact = _context_artifact()
     artifact["unexpected"] = True

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -548,6 +548,18 @@ def _context_artifact(**overrides: object) -> dict[str, object]:
     return {**authority, "artifact_digest": ownership._digest(authority)}
 
 
+def _prepare_context_identity(
+    root: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = root / "backend/scripts/example.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    test_module = root / "backend/tests/test_example.py"
+    test_module.parent.mkdir(parents=True, exist_ok=True)
+    test_module.write_text("def test_run(): pass\n", encoding="utf-8")
+    monkeypatch.setattr(ownership, "_tracked_at_revision", lambda *args: True)
+
+
 def test_context_evidence_is_separate_digest_bound_candidate_input(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -555,6 +567,7 @@ def test_context_evidence_is_separate_digest_bound_candidate_input(
     artifact = _context_artifact()
     _write_json(path, artifact)
     monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+    _prepare_context_identity(tmp_path, monkeypatch)
 
     result = ownership.validate_context_evidence(tmp_path, path)
 
@@ -586,6 +599,7 @@ def test_context_evidence_rejects_stale_partial_skip_and_deselect(
     path = tmp_path / "context.json"
     _write_json(path, _context_artifact(**updates))
     monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+    _prepare_context_identity(tmp_path, monkeypatch)
 
     with pytest.raises(ownership.BehaviorOwnershipError, match=error):
         ownership.validate_context_evidence(tmp_path, path)
@@ -599,6 +613,7 @@ def test_context_evidence_rejects_digest_drift_and_overwrite(
     artifact["artifact_digest"] = "0" * 64
     _write_json(path, artifact)
     monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+    _prepare_context_identity(tmp_path, monkeypatch)
     with pytest.raises(ownership.BehaviorOwnershipError, match="digest_mismatch"):
         ownership.validate_context_evidence(tmp_path, path)
     with pytest.raises(ownership.BehaviorOwnershipError, match="output_exists"):
@@ -631,6 +646,7 @@ def test_build_context_evidence_reuses_lane_collection_and_completion(
         "collect_nodes",
         lambda *args: (0, [node], []),
     )
+    monkeypatch.setattr(ownership, "_tracked_at_revision", lambda *args: True)
 
     def fake_run(arguments, *, cwd, env, check, timeout):
         metadata = Path(env[ownership.test_lanes.COLLECTED_ENV]).parent
@@ -682,6 +698,26 @@ def test_context_output_rejects_size_and_missing_parent(tmp_path: Path) -> None:
         )
     with pytest.raises(ownership.BehaviorOwnershipError, match="output_parent"):
         ownership._write_exclusive(tmp_path / "missing/out.json", b"{}\n")
+
+
+def test_context_identity_helpers_fail_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    monkeypatch.setattr(ownership.subprocess, "run", lambda *args, **kwargs: completed)
+    assert ownership._tracked_at_revision(tmp_path, "HEAD", "backend/scripts/example.py")
+    completed.returncode = 1
+    assert not ownership._tracked_at_revision(
+        tmp_path, "HEAD", "backend/scripts/example.py"
+    )
+    assert not ownership._tracked_at_revision(tmp_path, "HEAD", "../unsafe.py")
+    assert ownership._context_node_is_valid(
+        "tests/test_example.py::test_run", "tests/test_example.py"
+    )
+    assert not ownership._context_node_is_valid(
+        "tests/test_other.py::test_run", "tests/test_example.py"
+    )
+    assert not ownership._context_target_is_valid(tmp_path, "../unsafe.py")
 
 
 def test_coverage_context_reader_filters_noncompleted_and_requires_every_node(
@@ -754,6 +790,11 @@ def test_coverage_context_reader_rejects_invalid_data(
             },
             "invalid_context_callables",
         ),
+        ({"target": "../unsafe.py"}, "invalid_context_identity"),
+        ({"test_module": "../unsafe.py"}, "invalid_context_identity"),
+        ({"head_sha": "not-a-sha"}, "stale_context_evidence"),
+        ({"collected_nodes": ["invalid node"], "completed_nodes": ["invalid node"]}, "incomplete_context_evidence"),
+        ({"skipped_nodes": "wrong"}, "weakened_context_evidence"),
         (
             {
                 "callables": [
@@ -778,6 +819,7 @@ def test_context_validator_rejects_invalid_shapes(
     path = tmp_path / "context.json"
     _write_json(path, _context_artifact(**updates))
     monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+    _prepare_context_identity(tmp_path, monkeypatch)
     with pytest.raises(ownership.BehaviorOwnershipError, match=error):
         ownership.validate_context_evidence(tmp_path, path)
 
@@ -810,6 +852,8 @@ def test_context_validator_rejects_unsafe_and_unknown_shape(tmp_path: Path) -> N
         ("module", "invalid_context_test_module"),
         ("missing_module", "missing_context_test_module"),
         ("dirty", "dirty_context_tree"),
+        ("untracked", "untracked_context_input"),
+        ("symlink_output", "context_output_exists_or_unsafe"),
         ("output", "context_output_exists_or_unsafe"),
         ("collection", "invalid_context_collection"),
     ],
@@ -846,12 +890,19 @@ def test_context_builder_fails_closed_before_execution(
         lambda *args: () if case == "missing_module" else ("tests/test_example.py",),
     )
     monkeypatch.setattr(
+        ownership,
+        "_tracked_at_revision",
+        lambda *args: case != "untracked",
+    )
+    monkeypatch.setattr(
         ownership.test_lanes,
         "collect_nodes",
         lambda *args: (1, [], []) if case == "collection" else (0, ["node::id"], []),
     )
     if case == "output":
         output.write_text("existing", encoding="utf-8")
+    if case == "symlink_output":
+        output.symlink_to(tmp_path / "missing-context.json")
 
     with pytest.raises(ownership.BehaviorOwnershipError, match=error):
         ownership.build_context_evidence(

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -551,13 +551,19 @@ def _context_artifact(**overrides: object) -> dict[str, object]:
 def _prepare_context_identity(
     root: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    committed_source = "def run():\n    return 1\n"
     target = root / "backend/scripts/example.py"
     target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text("def run():\n    return 1\n", encoding="utf-8")
+    target.write_text(committed_source, encoding="utf-8")
     test_module = root / "backend/tests/test_example.py"
     test_module.parent.mkdir(parents=True, exist_ok=True)
     test_module.write_text("def test_run(): pass\n", encoding="utf-8")
     monkeypatch.setattr(ownership, "_tracked_at_revision", lambda *args: True)
+    monkeypatch.setattr(
+        ownership,
+        "_git_show_optional",
+        lambda root, revision, path: committed_source,
+    )
 
 
 def test_context_evidence_is_separate_digest_bound_candidate_input(
@@ -576,6 +582,23 @@ def test_context_evidence_is_separate_digest_bound_candidate_input(
     assert result["node_count"] == 1
     assert "status" not in artifact
     assert artifact["schema"] != ownership.CATALOGUE_SCHEMA
+
+
+def test_context_evidence_callable_spans_are_bound_to_committed_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "context.json"
+    artifact = _context_artifact()
+    _write_json(path, artifact)
+    monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+    _prepare_context_identity(tmp_path, monkeypatch)
+    (tmp_path / "backend/scripts/example.py").write_text(
+        "def changed():\n    return 2\n", encoding="utf-8"
+    )
+
+    result = ownership.validate_context_evidence(tmp_path, path)
+
+    assert result["callable_count"] == 1
 
 
 @pytest.mark.parametrize(
@@ -923,7 +946,7 @@ def test_context_builder_fails_closed_before_execution(
         "_tracked_at_revision",
         lambda *args: case != "untracked",
     )
-    def fake_collection(arguments, *, cwd, env, check, timeout):
+    def fake_collection(arguments, *, cwd, env, check, timeout=None):
         if case != "collection":
             Path(env[ownership.test_lanes.COLLECTED_ENV]).write_text(
                 json.dumps("tests/test_example.py::test_run") + "\n", encoding="utf-8"

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -605,6 +605,20 @@ def test_context_evidence_rejects_stale_partial_skip_and_deselect(
         ownership.validate_context_evidence(tmp_path, path)
 
 
+def test_context_evidence_rejects_missing_callable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "context.json"
+    _write_json(path, _context_artifact(callables=[]))
+    monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+    _prepare_context_identity(tmp_path, monkeypatch)
+
+    with pytest.raises(
+        ownership.BehaviorOwnershipError, match="incomplete_context_evidence"
+    ):
+        ownership.validate_context_evidence(tmp_path, path)
+
+
 def test_context_evidence_rejects_digest_drift_and_overwrite(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -519,6 +519,331 @@ def test_cli_inventory_generate_validate_and_errors(
     assert "behavior_ownership_error:bad" in capsys.readouterr().err
 
 
+def _context_artifact(**overrides: object) -> dict[str, object]:
+    node = "tests/test_example.py::test_run"
+    authority: dict[str, object] = {
+        "schema": ownership.CONTEXT_EVIDENCE_SCHEMA,
+        "authoritative": False,
+        "head_sha": "a" * 40,
+        "lane": "context_evidence",
+        "target": "backend/scripts/example.py",
+        "test_module": "tests/test_example.py",
+        "collection_complete": True,
+        "execution_complete": True,
+        "collected_nodes": [node],
+        "completed_nodes": [node],
+        "skipped_nodes": [],
+        "deselected_nodes": [],
+        "callables": [
+            {
+                "callable": "scripts.example.run",
+                "start_line": 1,
+                "end_line": 2,
+                "contexts": [{"nodeid": node, "lines": [1, 2]}],
+            }
+        ],
+        "elapsed_seconds": 1.25,
+    }
+    authority.update(overrides)
+    return {**authority, "artifact_digest": ownership._digest(authority)}
+
+
+def test_context_evidence_is_separate_digest_bound_candidate_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "context.json"
+    artifact = _context_artifact()
+    _write_json(path, artifact)
+    monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+
+    result = ownership.validate_context_evidence(tmp_path, path)
+
+    assert result["authoritative"] is False
+    assert result["schema"] == ownership.CONTEXT_EVIDENCE_SCHEMA
+    assert result["node_count"] == 1
+    assert "status" not in artifact
+    assert artifact["schema"] != ownership.CATALOGUE_SCHEMA
+
+
+@pytest.mark.parametrize(
+    ("updates", "error"),
+    [
+        ({"head_sha": "b" * 40}, "stale_context_evidence"),
+        ({"completed_nodes": []}, "incomplete_context_evidence"),
+        ({"skipped_nodes": ["tests/test_example.py::test_run"]}, "weakened_context_evidence"),
+        (
+            {"deselected_nodes": ["tests/test_example.py::test_run"]},
+            "weakened_context_evidence",
+        ),
+    ],
+)
+def test_context_evidence_rejects_stale_partial_skip_and_deselect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    updates: dict[str, object],
+    error: str,
+) -> None:
+    path = tmp_path / "context.json"
+    _write_json(path, _context_artifact(**updates))
+    monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+
+    with pytest.raises(ownership.BehaviorOwnershipError, match=error):
+        ownership.validate_context_evidence(tmp_path, path)
+
+
+def test_context_evidence_rejects_digest_drift_and_overwrite(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "context.json"
+    artifact = _context_artifact()
+    artifact["artifact_digest"] = "0" * 64
+    _write_json(path, artifact)
+    monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+    with pytest.raises(ownership.BehaviorOwnershipError, match="digest_mismatch"):
+        ownership.validate_context_evidence(tmp_path, path)
+    with pytest.raises(ownership.BehaviorOwnershipError, match="output_exists"):
+        ownership._write_exclusive(path, b"{}\n")
+
+
+def test_build_context_evidence_reuses_lane_collection_and_completion(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = "backend/scripts/example.py"
+    target_path = tmp_path / target
+    target_path.parent.mkdir(parents=True)
+    target_path.write_text("def run():\n    return 1\n", encoding="utf-8")
+    tests_dir = tmp_path / "backend/tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_example.py").write_text("def test_run(): pass\n", encoding="utf-8")
+    node = "tests/test_example.py::test_run"
+    monkeypatch.setattr(
+        ownership,
+        "_git",
+        lambda root, *arguments: "a" * 40 if arguments[0] == "rev-parse" else "",
+    )
+    monkeypatch.setattr(
+        ownership.test_lanes,
+        "discover_test_modules",
+        lambda *args: ("tests/test_example.py",),
+    )
+    monkeypatch.setattr(
+        ownership.test_lanes,
+        "collect_nodes",
+        lambda *args: (0, [node], []),
+    )
+
+    def fake_run(arguments, *, cwd, env, check, timeout):
+        metadata = Path(env[ownership.test_lanes.COLLECTED_ENV]).parent
+        for suffix in ("collected", "completed"):
+            (metadata / f"context.{suffix}.jsonl").write_text(
+                json.dumps(node) + "\n", encoding="utf-8"
+            )
+        (metadata / "context.skipped.jsonl").write_text("", encoding="utf-8")
+        (metadata / "context.deselected.jsonl").write_text("", encoding="utf-8")
+        Path(env["COVERAGE_FILE"]).write_bytes(b"coverage")
+        assert "--cov-context=test" in arguments
+        return subprocess.CompletedProcess(arguments, 0)
+
+    monkeypatch.setattr(ownership.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        ownership,
+        "_coverage_lines_by_context",
+        lambda path, target_path, completed: {node: {1, 2}},
+    )
+    output = tmp_path / "context.json"
+
+    artifact = ownership.build_context_evidence(
+        tmp_path,
+        target=target,
+        test_module="tests/test_example.py",
+        output=output,
+    )
+
+    assert output.stat().st_size <= ownership.CONTEXT_ARTIFACT_LIMIT_BYTES
+    assert artifact["collected_nodes"] == [node]
+    assert artifact["completed_nodes"] == [node]
+    assert artifact["callables"][0]["contexts"] == [{"nodeid": node, "lines": [1, 2]}]
+
+
+def test_context_output_rejects_size_and_missing_parent(tmp_path: Path) -> None:
+    with pytest.raises(ownership.BehaviorOwnershipError, match="too_large"):
+        ownership._write_exclusive(
+            tmp_path / "large.json", b"x" * (ownership.CONTEXT_ARTIFACT_LIMIT_BYTES + 1)
+        )
+    with pytest.raises(ownership.BehaviorOwnershipError, match="output_parent"):
+        ownership._write_exclusive(tmp_path / "missing/out.json", b"{}\n")
+
+
+def test_coverage_context_reader_filters_noncompleted_and_requires_every_node(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    node = "tests/test_example.py::test_run"
+
+    class FakeCoverageData:
+        def __init__(self, *, basename: str) -> None:
+            self.basename = basename
+            self.contexts: list[str] | None = []
+
+        def read(self) -> None:
+            return None
+
+        def measured_contexts(self) -> set[str]:
+            return {f"{node}|run", "tests/test_other.py::test_other|run"}
+
+        def set_query_contexts(self, contexts: list[str] | None) -> None:
+            self.contexts = contexts
+
+        def lines(self, filename: str) -> list[int]:
+            assert filename.endswith("example.py")
+            return [1, 2]
+
+    monkeypatch.setattr(ownership, "CoverageData", FakeCoverageData)
+    result = ownership._coverage_lines_by_context(
+        tmp_path / "coverage", tmp_path / "example.py", {node}
+    )
+    assert result == {node: {1, 2}}
+    with pytest.raises(ownership.BehaviorOwnershipError, match="missing_test_context"):
+        ownership._coverage_lines_by_context(
+            tmp_path / "coverage", tmp_path / "example.py", {node, "missing::node"}
+        )
+
+
+def test_coverage_context_reader_rejects_invalid_data(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class BrokenCoverageData:
+        def __init__(self, *, basename: str) -> None:
+            pass
+
+        def read(self) -> None:
+            raise ValueError("broken")
+
+    monkeypatch.setattr(ownership, "CoverageData", BrokenCoverageData)
+    with pytest.raises(ownership.BehaviorOwnershipError, match="invalid_context_coverage"):
+        ownership._coverage_lines_by_context(
+            tmp_path / "coverage", tmp_path / "example.py", {"tests/test_x.py::test_x"}
+        )
+
+
+@pytest.mark.parametrize(
+    ("updates", "error"),
+    [
+        ({"schema": "wrong"}, "invalid_context_evidence_schema"),
+        ({"elapsed_seconds": 121.0}, "invalid_context_elapsed"),
+        ({"callables": "wrong"}, "invalid_context_callables"),
+        (
+            {
+                "callables": [
+                    {
+                        "callable": "scripts.example.run",
+                        "start_line": 2,
+                        "end_line": 1,
+                        "contexts": [],
+                    }
+                ]
+            },
+            "invalid_context_callables",
+        ),
+        (
+            {
+                "callables": [
+                    {
+                        "callable": "scripts.example.run",
+                        "start_line": 1,
+                        "end_line": 2,
+                        "contexts": [{"nodeid": "missing::node", "lines": [3]}],
+                    }
+                ]
+            },
+            "invalid_context_callables",
+        ),
+    ],
+)
+def test_context_validator_rejects_invalid_shapes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    updates: dict[str, object],
+    error: str,
+) -> None:
+    path = tmp_path / "context.json"
+    _write_json(path, _context_artifact(**updates))
+    monkeypatch.setattr(ownership, "_git", lambda root, *arguments: "a" * 40)
+    with pytest.raises(ownership.BehaviorOwnershipError, match=error):
+        ownership.validate_context_evidence(tmp_path, path)
+
+
+def test_context_validator_rejects_unsafe_and_unknown_shape(tmp_path: Path) -> None:
+    with pytest.raises(ownership.BehaviorOwnershipError, match="unsafe_context_evidence"):
+        ownership.validate_context_evidence(tmp_path, tmp_path / "missing.json")
+    path = tmp_path / "context.json"
+    artifact = _context_artifact()
+    artifact["unexpected"] = True
+    _write_json(path, artifact)
+    with pytest.raises(ownership.BehaviorOwnershipError, match="invalid_context_evidence_shape"):
+        ownership.validate_context_evidence(tmp_path, path)
+
+
+@pytest.mark.parametrize(
+    ("case", "error"),
+    [
+        ("runtime", "invalid_context_runtime_limit"),
+        ("target", "unsafe_or_missing_target"),
+        ("module", "invalid_context_test_module"),
+        ("missing_module", "missing_context_test_module"),
+        ("dirty", "dirty_context_tree"),
+        ("output", "context_output_exists_or_unsafe"),
+        ("collection", "invalid_context_collection"),
+    ],
+)
+def test_context_builder_fails_closed_before_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    error: str,
+) -> None:
+    target = "backend/scripts/example.py"
+    path = tmp_path / target
+    path.parent.mkdir(parents=True)
+    path.write_text("def run():\n    return 1\n", encoding="utf-8")
+    tests = tmp_path / "backend/tests"
+    tests.mkdir(parents=True)
+    (tests / "test_example.py").write_text("def test_run(): pass\n", encoding="utf-8")
+    output = tmp_path / "context.json"
+    test_module = "../unsafe.py" if case == "module" else "tests/test_example.py"
+    selected_target = "backend/scripts/missing.py" if case == "target" else target
+    runtime = 0.0 if case == "runtime" else ownership.CONTEXT_RUNTIME_LIMIT_SECONDS
+    monkeypatch.setattr(
+        ownership,
+        "_git",
+        lambda root, *arguments: (
+            "dirty" if arguments[0] == "status" and case == "dirty" else "a" * 40
+            if arguments[0] == "rev-parse"
+            else ""
+        ),
+    )
+    monkeypatch.setattr(
+        ownership.test_lanes,
+        "discover_test_modules",
+        lambda *args: () if case == "missing_module" else ("tests/test_example.py",),
+    )
+    monkeypatch.setattr(
+        ownership.test_lanes,
+        "collect_nodes",
+        lambda *args: (1, [], []) if case == "collection" else (0, ["node::id"], []),
+    )
+    if case == "output":
+        output.write_text("existing", encoding="utf-8")
+
+    with pytest.raises(ownership.BehaviorOwnershipError, match=error):
+        ownership.build_context_evidence(
+            tmp_path,
+            target=selected_target,
+            test_module=test_module,
+            output=output,
+            runtime_limit_seconds=runtime,
+        )
+
+
 @pytest.mark.parametrize(
     "source",
     [

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -655,19 +655,16 @@ def test_build_context_evidence_reuses_lane_collection_and_completion(
         "discover_test_modules",
         lambda *args: ("tests/test_example.py",),
     )
+    monkeypatch.setattr(
+        ownership.test_lanes,
+        "collect_nodes",
+        lambda *args, **kwargs: (0, [node], []),
+    )
     monkeypatch.setattr(ownership, "_tracked_at_revision", lambda *args: True)
 
     def fake_run(arguments, *, cwd, env, check, timeout):
         assert env["PYTHONPATH"] == str(tmp_path / "backend")
         assert "UNRELATED_SECRET" not in env
-        if "--collect-only" in arguments:
-            Path(env[ownership.test_lanes.COLLECTED_ENV]).write_text(
-                json.dumps(node) + "\n", encoding="utf-8"
-            )
-            Path(env[ownership.test_lanes.DESELECTED_ENV]).write_text(
-                "", encoding="utf-8"
-            )
-            return subprocess.CompletedProcess(arguments, 0)
         metadata = Path(env[ownership.test_lanes.COLLECTED_ENV]).parent
         for suffix in ("collected", "completed"):
             (metadata / f"context.{suffix}.jsonl").write_text(

--- a/backend/tests/test_behavior_ownership.py
+++ b/backend/tests/test_behavior_ownership.py
@@ -908,6 +908,7 @@ def test_context_validator_rejects_unsafe_and_unknown_shape(tmp_path: Path) -> N
         ("symlink_output", "context_output_exists_or_unsafe"),
         ("output", "context_output_exists_or_unsafe"),
         ("collection", "invalid_context_collection"),
+        ("collection_timeout", "context_runtime_exceeded"),
     ],
 )
 def test_context_builder_fails_closed_before_execution(
@@ -947,6 +948,8 @@ def test_context_builder_fails_closed_before_execution(
         lambda *args: case != "untracked",
     )
     def fake_collection(arguments, *, cwd, env, check, timeout=None):
+        if case == "collection_timeout":
+            raise subprocess.TimeoutExpired(arguments, timeout)
         if case != "collection":
             Path(env[ownership.test_lanes.COLLECTED_ENV]).write_text(
                 json.dumps("tests/test_example.py::test_run") + "\n", encoding="utf-8"
@@ -967,6 +970,84 @@ def test_context_builder_fails_closed_before_execution(
             test_module=test_module,
             output=output,
             runtime_limit_seconds=runtime,
+        )
+
+
+@pytest.mark.parametrize(
+    ("case", "error"),
+    [
+        ("failure", "context_test_failure"),
+        ("incomplete", "incomplete_context_execution"),
+        ("skipped", "weakened_context_execution"),
+        ("deselected", "weakened_context_execution"),
+        ("missing_coverage", "missing_context_coverage"),
+        ("timeout", "context_runtime_exceeded"),
+    ],
+)
+def test_context_builder_fails_closed_after_collection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+    error: str,
+) -> None:
+    target = "backend/scripts/example.py"
+    target_path = tmp_path / target
+    target_path.parent.mkdir(parents=True)
+    target_path.write_text("def run():\n    return 1\n", encoding="utf-8")
+    tests = tmp_path / "backend/tests"
+    tests.mkdir(parents=True)
+    (tests / "test_example.py").write_text("def test_run(): pass\n", encoding="utf-8")
+    node = "tests/test_example.py::test_run"
+    monkeypatch.setattr(
+        ownership,
+        "_git",
+        lambda root, *arguments: "a" * 40 if arguments[0] == "rev-parse" else "",
+    )
+    monkeypatch.setattr(
+        ownership.test_lanes,
+        "discover_test_modules",
+        lambda *args: ("tests/test_example.py",),
+    )
+    monkeypatch.setattr(
+        ownership.test_lanes,
+        "collect_nodes",
+        lambda *args, **kwargs: (0, [node], []),
+    )
+    monkeypatch.setattr(ownership, "_tracked_at_revision", lambda *args: True)
+    monkeypatch.setattr(
+        ownership,
+        "_coverage_lines_by_context",
+        lambda *args: {node: {1, 2}},
+    )
+
+    def fake_run(arguments, *, cwd, env, check, timeout):
+        if case == "timeout":
+            raise subprocess.TimeoutExpired(arguments, timeout)
+        metadata = Path(env[ownership.test_lanes.COLLECTED_ENV]).parent
+        collected = [node]
+        completed = [f"{node}_other"] if case == "incomplete" else [node]
+        for suffix, values in (
+            ("collected", collected),
+            ("completed", completed),
+            ("skipped", [node] if case == "skipped" else []),
+            ("deselected", [node] if case == "deselected" else []),
+        ):
+            (metadata / f"context.{suffix}.jsonl").write_text(
+                "".join(json.dumps(value) + "\n" for value in values),
+                encoding="utf-8",
+            )
+        if case != "missing_coverage":
+            Path(env["COVERAGE_FILE"]).write_bytes(b"coverage")
+        return subprocess.CompletedProcess(arguments, 1 if case == "failure" else 0)
+
+    monkeypatch.setattr(ownership.subprocess, "run", fake_run)
+
+    with pytest.raises(ownership.BehaviorOwnershipError, match=error):
+        ownership.build_context_evidence(
+            tmp_path,
+            target=target,
+            test_module="tests/test_example.py",
+            output=tmp_path / "context.json",
         )
 
 

--- a/backend/tests/test_ci_test_lanes.py
+++ b/backend/tests/test_ci_test_lanes.py
@@ -491,6 +491,37 @@ def test_collection_rejects_duplicate_or_foreign_nodes(
         runner.collect_nodes((module,), tmp_path / "metadata", "a" * 40)
 
 
+def test_collection_accepts_a_minimal_base_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = "tests/test_alpha.py"
+    metadata = tmp_path / "metadata"
+    metadata.mkdir()
+
+    class Result:
+        returncode = 0
+
+    def fake_run(*_args, **kwargs):
+        environment = kwargs["env"]
+        assert environment["PYTHONPATH"] == str(runner.ROOT)
+        assert "UNRELATED_SECRET" not in environment
+        Path(environment[runner.COLLECTED_ENV]).write_text(
+            json.dumps(f"{module}::test_alpha") + "\n", encoding="utf-8"
+        )
+        return Result()
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    result = runner.collect_nodes(
+        (module,),
+        metadata,
+        "a" * 40,
+        base_environment={"PYTHONPATH": str(runner.ROOT)},
+    )
+
+    assert result == (0, [f"{module}::test_alpha"], [])
+
+
 def test_timing_summary_is_derived_from_exact_declared_lanes() -> None:
     lanes = [{"elapsed_seconds": value} for value in (1.125, 2.25, 0.5, 3.75, 1.0)]
 

--- a/backend/tests/test_ci_test_lanes.py
+++ b/backend/tests/test_ci_test_lanes.py
@@ -503,6 +503,7 @@ def test_collection_accepts_a_minimal_base_environment(
 
     def fake_run(*_args, **kwargs):
         environment = kwargs["env"]
+        assert kwargs["timeout"] == 12.5
         assert environment["PYTHONPATH"] == str(runner.ROOT)
         assert "UNRELATED_SECRET" not in environment
         Path(environment[runner.COLLECTED_ENV]).write_text(
@@ -517,6 +518,7 @@ def test_collection_accepts_a_minimal_base_environment(
         metadata,
         "a" * 40,
         base_environment={"PYTHONPATH": str(runner.ROOT)},
+        timeout_seconds=12.5,
     )
 
     assert result == (0, [f"{module}::test_alpha"], [])

--- a/backend/tests/test_ci_test_lanes.py
+++ b/backend/tests/test_ci_test_lanes.py
@@ -491,37 +491,6 @@ def test_collection_rejects_duplicate_or_foreign_nodes(
         runner.collect_nodes((module,), tmp_path / "metadata", "a" * 40)
 
 
-def test_collection_accepts_a_minimal_base_environment(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    module = "tests/test_alpha.py"
-    metadata = tmp_path / "metadata"
-    metadata.mkdir()
-
-    class Result:
-        returncode = 0
-
-    def fake_run(*_args, **kwargs):
-        environment = kwargs["env"]
-        assert environment["PYTHONPATH"] == str(runner.ROOT)
-        assert "UNRELATED_SECRET" not in environment
-        Path(environment[runner.COLLECTED_ENV]).write_text(
-            json.dumps(f"{module}::test_alpha") + "\n", encoding="utf-8"
-        )
-        return Result()
-
-    monkeypatch.setattr(runner.subprocess, "run", fake_run)
-
-    result = runner.collect_nodes(
-        (module,),
-        metadata,
-        "a" * 40,
-        base_environment={"PYTHONPATH": str(runner.ROOT)},
-    )
-
-    assert result == (0, [f"{module}::test_alpha"], [])
-
-
 def test_timing_summary_is_derived_from_exact_declared_lanes() -> None:
     lanes = [{"elapsed_seconds": value} for value in (1.125, 2.25, 0.5, 3.75, 1.0)]
 

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -241,3 +241,7 @@ its digest. It contains no environment values, credentials, payloads, logs, or
 database values; keep it outside `.ci/behavior-ownership/` and do not commit it.
 The catalogue validator never consumes this artifact, and no workflow or
 required check invokes the command.
+
+Only pytest `|run` coverage contexts count as callable-execution evidence.
+Fixture setup and teardown coverage is intentionally excluded because it does
+not prove that the test body exercised the callable.

--- a/docs/operations_backend_testing.md
+++ b/docs/operations_backend_testing.md
@@ -214,3 +214,30 @@ loops, raises, awaits, mutation, I/O, SQL, validators, or other side effects.
 Until population and a separately approved changed-line reactivation chunk are
 complete, Backend lanes and existing coverage floors remain the only hosted
 test authority.
+
+### Local coverage-context evidence
+
+Coverage contexts can suggest which exact tests execute a callable, but they do
+not prove assertions or establish reviewed ownership. Generate one temporary,
+non-catalogue artifact from a clean committed tree:
+
+```bash
+cd backend
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
+.venv/bin/python -m scripts.behavior_ownership context-evidence \
+  --target backend/scripts/behavior_ownership.py \
+  --test-module tests/test_behavior_ownership.py \
+  --output "$tmp_dir/context-evidence.json"
+.venv/bin/python -m scripts.behavior_ownership validate-context-evidence \
+  --input "$tmp_dir/context-evidence.json"
+```
+
+The command reuses semantic-lane pytest collection and completion custody,
+rejects dirty trees, skipped/deselected/partial execution, stale heads,
+overwrite attempts, digest drift, runs over two minutes, and artifacts over 10
+MiB. The private output contains only exact Git/test/callable/line metadata and
+its digest. It contains no environment values, credentials, payloads, logs, or
+database values; keep it outside `.ci/behavior-ownership/` and do not commit it.
+The catalogue validator never consumes this artifact, and no workflow or
+required check invokes the command.


### PR DESCRIPTION
# Workstream PR Trust Bundle

## Chunk

`WS-QUAL-002-02` - Local Coverage-Context Evidence

## Goal

Emit bounded, non-authoritative callable-to-test candidate evidence from exact
local coverage contexts without adding hosted CI infrastructure.

## Intent And Planning Context

- Intent: `../INTENT.md`
- Chunk contract: `../chunks/WS-QUAL-002-02-context-evidence.md`

## What Changed

- Added manual `context-evidence` generation and validation commands.
- Reused semantic-lane collection and completion custody.
- Mapped per-test coverage contexts to exact callable spans.
- Added digest, exact-head, clean-tree, runtime, size, path, overwrite, privacy,
  and non-authoritative-schema controls.
- Added focused fail-closed tests and operational documentation.

## Why It Changed

Imports and coverage totals do not show which exact tests execute a callable.
This bounded evidence makes later ownership review better informed without
claiming that inferred execution proves assertions or reviewed ownership.

## Design Chosen

One local-only artifact uses the existing lane plugin for collection and
completion, coverage.py test contexts for line evidence, and an independent
schema that catalogue validation cannot consume.

## Alternatives Rejected

- Hosted collection was rejected because this calibration chunk must add no CI
  cost or required gate.
- Import-based inference was rejected because importing code does not prove
  behavior execution.
- Automatic catalogue population was rejected because candidate evidence is
  not reviewed ownership.

## Scope Control

### Allowed Files Changed

- WS-QUAL-002 plan, status, contract, and review evidence.
- `backend/scripts/behavior_ownership.py` and `run_test_lanes.py`.
- Their focused tests and backend testing operations documentation.

### Files Outside Stated Scope

- None.

## Product Behavior

- [x] No Workstream product behavior changed.
- [ ] Product behavior changed and is explained here.

## Evidence

### Commands Run

```bash
cd backend
.venv/bin/ruff check scripts/behavior_ownership.py scripts/run_test_lanes.py \
  tests/test_behavior_ownership.py tests/test_ci_test_lanes.py
.venv/bin/python -m pytest -q \
  tests/test_behavior_ownership.py tests/test_ci_test_lanes.py
.venv/bin/coverage erase
.venv/bin/python -m pytest -q --cov=scripts.behavior_ownership \
  --cov-report=term tests/test_behavior_ownership.py
python3 ../scripts/check_markdown_links.py
python3 ../scripts/check_stale_workstream_wording.py
git diff --check origin/main...HEAD
```

### Result Summary

```text
124 focused tests passed.
90 behavior-ownership tests passed.
scripts.behavior_ownership coverage: 91 percent.
Ruff, Markdown links, stale wording, and diff integrity passed.
```

The exact implementation-head calibration completed 90 nodes in 18.12 seconds
and emitted 141,701 bytes, below both adoption limits.

## Acceptance Criteria Proof

- [x] Exact head, callable lines, and collected nodes are bound and validated.
- [x] Collection and completion reuse `run_test_lanes.py`.
- [x] Candidate evidence cannot satisfy reviewed catalogue ownership.
- [x] The artifact is local, separate, non-catalogue, and never committed.
- [x] No workflow or required check invokes the command.
- [x] Runtime and artifact size remain below two minutes and 10 MiB.
- [x] Artifact fields exclude environment values, secrets, payloads, and logs.
- [x] Validation fails closed on stale, partial, skipped, deselected,
  digest-mismatched, overwritten, or timeout evidence.

## Test Delta

### Tests Added

- Context artifact identity, digest, exact-head, callable, path, size, runtime,
  collection, completion, skip/deselect, coverage, and privacy behavior.
- Minimal sanitized collection environment and timeout forwarding.

### Tests Modified

- Existing collection mocks accept the canonical optional timeout contract.

### Tests Removed Or Skipped

- None.

## Internal Reviewer Results

Reviewed implementation SHA: `836865b1d84d06f534c0c45f551e72f335d810aa`

Reviewed at: 2026-08-09

Reviewer run IDs: `qual002_02_{arch,qa,security,ci,reuse,test_delta}`

| Reviewer | Result | Blocking Findings | Notes |
|---|---:|---|---|
| Senior engineering | N/A - proportionate L1 review | None | Required focused tracks cover this bounded tool |
| QA/test | PASS AFTER FIXES | None | Exact-head and fail-closed custody repaired |
| Security/auth | PASS AFTER FIXES | None | Environment, path, digest, and Git custody reviewed |
| Product/ops | N/A - no product behavior | None | Local engineering evidence only |
| Architecture | PASS | None | Non-authoritative boundary preserved |
| CI integrity | PASS | None | No workflow or gate weakening |
| Docs | N/A - focused operational update | None | Links and stale wording pass |
| Reuse/dedup | PASS | None | Canonical collector reused |
| Test delta | PASS | None | Additive tests; none skipped or weakened |

## External Review

| Source | Status | Notes |
|---|---:|---|
| CodeRabbit | PASS AFTER FIXES | Valid earlier findings addressed; newest run rate-limited |
| GitHub checks | Pending | Exact-head checks are running |

## CI And Gate Integrity

- [x] No workflow weakening.
- [x] No lint/test/docstring gate weakening.
- [x] No coverage threshold weakening.
- [x] No package script weakening.
- [x] No unpinned new GitHub Action.
- [x] Checkout credential persistence disabled where checkout is used.

## Remaining Risks

The artifact is candidate evidence only. It cannot establish reviewed ownership
and no authoritative catalogue consumer accepts it.

## Follow-Up Work

Use this evidence during later bounded catalogue-population chunks. Promote a
public lane-runner API only if a second consumer needs the same custody path.

## Human Review Focus

Please inspect the non-authoritative boundary, shared runtime budget,
secret-free subprocesses, exact-head callable custody, and lack of hosted-CI
changes.

## Human Merge Ownership

- [x] I can explain what changed.
- [x] I can explain why it changed.
- [x] I know what could break.
- [x] I accept the remaining risks.
- [x] The user explicitly approved this specific PR for merge.
