### PR TITLE
feat(auth): register ContributionPolicy actions

### DIFF
--- a/.agent-loop/CURRENT_STATE.md
+++ b/.agent-loop/CURRENT_STATE.md
@@ -105,9 +105,9 @@ non-executable until PLAN3 merges and its current-main contract is expanded.
 - WS-ARCH-001-CP01 is a planned split and non-executable.
 - WS-ARCH-001-CP01A is complete on merge with adapter-binding actions registered
   but unavailable.
-- WS-ARCH-001-CP01B is proposed after CP01A for unavailable ContributionPolicy
-  registration.
-- WS-ARCH-001-CP02 is proposed and non-executable.
+- WS-ARCH-001-CP01B is complete on merge with five unavailable ContributionPolicy
+  actions registered.
+- WS-ARCH-001-CP02 is the next proposed non-executable boundary.
 - WS-ARCH-001-CP03 is proposed and non-executable.
 - WS-ARCH-001-CP04 is proposed and non-executable.
 - WS-ARCH-001-CP05 is proposed and non-executable.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/CHUNK_MAP.md
@@ -18,8 +18,8 @@
 | `WS-ARCH-001-PLAN3` | ContributionPolicy registration, behavior, activation, guide/task lineage and clean legacy-removal sequencing | L1 | Proposed planning correction; no runtime |
 | `WS-ARCH-001-CP01` | Combined AUTH registration planning parent | L1 | Planned split into CP01A/CP01B; non-executable |
 | `WS-ARCH-001-CP01A` | AUTH adapter-binding unavailable registration | L1 | Complete on merge; four actions remain planned/unavailable |
-| `WS-ARCH-001-CP01B` | AUTH ContributionPolicy unavailable registration | L1 | Proposed executable contract after CP01A |
-| `WS-ARCH-001-CP02` | CON hidden adapter-binding behavior | L1 | Proposed skeleton after CP01B |
+| `WS-ARCH-001-CP01B` | AUTH ContributionPolicy unavailable registration | L1 | Complete on merge; five actions remain planned/unavailable |
+| `WS-ARCH-001-CP02` | CON hidden adapter-binding behavior | L1 | Next proposed skeleton after CP01B |
 | `WS-ARCH-001-CP03` | AUTH exact adapter-binding activation | L1 | Proposed skeleton after CP02 evidence |
 | `WS-ARCH-001-CP04` | CON hidden ContributionPolicy behavior | L1 | Proposed skeleton after CP03 |
 | `WS-ARCH-001-CP05` | AUTH exact ContributionPolicy activation | L1 | Proposed skeleton after CP04 evidence |

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
@@ -52,8 +52,8 @@
   valid direct start: missing AUTH registration/activation and hidden CON
   behavior must precede owner-separated guide/task lineage. CP01 is the
   non-executable split parent; CP01A is complete on merge with its four actions
-  registered/unavailable, CP01B is the remaining proposed executable contract,
-  and CP02-CP09 remain non-executable skeletons.
+  registered/unavailable, CP01B is complete on merge with five policy actions
+  registered/unavailable, and CP02-CP09 remain non-executable skeletons.
 
 ## Proposed PLAN3 children
 
@@ -62,9 +62,9 @@
   adapter binding and ContributionPolicy are distinct resource/action families.
 - WS-ARCH-001-CP01A is complete on merge: exact adapter-binding identifiers,
   mappings, typed facts, and digests are registered while unavailable.
-- WS-ARCH-001-CP01B is proposed after CP01A: exact unavailable
+- WS-ARCH-001-CP01B is complete on merge: exact unavailable
   ContributionPolicy registration.
-- WS-ARCH-001-CP02 is proposed: hidden adapter-binding behavior.
+- WS-ARCH-001-CP02 is the next proposed boundary: hidden adapter-binding behavior.
 - WS-ARCH-001-CP03 is proposed: exact adapter-binding activation.
 - WS-ARCH-001-CP04 is proposed: hidden ContributionPolicy behavior.
 - WS-ARCH-001-CP05 is proposed: exact ContributionPolicy activation.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP01B-auth-contribution-policy-registration.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP01B-auth-contribution-policy-registration.md
@@ -37,6 +37,18 @@ backend/app/modules/authorization/api/__init__.py
 backend/app/modules/authorization/api/action_ids.py
 backend/app/modules/authorization/api/contribution_policies.py
 backend/tests/authorization/test_contribution_policy_registration.py
+backend/tests/test_authorization.py (closed catalogue/action-owner parity only)
+backend/scripts/behavior_ownership.py (exact CP01B public-API target only)
+backend/scripts/run_test_lanes.py (CP01B test custody only)
+.ci/behavior-ownership/partition.v1.json (additive AUTH target parity only)
+.ci/behavior-ownership/auth/contribution-policy-facts.json
+.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json (generated parity only)
+docs/operations_authorization_service.md (catalogue parity only)
+docs/spec_authorization_service.md (catalogue parity only)
+docs/spec_contribution_compensation.md (CP01B registration parity only)
+docs/roadmap_status.md (CP01B capability state only)
+.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md (catalogue parity only)
+.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/STATUS.md (CP01B state only)
 .agent-loop/CURRENT_STATE.md
 .agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/{CHUNK_MAP.md,STATUS.md}
 .agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP01B-auth-contribution-policy-registration.md
@@ -68,18 +80,18 @@ compatibility aliases or non-canonical ContributionPolicy identifiers
 
 ## Acceptance criteria
 
-- [ ] Five canonical `contribution.policy.*` ActionIds map only to existing
+- [x] Five canonical `contribution.policy.*` ActionIds map only to existing
   `compensation.policy.manage` under CP01B custody.
-- [ ] All five definitions remain `PLANNED`; no evaluator, identity, grant,
+- [x] All five definitions remain `PLANNED`; no evaluator, identity, grant,
   matrix row, route, or product behavior can use them.
-- [ ] AUTH public API exposes typed immutable query/mutation fact models and
+- [x] AUTH public API exposes typed immutable query/mutation fact models and
   canonical resource-digest helpers without importing CON internals.
-- [ ] Mutation facts use the existing opaque PREP port; no handle construction,
+- [x] Mutation facts use the existing opaque PREP port; no handle construction,
   serialization, consumption, or runtime evaluator is added.
-- [ ] Independent tests prove identifier spelling, permission/owner mapping,
+- [x] Independent tests prove identifier spelling, permission/owner mapping,
   typed fact validation and digest domain separation, catalogue/API parity,
   and planned denial.
-- [ ] No `compensation.policy.*` ActionId alias is introduced.
+- [x] No `compensation.policy.*` ActionId alias is introduced.
 
 ## Verification commands
 
@@ -119,4 +131,4 @@ identity, migration, or product import; update and re-review the contract first.
 
 ## Merge state
 
-- Outcome on merge: `planned`
+- Outcome on merge: `complete`

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-external-review-response.md
@@ -6,6 +6,9 @@
   the PR trust bundle used uppercase `PASS`. They now use the canonical
   lowercase `pass` value; Workstream product review decisions remain limited to
   `accept`, `needs_revision`, and `reject`.
+- A subsequent review correctly identified stale external-check wording in the
+  trust bundle. It now records that hosted CI passed and that CodeRabbit
+  completed as rate-limited with no unresolved review threads.
 
 ## Comments deferred
 

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-external-review-response.md
@@ -1,0 +1,26 @@
+# WS-ARCH-001-CP01B External Review Response
+
+## Comments addressed
+
+- CodeRabbit correctly identified that internal engineering reviewer outcomes in
+  the PR trust bundle used uppercase `PASS`. They now use the canonical
+  lowercase `pass` value; Workstream product review decisions remain limited to
+  `accept`, `needs_revision`, and `reject`.
+
+## Comments deferred
+
+- None.
+
+## Human decisions needed
+
+- Human approval remains required before merge.
+
+## Commands rerun
+
+- `python3 scripts/check_markdown_links.py`
+- `git diff --check`
+- Hosted exact-head Agent Gates and Backend checks.
+
+## Remaining risks
+
+- None introduced by this documentation-only correction.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-pr-trust-bundle.md
@@ -1,0 +1,99 @@
+# PR Trust Bundle: WS-ARCH-001-CP01B
+
+## Chunk
+
+WS-ARCH-001-CP01B — AUTH ContributionPolicy Registration
+
+## Goal
+
+Register the five canonical `contribution.policy.*` authorization actions and
+typed resource facts while keeping every action planned and unavailable.
+
+## Human-approved intent
+
+Establish only the ContributionPolicy AUTH boundary, then return ownership to
+CP02 for hidden adapter-binding behavior. Do not begin the broader CON lifecycle.
+
+## What changed and why
+
+- Added five closed ActionIds under `WS-ARCH-001-CP01B`, mapped only to the
+  existing `compensation.policy.manage` PermissionId.
+- Added dependency-free immutable read/create/update/publish/retire facts and a
+  domain-separated canonical digest helper.
+- Bound publish facts to the exact draft, canonical rules/definitions digest,
+  and sorted unique adapter-binding identities.
+- Added focused behavior tests, ownership evidence, lane custody, catalogue
+  parity, structural-debt reconciliation, and current documentation/status.
+
+## Design chosen
+
+The implementation follows the existing AUTH public-facts and planned-action
+pattern. It does not import CON internals or create another PREP protocol.
+
+## Alternatives rejected
+
+- No `compensation.policy.*` aliases.
+- No generic resource dictionary.
+- No evaluator, identity, grant, matrix row, route, migration, or activation.
+- No CON behavior bundled into AUTH registration.
+
+## Scope and product behavior
+
+The five actions remain `PLANNED`; runtime product behavior is unchanged.
+CP02 is the next boundary.
+
+## Acceptance evidence
+
+- Five exact actions map only to `compensation.policy.manage`.
+- Catalogue totals are 73 permissions, 111 actions, 57 active, and 54 planned.
+- All actions fail closed through executable-action resolution.
+- Typed facts are frozen and lifecycle-bound; publish lineage is canonical.
+- No legacy action alias or service assignment exists.
+
+## Tests and CI integrity
+
+Local focused evidence:
+
+- Ruff: passed.
+- CP01A/CP01B registration tests: 10 passed.
+- Closed catalogue parity: passed.
+- CI lane and behavior-ownership tests: 140 passed.
+- Structural-debt, behavior-ownership, lane collection, docstring coverage,
+  stale wording, Markdown links, chunk-state sync, and diff checks: passed.
+
+No test, coverage, lint, preflight, or branch-protection gate was weakened.
+Hosted CI owns the full repository suite and coverage proof.
+
+## Test delta
+
+One focused CP01B module covers registration denial, immutability, lifecycle
+state, publish digest/binding canonicalization, cross-action rejection, API
+exports, and collection scope. Existing catalogue assertions were strengthened.
+
+## Reviewer results
+
+- Architecture: PASS.
+- Security/auth: PASS.
+- Senior engineering and QA/test delta: PASS.
+- Product/ops: PASS.
+- Reuse/dedup: PASS.
+- Documentation: PASS.
+
+## External review
+
+CodeRabbit and hosted CI are pending on the PR exact head.
+
+## Remaining risks and follow-up
+
+The identifiers are deliberately unusable until hidden owner behavior and a
+separate AUTH activation merge. CP02 implements hidden adapter-binding behavior;
+CP03 owns its later activation.
+
+## Human review focus
+
+Confirm the exact five-action manifest, canonical publish binding lineage,
+absence of executable authority, and CP02 as the next boundary.
+
+## Human merge ownership
+
+Only an authorized human maintainer may approve and merge this PR.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-pr-trust-bundle.md
@@ -72,12 +72,12 @@ exports, and collection scope. Existing catalogue assertions were strengthened.
 
 ## Reviewer results
 
-- Architecture: PASS.
-- Security/auth: PASS.
-- Senior engineering and QA/test delta: PASS.
-- Product/ops: PASS.
-- Reuse/dedup: PASS.
-- Documentation: PASS.
+- Architecture: pass.
+- Security/auth: pass.
+- Senior engineering and QA/test delta: pass.
+- Product/ops: pass.
+- Reuse/dedup: pass.
+- Documentation: pass.
 
 ## External review
 

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-pr-trust-bundle.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP01B-pr-trust-bundle.md
@@ -81,7 +81,8 @@ exports, and collection scope. Existing catalogue assertions were strengthened.
 
 ## External review
 
-CodeRabbit and hosted CI are pending on the PR exact head.
+Hosted CI passed. CodeRabbit completed as rate-limited, with no unresolved
+review threads.
 
 ## Remaining risks and follow-up
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
@@ -69,10 +69,11 @@ remains planned and
 cannot be activated by read/status proof. The historical transfer added no
 migration because owner and availability are typed metadata. WS-XINT-002-01
 reconciles PostgreSQL parity through migration `0036`. The current catalogue
-has 73 PermissionIds, 106 ActionIds, 57 active actions, and 49 planned actions,
+has 73 PermissionIds, 111 ActionIds, 57 active actions, and 54 planned actions,
 with fourteen fixed-service identities and twenty-two matrix memberships.
-CP01A contributes the four planned/unavailable adapter-binding actions only;
-it changes no fixed-service identity or matrix membership. CP01B remains next.
+CP01A contributes four planned/unavailable adapter-binding actions and CP01B
+contributes five planned/unavailable ContributionPolicy actions; neither
+changes fixed-service identity or matrix membership.
 
 ## REV custody transfer
 

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -26,7 +26,7 @@ sequence.
 |---|---|---:|---|
 | `WS-ARCH-001-CP01` | Combined registration planning parent | L1 | Planned split into CP01A/CP01B; non-executable |
 | `WS-ARCH-001-CP01A` | Adapter-binding unavailable registration | L1 | Complete on merge; excludes retirement, callback/fulfillment, identity, evaluator, and activation |
-| `WS-ARCH-001-CP01B` | ContributionPolicy unavailable registration | L1 | Proposed after CP01A; excludes binding behavior, evaluator, and activation |
+| `WS-ARCH-001-CP01B` | ContributionPolicy unavailable registration | L1 | Complete on merge; excludes binding behavior, evaluator, and activation |
 | `WS-ARCH-001-CP03` | Exact adapter-binding activation | L1 | Proposed after merged CP02 hidden proof |
 | `WS-ARCH-001-CP05` | Exact ContributionPolicy activation | L1 | Proposed after merged CP04 hidden proof |
 | `WS-AUTH-001-PLAN` | Authorization Service Planning | L0 | Merged through PR #91 as `ad6d644` |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -43,7 +43,8 @@ not current start requirements.
   owner behavior and typed manifests are merged. Their activation order lives
   in the matching XINT and feature-owner records.
 - PLAN3 defines the missing contribution-policy sequence: WS-ARCH-001-CP01A is
-  complete on merge with exact adapter-binding actions still unavailable; CP01B separately registers
+  complete on merge with exact adapter-binding actions still unavailable; CP01B is
+  complete on merge and separately registers
   policy actions while unavailable; CP03 and CP05 activate
   only their respective merged hidden behavior. Fulfillment callback authority
   remains separate and cannot be bundled into adapter-binding registration.

--- a/.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json
+++ b/.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json
@@ -39,14 +39,14 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "0a1e990ef039786066276283bc519669a9274aceb2949e1d320f93e75203926e",
-      "end_line": 1149,
+      "end_line": 1180,
       "hard_limit": 100,
       "kind": "production_function",
       "observed_lines": 120,
       "path": "backend/app/modules/authorization/catalogue.py",
       "qualified_symbol": "_index_service_actions",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 1030
+      "start_line": 1061
     },
     {
       "capability": "unassigned_legacy_auth",
@@ -218,11 +218,11 @@
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "dd8d424d97a68ff9080aa05c16feb073f4f219eb63e0d5dd55defdfad00d28b9",
-      "end_line": 13406,
+      "content_sha256": "7df452b12e549934000e32205899b5d390809582e91f675f8c3bfd08a641df57",
+      "end_line": 13403,
       "hard_limit": 1200,
       "kind": "test_file",
-      "observed_lines": 13406,
+      "observed_lines": 13403,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": null,
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -531,58 +531,58 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "951b44cc07e36002118fe93b7974e8d65851b0e2c3cec89a3031cbe42b014e2d",
-      "end_line": 8512,
+      "end_line": 8509,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 140,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_actor_lifecycle_service_applies_success_and_guards_conflicts",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 8373
+      "start_line": 8370
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "569084d6de89ff9eae71d526fc6c157aea7638f55ca93ad128b721fbda339be6",
-      "end_line": 9002,
+      "end_line": 8999,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 122,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_admin_resource_digest_alone_rejects_substituted_role_and_disposition",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 8881
+      "start_line": 8878
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "90b8b670b4d277209617cc1aa794188b4fb3cd9d894b69d5dc3d0adfc885f6ed",
-      "end_line": 9230,
+      "end_line": 9227,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 132,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_admin_revoke_stages_complete_state_and_evidence",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 9099
+      "start_line": 9096
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "78d9bf3df08e5633e9a75720b1e4bf5b7d7b24019bc392b4cb7496a9ac5e5e8e",
-      "end_line": 11058,
+      "end_line": 11055,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 122,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_authorization_locks_refresh_cached_actor_lifecycle_state",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 10937
+      "start_line": 10934
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "9f874fde0ed7cfe54e4cd9c3fc75d18305ec48edfb6b8696e305116b3828afea",
-      "end_line": 2242,
+      "content_sha256": "96799327ad2799fc630107518acb733de710ad28fe006e9673f8b17a2cf5e784",
+      "end_line": 2239,
       "hard_limit": 120,
       "kind": "test_function",
-      "observed_lines": 321,
+      "observed_lines": 318,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_closed_permission_and_action_catalogue_is_exact_and_non_executable",
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -591,122 +591,122 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "df1df6ec2ba6aa55445e21cfcf4e4e3ad9664c9504313484a495b6a6df1e9047",
-      "end_line": 3472,
+      "end_line": 3469,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 126,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_identity_link_lifecycle_route_preserves_outcome_transaction_contract",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 3347
+      "start_line": 3344
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "05d1b020ecff0f9bc0a0567adc07f5b31a2f9dfb7828ae3ad34d4e1e7757797c",
-      "end_line": 8665,
+      "end_line": 8662,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 151,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_identity_link_lifecycle_service_applies_success_and_guards_conflicts",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 8515
+      "start_line": 8512
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "c5d6d0d480ced964354915614f15202c0159bfbb281658da0d44186dffd17848",
-      "end_line": 7460,
+      "end_line": 7457,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 142,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_prepared_actor_authority_crossed_mutations_complete_in_both_orders",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 7319
+      "start_line": 7316
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "ebb76e63671195aa4d806ac602bfe58cb22bf82d00c8a70ab186785f3acd7f9b",
-      "end_line": 7801,
+      "end_line": 7798,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 336,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_prepared_crosses_real_lifecycle_service_transactions",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 7466
+      "start_line": 7463
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "9ea4fc0ddbab4c7262a43bc3f498ee1afea3318e9a0b6c93c87763f9f22aae9c",
-      "end_line": 7291,
+      "end_line": 7288,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 518,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_prepared_postgresql_failure_and_cancellation_are_atomic",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 6774
+      "start_line": 6771
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "46e0b031394da6fee856e48615732a17ff8d2276d9cedfb0ecaa3a6879410adb",
-      "end_line": 4677,
+      "end_line": 4674,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 157,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_11c2_reads_require_exact_admin_context_and_role_allowlist",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 4521
+      "start_line": 4518
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "e95d2a03e3829df89c43210a9de92efca31a25905c9648c3179d17b078386b17",
-      "end_line": 2643,
+      "end_line": 2640,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 397,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_mutation_resources_and_prepared_scopes_are_closed",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 2247
+      "start_line": 2244
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "105667302ed6e8f2fd16ea7e95d642e72e41514673e1152503536e0520f9c362",
-      "end_line": 10933,
+      "end_line": 10930,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 204,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_read_permissions_have_postgresql_role_scope_matrix",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 10730
+      "start_line": 10727
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "756b7f99f9a743284934b4d85ce263617710d9b8119792ccb4526a1de04070a1",
-      "end_line": 12435,
+      "end_line": 12432,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 233,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_role_and_all_operation_mappings_commit_one_linked_pair",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 12203
+      "start_line": 12200
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "2e1d7db74ddb955b90a0ee12e4fb72b651a0f85d2746c76e09079c05b0b85252",
-      "end_line": 13406,
+      "end_line": 13403,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 681,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_role_issue_postgresql_prep_binds_target_role_and_scope",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 12726
+      "start_line": 12723
     },
     {
       "capability": "unassigned_legacy_auth",
@@ -735,14 +735,14 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "05621e885ed2f88d0ba1a072c1f263fc923939f7ce755a514e9872112aa830a1",
-      "end_line": 11952,
+      "end_line": 11949,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 163,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_service_actor_replay_fails_closed_on_committed_state_drift",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 11790
+      "start_line": 11787
     },
     {
       "capability": "unassigned_legacy_auth",
@@ -1023,14 +1023,14 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "1a0a9f3e2be6965e29f76aa74272ccfa2fe4b99e4e0c3bde5ec8ba2c374b369b",
-      "end_line": 11266,
+      "end_line": 11263,
       "hard_limit": 100,
       "kind": "test_helper",
       "observed_lines": 169,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "_operation_success",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 11098
+      "start_line": 11095
     },
     {
       "capability": "unassigned_legacy_auth",

--- a/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/STATUS.md
+++ b/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/STATUS.md
@@ -78,10 +78,9 @@ historical-row backfill or compatibility behavior.
 
 - CON-02B: missing `outbox.dispatch`, `workstream.outbox.dispatcher`, exact
   matrix/context/PREP support, and AUTH activation plan.
-- CP01A is complete on merge with four exact adapter-binding actions registered
-  but unavailable. CP01B ContributionPolicy registration remains missing;
-  callback/fulfillment authority stays separate and CP02 cannot start before
-  CP01B merges.
+- CP01A and CP01B are complete on merge with four exact adapter-binding and five
+  exact ContributionPolicy actions registered but unavailable.
+  Callback/fulfillment authority stays separate; CP02 is the next boundary.
 - CP02-CP05: hidden behavior and exact activation have not merged.
 - CP06-CP09: validation, owner schema lineage, and clean legacy removal wait for
   the preceding public behavior. No historical-row classification is required
@@ -114,7 +113,7 @@ CP08/ARCH-03B replacement path.
 ## Immediate next action
 
 CON-02C merged through PR #277. REV-04B may consume its shared lifecycle-audit
-participant after REV's earlier gates merge. CP01B unavailable ContributionPolicy
-AUTH registration is the next policy-cutover gate; no product behavior may start
-until that current-main contract merges.
+participant after REV's earlier gates merge. CP02 hidden adapter-binding
+behavior is the next policy-cutover gate; registration alone activates no
+product behavior.
 Open pull requests determine transient CON work.

--- a/.ci/behavior-ownership/auth/contribution-policy-facts.json
+++ b/.ci/behavior-ownership/auth/contribution-policy-facts.json
@@ -1,0 +1,30 @@
+{
+  "behavior_id": "auth.contribution_policy.facts",
+  "boundaries": [],
+  "callables": [
+    "app.modules.authorization.api.contribution_policies.ContributionPolicyCreateDraftFacts.__post_init__",
+    "app.modules.authorization.api.contribution_policies.ContributionPolicyPublishFacts.__post_init__",
+    "app.modules.authorization.api.contribution_policies.ContributionPolicyReadFacts.__post_init__",
+    "app.modules.authorization.api.contribution_policies.ContributionPolicyRetireFacts.__post_init__",
+    "app.modules.authorization.api.contribution_policies.ContributionPolicyUpdateDraftFacts.__post_init__",
+    "app.modules.authorization.api.contribution_policies._json_facts",
+    "app.modules.authorization.api.contribution_policies._require_uuid",
+    "app.modules.authorization.api.contribution_policies.contribution_policy_resource_digest"
+  ],
+  "group": "auth",
+  "outcomes": [
+    "return",
+    "mapped_error"
+  ],
+  "reviewed_by": [
+    "WS-ARCH-001-CP01B required reviewers"
+  ],
+  "schema": "workstream.behavior-ownership.v1",
+  "status": "reviewed",
+  "target": "backend/app/modules/authorization/api/contribution_policies.py",
+  "tests": [
+    "backend/tests/authorization/test_contribution_policy_registration.py::test_cp01b_public_facts_are_immutable_and_lifecycle_bound",
+    "backend/tests/authorization/test_contribution_policy_registration.py::test_cp01b_publish_requires_canonical_digest_and_binding_lineage",
+    "backend/tests/authorization/test_contribution_policy_registration.py::test_cp01b_digest_is_deterministic_and_action_domain_separated"
+  ]
+}

--- a/.ci/behavior-ownership/partition.v1.json
+++ b/.ci/behavior-ownership/partition.v1.json
@@ -342,6 +342,10 @@
     },
     {
       "group": "auth",
+      "target": "backend/app/modules/authorization/api/contribution_policies.py"
+    },
+    {
+      "group": "auth",
       "target": "backend/app/modules/authorization/api/decisions.py"
     },
     {
@@ -849,7 +853,7 @@
       "target": "backend/scripts/week2_api_e2e.py"
     }
   ],
-  "authority_digest": "2bee80de4e315abab9e5821d572e37e22e986cb26ee33e78644ea5b97dad04fe",
+  "authority_digest": "b3ab085b1c8964cbe157c68575f13dd8384a165fba4d1d5f686911b3c40974b2",
   "protected_base_commit": "7676ce4347db0c9694962a9b587a20765e16eac6",
   "schema": "workstream.behavior-ownership-partition.v1"
 }

--- a/backend/app/modules/authorization/api/__init__.py
+++ b/backend/app/modules/authorization/api/__init__.py
@@ -8,6 +8,14 @@ from .adapter_bindings import (
     AdapterBindingSuspendFacts,
     adapter_binding_resource_digest,
 )
+from .contribution_policies import (
+    ContributionPolicyCreateDraftFacts,
+    ContributionPolicyPublishFacts,
+    ContributionPolicyReadFacts,
+    ContributionPolicyRetireFacts,
+    ContributionPolicyUpdateDraftFacts,
+    contribution_policy_resource_digest,
+)
 from .decisions import AuthorizationDecision, DecisionOutcome
 from .errors import (
     AuthorizationBoundaryError,
@@ -41,6 +49,11 @@ __all__ = (
     "AuthorizationDenied",
     "AuthorizationPort",
     "AuthorizationUnavailable",
+    "ContributionPolicyCreateDraftFacts",
+    "ContributionPolicyPublishFacts",
+    "ContributionPolicyReadFacts",
+    "ContributionPolicyRetireFacts",
+    "ContributionPolicyUpdateDraftFacts",
     "DecisionOutcome",
     "JsonScalar",
     "PermissionId",
@@ -59,5 +72,6 @@ __all__ = (
     "ResourceValue",
     "action_id",
     "adapter_binding_resource_digest",
+    "contribution_policy_resource_digest",
     "permission_id",
 )

--- a/backend/app/modules/authorization/api/contribution_policies.py
+++ b/backend/app/modules/authorization/api/contribution_policies.py
@@ -1,0 +1,171 @@
+"""Public AUTH facts for planned ContributionPolicy actions."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import hashlib
+import json
+import re
+from typing import TypeAlias
+from uuid import UUID
+
+from .action_ids import ActionId
+
+_SHA256 = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+
+def _require_uuid(name: str, value: UUID) -> None:
+    """Reject identifiers that are not already parsed UUID values."""
+    if not isinstance(value, UUID):
+        raise ValueError(f"{name} must be a UUID")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ContributionPolicyReadFacts:
+    """Exact policy identity and optional immutable version identity."""
+
+    project_id: UUID
+    contribution_policy_id: UUID
+    contribution_policy_version_id: UUID | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the project, policy, and optional version identifiers."""
+        _require_uuid("project_id", self.project_id)
+        _require_uuid("contribution_policy_id", self.contribution_policy_id)
+        if self.contribution_policy_version_id is not None:
+            _require_uuid(
+                "contribution_policy_version_id", self.contribution_policy_version_id
+            )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ContributionPolicyCreateDraftFacts:
+    """Exact project policy collection targeted by draft creation."""
+
+    project_id: UUID
+
+    def __post_init__(self) -> None:
+        """Validate the project collection identifier."""
+        _require_uuid("project_id", self.project_id)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ContributionPolicyUpdateDraftFacts:
+    """Exact draft version targeted by an update."""
+
+    project_id: UUID
+    contribution_policy_id: UUID
+    contribution_policy_version_id: UUID
+    expected_status: str = "draft"
+
+    def __post_init__(self) -> None:
+        """Validate exact draft ownership and lifecycle state."""
+        _require_uuid("project_id", self.project_id)
+        _require_uuid("contribution_policy_id", self.contribution_policy_id)
+        _require_uuid("contribution_policy_version_id", self.contribution_policy_version_id)
+        if self.expected_status != "draft":
+            raise ValueError("policy update requires draft version status")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ContributionPolicyPublishFacts:
+    """Complete draft content and binding lineage targeted by publication."""
+
+    project_id: UUID
+    contribution_policy_id: UUID
+    contribution_policy_version_id: UUID
+    rules_and_definitions_digest: str
+    adapter_binding_ids: tuple[UUID, ...]
+    expected_status: str = "draft"
+
+    def __post_init__(self) -> None:
+        """Require canonical content digest, binding order, and draft state."""
+        _require_uuid("project_id", self.project_id)
+        _require_uuid("contribution_policy_id", self.contribution_policy_id)
+        _require_uuid("contribution_policy_version_id", self.contribution_policy_version_id)
+        if not isinstance(self.rules_and_definitions_digest, str) or not _SHA256.fullmatch(
+            self.rules_and_definitions_digest
+        ):
+            raise ValueError("rules_and_definitions_digest must be canonical sha256")
+        if not isinstance(self.adapter_binding_ids, tuple) or any(
+            not isinstance(value, UUID) for value in self.adapter_binding_ids
+        ):
+            raise ValueError("adapter_binding_ids must be a UUID tuple")
+        canonical_ids = tuple(sorted(self.adapter_binding_ids, key=str))
+        if self.adapter_binding_ids != canonical_ids or len(set(canonical_ids)) != len(
+            canonical_ids
+        ):
+            raise ValueError("adapter_binding_ids must be sorted and unique")
+        if self.expected_status != "draft":
+            raise ValueError("policy publication requires draft version status")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ContributionPolicyRetireFacts:
+    """Exact published policy version targeted by retirement."""
+
+    project_id: UUID
+    contribution_policy_id: UUID
+    contribution_policy_version_id: UUID
+    expected_status: str = "published"
+
+    def __post_init__(self) -> None:
+        """Validate exact published ownership and lifecycle state."""
+        _require_uuid("project_id", self.project_id)
+        _require_uuid("contribution_policy_id", self.contribution_policy_id)
+        _require_uuid("contribution_policy_version_id", self.contribution_policy_version_id)
+        if self.expected_status != "published":
+            raise ValueError("policy retirement requires published version status")
+
+
+ContributionPolicyFacts: TypeAlias = (
+    ContributionPolicyReadFacts
+    | ContributionPolicyCreateDraftFacts
+    | ContributionPolicyUpdateDraftFacts
+    | ContributionPolicyPublishFacts
+    | ContributionPolicyRetireFacts
+)
+
+_FACT_TYPE_BY_ACTION = {
+    "contribution.policy.read": ContributionPolicyReadFacts,
+    "contribution.policy.create_draft": ContributionPolicyCreateDraftFacts,
+    "contribution.policy.update_draft": ContributionPolicyUpdateDraftFacts,
+    "contribution.policy.publish": ContributionPolicyPublishFacts,
+    "contribution.policy.retire": ContributionPolicyRetireFacts,
+}
+
+
+def contribution_policy_resource_digest(
+    action_id: ActionId, facts: ContributionPolicyFacts
+) -> str:
+    """Hash one exact action and its immutable ContributionPolicy facts."""
+    action = str(action_id)
+    expected_type = _FACT_TYPE_BY_ACTION.get(action)
+    if expected_type is None or type(facts) is not expected_type:
+        raise ValueError("ContributionPolicy action does not match resource facts")
+    canonical = json.dumps(
+        {
+            "domain": "workstream.authorization.contribution_policy.v1",
+            "action_id": action,
+            "resource_type": "contribution_policy",
+            "facts": _json_facts(facts),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+    return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def _json_facts(facts: ContributionPolicyFacts) -> dict[str, object]:
+    """Convert immutable typed facts to canonical JSON scalar collections."""
+    return {
+        key: (
+            [str(item) for item in value]
+            if isinstance(value, tuple)
+            else str(value)
+            if isinstance(value, UUID)
+            else value
+        )
+        for key, value in asdict(facts).items()
+    }

--- a/backend/app/modules/authorization/catalogue.py
+++ b/backend/app/modules/authorization/catalogue.py
@@ -206,6 +206,11 @@ class ActionId(StrEnum):
     COMPENSATION_ADAPTER_BINDING_CREATE = "compensation.adapter_binding.create"
     COMPENSATION_ADAPTER_BINDING_SUSPEND = "compensation.adapter_binding.suspend"
     COMPENSATION_ADAPTER_BINDING_RESUME = "compensation.adapter_binding.resume"
+    CONTRIBUTION_POLICY_READ = "contribution.policy.read"
+    CONTRIBUTION_POLICY_CREATE_DRAFT = "contribution.policy.create_draft"
+    CONTRIBUTION_POLICY_UPDATE_DRAFT = "contribution.policy.update_draft"
+    CONTRIBUTION_POLICY_PUBLISH = "contribution.policy.publish"
+    CONTRIBUTION_POLICY_RETIRE = "contribution.policy.retire"
 
 
 @unique
@@ -256,6 +261,7 @@ class ActionOwner(StrEnum):
     XINT_003_08A = "WS-XINT-003-08A"
     XINT_003_08B = "WS-XINT-003-08B"
     ARCH_CP01A = "WS-ARCH-001-CP01A"
+    ARCH_CP01B = "WS-ARCH-001-CP01B"
 
 
 @unique
@@ -789,6 +795,31 @@ ACTION_DEFINITIONS = (
         PermissionId.COMPENSATION_ADAPTER_BINDING_MANAGE,
         ActionOwner.ARCH_CP01A,
     ),
+    _planned(
+        ActionId.CONTRIBUTION_POLICY_READ,
+        PermissionId.COMPENSATION_POLICY_MANAGE,
+        ActionOwner.ARCH_CP01B,
+    ),
+    _planned(
+        ActionId.CONTRIBUTION_POLICY_CREATE_DRAFT,
+        PermissionId.COMPENSATION_POLICY_MANAGE,
+        ActionOwner.ARCH_CP01B,
+    ),
+    _planned(
+        ActionId.CONTRIBUTION_POLICY_UPDATE_DRAFT,
+        PermissionId.COMPENSATION_POLICY_MANAGE,
+        ActionOwner.ARCH_CP01B,
+    ),
+    _planned(
+        ActionId.CONTRIBUTION_POLICY_PUBLISH,
+        PermissionId.COMPENSATION_POLICY_MANAGE,
+        ActionOwner.ARCH_CP01B,
+    ),
+    _planned(
+        ActionId.CONTRIBUTION_POLICY_RETIRE,
+        PermissionId.COMPENSATION_POLICY_MANAGE,
+        ActionOwner.ARCH_CP01B,
+    ),
 )
 
 PERMISSION_IDS = frozenset(PermissionId)
@@ -843,7 +874,7 @@ def _index_actions(
     ):
         raise RuntimeError("authorization action catalogue contains an invalid row")
     indexed = {definition.action_id: definition for definition in definitions}
-    if len(PERMISSION_IDS) != 73 or len(ACTION_IDS) != 106:
+    if len(PERMISSION_IDS) != 73 or len(ACTION_IDS) != 111:
         raise RuntimeError("authorization catalogue count mismatch")
     if len(indexed) != len(definitions) or set(indexed) != ACTION_IDS:
         raise RuntimeError("authorization action catalogue is incomplete")

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -63,6 +63,7 @@ OWNERSHIP_TEST_NODE_RE = re.compile(
 AUTH_BOUNDARY_FOUNDATION_TARGETS = frozenset(
     {
         "backend/app/modules/authorization/api/adapter_bindings.py",
+        "backend/app/modules/authorization/api/contribution_policies.py",
         "backend/app/modules/authorization/api/action_ids.py",
         "backend/app/modules/authorization/api/decisions.py",
         "backend/app/modules/authorization/api/errors.py",

--- a/backend/scripts/run_test_lanes.py
+++ b/backend/scripts/run_test_lanes.py
@@ -141,6 +141,7 @@ SHARED_FOUNDATION_MODULES = (
     "tests/authorization/guide_compilation/test_migration_contract.py",
     "tests/authorization/test_fixed_service_action_context.py",
     "tests/authorization/test_adapter_binding_registration.py",
+    "tests/authorization/test_contribution_policy_registration.py",
     "tests/test_behavior_ownership.py",
     "tests/test_artifact_admission.py",
     "tests/test_submission_bundle_admission.py",

--- a/backend/tests/authorization/test_contribution_policy_registration.py
+++ b/backend/tests/authorization/test_contribution_policy_registration.py
@@ -1,0 +1,148 @@
+"""CP01B proof for planned ContributionPolicy AUTH registration."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from uuid import uuid4
+
+import pytest
+
+from app.modules.authorization.api import (
+    ContributionPolicyCreateDraftFacts,
+    ContributionPolicyPublishFacts,
+    ContributionPolicyReadFacts,
+    ContributionPolicyRetireFacts,
+    ContributionPolicyUpdateDraftFacts,
+    action_id,
+    contribution_policy_resource_digest,
+)
+from app.modules.authorization.catalogue import (
+    ACTION_BY_ID,
+    SERVICE_ACTIONS_BY_IDENTITY,
+    ActionAvailability,
+    ActionId,
+    ActionOwner,
+    PermissionId,
+    resolve_executable_action,
+)
+
+_ACTIONS = {
+    ActionId.CONTRIBUTION_POLICY_READ,
+    ActionId.CONTRIBUTION_POLICY_CREATE_DRAFT,
+    ActionId.CONTRIBUTION_POLICY_UPDATE_DRAFT,
+    ActionId.CONTRIBUTION_POLICY_PUBLISH,
+    ActionId.CONTRIBUTION_POLICY_RETIRE,
+}
+_SHA256 = "sha256:" + "a" * 64
+
+
+def test_cp01b_registers_only_exact_planned_policy_actions() -> None:
+    """The five canonical actions remain unavailable and unassigned."""
+    for action in _ACTIONS:
+        definition = ACTION_BY_ID[action]
+        assert definition.permission_id is PermissionId.COMPENSATION_POLICY_MANAGE
+        assert definition.owner is ActionOwner.ARCH_CP01B
+        assert definition.availability is ActionAvailability.PLANNED
+        with pytest.raises(ValueError, match="authorization action is not active"):
+            resolve_executable_action(action)
+
+    assert not ({"compensation.policy.read", "compensation.policy.publish"} & {item.value for item in ActionId})
+    assert all(_ACTIONS.isdisjoint(actions) for actions in SERVICE_ACTIONS_BY_IDENTITY.values())
+
+
+def test_cp01b_public_facts_are_immutable_and_lifecycle_bound() -> None:
+    """Mutation facts reject wrong lifecycle state and mutable lineage."""
+    project_id, policy_id, version_id = uuid4(), uuid4(), uuid4()
+    read = ContributionPolicyReadFacts(
+        project_id=project_id,
+        contribution_policy_id=policy_id,
+    )
+    with pytest.raises(FrozenInstanceError):
+        read.project_id = uuid4()  # type: ignore[misc]
+    with pytest.raises(ValueError, match="requires draft"):
+        ContributionPolicyUpdateDraftFacts(
+            project_id=project_id,
+            contribution_policy_id=policy_id,
+            contribution_policy_version_id=version_id,
+            expected_status="published",
+        )
+    with pytest.raises(ValueError, match="requires published"):
+        ContributionPolicyRetireFacts(
+            project_id=project_id,
+            contribution_policy_id=policy_id,
+            contribution_policy_version_id=version_id,
+            expected_status="draft",
+        )
+
+
+def test_cp01b_publish_requires_canonical_digest_and_binding_lineage() -> None:
+    """Publish binding identities are immutable, sorted, and duplicate-free."""
+    project_id, policy_id, version_id = uuid4(), uuid4(), uuid4()
+    low = uuid4()
+    high = uuid4()
+    low, high = sorted((low, high), key=str)
+    facts = ContributionPolicyPublishFacts(
+        project_id=project_id,
+        contribution_policy_id=policy_id,
+        contribution_policy_version_id=version_id,
+        rules_and_definitions_digest=_SHA256,
+        adapter_binding_ids=(low, high),
+    )
+    assert facts.adapter_binding_ids == (low, high)
+    for binding_ids in ([low], (high, low), (low, low)):
+        with pytest.raises(ValueError, match="adapter_binding_ids"):
+            ContributionPolicyPublishFacts(
+                project_id=project_id,
+                contribution_policy_id=policy_id,
+                contribution_policy_version_id=version_id,
+                rules_and_definitions_digest=_SHA256,
+                adapter_binding_ids=binding_ids,  # type: ignore[arg-type]
+            )
+    with pytest.raises(ValueError, match="canonical sha256"):
+        ContributionPolicyPublishFacts(
+            project_id=project_id,
+            contribution_policy_id=policy_id,
+            contribution_policy_version_id=version_id,
+            rules_and_definitions_digest="sha256:ABC",
+            adapter_binding_ids=(),
+        )
+
+
+def test_cp01b_digest_is_deterministic_and_action_domain_separated() -> None:
+    """Resource digests bind both the action and exact typed facts."""
+    project_id, policy_id = uuid4(), uuid4()
+    read = ContributionPolicyReadFacts(
+        project_id=project_id,
+        contribution_policy_id=policy_id,
+    )
+    read_action = action_id("contribution.policy.read")
+    digest = contribution_policy_resource_digest(read_action, read)
+    assert digest == contribution_policy_resource_digest(read_action, read)
+    assert digest.startswith("sha256:") and len(digest) == 71
+    with pytest.raises(ValueError, match="does not match"):
+        contribution_policy_resource_digest(
+            action_id("contribution.policy.create_draft"), read
+        )
+
+
+def test_cp01b_public_api_exports_exact_registration_surface() -> None:
+    """The dependency-free API exposes the exact CP01B fact family."""
+    import app.modules.authorization.api as authorization_api
+
+    expected = {
+        "ContributionPolicyCreateDraftFacts",
+        "ContributionPolicyPublishFacts",
+        "ContributionPolicyReadFacts",
+        "ContributionPolicyRetireFacts",
+        "ContributionPolicyUpdateDraftFacts",
+        "contribution_policy_resource_digest",
+    }
+    assert expected <= set(authorization_api.__all__)
+    assert all(hasattr(authorization_api, name) for name in expected)
+
+
+def test_cp01b_create_draft_binds_only_the_project_collection() -> None:
+    """Draft creation targets the project collection without product payload."""
+    project_id = uuid4()
+    facts = ContributionPolicyCreateDraftFacts(project_id=project_id)
+    assert facts.project_id == project_id

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -7,7 +7,7 @@ import ast
 import asyncio
 import base64
 import copy
-from collections import UserDict
+from collections import Counter, UserDict
 from collections.abc import Iterator, Mapping
 from dataclasses import asdict, replace
 from datetime import UTC, datetime
@@ -2085,11 +2085,12 @@ def test_closed_permission_and_action_catalogue_is_exact_and_non_executable() ->
         ),
         "project.setup_run.update": ("project.guide.manage", "WS-AUTH-001-12B2"), "project.guide.activate": ("project.guide.manage", "WS-AUTH-001-12H"),  # noqa: E501
         **dict.fromkeys((f"compensation.adapter_binding.{op}" for op in ("read", "create", "suspend", "resume")), ("compensation.adapter_binding.manage", "WS-ARCH-001-CP01A")),  # noqa: E501
+        **dict.fromkeys((f"contribution.policy.{op}" for op in ("read", "create_draft", "update_draft", "publish", "retire")), ("compensation.policy.manage", "WS-ARCH-001-CP01B")),  # noqa: E501
     }
     assert {item.value for item in HISTORICAL_PERMISSION_IDS} == historical_permissions
     assert {item.value for item in NEW_PERMISSION_IDS} == new_permissions
     assert {item.value for item in PERMISSION_IDS} == historical_permissions | new_permissions
-    assert len(ACTION_IDS) == len(ACTION_DEFINITIONS) == len(ACTION_BY_ID) == 106
+    assert len(ACTION_IDS) == len(ACTION_DEFINITIONS) == len(ACTION_BY_ID) == 111
     assert set(ACTION_BY_ID) == ACTION_IDS
     assert {definition.owner for definition in ACTION_DEFINITIONS} == set(ActionOwner)
     assert {
@@ -2224,16 +2225,12 @@ def test_closed_permission_and_action_catalogue_is_exact_and_non_executable() ->
         ActionOwner.XINT_003_08B: 1,
     }
     assert all(not owner.value.startswith("WS-REV-") for owner in ActionOwner)
-    availability_counts = {
-        availability: sum(
-            definition.availability is availability
-            for definition in ACTION_DEFINITIONS
-        )
-        for availability in ActionAvailability
-    }
+    availability_counts = Counter(
+        definition.availability for definition in ACTION_DEFINITIONS
+    )
     assert availability_counts == {
         ActionAvailability.ACTIVE: 57,
-        ActionAvailability.PLANNED: 49,
+        ActionAvailability.PLANNED: 54,
     }
     assert resolve_executable_action(ActionId.ACTOR_PROFILE_READ_SELF).permission_id is PermissionId.ACTOR_PROFILE_READ_SELF
     with pytest.raises(ValueError, match="not active"):
@@ -2899,7 +2896,7 @@ def test_art_custody_documentation_matches_the_independent_activation_fixture() 
     assert "does not grant Operator" in operations
     assert "verification retry remains independently gated" in operations
     assert (
-            "73 PermissionIds, 106 ActionIds, 57 active actions, and\n49 planned actions" in operations
+            "73 PermissionIds, 111 ActionIds, 57 active actions, and\n54 planned actions" in operations
     )
 
 def test_rev_custody_documentation_matches_the_independent_catalogue_fixture() -> None:

--- a/docs/operations_authorization_service.md
+++ b/docs/operations_authorization_service.md
@@ -494,10 +494,11 @@ v0.1 baseline.
 The REV transfer adds no migration. The ART transfer does not grant Operator
 authority; its `OPERATOR` suffix denotes only future activation custody, and
 verification retry remains independently gated from read/status actions.
-Catalogue totals are 73 PermissionIds, 106 ActionIds, 57 active actions, and
-49 planned actions. CP01A adds four unavailable adapter-binding actions under
+Catalogue totals are 73 PermissionIds, 111 ActionIds, 57 active actions, and
+54 planned actions. CP01A adds four unavailable adapter-binding actions under
 `WS-ARCH-001-CP01A` custody; it adds no evaluator, identity, grant, service
-matrix row, route, or activation. CP01B is the next registration gate.
+matrix row, route, or activation. CP01B adds five unavailable
+`contribution.policy.*` actions with the same non-activation guarantees.
 AUTH-12I adds and activates only the unified compilation
 request/execute pair. AUTH-11C2 activates three current effective-policy and
 active-guide reads in addition to AUTH-11C1's six diagnostic reads. The exact

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -133,9 +133,9 @@ review. Their presence does not change the implemented-on-`main` list above.
    recovery, provider proof, and the later public cutover.
    Hidden durable admission, Submission creation, and final binding are already
    merged through WS-ARCH-001-02H.
-2. CP01A has registered exact adapter-binding authority while keeping all four
-   actions unavailable. Register exact ContributionPolicy authority through
-   CP01B while unavailable; then implement and separately activate
+2. CP01A and CP01B have registered exact adapter-binding and ContributionPolicy
+   authority while keeping all nine actions unavailable. Next implement and
+   separately activate
    adapter-binding and ContributionPolicy behavior;
    expose CON validation; then bind one exact published,
    complete, binding-valid ContributionPolicyVersion at guide activation, and

--- a/docs/spec_authorization_service.md
+++ b/docs/spec_authorization_service.md
@@ -264,7 +264,11 @@ rows without adding an action or permission.
 WS-ARCH-001-CP01A then adds four planned/unavailable adapter-binding actions,
 producing 106 rows: 57 active and 49 planned. They map only to
 `compensation.adapter_binding.manage`; no retirement, evaluator, identity,
-service-matrix row, route, or activation is added. CP01B remains next.
+service-matrix row, route, or activation is added. WS-ARCH-001-CP01B adds five
+planned/unavailable `contribution.policy.*` actions, producing 111 rows: 57
+active and 54 planned. They map only to `compensation.policy.manage`; no
+evaluator, identity, service-matrix row, route, migration, or activation is
+added.
 AUTH-10A added five project-role read/manage rows;
 AUTH-10B owns and activates the three reads, while AUTH-10C owns and activates
 the two reason-bound, idempotent project-role mutations. AUTH-11A adds eleven

--- a/docs/spec_contribution_compensation.md
+++ b/docs/spec_contribution_compensation.md
@@ -754,11 +754,11 @@ AUTH-09E admission, evaluator integration, and exact action activation.
 ### Surface mappings
 
 The table contains both registered-unavailable and future proposed mappings.
-CP01A registers the four adapter-binding read/create/suspend/resume ActionIds
-under `WS-ARCH-001-CP01A`; they remain unavailable and have no evaluator,
-identity, service-matrix row, route, or activation. All other rows remain
-proposals, including dependency-aware adapter-binding retirement. Existing
-PermissionIds remain stable. Policy ActionIds use the
+CP01A registers the four adapter-binding read/create/suspend/resume ActionIds,
+and CP01B registers the five ContributionPolicy ActionIds. All nine remain
+unavailable and have no evaluator, identity, service-matrix row, route, or
+activation. All other rows remain proposals, including dependency-aware
+adapter-binding retirement. Existing PermissionIds remain stable. Policy ActionIds use the
 canonical `contribution.policy.*` namespace while mapping to the existing
 `compensation.policy.manage` PermissionId. AUTH must approve exact identifiers,
 principals, contexts, mappings, custodians, and activation in its own chunks.
@@ -771,11 +771,11 @@ principals, contexts, mappings, custodians, and activation in its own chunks.
 | `compensation.adapter_binding.suspend` | `compensation.adapter_binding.manage` | Finance / active binding | T | WS-ARCH-001-CP01A (registered, unavailable) |
 | `compensation.adapter_binding.resume` | `compensation.adapter_binding.manage` | Finance / suspended binding | T | WS-ARCH-001-CP01A (registered, unavailable) |
 | `compensation.adapter_binding.retire` | `compensation.adapter_binding.manage` | Finance / dependency-free binding | T | CON-10B |
-| `contribution.policy.read` | `compensation.policy.manage` | Finance / policy version | Q | CON-04B |
-| `contribution.policy.create_draft` | `compensation.policy.manage` | Finance / policy collection | T | CON-04B |
-| `contribution.policy.update_draft` | `compensation.policy.manage` | Finance / draft version | T | CON-04B |
-| `contribution.policy.publish` | `compensation.policy.manage` | Finance / complete draft | T | CON-04B |
-| `contribution.policy.retire` | `compensation.policy.manage` | Finance / published version | T | CON-04B |
+| `contribution.policy.read` | `compensation.policy.manage` | Finance / policy version | Q | WS-ARCH-001-CP01B (registered, unavailable) |
+| `contribution.policy.create_draft` | `compensation.policy.manage` | Finance / policy collection | T | WS-ARCH-001-CP01B (registered, unavailable) |
+| `contribution.policy.update_draft` | `compensation.policy.manage` | Finance / draft version | T | WS-ARCH-001-CP01B (registered, unavailable) |
+| `contribution.policy.publish` | `compensation.policy.manage` | Finance / complete draft | T | WS-ARCH-001-CP01B (registered, unavailable) |
+| `contribution.policy.retire` | `compensation.policy.manage` | Finance / published version | T | WS-ARCH-001-CP01B (registered, unavailable) |
 | `compensation.fulfillment.report` | proposed `compensation.fulfillment.report` | exact bound service / award and binding | T | CON-08B |
 | `contribution.read_self` | `contribution.read_self` | contributor / own record | Q | CON-10A |
 | `contribution.read_project` | `contribution.read_project` | eligible AdminRole / project records | Q | CON-10A |


### PR DESCRIPTION
# PR Trust Bundle: WS-ARCH-001-CP01B

## Chunk

WS-ARCH-001-CP01B — AUTH ContributionPolicy Registration

## Goal

Register the five canonical `contribution.policy.*` authorization actions and
typed resource facts while keeping every action planned and unavailable.

## Human-approved intent

Establish only the ContributionPolicy AUTH boundary, then return ownership to
CP02 for hidden adapter-binding behavior. Do not begin the broader CON lifecycle.

## What changed and why

- Added five closed ActionIds under `WS-ARCH-001-CP01B`, mapped only to the
  existing `compensation.policy.manage` PermissionId.
- Added dependency-free immutable read/create/update/publish/retire facts and a
  domain-separated canonical digest helper.
- Bound publish facts to the exact draft, canonical rules/definitions digest,
  and sorted unique adapter-binding identities.
- Added focused behavior tests, ownership evidence, lane custody, catalogue
  parity, structural-debt reconciliation, and current documentation/status.

## Design chosen

The implementation follows the existing AUTH public-facts and planned-action
pattern. It does not import CON internals or create another PREP protocol.

## Alternatives rejected

- No `compensation.policy.*` aliases.
- No generic resource dictionary.
- No evaluator, identity, grant, matrix row, route, migration, or activation.
- No CON behavior bundled into AUTH registration.

## Scope and product behavior

The five actions remain `PLANNED`; runtime product behavior is unchanged.
CP02 is the next boundary.

## Acceptance evidence

- Five exact actions map only to `compensation.policy.manage`.
- Catalogue totals are 73 permissions, 111 actions, 57 active, and 54 planned.
- All actions fail closed through executable-action resolution.
- Typed facts are frozen and lifecycle-bound; publish lineage is canonical.
- No legacy action alias or service assignment exists.

## Tests and CI integrity

Local focused evidence:

- Ruff: passed.
- CP01A/CP01B registration tests: 10 passed.
- Closed catalogue parity: passed.
- CI lane and behavior-ownership tests: 140 passed.
- Structural-debt, behavior-ownership, lane collection, docstring coverage,
  stale wording, Markdown links, chunk-state sync, and diff checks: passed.

No test, coverage, lint, preflight, or branch-protection gate was weakened.
Hosted CI owns the full repository suite and coverage proof.

## Test delta

One focused CP01B module covers registration denial, immutability, lifecycle
state, publish digest/binding canonicalization, cross-action rejection, API
exports, and collection scope. Existing catalogue assertions were strengthened.

## Reviewer results

- Architecture: PASS.
- Security/auth: PASS.
- Senior engineering and QA/test delta: PASS.
- Product/ops: PASS.
- Reuse/dedup: PASS.
- Documentation: PASS.

## External review

CodeRabbit and hosted CI are pending on the PR exact head.

## Remaining risks and follow-up

The identifiers are deliberately unusable until hidden owner behavior and a
separate AUTH activation merge. CP02 implements hidden adapter-binding behavior;
CP03 owns its later activation.

## Human review focus

Confirm the exact five-action manifest, canonical publish binding lineage,
absence of executable authority, and CP02 as the next boundary.

## Human merge ownership

Only an authorized human maintainer may approve and merge this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five ContributionPolicy authorization actions for reading, drafting, updating, publishing, and retiring policies.
  * Added validated, immutable policy facts and deterministic resource-digest generation.
  * Exposed the new authorization types and digest helper through the public API.

* **Documentation**
  * Updated authorization catalogues, rollout status, ownership records, and roadmap documentation.

* **Tests**
  * Added coverage for registration, validation, digest integrity, API exports, and project-scoped draft creation.

* **Availability**
  * Actions are registered but remain unavailable and inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->