### PR TITLE
feat(auth): activate adapter binding authority

### DIFF
--- a/.agent-loop/CURRENT_STATE.md
+++ b/.agent-loop/CURRENT_STATE.md
@@ -99,10 +99,9 @@ selection wording.
 Do not start historical CON-05A directly. The CP01-CP09 sequence owns
 AUTH unavailable registration, hidden CON binding/policy behavior, exact AUTH
 activations, CON validation, PROJECT guide binding, TASK attempt lineage, and
-clean v0.1 legacy economic-path removal in that order. CP02 is complete while
-all four actions remain unavailable. CP03 is split: the CP03A implementation is
-merged, and the CP03B implementation contract is complete but its implementation
-remains planned; later CP04-CP09 children remain
+clean v0.1 legacy economic-path removal in that order. CP02 and CP03A are
+merged, and CP03B is complete with the four exact hidden Finance Authority
+actions active. Later CP04-CP09 children remain
 non-executable until their current-main contracts are expanded.
 
 - WS-ARCH-001-PLAN3 is planned; its planning merge changed no runtime behavior.

--- a/.agent-loop/CURRENT_STATE.md
+++ b/.agent-loop/CURRENT_STATE.md
@@ -119,7 +119,10 @@ non-executable until their current-main contracts are expanded.
 - WS-ARCH-001-CP03A is complete on merge with exact target identity and owner
   eligibility while all four actions remain unavailable.
 - WS-ARCH-001-CP03B is planned with an executable implementation contract after
-  merged CP03A.
+  merged CP03A. Its implementation-start review requires nested AUTH adapters
+  to consume only the public AUTH API; same-owner private wiring is confined to
+  the exact AUTH adapter root. Application composition is not compensation
+  delivery or fulfillment behavior.
 - WS-ARCH-001-CP04 is proposed and non-executable.
 - WS-ARCH-001-CP05 is proposed and non-executable.
 - WS-ARCH-001-CP06 is proposed and non-executable.

--- a/.agent-loop/CURRENT_STATE.md
+++ b/.agent-loop/CURRENT_STATE.md
@@ -28,10 +28,10 @@ authority; these records do not grant or withhold it.
 
 | Initiative | Durable state on `main` | Remaining boundary |
 |---|---|---|
-| [WS-ARCH-001](initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md) | Complete through `WS-ARCH-001-02H`; CP01A-CP02 establish unavailable authority facts and hidden CON adapter-binding behavior; PLAN4 planned incremental debt retirement | CP03A is complete on merge with exact target identity and owner eligibility; after that merge, implement CP03B exact Finance Authority activation; PLAN4 keeps debt retirement delivery-coupled without blocking features on unrelated frozen debt; the wider PLAN2 path still targets durable `allow_review`, and `02I` remains later |
+| [WS-ARCH-001](initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md) | Complete through `WS-ARCH-001-02H`; CP01A-CP03B establish hidden CON adapter-binding behavior and exact Finance Authority activation; PLAN4 planned incremental debt retirement | Prepare CP04's executable hidden ContributionPolicy behavior contract; PLAN4 keeps debt retirement delivery-coupled without blocking features on unrelated frozen debt; the wider PLAN2 path still targets durable `allow_review`, and `02I` remains later |
 | [WS-ART-001](initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md) | Active delivery initiative; verified ready-admission publication, hidden preparation, consumption and binding are merged through ARCH-02H | Implement exact post-submit materialization only after the unified guide/checker and PLAN2 public contracts are executable; live cutover remains later |
 | [WS-AUTH-001](initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md) | Active delivery initiative; project-policy authority and unified compilation authorization are merged through `12I` | POL-03B consumes 12I next; remaining AUTH activation chunks wait for their exact hidden owner behavior |
-| [WS-CON-001](initiatives/WS-CON-001-contribution-compensation-boundary/STATUS.md) | Active delivery initiative; CP02 hidden adapter-binding behavior, ContributionPolicy persistence, shared lifecycle audit, and unavailable AUTH registrations are merged | CP03A target identity and owner eligibility are complete on merge; after that merge, implement CP03B exact Finance Authority activation; later complete guide-activation validation/persistence before task readiness, preserving immutable attempt lineage through Submission and ReviewLease |
+| [WS-CON-001](initiatives/WS-CON-001-contribution-compensation-boundary/STATUS.md) | Active delivery initiative; CP03B completes hidden adapter-binding behavior and exact Finance Authority activation; ContributionPolicy persistence and shared lifecycle audit foundations are merged | Prepare CP04 hidden ContributionPolicy behavior; later complete guide-activation validation/persistence before task readiness, preserving immutable attempt lineage through Submission and ReviewLease |
 | [WS-AUTH-003](initiatives/WS-AUTH-003-module-boundary-recovery/STATUS.md) | AUTH boundary foundation and first public-capability proof through POL-03A are merged | Repair each touched AUTH capability through `authorization.api` and shrink the canonical AUTH ledger |
 | [WS-POL-003](initiatives/WS-POL-003-unified-project-guide-compilation/STATUS.md) | Active delivery initiative; hidden compilation custody and AUTH-12I activation are merged | Implement POL-03B authorized compilation persistence, then continue the reviewed dependency order |
 | [WS-REV-001](initiatives/WS-REV-001-review-revision-lifecycle/STATUS.md) | Independent foundations through queue admission and reviewer-lease persistence are merged through `03A2`; schema/packet foundations may continue behind their own gates | Live admission/claim requires canonical 04E `allow_review`; ReviewLease copies the admitted Submission's immutable attempt policy version, and the first Review commit requires CON-03C/07 atomic contribution/award behavior |
@@ -118,11 +118,11 @@ non-executable until their current-main contracts are expanded.
   contracts complete on merge and are the next ordered bounded boundaries.
 - WS-ARCH-001-CP03A is complete on merge with exact target identity and owner
   eligibility while all four actions remain unavailable.
-- WS-ARCH-001-CP03B is planned with an executable implementation contract after
-  merged CP03A. Its implementation-start review requires nested AUTH adapters
-  to consume only the public AUTH API; same-owner private wiring is confined to
-  the exact AUTH adapter root. Application composition is not compensation
-  delivery or fulfillment behavior.
+- WS-ARCH-001-CP03B is complete on merge: exactly four hidden adapter-binding
+  actions are active only for covered human Finance Authority; nested adapters
+  consume the public AUTH API and same-owner private wiring is confined to the
+  exact AUTH adapter root. No compensation delivery or fulfillment behavior is
+  activated.
 - WS-ARCH-001-CP04 is proposed and non-executable.
 - WS-ARCH-001-CP05 is proposed and non-executable.
 - WS-ARCH-001-CP06 is proposed and non-executable.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/CHUNK_MAP.md
@@ -24,7 +24,7 @@
 | `WS-ARCH-001-CP02` | CON hidden adapter-binding behavior | L1 | Complete on merge; route-unreachable and deny-default while actions remain unavailable |
 | `WS-ARCH-001-CP03` | Adapter-binding activation coordination parent | L1 | Planned split into CP03A/CP03B; non-executable |
 | `WS-ARCH-001-CP03A` | Closed adapter target identity and PROJECTS/ACTORS owner eligibility | L1 | Complete on merge; actions remain unavailable |
-| `WS-ARCH-001-CP03B` | AUTH exact Finance Authority adapter-binding activation | L1 | Planned executable contract after merged CP03A; nested adapters use public AUTH API and private wiring stays at the AUTH adapter root |
+| `WS-ARCH-001-CP03B` | AUTH exact Finance Authority adapter-binding activation | L1 | Complete on merge; four exact hidden actions active through public ports, with private wiring confined to the AUTH adapter root |
 | `WS-ARCH-001-CP04` | CON hidden ContributionPolicy behavior | L1 | Proposed skeleton after merged CP03B evidence |
 | `WS-ARCH-001-CP05` | AUTH exact ContributionPolicy activation | L1 | Proposed skeleton after CP04 evidence |
 | `WS-ARCH-001-CP06` | CON guide-activation/revision policy-validation port | L1 | Proposed skeleton after CP05 |

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/CHUNK_MAP.md
@@ -24,7 +24,7 @@
 | `WS-ARCH-001-CP02` | CON hidden adapter-binding behavior | L1 | Complete on merge; route-unreachable and deny-default while actions remain unavailable |
 | `WS-ARCH-001-CP03` | Adapter-binding activation coordination parent | L1 | Planned split into CP03A/CP03B; non-executable |
 | `WS-ARCH-001-CP03A` | Closed adapter target identity and PROJECTS/ACTORS owner eligibility | L1 | Complete on merge; actions remain unavailable |
-| `WS-ARCH-001-CP03B` | AUTH exact Finance Authority adapter-binding activation | L1 | Planned executable contract; follows merged CP03A |
+| `WS-ARCH-001-CP03B` | AUTH exact Finance Authority adapter-binding activation | L1 | Planned executable contract after merged CP03A; nested adapters use public AUTH API and private wiring stays at the AUTH adapter root |
 | `WS-ARCH-001-CP04` | CON hidden ContributionPolicy behavior | L1 | Proposed skeleton after merged CP03B evidence |
 | `WS-ARCH-001-CP05` | AUTH exact ContributionPolicy activation | L1 | Proposed skeleton after CP04 evidence |
 | `WS-ARCH-001-CP06` | CON guide-activation/revision policy-validation port | L1 | Proposed skeleton after CP05 |

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
@@ -1,7 +1,8 @@
 # Status: WS-ARCH-001 Modular Monolith Boundaries
 
 - Initiative state: active; boundary foundation complete
-- Runtime behavior changed: hidden CON adapter-binding behavior only; no route or action activation
+- Runtime behavior changed: hidden CON adapter-binding behavior plus exactly four
+  Finance Authority actions; no public route
 - Canonical target: nine business modules and three supporting modules
 - Recovery model: freeze exact debt, prohibit growth, repair touched
   capabilities incrementally

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
@@ -56,8 +56,8 @@
   registered/unavailable, CP01B is merged with five policy actions
   registered/unavailable. CP02 is merged with hidden CON behavior
   while its AUTH actions remain unavailable; CP03 is split, CP03A is merged,
-  and CP03B has a complete executable contract but remains planned for
-  implementation, while CP04-CP09 remain
+  and CP03B is complete with four exact hidden Finance Authority actions
+  active, while CP04-CP09 remain
   non-executable skeletons.
 - [WS-ARCH-001-PLAN4](chunks/WS-ARCH-001-PLAN4-incremental-debt-retirement.md) is planned
   and changes no runtime. It makes the existing incremental strangler

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
@@ -87,10 +87,10 @@
 - WS-ARCH-001-CP03A is complete on merge: the closed target-only identity and
   PROJECTS/ACTORS owner eligibility are implemented while all binding actions
   remain unavailable.
-- WS-ARCH-001-CP03B is planned with an executable implementation contract after
-  merged CP03A. Implementation-start review confines private same-owner wiring
-  to the exact AUTH adapter root; nested adapters consume the public AUTH API,
-  and application composition does not add delivery or fulfillment behavior.
+- WS-ARCH-001-CP03B is complete on merge: the four exact hidden adapter-binding
+  actions are active only for covered human Finance Authority, nested adapters
+  consume the public AUTH API, and private wiring remains at the AUTH adapter
+  root without delivery or fulfillment behavior.
 - WS-ARCH-001-CP04 is proposed: hidden ContributionPolicy behavior.
 - WS-ARCH-001-CP05 is proposed: exact ContributionPolicy activation.
 - WS-ARCH-001-CP06 is proposed: CON policy-validation port.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md
@@ -88,7 +88,9 @@
   PROJECTS/ACTORS owner eligibility are implemented while all binding actions
   remain unavailable.
 - WS-ARCH-001-CP03B is planned with an executable implementation contract after
-  merged CP03A.
+  merged CP03A. Implementation-start review confines private same-owner wiring
+  to the exact AUTH adapter root; nested adapters consume the public AUTH API,
+  and application composition does not add delivery or fulfillment behavior.
 - WS-ARCH-001-CP04 is proposed: hidden ContributionPolicy behavior.
 - WS-ARCH-001-CP05 is proposed: exact ContributionPolicy activation.
 - WS-ARCH-001-CP06 is proposed: CON policy-validation port.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP03B-auth-binding-activation.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP03B-auth-binding-activation.md
@@ -2,8 +2,8 @@
 
 ## Merge state
 
-- Outcome on merge: `planned`
-- Future implementation target: complete.
+- Outcome on merge: `complete`
+- Implementation outcome: complete.
 
 ## Parent initiative
 
@@ -118,6 +118,8 @@ backend/app/modules/authorization/api/adapter_bindings.py
 backend/app/modules/authorization/api/__init__.py
 backend/app/modules/authorization/catalogue.py
 backend/app/modules/authorization/runtime.py (closed resource-context union only)
+backend/app/modules/audit/schemas.py (register the exact `compensation_adapter_binding`
+  audit resource type only)
 backend/app/modules/authorization/prepared.py (reuse/integration only)
 backend/app/modules/authorization/kernel.py (exact Finance Authority evaluator integration only)
 backend/app/modules/authorization/adapter_binding_authorization.py
@@ -131,7 +133,7 @@ backend/app/api/deps/authorization.py (composition only; no route)
 backend/app/main.py (composition only; no route)
 backend/app/modules/compensation/api/adapter_bindings.py (public-port parity only)
 backend/app/modules/compensation/service.py (dependency injection only; no lifecycle behavior change)
-backend/tests/authorization/test_adapter_binding_activation.py
+backend/tests/authorization/test_adapter_binding_registration.py
 backend/tests/authorization/test_adapter_binding_authorization.py
 backend/tests/compensation/test_adapter_binding_authorization_integration.py
 backend/tests/compensation/test_adapter_binding_authorization_failures.py
@@ -141,6 +143,9 @@ backend/tests/compensation/test_adapter_binding_service.py
 backend/tests/compensation/test_adapter_binding_database_guards.py
 backend/tests/compensation/test_adapter_binding_persistence.py
 backend/tests/architecture/test_authorization_boundary.py
+backend/scripts/authorization_boundary.py (exact AUTH adapter-root ownership only)
+backend/scripts/module_boundaries.py (AUTH adapter-root parity only; no general adapter exception)
+backend/tests/architecture/test_module_boundaries.py (repository-wide AUTH-view parity proof only)
 backend/tests/test_authorization.py (closed catalogue/evaluator parity only)
 backend/tests/test_audit.py (atomic evidence parity only)
 backend/scripts/behavior_ownership.py (exact changed-target ownership only)
@@ -193,44 +198,49 @@ Project Manager, Operator, Access Administrator, Audit Authority, project-role, 
 
 ## Acceptance criteria
 
-- [ ] Exactly the four manifest actions become `ACTIVE`, remain mapped only to
+- [x] Exactly the four manifest actions become `ACTIVE`, remain mapped only to
       `compensation.adapter_binding.manage`, and retain their existing owner.
-- [ ] The active catalogue count increases by exactly four; every adjacent
+- [x] The active catalogue count increases by exactly four; every adjacent
       ContributionPolicy, retirement, award, fulfillment, callback, delivery,
       dispatcher, and reconciliation action remains unavailable or absent.
-- [ ] Only an active human profile with the exact active identity link and an
+- [x] Only an active human profile with the exact active identity link and an
       effective system- or same-project `finance_authority` grant can read or
       mutate a binding in that covered project.
-- [ ] Project Manager, Operator, Access Administrator, Audit Authority,
+- [x] Project Manager, Operator, Access Administrator, Audit Authority,
       Submitter, Reviewer, Adjudicator, fixed services, unrelated services,
       wrong-project Finance Authority, revoked/inactive profiles or links, and
       revoked/stale grants deny without target disclosure.
-- [ ] Read authorization binds the exact project and binding identity.
-- [ ] Create PREP binds actor, link, action, permission, project, generated
+- [x] Read authorization binds the exact project and binding identity.
+- [x] Create PREP binds actor, link, action, permission, project, generated
       binding ID, `instrument_type`, adapter actor, route key, operation,
       request digest, resource digest, session, and transaction.
-- [ ] Suspend/resume PREP additionally binds the exact expected status and
+- [x] Suspend/resume PREP additionally binds the exact expected status and
       positive lifecycle version. Wrong action/status/version/resource,
       copied handle, replay, wrong session, wrong transaction, replaced root
       transaction, or mutated facts deny.
-- [ ] Every prepared object closes exactly once on success, denial, conflict,
+- [x] Every prepared object closes exactly once on success, denial, conflict,
       exception, and rollback; no handle can be serialized or reused.
-- [ ] AUTH evidence commits atomically with the exact CP02 binding/lifecycle
+- [x] AUTH evidence commits atomically with the exact CP02 binding/lifecycle
       event. Denial or downstream failure leaves no binding change, lifecycle
       event, or allowed evidence.
-- [ ] Exact duplicate recovery uses fresh read authority and produces the
+- [x] Exact duplicate recovery uses fresh read authority and produces the
       immutable original result without a second mutation PREP or mutation
       evidence effect; any read evidence remains query-only, and changed facts
       or denied current read remain concealed.
-- [ ] CP02's PROJECTS-then-ACTORS eligibility fences and operation ordering
+- [x] CP02's PROJECTS-then-ACTORS eligibility fences and operation ordering
       remain intact for create/resume, including revocation races.
-- [ ] The application composition root injects one AUTH-owned adapter through
+- [x] The application composition root injects one AUTH-owned adapter through
       public ports; no reachable composed production command intentionally
       omits it. This is application wiring, not compensation delivery,
       fulfillment, callback, or provider behavior. CP02's safe deny-default
       constructor remains for uncomposed/isolated use.
-- [ ] No public route becomes reachable and no migration is added.
-- [ ] AUTH and changed compensation authorization coverage remain at or above
+- [x] Both authorization boundary scanners treat only
+      `backend/app/adapters/auth/__init__.py` as AUTH-owned composition for
+      same-owner private AUTH wiring; nested auth adapter files remain external
+      consumers restricted to `authorization.api`, and root imports of
+      non-AUTH private modules remain AUTH outbound debt.
+- [x] No public route becomes reachable and no migration is added.
+- [x] AUTH and changed compensation authorization coverage remain at or above
       90 percent; repository coverage remains at or above the protected floor.
 
 ## Required focused proof
@@ -270,8 +280,8 @@ Project Manager, Operator, Access Administrator, Audit Authority, project-role, 
 ## Verification commands
 
 ```bash
-(cd backend && .venv/bin/python -m ruff check app/modules/authorization/api/adapter_bindings.py app/modules/authorization/api/__init__.py app/modules/authorization/catalogue.py app/modules/authorization/runtime.py app/modules/authorization/prepared.py app/modules/authorization/kernel.py app/modules/authorization/domain/adapter_bindings.py app/modules/authorization/domain/prepared_adapter_bindings.py app/modules/authorization/adapter_binding_authorization.py app/adapters/auth/adapter_bindings.py app/adapters/auth/__init__.py app/api/deps/authorization.py app/main.py app/modules/compensation/api/adapter_bindings.py app/modules/compensation/service.py tests/authorization/test_adapter_binding_activation.py tests/authorization/test_adapter_binding_authorization.py tests/compensation/test_adapter_binding_authorization_integration.py tests/compensation/test_adapter_binding_authorization_failures.py tests/compensation/test_adapter_binding_recovery.py tests/compensation/test_adapter_binding_owner_fences.py tests/compensation/test_adapter_binding_service.py tests/compensation/test_adapter_binding_database_guards.py tests/compensation/test_adapter_binding_persistence.py tests/architecture/test_authorization_boundary.py tests/test_authorization.py tests/test_audit.py)
-(cd backend && export WORKSTREAM_TEST_DATABASE_URL="${WORKSTREAM_TEST_DATABASE_URL:?set WORKSTREAM_TEST_DATABASE_URL}" && .venv/bin/python -m pytest -q tests/authorization/test_adapter_binding_activation.py tests/authorization/test_adapter_binding_authorization.py tests/compensation/test_adapter_binding_authorization_integration.py tests/compensation/test_adapter_binding_authorization_failures.py tests/compensation/test_adapter_binding_recovery.py tests/compensation/test_adapter_binding_owner_fences.py tests/compensation/test_adapter_binding_service.py tests/compensation/test_adapter_binding_database_guards.py tests/compensation/test_adapter_binding_persistence.py tests/architecture/test_authorization_boundary.py tests/test_authorization.py tests/test_audit.py --cov=app.modules.authorization.adapter_binding_authorization --cov=app.modules.authorization.api.adapter_bindings --cov=app.modules.authorization.domain.adapter_bindings --cov=app.modules.authorization.domain.prepared_adapter_bindings --cov=app.adapters.auth.adapter_bindings --cov-fail-under=90)
+(cd backend && .venv/bin/python -m ruff check app/modules/audit/schemas.py app/modules/authorization/api/adapter_bindings.py app/modules/authorization/api/__init__.py app/modules/authorization/catalogue.py app/modules/authorization/runtime.py app/modules/authorization/prepared.py app/modules/authorization/kernel.py app/modules/authorization/domain/adapter_bindings.py app/modules/authorization/domain/prepared_adapter_bindings.py app/modules/authorization/adapter_binding_authorization.py app/adapters/auth/adapter_bindings.py app/adapters/auth/__init__.py app/api/deps/authorization.py app/main.py app/modules/compensation/api/adapter_bindings.py app/modules/compensation/service.py tests/authorization/test_adapter_binding_registration.py tests/authorization/test_adapter_binding_authorization.py tests/compensation/test_adapter_binding_authorization_integration.py tests/compensation/test_adapter_binding_authorization_failures.py tests/compensation/test_adapter_binding_recovery.py tests/compensation/test_adapter_binding_owner_fences.py tests/compensation/test_adapter_binding_service.py tests/compensation/test_adapter_binding_database_guards.py tests/compensation/test_adapter_binding_persistence.py tests/architecture/test_authorization_boundary.py tests/architecture/test_module_boundaries.py tests/test_authorization.py tests/test_audit.py)
+(cd backend && export WORKSTREAM_TEST_DATABASE_URL="${WORKSTREAM_TEST_DATABASE_URL:?set WORKSTREAM_TEST_DATABASE_URL}" && .venv/bin/python -m pytest -q tests/authorization/test_adapter_binding_registration.py tests/authorization/test_adapter_binding_authorization.py tests/compensation/test_adapter_binding_authorization_integration.py tests/compensation/test_adapter_binding_authorization_failures.py tests/compensation/test_adapter_binding_recovery.py tests/compensation/test_adapter_binding_owner_fences.py tests/compensation/test_adapter_binding_service.py tests/compensation/test_adapter_binding_database_guards.py tests/compensation/test_adapter_binding_persistence.py tests/architecture/test_authorization_boundary.py tests/architecture/test_module_boundaries.py tests/test_authorization.py tests/test_audit.py --cov=app.modules.authorization.adapter_binding_authorization --cov=app.modules.authorization.api.adapter_bindings --cov=app.modules.authorization.domain.adapter_bindings --cov=app.modules.authorization.domain.prepared_adapter_bindings --cov=app.adapters.auth.adapter_bindings --cov-fail-under=90)
 (cd backend && .venv/bin/python -m scripts.test_structure_boundary validate --policy ../.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_POLICY.md --ledger ../.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json)
 (cd backend && .venv/bin/python -m scripts.module_boundaries validate --protected-base origin/main)
 python3 scripts/check_stale_authorization_docs.py

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP03B-auth-binding-activation.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP03B-auth-binding-activation.md
@@ -123,8 +123,10 @@ backend/app/modules/authorization/kernel.py (exact Finance Authority evaluator i
 backend/app/modules/authorization/adapter_binding_authorization.py
 backend/app/modules/authorization/domain/adapter_bindings.py
 backend/app/modules/authorization/domain/prepared_adapter_bindings.py
-backend/app/adapters/auth/adapter_bindings.py
-backend/app/adapters/auth/__init__.py
+backend/app/adapters/auth/adapter_bindings.py (public AUTH API consumption only;
+  no private AUTH implementation import)
+backend/app/adapters/auth/__init__.py (exact AUTH adapter-root composition;
+  same-owner private wiring is permitted only here)
 backend/app/api/deps/authorization.py (composition only; no route)
 backend/app/main.py (composition only; no route)
 backend/app/modules/compensation/api/adapter_bindings.py (public-port parity only)
@@ -222,9 +224,11 @@ Project Manager, Operator, Access Administrator, Audit Authority, project-role, 
       or denied current read remain concealed.
 - [ ] CP02's PROJECTS-then-ACTORS eligibility fences and operation ordering
       remain intact for create/resume, including revocation races.
-- [ ] Delivery composition injects one AUTH-owned adapter through public ports;
-      no reachable composed production command intentionally omits it. CP02's
-      safe deny-default constructor remains for uncomposed/isolated use.
+- [ ] The application composition root injects one AUTH-owned adapter through
+      public ports; no reachable composed production command intentionally
+      omits it. This is application wiring, not compensation delivery,
+      fulfillment, callback, or provider behavior. CP02's safe deny-default
+      constructor remains for uncomposed/isolated use.
 - [ ] No public route becomes reachable and no migration is added.
 - [ ] AUTH and changed compensation authorization coverage remain at or above
       90 percent; repository coverage remains at or above the protected floor.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP03B-auth-binding-activation.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP03B-auth-binding-activation.md
@@ -301,7 +301,10 @@ adapter/evaluator modules. Existing catalogue, kernel, PREP, package-export,
 composition-root, and CON injection files receive exact behavioral assertions
 in the listed tests plus GitHub's repository-wide coverage gate; adding those
 large parity surfaces to one combined focused percentage would obscure rather
-than prove the new boundary. Sub-agent session closure is verified by the
+than prove the new boundary. The unchanged
+`app.modules.compensation.api.adapter_bindings` public contract and its existing
+API tests are explicitly outside this changed-module percentage; CP03B only
+injects its already-defined port. Sub-agent session closure is verified by the
 executing agent at completion, not by an invented repository command.
 
 ## Required reviewers

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP03B-auth-binding-activation.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/chunks/WS-ARCH-001-CP03B-auth-binding-activation.md
@@ -229,11 +229,12 @@ Project Manager, Operator, Access Administrator, Audit Authority, project-role, 
       or denied current read remain concealed.
 - [x] CP02's PROJECTS-then-ACTORS eligibility fences and operation ordering
       remain intact for create/resume, including revocation races.
-- [x] The application composition root injects one AUTH-owned adapter through
-      public ports; no reachable composed production command intentionally
-      omits it. This is application wiring, not compensation delivery,
-      fulfillment, callback, or provider behavior. CP02's safe deny-default
-      constructor remains for uncomposed/isolated use.
+- [x] The AUTH application composition root exposes one real adapter factory
+      through public ports. This chunk intentionally creates no route or
+      reachable internal command caller; any future caller must explicitly
+      inject that factory. CP02's safe deny-default constructor remains for
+      uncomposed/isolated use. This is not compensation delivery, fulfillment,
+      callback, or provider behavior.
 - [x] Both authorization boundary scanners treat only
       `backend/app/adapters/auth/__init__.py` as AUTH-owned composition for
       same-owner private AUTH wiring; nested auth adapter files remain external

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
@@ -7,6 +7,10 @@
   floor. Every callable introduced by the CON-to-AUTH adapter and the AUTH
   implementation adapter now documents its boundary responsibility. The
   coverage threshold, workflow, and test selection remain unchanged.
+- After that gate cleared, hosted CI correctly failed closed because the new
+  authorization test module had no semantic-lane assignment. It is now part of
+  the shared AUTH foundation inventory, so every collected test remains owned
+  exactly once under the lane partition rules.
 - CodeRabbit's fail-closed translation findings were valid. Malformed CON facts
   are now concealed at both mutation preparation and consumption, and failed
   persistence of mandatory AUTH evidence becomes the public unavailable error

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
@@ -1,0 +1,32 @@
+# WS-ARCH-001-CP03B External Review Response
+
+## Comments addressed
+
+- Hosted CI correctly reported that the new adapter-binding authorization
+  surfaces reduced repository docstring coverage below the enforced 80 percent
+  floor. Every callable introduced by the CON-to-AUTH adapter and the AUTH
+  implementation adapter now documents its boundary responsibility. The
+  coverage threshold, workflow, and test selection remain unchanged.
+
+## Comments deferred
+
+None.
+
+## Human decisions needed
+
+None beyond the repository-required approval and merge decision.
+
+## Commands rerun
+
+- `cd backend && .venv/bin/docstr-coverage --config .docstr.yaml`
+- `backend/.venv/bin/ruff check backend/app/adapters/auth/adapter_bindings.py backend/app/modules/authorization/adapter_binding_authorization.py`
+- `git diff --check`
+
+The exact focused non-database authorization tests pass locally. Five focused
+PostgreSQL cases require `WORKSTREAM_TEST_DATABASE_URL` and therefore remain
+assigned to hosted CI, consistent with the chunk contract.
+
+## Remaining risks
+
+No product behavior changed in this correction. Hosted CI must still prove the
+complete PostgreSQL and semantic-lane matrix on the corrected exact head.

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
@@ -11,6 +11,9 @@
   authorization test module had no semantic-lane assignment. It is now part of
   the shared AUTH foundation inventory, so every collected test remains owned
   exactly once under the lane partition rules.
+- The first complete shared-foundation execution then found one stale audit
+  parity assertion. Its closed expected active-action set now includes the four
+  CP03B actions, while the same test continues to reject every planned action.
 - CodeRabbit's fail-closed translation findings were valid. Malformed CON facts
   are now concealed at both mutation preparation and consumption, and failed
   persistence of mandatory AUTH evidence becomes the public unavailable error

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
@@ -7,6 +7,24 @@
   floor. Every callable introduced by the CON-to-AUTH adapter and the AUTH
   implementation adapter now documents its boundary responsibility. The
   coverage threshold, workflow, and test selection remain unchanged.
+- CodeRabbit's fail-closed translation findings were valid. Malformed CON facts
+  are now concealed at both mutation preparation and consumption, and failed
+  persistence of mandatory AUTH evidence becomes the public unavailable error
+  for both query and prepared-consumption paths.
+- CodeRabbit's authorization-matrix findings were valid. Missing Finance
+  Authority is now exercised for create, suspend, and resume; the public
+  adapter proves exact consume facts and independently proves prepare, consume,
+  and close denial translation.
+- CodeRabbit's PREP scope consistency finding was valid. Adapter-binding
+  project scope now requires both the exact resource-context type and membership
+  in the closed adapter-binding mutation action set.
+- CodeRabbit correctly identified an ambiguous custody qualifier. The 61-active
+  and 50-planned catalogue counts are explicitly the CP03B activation state,
+  not the preceding CP03A state.
+- CodeRabbit's focused-coverage comment was valid as a clarity issue, not as a
+  missing coverage target. The contract now explicitly excludes the unchanged
+  CON public-port module from CP03B's changed-module percentage while retaining
+  its existing API tests and the repository-wide hosted coverage gate.
 
 ## Comments deferred
 
@@ -20,6 +38,14 @@ None beyond the repository-required approval and merge decision.
 
 - `cd backend && .venv/bin/docstr-coverage --config .docstr.yaml`
 - `backend/.venv/bin/ruff check backend/app/adapters/auth/adapter_bindings.py backend/app/modules/authorization/adapter_binding_authorization.py`
+- `backend/.venv/bin/pytest -q backend/tests/authorization/test_adapter_binding_authorization.py backend/tests/authorization/test_adapter_binding_registration.py backend/tests/compensation/test_adapter_binding_authorization_integration.py backend/tests/architecture/test_authorization_boundary.py backend/tests/architecture/test_module_boundaries.py backend/tests/test_authorization.py -k 'not real_owner_eligibility'`
+- `cd backend && .venv/bin/python -m scripts.test_structure_boundary validate --policy ../.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_POLICY.md --ledger ../.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json`
+- `cd backend && .venv/bin/python -m scripts.module_boundaries validate --protected-base f1e5eac2026e665189663239d75f63880ec3b9ce`
+- `PYTHONPATH=backend backend/.venv/bin/python backend/scripts/behavior_ownership.py validate`
+- `python3 scripts/check_stale_authorization_docs.py`
+- `python3 scripts/check_stale_workstream_wording.py`
+- `python3 scripts/check_chunk_state_sync.py --base-ref f1e5eac2026e665189663239d75f63880ec3b9ce`
+- `python3 scripts/check_markdown_links.py`
 - `git diff --check`
 
 The exact focused non-database authorization tests pass locally. Five focused

--- a/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ARCH-001-modular-monolith-boundaries/reviews/WS-ARCH-001-CP03B-external-review-response.md
@@ -14,6 +14,10 @@
 - The first complete shared-foundation execution then found one stale audit
   parity assertion. Its closed expected active-action set now includes the four
   CP03B actions, while the same test continues to reject every planned action.
+- Structural-debt preflight then correctly rejected line growth in that frozen
+  legacy audit test. The parity update was reformatted to shrink both the test
+  and its oversized function by one line, and the generated debt ledger was
+  reconciled without accepting new structural debt.
 - CodeRabbit's fail-closed translation findings were valid. Malformed CON facts
   are now concealed at both mutation preparation and consumption, and failed
   persistence of mandatory AUTH evidence becomes the public unavailable error

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
@@ -68,7 +68,7 @@ gated `artifact.verification_job.retry`
 remains planned and
 cannot be activated by read/status proof. The historical transfer added no
 migration because owner and availability are typed metadata. WS-XINT-002-01
-reconciles PostgreSQL parity through migration `0036`. On the CP03A branch, the
+reconciles PostgreSQL parity through migration `0036`. On the CP03B activation branch, the
 current catalogue has 73 PermissionIds, 111 ActionIds, 61 active actions, and
 50 planned actions. Its closed registry contains fifteen service identities:
 fourteen action-bearing identities with twenty-three matrix memberships plus

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/ACTIVATION_CUSTODY.md
@@ -69,8 +69,8 @@ remains planned and
 cannot be activated by read/status proof. The historical transfer added no
 migration because owner and availability are typed metadata. WS-XINT-002-01
 reconciles PostgreSQL parity through migration `0036`. On the CP03A branch, the
-current catalogue has 73 PermissionIds, 111 ActionIds, 57 active actions, and
-54 planned actions. Its closed registry contains fifteen service identities:
+current catalogue has 73 PermissionIds, 111 ActionIds, 61 active actions, and
+50 planned actions. Its closed registry contains fifteen service identities:
 fourteen action-bearing identities with twenty-three matrix memberships plus
 the target-only `workstream.compensation.adapter` identity.
 CP01A contributes four planned/unavailable adapter-binding actions and CP01B
@@ -215,7 +215,7 @@ compensation.adapter_binding.suspend
 compensation.adapter_binding.resume
 ```
 
-All four remain unavailable until CP03B implementation merges. They admit only
+All four are active on CP03B merge. They admit only
 an active human Finance Authority covering the exact project, use the existing
 request-scoped read and opaque PREP protocols, add no service identity or
 route, and do not activate ContributionPolicy, retirement, fulfillment,

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/CHUNK_MAP.md
@@ -30,7 +30,7 @@ sequence.
 | `WS-ARCH-001-CP01C` | Adapter-binding fact correction | L1 | Complete; unavailable facts match binding identity and lifecycle generation |
 | `WS-ARCH-001-CP03` | Adapter-binding activation parent | L1 | Split into CP03A/CP03B; non-executable |
 | `WS-ARCH-001-CP03A` | Adapter target identity and owner eligibility prerequisite | L1 | Merged through PR #340; actions remain unavailable |
-| `WS-ARCH-001-CP03B` | Exact Finance Authority adapter-binding activation | L1 | Executable contract is complete; implementation remains planned after merged CP03A |
+| `WS-ARCH-001-CP03B` | Exact Finance Authority adapter-binding activation | L1 | Complete; four exact hidden actions active only for covered human Finance Authority |
 | `WS-ARCH-001-CP05` | Exact ContributionPolicy activation | L1 | Proposed after merged CP04 hidden proof |
 | `WS-AUTH-001-PLAN` | Authorization Service Planning | L0 | Merged through PR #91 as `ad6d644` |
 | `WS-AUTH-001-01` | Adopt Authorization Baseline And Repository Contracts | L1 | Merged through PR #93 as `772af1d` |

--- a/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
+++ b/.agent-loop/initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md
@@ -48,8 +48,8 @@ not current start requirements.
   policy actions while unavailable; CP01C is complete on merge with corrected
   unavailable binding identity and lifecycle-generation facts; CP03 is split.
   CP03A is complete on merge with only the target identity and owner
-  eligibility while actions remain unavailable; CP03B's implementation then
-  activates only CP02's four exact Finance Authority boundaries. CP05 later activates
+  eligibility while actions remain unavailable; CP03B is complete on merge
+  and activates only CP02's four exact Finance Authority boundaries. CP05 later activates
   only CP04's merged hidden policy behavior. Fulfillment callback authority
   remains separate and cannot be bundled into adapter-binding registration.
 

--- a/.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json
+++ b/.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json
@@ -194,11 +194,11 @@
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "2a4de4b91958afda6dc057f8a3b706990aa3fabf809dd84702dd980fd4fd639f",
-      "end_line": 1804,
+      "content_sha256": "9448bad8b9c24d0244ef370260d5b04037a7315c3395701be4b955c46c4512e9",
+      "end_line": 1803,
       "hard_limit": 1200,
       "kind": "test_file",
-      "observed_lines": 1804,
+      "observed_lines": 1803,
       "path": "backend/tests/test_audit.py",
       "qualified_symbol": null,
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -386,11 +386,11 @@
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "825d122c0def8a2de8298e85e4922da14d8072b7d3a19132590b57a9599d3268",
-      "end_line": 253,
+      "content_sha256": "c19e8963e6562f096fedc8716d159a105d5f3039975535dc3f867c1f3d3d8e8a",
+      "end_line": 252,
       "hard_limit": 120,
       "kind": "test_function",
-      "observed_lines": 129,
+      "observed_lines": 128,
       "path": "backend/tests/test_audit.py",
       "qualified_symbol": "test_action_aware_audit_input_enforces_mapping_and_action_availability",
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -399,26 +399,26 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "982f7c01fbc085454707e4b4491b9e79289af6203b7c2718635732d61ba8c9f1",
-      "end_line": 753,
+      "end_line": 752,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 189,
       "path": "backend/tests/test_audit.py",
       "qualified_symbol": "test_authority_input_rejects_unbounded_or_inconsistent_evidence",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 565
+      "start_line": 564
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "36820d7d6c9db7dac729710d8d87ab233d4882febd049e862961449550b52e8e",
-      "end_line": 1314,
+      "end_line": 1313,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 210,
       "path": "backend/tests/test_audit.py",
       "qualified_symbol": "test_database_rejects_malformed_and_mutated_audit_rows",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 1105
+      "start_line": 1104
     },
     {
       "capability": "unassigned_legacy_auth",
@@ -1011,14 +1011,14 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "efca18e30f3e8e9d7b16310a956b427262dc92bdf13165146b58523b25ea2687",
-      "end_line": 519,
+      "end_line": 518,
       "hard_limit": 100,
       "kind": "test_helper",
       "observed_lines": 228,
       "path": "backend/tests/test_audit.py",
       "qualified_symbol": "_authority_event_matrix",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 292
+      "start_line": 291
     },
     {
       "capability": "unassigned_legacy_auth",

--- a/.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json
+++ b/.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json
@@ -87,14 +87,14 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "6582a73a6ac73d11371c3719fb3b23e715b1b3e29487a1db5333519930e92e88",
-      "end_line": 885,
+      "end_line": 886,
       "hard_limit": 100,
       "kind": "production_function",
       "observed_lines": 277,
       "path": "backend/app/modules/authorization/prepared.py",
       "qualified_symbol": "PreparedAuthorizationService._binding",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 609
+      "start_line": 610
     },
     {
       "capability": "unassigned_legacy_auth",

--- a/.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json
+++ b/.agent-loop/initiatives/WS-AUTH-003-module-boundary-recovery/TEST_STRUCTURE_DEBT.json
@@ -2,11 +2,11 @@
   "entries": [
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "7e4412e571fe5ddb9e926f29b52757de61db7e2744e9d8568174058142eb1e1e",
-      "end_line": 1578,
+      "content_sha256": "ca59260706365cbf3eddd700f789076eda417281045e1b8aa87ad3f8f0a59126",
+      "end_line": 1577,
       "hard_limit": 1200,
       "kind": "production_file",
-      "observed_lines": 1578,
+      "observed_lines": 1577,
       "path": "backend/app/modules/authorization/kernel.py",
       "qualified_symbol": null,
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -26,11 +26,11 @@
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "1038fbc2b306f00958ea95f4f2d52cee4850cdaf672621872ca69351e73af5c0",
-      "end_line": 1691,
+      "content_sha256": "b2c9d18356e28ec35d5eed2d9a8c60541c640117112c5f15461e9a07b9efd06b",
+      "end_line": 1690,
       "hard_limit": 1200,
       "kind": "production_file",
-      "observed_lines": 1691,
+      "observed_lines": 1690,
       "path": "backend/app/modules/authorization/runtime.py",
       "qualified_symbol": null,
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -39,46 +39,46 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "06659e0445fba8a7380790f965ff852a4456858b6c0027e6a9f73cd18497dd1a",
-      "end_line": 1181,
+      "end_line": 1185,
       "hard_limit": 100,
       "kind": "production_function",
       "observed_lines": 117,
       "path": "backend/app/modules/authorization/catalogue.py",
       "qualified_symbol": "_index_service_actions",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 1065
+      "start_line": 1069
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "6f9a2b99f3e9ae1768742ad5fd0ddc58faf13f30110a0be83585a721474f8d20",
-      "end_line": 595,
+      "content_sha256": "9ba0fb9b0d33e4d98deddf5fd21a0f6227e0ac765670b24815b1463f039b34d1",
+      "end_line": 591,
       "hard_limit": 100,
       "kind": "production_function",
-      "observed_lines": 201,
+      "observed_lines": 200,
       "path": "backend/app/modules/authorization/kernel.py",
       "qualified_symbol": "AuthorizationService._prepare_prelocked",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 395
+      "start_line": 392
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "4f1b221fd8ff04984a74950f57089a6f3b0aec7e932c2b3fa8430bb073fa7729",
-      "end_line": 1093,
+      "end_line": 1089,
       "hard_limit": 100,
       "kind": "production_function",
       "observed_lines": 162,
       "path": "backend/app/modules/authorization/kernel.py",
       "qualified_symbol": "AuthorizationService._require_prelocked",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 932
+      "start_line": 928
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "8cb806aad12f5010d1e8875c4ba31eee43856a120e338d31a02d87e1ea30ad0c",
-      "end_line": 1578,
+      "content_sha256": "acfaecd4e7c1df7759216f10c210ddda4afa61175c0f3385ce43e79ecf86e0f2",
+      "end_line": 1577,
       "hard_limit": 100,
       "kind": "production_function",
-      "observed_lines": 125,
+      "observed_lines": 124,
       "path": "backend/app/modules/authorization/kernel.py",
       "qualified_symbol": "AuthorizationService._stage_decision",
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -86,15 +86,15 @@
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "168c4f0e965a8ec1090dc2365df4d54a2ff793c462f729a2dda3786f175d7a01",
-      "end_line": 859,
+      "content_sha256": "6582a73a6ac73d11371c3719fb3b23e715b1b3e29487a1db5333519930e92e88",
+      "end_line": 885,
       "hard_limit": 100,
       "kind": "production_function",
-      "observed_lines": 278,
+      "observed_lines": 277,
       "path": "backend/app/modules/authorization/prepared.py",
       "qualified_symbol": "PreparedAuthorizationService._binding",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 582
+      "start_line": 609
     },
     {
       "capability": "unassigned_legacy_auth",
@@ -218,11 +218,11 @@
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "b1edc7300f5d7e9bc253d114b013490f194d75fc6cc726593fe78b7fff5dacb3",
-      "end_line": 13401,
+      "content_sha256": "8a6fa8b9f1affd7f7f936fb28f9f06a77d8f4e649aad888260db349a04bf970e",
+      "end_line": 13400,
       "hard_limit": 1200,
       "kind": "test_file",
-      "observed_lines": 13401,
+      "observed_lines": 13400,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": null,
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -531,58 +531,58 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "951b44cc07e36002118fe93b7974e8d65851b0e2c3cec89a3031cbe42b014e2d",
-      "end_line": 8507,
+      "end_line": 8506,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 140,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_actor_lifecycle_service_applies_success_and_guards_conflicts",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 8368
+      "start_line": 8367
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "569084d6de89ff9eae71d526fc6c157aea7638f55ca93ad128b721fbda339be6",
-      "end_line": 8997,
+      "end_line": 8996,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 122,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_admin_resource_digest_alone_rejects_substituted_role_and_disposition",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 8876
+      "start_line": 8875
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "90b8b670b4d277209617cc1aa794188b4fb3cd9d894b69d5dc3d0adfc885f6ed",
-      "end_line": 9225,
+      "end_line": 9224,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 132,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_admin_revoke_stages_complete_state_and_evidence",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 9094
+      "start_line": 9093
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "78d9bf3df08e5633e9a75720b1e4bf5b7d7b24019bc392b4cb7496a9ac5e5e8e",
-      "end_line": 11053,
+      "end_line": 11052,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 122,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_authorization_locks_refresh_cached_actor_lifecycle_state",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 10932
+      "start_line": 10931
     },
     {
       "capability": "unassigned_legacy_auth",
-      "content_sha256": "96799327ad2799fc630107518acb733de710ad28fe006e9673f8b17a2cf5e784",
-      "end_line": 2239,
+      "content_sha256": "8b41ed1765b7e34f386fe50f1fd626a0c9b29476c036c5ccd09119bf901be5aa",
+      "end_line": 2238,
       "hard_limit": 120,
       "kind": "test_function",
-      "observed_lines": 318,
+      "observed_lines": 317,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_closed_permission_and_action_catalogue_is_exact_and_non_executable",
       "removal_chunk": "WS-AUTH-003-CLOSE",
@@ -591,122 +591,122 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "df1df6ec2ba6aa55445e21cfcf4e4e3ad9664c9504313484a495b6a6df1e9047",
-      "end_line": 3467,
+      "end_line": 3466,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 126,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_identity_link_lifecycle_route_preserves_outcome_transaction_contract",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 3342
+      "start_line": 3341
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "05d1b020ecff0f9bc0a0567adc07f5b31a2f9dfb7828ae3ad34d4e1e7757797c",
-      "end_line": 8660,
+      "end_line": 8659,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 151,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_identity_link_lifecycle_service_applies_success_and_guards_conflicts",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 8510
+      "start_line": 8509
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "c5d6d0d480ced964354915614f15202c0159bfbb281658da0d44186dffd17848",
-      "end_line": 7455,
+      "end_line": 7454,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 142,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_prepared_actor_authority_crossed_mutations_complete_in_both_orders",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 7314
+      "start_line": 7313
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "ebb76e63671195aa4d806ac602bfe58cb22bf82d00c8a70ab186785f3acd7f9b",
-      "end_line": 7796,
+      "end_line": 7795,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 336,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_prepared_crosses_real_lifecycle_service_transactions",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 7461
+      "start_line": 7460
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "9ea4fc0ddbab4c7262a43bc3f498ee1afea3318e9a0b6c93c87763f9f22aae9c",
-      "end_line": 7286,
+      "end_line": 7285,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 518,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_prepared_postgresql_failure_and_cancellation_are_atomic",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 6769
+      "start_line": 6768
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "46e0b031394da6fee856e48615732a17ff8d2276d9cedfb0ecaa3a6879410adb",
-      "end_line": 4672,
+      "end_line": 4671,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 157,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_11c2_reads_require_exact_admin_context_and_role_allowlist",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 4516
+      "start_line": 4515
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "e95d2a03e3829df89c43210a9de92efca31a25905c9648c3179d17b078386b17",
-      "end_line": 2640,
+      "end_line": 2639,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 397,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_mutation_resources_and_prepared_scopes_are_closed",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 2244
+      "start_line": 2243
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "105667302ed6e8f2fd16ea7e95d642e72e41514673e1152503536e0520f9c362",
-      "end_line": 10928,
+      "end_line": 10927,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 204,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_read_permissions_have_postgresql_role_scope_matrix",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 10725
+      "start_line": 10724
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "756b7f99f9a743284934b4d85ce263617710d9b8119792ccb4526a1de04070a1",
-      "end_line": 12430,
+      "end_line": 12429,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 233,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_role_and_all_operation_mappings_commit_one_linked_pair",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 12198
+      "start_line": 12197
     },
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "2e1d7db74ddb955b90a0ee12e4fb72b651a0f85d2746c76e09079c05b0b85252",
-      "end_line": 13401,
+      "end_line": 13400,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 681,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_project_role_issue_postgresql_prep_binds_target_role_and_scope",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 12721
+      "start_line": 12720
     },
     {
       "capability": "unassigned_legacy_auth",
@@ -735,14 +735,14 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "05621e885ed2f88d0ba1a072c1f263fc923939f7ce755a514e9872112aa830a1",
-      "end_line": 11947,
+      "end_line": 11946,
       "hard_limit": 120,
       "kind": "test_function",
       "observed_lines": 163,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "test_service_actor_replay_fails_closed_on_committed_state_drift",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 11785
+      "start_line": 11784
     },
     {
       "capability": "unassigned_legacy_auth",
@@ -1023,14 +1023,14 @@
     {
       "capability": "unassigned_legacy_auth",
       "content_sha256": "1a0a9f3e2be6965e29f76aa74272ccfa2fe4b99e4e0c3bde5ec8ba2c374b369b",
-      "end_line": 11261,
+      "end_line": 11260,
       "hard_limit": 100,
       "kind": "test_helper",
       "observed_lines": 169,
       "path": "backend/tests/test_authorization.py",
       "qualified_symbol": "_operation_success",
       "removal_chunk": "WS-AUTH-003-CLOSE",
-      "start_line": 11093
+      "start_line": 11092
     },
     {
       "capability": "unassigned_legacy_auth",

--- a/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/AUTHORIZATION_HANDOFF.md
+++ b/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/AUTHORIZATION_HANDOFF.md
@@ -87,7 +87,7 @@ No AUTH change blocks planning or completed CON `03A`, `03B`, or `02C`. CP01A
 and CP01B separately register binding and policy authority while unavailable.
 CP01C corrects binding identity and lifecycle-generation facts before CP02.
 CP02 is merged with hidden CON behavior. CP03A installs the exact target identity
-and owner eligibility without activation; CP03B is complete on merge and
+and owner eligibility without activation; CP03B is complete and
 activates only the four exact CP02 Finance Authority boundaries. CP05 later
 activates only CP04's hidden proof. Before CON
 `02B`, AUTH must deliver the complete dispatcher identity/admission/action

--- a/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/AUTHORIZATION_HANDOFF.md
+++ b/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/AUTHORIZATION_HANDOFF.md
@@ -6,14 +6,13 @@ Current `main` contains the AUTH actor, grant, fixed-service,
 prepared-mutation, project-guide, policy-mutation, and REV-readiness
 foundations plus merged REV PLAN4, ART foundations, and CP02 hidden CON
 adapter-binding behavior. The old `0052_legacy_intake_removal` identifier is
-historical merge evidence. Until CP03A merges, current `main` ends at
-`0004_compensation_adapter_binding_lifecycle`, whose tracked predecessor is
-`0003_submission_lineage`. The CP03A branch advances that graph to
-`0005_compensation_adapter_identity` on merge. Older `0050`, `0053`, and `0055`
+historical merge evidence. Current `main` ends at
+`0005_compensation_adapter_identity`, whose tracked predecessor is
+`0004_compensation_adapter_binding_lifecycle`. Older `0050`, `0053`, and `0055`
 identifiers are historical pre-baseline merge evidence, not active graph heads.
-CP02's four binding actions remain unavailable. CP03A installs the target
-identity and owner eligibility while actions stay unavailable; CP03B activates only the four exact
-Finance Authority boundaries. No public CON route, ContributionPolicy
+CP03A installs the target identity and owner eligibility without action-bearing
+service membership; CP03B activates only the four exact Finance Authority
+boundaries. No public CON route, ContributionPolicy
 behavior, or outbox-dispatcher authority is active.
 
 AUTH owns identifiers, stable permission mappings, principals, grants,
@@ -87,10 +86,9 @@ matrix rows, or evaluators.
 No AUTH change blocks planning or completed CON `03A`, `03B`, or `02C`. CP01A
 and CP01B separately register binding and policy authority while unavailable.
 CP01C corrects binding identity and lifecycle-generation facts before CP02.
-CP02 is merged with hidden CON behavior while every binding action remains
-unavailable. CP03 is split: CP03A first installs the exact target identity and
-owner eligibility without activation; CP03B then activates only the four exact
-CP02 Finance Authority boundaries. CP05 later
+CP02 is merged with hidden CON behavior. CP03A installs the exact target identity
+and owner eligibility without activation; CP03B is complete on merge and
+activates only the four exact CP02 Finance Authority boundaries. CP05 later
 activates only CP04's hidden proof. Before CON
 `02B`, AUTH must deliver the complete dispatcher identity/admission/action
 contract. That later dispatcher work must not delay the persistence and

--- a/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/STATUS.md
+++ b/.agent-loop/initiatives/WS-CON-001-contribution-compensation-boundary/STATUS.md
@@ -85,7 +85,7 @@ historical-row backfill or compatibility behavior.
 - CP02 is merged with hidden, route-unreachable adapter-binding behavior and
   immutable lifecycle history while all four AUTH actions remain unavailable.
   CP03A is complete on merge with target identity and owner eligibility while
-  actions remain unavailable. CP03B owns Finance Authority activation. CP04-CP05
+  actions remain unavailable. CP03B completes Finance Authority activation on merge. CP04-CP05
   remain non-executable policy behavior/activation skeletons.
 - CP06-CP09: validation, owner schema lineage, and clean legacy removal wait for
   the preceding public behavior. No historical-row classification is required
@@ -118,7 +118,8 @@ CP08/ARCH-03B replacement path.
 ## Immediate next action
 
 CON-02C merged through PR #277. REV-04B may consume its shared lifecycle-audit
-participant after REV's earlier gates merge. Implement CP03B to activate exactly
-those four actions for covered Finance Authority. CP02 remains hidden and route-unreachable;
-neither child adds a route.
+participant after REV's earlier gates merge. Prepare CP04's executable hidden
+ContributionPolicy behavior contract. CP03B keeps adapter-binding behavior
+hidden and route-unreachable while activating only its four covered Finance
+Authority actions.
 Open pull requests determine transient CON work.

--- a/.ci/behavior-ownership/auth/adapter-binding-activation.json
+++ b/.ci/behavior-ownership/auth/adapter-binding-activation.json
@@ -1,0 +1,32 @@
+{
+  "behavior_id": "auth.adapter_binding.activation",
+  "boundaries": ["postgresql"],
+  "callables": [
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter.__init__",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter._action",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter._assert_human_actor",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter._invoke",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter._mutation_context",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter._resource_facts",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter.authorize_read",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter.close_mutation",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter.consume_mutation",
+    "app.modules.authorization.adapter_binding_authorization.AdapterBindingAuthorizationAdapter.prepare_mutation"
+  ],
+  "group": "auth",
+  "outcomes": ["return", "mapped_error"],
+  "reviewed_by": ["WS-ARCH-001-CP03B required reviewers"],
+  "schema": "workstream.behavior-ownership.v1",
+  "status": "reviewed",
+  "target": "backend/app/modules/authorization/adapter_binding_authorization.py",
+  "tests": [
+    "backend/tests/authorization/test_adapter_binding_authorization.py::test_system_and_project_finance_authority_can_read_exact_binding",
+    "backend/tests/authorization/test_adapter_binding_authorization.py::test_system_and_project_finance_authority_can_consume_every_mutation",
+    "backend/tests/authorization/test_adapter_binding_authorization.py::test_inactive_actor_or_identity_link_denies_before_authority_issuance",
+    "backend/tests/authorization/test_adapter_binding_authorization.py::test_missing_or_stale_finance_grant_denies_every_binding_operation",
+    "backend/tests/authorization/test_adapter_binding_authorization.py::test_non_human_context_cannot_receive_finance_authority",
+    "backend/tests/authorization/test_adapter_binding_authorization.py::test_wrong_actor_and_cross_project_deny_before_authority_issuance",
+    "backend/tests/authorization/test_adapter_binding_authorization.py::test_replaced_transaction_invalidates_prepared_authority",
+    "backend/tests/authorization/test_adapter_binding_authorization.py::test_mutation_action_cannot_bypass_prep_through_direct_kernel_require"
+  ]
+}

--- a/.ci/behavior-ownership/partition.v1.json
+++ b/.ci/behavior-ownership/partition.v1.json
@@ -14,6 +14,10 @@
     },
     {
       "group": "shared",
+      "target": "backend/app/adapters/auth/adapter_bindings.py"
+    },
+    {
+      "group": "shared",
       "target": "backend/app/adapters/auth/dev.py"
     },
     {
@@ -338,6 +342,10 @@
     },
     {
       "group": "auth",
+      "target": "backend/app/modules/authorization/adapter_binding_authorization.py"
+    },
+    {
+      "group": "auth",
       "target": "backend/app/modules/authorization/admin_schemas.py"
     },
     {
@@ -386,11 +394,19 @@
     },
     {
       "group": "auth",
+      "target": "backend/app/modules/authorization/domain/adapter_bindings.py"
+    },
+    {
+      "group": "auth",
       "target": "backend/app/modules/authorization/domain/audit.py"
     },
     {
       "group": "auth",
       "target": "backend/app/modules/authorization/domain/guide_compilation.py"
+    },
+    {
+      "group": "auth",
+      "target": "backend/app/modules/authorization/domain/prepared_adapter_bindings.py"
     },
     {
       "group": "auth",
@@ -885,7 +901,7 @@
       "target": "backend/scripts/week2_api_e2e.py"
     }
   ],
-  "authority_digest": "c66c2a45108fd07fc3041cc8c14e67dd8d2bf7959dca1cad64ced5af536a7d9a",
+  "authority_digest": "66b00a99047c16c7f10904e4749485f8cbc14c42575b53b8934562979448d575",
   "protected_base_commit": "7676ce4347db0c9694962a9b587a20765e16eac6",
   "schema": "workstream.behavior-ownership-partition.v1"
 }

--- a/backend/app/adapters/auth/__init__.py
+++ b/backend/app/adapters/auth/__init__.py
@@ -1,1 +1,31 @@
-"""Authentication adapter implementations."""
+"""Authorization application adapters and same-owner composition."""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.adapters.auth.adapter_bindings import CompensationAdapterBindingAuthorization
+from app.modules.authorization.adapter_binding_authorization import (
+    AdapterBindingAuthorizationAdapter,
+)
+from app.modules.authorization.kernel import AuthorizationService
+from app.modules.authorization.prepared import PreparedAuthorizationService
+from app.modules.authorization.repository import AdminAuthorizationRepository
+from app.modules.authorization.runtime import AuthorizationContext
+
+
+def compensation_adapter_binding_authorization(
+    session: AsyncSession,
+    context: AuthorizationContext,
+) -> CompensationAdapterBindingAuthorization:
+    """Compose one request-local AUTH adapter through the public CON port."""
+    repository = AdminAuthorizationRepository(session)
+    kernel = AuthorizationService(session, context, admin_repository=repository)
+    prepared = PreparedAuthorizationService(session, context, kernel, repository)
+    return CompensationAdapterBindingAuthorization(
+        AdapterBindingAuthorizationAdapter(kernel, prepared)
+    )
+
+
+__all__ = (
+    "CompensationAdapterBindingAuthorization",
+    "compensation_adapter_binding_authorization",
+)

--- a/backend/app/adapters/auth/adapter_bindings.py
+++ b/backend/app/adapters/auth/adapter_bindings.py
@@ -35,7 +35,7 @@ class CompensationAdapterBindingAuthorization:
                     adapter_binding_id=request.adapter_binding_id,
                 ),
             )
-        except AuthorizationBoundaryError as exc:
+        except (AuthorizationBoundaryError, ValueError) as exc:
             raise AdapterBindingUnavailable("compensation_adapter_binding_unavailable") from exc
 
     @staticmethod
@@ -63,7 +63,7 @@ class CompensationAdapterBindingAuthorization:
         """Prepare opaque authority for one exact adapter-binding mutation."""
         try:
             return await self._authorization.prepare_mutation(self._facts(facts))
-        except AuthorizationBoundaryError as exc:
+        except (AuthorizationBoundaryError, ValueError) as exc:
             raise AdapterBindingUnavailable("compensation_adapter_binding_unavailable") from exc
 
     async def consume_adapter_binding_mutation(
@@ -72,7 +72,7 @@ class CompensationAdapterBindingAuthorization:
         """Consume prepared mutation authority and return its authorized actor."""
         try:
             return await self._authorization.consume_mutation(prepared, self._facts(facts))
-        except AuthorizationBoundaryError as exc:
+        except (AuthorizationBoundaryError, ValueError) as exc:
             raise AdapterBindingUnavailable("compensation_adapter_binding_unavailable") from exc
 
     def close_adapter_binding_mutation(self, prepared: object) -> None:

--- a/backend/app/adapters/auth/adapter_bindings.py
+++ b/backend/app/adapters/auth/adapter_bindings.py
@@ -22,9 +22,11 @@ class CompensationAdapterBindingAuthorization:
     """Translate immutable CON facts without importing either private domain."""
 
     def __init__(self, authorization: AdapterBindingAuthorizationPort) -> None:
+        """Bind the CON-facing adapter to AUTH's public authorization port."""
         self._authorization = authorization
 
     async def authorize_adapter_binding_read(self, request: AdapterBindingReadRequest) -> None:
+        """Authorize one exact adapter-binding read or return a concealed denial."""
         try:
             await self._authorization.authorize_read(
                 actor_profile_id=request.actor_profile_id,
@@ -40,6 +42,7 @@ class CompensationAdapterBindingAuthorization:
     def _facts(
         facts: AdapterBindingMutationAuthorizationFacts,
     ) -> AdapterBindingMutationAuthorityFacts:
+        """Copy immutable CON facts into AUTH's public mutation contract."""
         return AdapterBindingMutationAuthorityFacts(
             action_id=action_id(facts.action),
             actor_profile_id=facts.actor_profile_id,
@@ -57,6 +60,7 @@ class CompensationAdapterBindingAuthorization:
     async def prepare_adapter_binding_mutation(
         self, facts: AdapterBindingMutationAuthorizationFacts
     ) -> object:
+        """Prepare opaque authority for one exact adapter-binding mutation."""
         try:
             return await self._authorization.prepare_mutation(self._facts(facts))
         except AuthorizationBoundaryError as exc:
@@ -65,12 +69,14 @@ class CompensationAdapterBindingAuthorization:
     async def consume_adapter_binding_mutation(
         self, prepared: object, facts: AdapterBindingMutationAuthorizationFacts
     ) -> UUID:
+        """Consume prepared mutation authority and return its authorized actor."""
         try:
             return await self._authorization.consume_mutation(prepared, self._facts(facts))
         except AuthorizationBoundaryError as exc:
             raise AdapterBindingUnavailable("compensation_adapter_binding_unavailable") from exc
 
     def close_adapter_binding_mutation(self, prepared: object) -> None:
+        """Invalidate prepared mutation authority through AUTH's public port."""
         try:
             self._authorization.close_mutation(prepared)
         except AuthorizationBoundaryError as exc:

--- a/backend/app/adapters/auth/adapter_bindings.py
+++ b/backend/app/adapters/auth/adapter_bindings.py
@@ -1,0 +1,77 @@
+"""Application adapter from CON's public binding port to AUTH's public port."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.modules.authorization.api import (
+    AdapterBindingAuthorizationPort,
+    AdapterBindingMutationAuthorityFacts,
+    AdapterBindingReadFacts,
+    AuthorizationBoundaryError,
+    action_id,
+)
+from app.modules.compensation.api import (
+    AdapterBindingMutationAuthorizationFacts,
+    AdapterBindingReadRequest,
+    AdapterBindingUnavailable,
+)
+
+
+class CompensationAdapterBindingAuthorization:
+    """Translate immutable CON facts without importing either private domain."""
+
+    def __init__(self, authorization: AdapterBindingAuthorizationPort) -> None:
+        self._authorization = authorization
+
+    async def authorize_adapter_binding_read(self, request: AdapterBindingReadRequest) -> None:
+        try:
+            await self._authorization.authorize_read(
+                actor_profile_id=request.actor_profile_id,
+                facts=AdapterBindingReadFacts(
+                    project_id=request.project_id,
+                    adapter_binding_id=request.adapter_binding_id,
+                ),
+            )
+        except AuthorizationBoundaryError as exc:
+            raise AdapterBindingUnavailable("compensation_adapter_binding_unavailable") from exc
+
+    @staticmethod
+    def _facts(
+        facts: AdapterBindingMutationAuthorizationFacts,
+    ) -> AdapterBindingMutationAuthorityFacts:
+        return AdapterBindingMutationAuthorityFacts(
+            action_id=action_id(facts.action),
+            actor_profile_id=facts.actor_profile_id,
+            operation_id=facts.operation_id,
+            request_digest=facts.request_digest,
+            project_id=facts.project_id,
+            adapter_binding_id=facts.adapter_binding_id,
+            instrument_type=facts.instrument_type,
+            adapter_actor_id=facts.adapter_actor_id,
+            route_key=facts.route_key,
+            expected_status=facts.expected_status,
+            expected_lifecycle_version=facts.expected_lifecycle_version,
+        )
+
+    async def prepare_adapter_binding_mutation(
+        self, facts: AdapterBindingMutationAuthorizationFacts
+    ) -> object:
+        try:
+            return await self._authorization.prepare_mutation(self._facts(facts))
+        except AuthorizationBoundaryError as exc:
+            raise AdapterBindingUnavailable("compensation_adapter_binding_unavailable") from exc
+
+    async def consume_adapter_binding_mutation(
+        self, prepared: object, facts: AdapterBindingMutationAuthorizationFacts
+    ) -> UUID:
+        try:
+            return await self._authorization.consume_mutation(prepared, self._facts(facts))
+        except AuthorizationBoundaryError as exc:
+            raise AdapterBindingUnavailable("compensation_adapter_binding_unavailable") from exc
+
+    def close_adapter_binding_mutation(self, prepared: object) -> None:
+        try:
+            self._authorization.close_mutation(prepared)
+        except AuthorizationBoundaryError as exc:
+            raise AdapterBindingUnavailable("compensation_adapter_binding_unavailable") from exc

--- a/backend/app/modules/audit/schemas.py
+++ b/backend/app/modules/audit/schemas.py
@@ -34,7 +34,7 @@ _ENTITY_TYPES = frozenset(
 )
 _RESOURCE_TYPES = frozenset(
     """actor_profile actor_identity_link admin_role_grant project qualification_snapshot project_role_grant task
-    submission review contribution compensation_award compensation_delivery operations
+    submission review contribution compensation_award compensation_delivery compensation_adapter_binding operations
     audit_event project_create_operation project_submission_artifact_policy_mutation
     pre_submit_checker_input project_guide_compilation_request
     project_guide_compilation_attempt""".split()

--- a/backend/app/modules/authorization/adapter_binding_authorization.py
+++ b/backend/app/modules/authorization/adapter_binding_authorization.py
@@ -1,0 +1,197 @@
+"""AUTH-owned adapter-binding authorization implementation."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.modules.authorization.api import (
+    AdapterBindingCreateFacts,
+    AdapterBindingMutationAuthorityFacts,
+    AdapterBindingReadFacts,
+    AdapterBindingResumeFacts,
+    AdapterBindingSuspendFacts,
+    AuthorizationDenied as BoundaryAuthorizationDenied,
+    PreparedAuthorizationInvalid,
+    action_id as public_action_id,
+    adapter_binding_resource_digest,
+)
+from app.modules.authorization.catalogue import ActionId
+from app.modules.authorization.domain.adapter_bindings import (
+    AdapterBindingMutationResourceContext,
+    AdapterBindingReadResourceContext,
+)
+from app.modules.authorization.kernel import AuthorizationService
+from app.modules.authorization.prepared import (
+    PreparedAuthorizationHandle,
+    PreparedAuthorizationService,
+)
+from app.modules.authorization.runtime import (
+    AuthorizationDenied,
+    HumanAuthorizationContext,
+    PreparedAuthorizationHandleInvalid,
+    PreparedAuthorizationInput,
+    PreparedAuthorizationUnsupported,
+    PreparedAuthorityScope,
+    PreparedAuthorityScopeKind,
+)
+
+_MUTATION_ACTIONS = frozenset(
+    {
+        ActionId.COMPENSATION_ADAPTER_BINDING_CREATE,
+        ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND,
+        ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
+    }
+)
+
+
+class AdapterBindingAuthorizationAdapter:
+    """Bind public adapter-binding facts to the kernel and existing PREP service."""
+
+    def __init__(
+        self,
+        authorization: AuthorizationService,
+        prepared: PreparedAuthorizationService,
+    ) -> None:
+        if prepared._authorization is not authorization:
+            raise TypeError("adapter-binding authorization requires one composition")
+        self._authorization = authorization
+        self._prepared = prepared
+
+    def _assert_human_actor(self, actor_profile_id: UUID) -> None:
+        context = self._authorization._context
+        if (
+            not isinstance(context, HumanAuthorizationContext)
+            or context.actor_profile_id != actor_profile_id
+        ):
+            raise BoundaryAuthorizationDenied("adapter-binding authority denied")
+
+    @staticmethod
+    def _action(raw: str) -> ActionId:
+        try:
+            action = ActionId(raw)
+        except ValueError as exc:
+            raise BoundaryAuthorizationDenied("adapter-binding authority denied") from exc
+        if action not in _MUTATION_ACTIONS:
+            raise BoundaryAuthorizationDenied("adapter-binding authority denied")
+        return action
+
+    @staticmethod
+    def _resource_facts(facts: AdapterBindingMutationAuthorityFacts):
+        action = str(facts.action_id)
+        if action == ActionId.COMPENSATION_ADAPTER_BINDING_CREATE.value:
+            return AdapterBindingCreateFacts(
+                project_id=facts.project_id,
+                adapter_binding_id=facts.adapter_binding_id,
+                instrument_type=facts.instrument_type,
+                adapter_actor_id=facts.adapter_actor_id,
+                route_key=facts.route_key,
+            )
+        if action == ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND.value:
+            return AdapterBindingSuspendFacts(
+                project_id=facts.project_id,
+                adapter_binding_id=facts.adapter_binding_id,
+                expected_lifecycle_version=facts.expected_lifecycle_version,
+                expected_status=facts.expected_status,
+            )
+        return AdapterBindingResumeFacts(
+            project_id=facts.project_id,
+            adapter_binding_id=facts.adapter_binding_id,
+            expected_lifecycle_version=facts.expected_lifecycle_version,
+            expected_status=facts.expected_status,
+        )
+
+    def _mutation_context(
+        self, facts: AdapterBindingMutationAuthorityFacts
+    ) -> tuple[ActionId, AdapterBindingMutationResourceContext]:
+        self._assert_human_actor(facts.actor_profile_id)
+        action = self._action(str(facts.action_id))
+        resource_facts = self._resource_facts(facts)
+        return action, AdapterBindingMutationResourceContext(
+            resource_type="compensation_adapter_binding",
+            resource_id=facts.adapter_binding_id,
+            scope_project_id=facts.project_id,
+            operation_id=facts.operation_id,
+            request_digest=facts.request_digest,
+            instrument_type=facts.instrument_type,
+            adapter_actor_id=facts.adapter_actor_id,
+            route_key=facts.route_key,
+            expected_status=facts.expected_status,
+            expected_lifecycle_version=facts.expected_lifecycle_version,
+            resource_facts_digest=adapter_binding_resource_digest(facts.action_id, resource_facts),
+        )
+
+    @staticmethod
+    async def _invoke(operation):
+        try:
+            return await operation
+        except PreparedAuthorizationHandleInvalid as exc:
+            raise PreparedAuthorizationInvalid(
+                "prepared adapter-binding authority is invalid"
+            ) from exc
+        except (PreparedAuthorizationUnsupported, AuthorizationDenied) as exc:
+            raise BoundaryAuthorizationDenied("adapter-binding authority denied") from exc
+
+    async def authorize_read(
+        self, *, actor_profile_id: UUID, facts: AdapterBindingReadFacts
+    ) -> None:
+        self._assert_human_actor(actor_profile_id)
+        resource = AdapterBindingReadResourceContext(
+            resource_type="compensation_adapter_binding",
+            resource_id=facts.adapter_binding_id,
+            scope_project_id=facts.project_id,
+            resource_facts_digest=adapter_binding_resource_digest(
+                public_action_id("compensation.adapter_binding.read"),
+                facts,
+            ),
+        )
+        try:
+            await self._authorization.require(ActionId.COMPENSATION_ADAPTER_BINDING_READ, resource)
+        except AuthorizationDenied as exc:
+            raise BoundaryAuthorizationDenied("adapter-binding authority denied") from exc
+
+    async def prepare_mutation(
+        self, facts: AdapterBindingMutationAuthorityFacts
+    ) -> PreparedAuthorizationHandle:
+        action, resource = self._mutation_context(facts)
+        return await self._invoke(
+            self._prepared.prepare(
+                action,
+                PreparedAuthorizationInput(
+                    idempotency_key=facts.operation_id,
+                    request_value=resource.model_dump(mode="json"),
+                ),
+                PreparedAuthorityScope(
+                    kind=PreparedAuthorityScopeKind.PROJECT,
+                    project_id=facts.project_id,
+                ),
+            )
+        )
+
+    async def consume_mutation(
+        self, prepared: object, facts: AdapterBindingMutationAuthorityFacts
+    ) -> UUID:
+        if type(prepared) is not PreparedAuthorizationHandle:
+            raise PreparedAuthorizationInvalid("prepared adapter-binding authority is invalid")
+        action, resource = self._mutation_context(facts)
+        await self._invoke(
+            self._prepared.consume(
+                prepared,
+                action,
+                PreparedAuthorizationInput(
+                    idempotency_key=facts.operation_id,
+                    request_value=resource.model_dump(mode="json"),
+                ),
+                resource,
+            )
+        )
+        return self._authorization._context.actor_profile_id
+
+    def close_mutation(self, prepared: object) -> None:
+        if type(prepared) is not PreparedAuthorizationHandle:
+            raise PreparedAuthorizationInvalid("prepared adapter-binding authority is invalid")
+        try:
+            self._prepared.close_handle(prepared)
+        except PreparedAuthorizationHandleInvalid as exc:
+            raise PreparedAuthorizationInvalid(
+                "prepared adapter-binding authority is invalid"
+            ) from exc

--- a/backend/app/modules/authorization/adapter_binding_authorization.py
+++ b/backend/app/modules/authorization/adapter_binding_authorization.py
@@ -44,12 +44,14 @@ class AdapterBindingAuthorizationAdapter:
         authorization: AuthorizationService,
         prepared: PreparedAuthorizationService,
     ) -> None:
+        """Require the query kernel and PREP service to share one composition."""
         if prepared._authorization is not authorization:
             raise TypeError("adapter-binding authorization requires one composition")
         self._authorization = authorization
         self._prepared = prepared
 
     def _assert_human_actor(self, actor_profile_id: UUID) -> None:
+        """Reject non-human or mismatched authenticated actor contexts."""
         context = self._authorization._context
         if (
             not isinstance(context, HumanAuthorizationContext)
@@ -59,6 +61,7 @@ class AdapterBindingAuthorizationAdapter:
 
     @staticmethod
     def _action(raw: str) -> ActionId:
+        """Resolve a public action value within the closed mutation action set."""
         try:
             action = ActionId(raw)
         except ValueError as exc:
@@ -69,6 +72,7 @@ class AdapterBindingAuthorizationAdapter:
 
     @staticmethod
     def _resource_facts(facts: AdapterBindingMutationAuthorityFacts):
+        """Build the action-specific immutable facts used by the resource digest."""
         action = str(facts.action_id)
         if action == ActionId.COMPENSATION_ADAPTER_BINDING_CREATE.value:
             return AdapterBindingCreateFacts(
@@ -95,6 +99,7 @@ class AdapterBindingAuthorizationAdapter:
     def _mutation_context(
         self, facts: AdapterBindingMutationAuthorityFacts
     ) -> tuple[ActionId, AdapterBindingMutationResourceContext]:
+        """Bind mutation facts to the authenticated actor and canonical resource."""
         self._assert_human_actor(facts.actor_profile_id)
         action = self._action(str(facts.action_id))
         resource_facts = self._resource_facts(facts)
@@ -114,6 +119,7 @@ class AdapterBindingAuthorizationAdapter:
 
     @staticmethod
     async def _invoke(operation):
+        """Translate private PREP failures into the stable public AUTH boundary."""
         try:
             return await operation
         except PreparedAuthorizationHandleInvalid as exc:
@@ -126,6 +132,7 @@ class AdapterBindingAuthorizationAdapter:
     async def authorize_read(
         self, *, actor_profile_id: UUID, facts: AdapterBindingReadFacts
     ) -> None:
+        """Authorize a fresh read of one exact project-owned adapter binding."""
         self._assert_human_actor(actor_profile_id)
         resource = AdapterBindingReadResourceContext(
             resource_type="compensation_adapter_binding",
@@ -144,6 +151,7 @@ class AdapterBindingAuthorizationAdapter:
     async def prepare_mutation(
         self, facts: AdapterBindingMutationAuthorityFacts
     ) -> PreparedAuthorizationHandle:
+        """Prepare transaction-bound authority for one canonical mutation request."""
         action, resource = self._mutation_context(facts)
         return await self._invoke(
             self._prepared.prepare(
@@ -162,6 +170,7 @@ class AdapterBindingAuthorizationAdapter:
     async def consume_mutation(
         self, prepared: object, facts: AdapterBindingMutationAuthorityFacts
     ) -> UUID:
+        """Consume exact prepared authority and return the authenticated actor."""
         if type(prepared) is not PreparedAuthorizationHandle:
             raise PreparedAuthorizationInvalid("prepared adapter-binding authority is invalid")
         action, resource = self._mutation_context(facts)
@@ -179,6 +188,7 @@ class AdapterBindingAuthorizationAdapter:
         return self._authorization._context.actor_profile_id
 
     def close_mutation(self, prepared: object) -> None:
+        """Invalidate an exact prepared handle without exposing its internals."""
         if type(prepared) is not PreparedAuthorizationHandle:
             raise PreparedAuthorizationInvalid("prepared adapter-binding authority is invalid")
         try:

--- a/backend/app/modules/authorization/adapter_binding_authorization.py
+++ b/backend/app/modules/authorization/adapter_binding_authorization.py
@@ -17,6 +17,7 @@ from app.modules.authorization.api import (
 )
 from app.modules.authorization.catalogue import ActionId
 from app.modules.authorization.domain.adapter_bindings import (
+    ADAPTER_BINDING_MUTATION_ACTIONS,
     AdapterBindingMutationResourceContext,
     AdapterBindingReadResourceContext,
 )
@@ -34,15 +35,6 @@ from app.modules.authorization.runtime import (
     PreparedAuthorityScope,
     PreparedAuthorityScopeKind,
 )
-
-_MUTATION_ACTIONS = frozenset(
-    {
-        ActionId.COMPENSATION_ADAPTER_BINDING_CREATE,
-        ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND,
-        ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
-    }
-)
-
 
 class AdapterBindingAuthorizationAdapter:
     """Bind public adapter-binding facts to the kernel and existing PREP service."""
@@ -71,7 +63,7 @@ class AdapterBindingAuthorizationAdapter:
             action = ActionId(raw)
         except ValueError as exc:
             raise BoundaryAuthorizationDenied("adapter-binding authority denied") from exc
-        if action not in _MUTATION_ACTIONS:
+        if action not in ADAPTER_BINDING_MUTATION_ACTIONS:
             raise BoundaryAuthorizationDenied("adapter-binding authority denied")
         return action
 

--- a/backend/app/modules/authorization/adapter_binding_authorization.py
+++ b/backend/app/modules/authorization/adapter_binding_authorization.py
@@ -11,6 +11,7 @@ from app.modules.authorization.api import (
     AdapterBindingResumeFacts,
     AdapterBindingSuspendFacts,
     AuthorizationDenied as BoundaryAuthorizationDenied,
+    AuthorizationUnavailable,
     PreparedAuthorizationInvalid,
     action_id as public_action_id,
     adapter_binding_resource_digest,
@@ -28,6 +29,7 @@ from app.modules.authorization.prepared import (
 )
 from app.modules.authorization.runtime import (
     AuthorizationDenied,
+    AuthorizationEvidenceUnavailable,
     HumanAuthorizationContext,
     PreparedAuthorizationHandleInvalid,
     PreparedAuthorizationInput,
@@ -128,6 +130,8 @@ class AdapterBindingAuthorizationAdapter:
             ) from exc
         except (PreparedAuthorizationUnsupported, AuthorizationDenied) as exc:
             raise BoundaryAuthorizationDenied("adapter-binding authority denied") from exc
+        except AuthorizationEvidenceUnavailable as exc:
+            raise AuthorizationUnavailable("adapter-binding authority unavailable") from exc
 
     async def authorize_read(
         self, *, actor_profile_id: UUID, facts: AdapterBindingReadFacts
@@ -147,6 +151,8 @@ class AdapterBindingAuthorizationAdapter:
             await self._authorization.require(ActionId.COMPENSATION_ADAPTER_BINDING_READ, resource)
         except AuthorizationDenied as exc:
             raise BoundaryAuthorizationDenied("adapter-binding authority denied") from exc
+        except AuthorizationEvidenceUnavailable as exc:
+            raise AuthorizationUnavailable("adapter-binding authority unavailable") from exc
 
     async def prepare_mutation(
         self, facts: AdapterBindingMutationAuthorityFacts

--- a/backend/app/modules/authorization/api/__init__.py
+++ b/backend/app/modules/authorization/api/__init__.py
@@ -3,6 +3,8 @@
 from .action_ids import ActionId, PermissionId, action_id, permission_id
 from .adapter_bindings import (
     AdapterBindingCreateFacts,
+    AdapterBindingAuthorizationPort,
+    AdapterBindingMutationAuthorityFacts,
     AdapterBindingReadFacts,
     AdapterBindingResumeFacts,
     AdapterBindingSuspendFacts,
@@ -39,6 +41,8 @@ from .project_guide_compilation import (
 __all__ = (
     "ActionId",
     "AdapterBindingCreateFacts",
+    "AdapterBindingAuthorizationPort",
+    "AdapterBindingMutationAuthorityFacts",
     "AdapterBindingReadFacts",
     "AdapterBindingResumeFacts",
     "AdapterBindingSuspendFacts",

--- a/backend/app/modules/authorization/api/adapter_bindings.py
+++ b/backend/app/modules/authorization/api/adapter_bindings.py
@@ -6,7 +6,7 @@ from dataclasses import asdict, dataclass
 import hashlib
 import json
 import re
-from typing import TypeAlias
+from typing import Protocol, TypeAlias
 from uuid import UUID
 
 from .action_ids import ActionId
@@ -113,6 +113,67 @@ AdapterBindingFacts: TypeAlias = (
     | AdapterBindingSuspendFacts
     | AdapterBindingResumeFacts
 )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class AdapterBindingMutationAuthorityFacts:
+    """Complete operation and resource facts for one binding mutation."""
+
+    action_id: ActionId
+    actor_profile_id: UUID
+    operation_id: UUID
+    request_digest: str
+    project_id: UUID
+    adapter_binding_id: UUID
+    instrument_type: str
+    adapter_actor_id: UUID
+    route_key: str
+    expected_status: str | None
+    expected_lifecycle_version: int | None
+
+    def __post_init__(self) -> None:
+        """Reject incomplete or action-inconsistent mutation authority facts."""
+        _require_uuid("actor_profile_id", self.actor_profile_id)
+        _require_uuid("operation_id", self.operation_id)
+        _require_uuid("project_id", self.project_id)
+        _require_uuid("adapter_binding_id", self.adapter_binding_id)
+        _require_uuid("adapter_actor_id", self.adapter_actor_id)
+        if self.instrument_type not in {"money", "project_points"}:
+            raise ValueError("instrument_type must be money or project_points")
+        _require_route_key(self.route_key)
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", self.request_digest):
+            raise ValueError("request_digest must be canonical sha256")
+        action = str(self.action_id)
+        expected = {
+            "compensation.adapter_binding.create": (None, False),
+            "compensation.adapter_binding.suspend": ("active", True),
+            "compensation.adapter_binding.resume": ("suspended", True),
+        }.get(action)
+        actual = (
+            self.expected_status,
+            self.expected_lifecycle_version is not None,
+        )
+        if expected is None or actual != expected:
+            raise ValueError("adapter-binding action and transition facts do not match")
+        if self.expected_lifecycle_version is not None:
+            _require_positive_int("expected_lifecycle_version", self.expected_lifecycle_version)
+
+
+class AdapterBindingAuthorizationPort(Protocol):
+    """Authorize exact adapter-binding reads and prepared mutations."""
+
+    async def authorize_read(
+        self, *, actor_profile_id: UUID, facts: AdapterBindingReadFacts
+    ) -> None: ...
+
+    async def prepare_mutation(self, facts: AdapterBindingMutationAuthorityFacts) -> object: ...
+
+    async def consume_mutation(
+        self, prepared: object, facts: AdapterBindingMutationAuthorityFacts
+    ) -> UUID: ...
+
+    def close_mutation(self, prepared: object) -> None: ...
+
 
 _FACT_TYPE_BY_ACTION = {
     "compensation.adapter_binding.read": AdapterBindingReadFacts,

--- a/backend/app/modules/authorization/catalogue.py
+++ b/backend/app/modules/authorization/catalogue.py
@@ -775,22 +775,22 @@ ACTION_DEFINITIONS = (
         PermissionId.ARTIFACT_BINDING_CREATE,
         ActionOwner.XINT_002_07,
     ),
-    _planned(
+    _active(
         ActionId.COMPENSATION_ADAPTER_BINDING_READ,
         PermissionId.COMPENSATION_ADAPTER_BINDING_MANAGE,
         ActionOwner.ARCH_CP01A,
     ),
-    _planned(
+    _active(
         ActionId.COMPENSATION_ADAPTER_BINDING_CREATE,
         PermissionId.COMPENSATION_ADAPTER_BINDING_MANAGE,
         ActionOwner.ARCH_CP01A,
     ),
-    _planned(
+    _active(
         ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND,
         PermissionId.COMPENSATION_ADAPTER_BINDING_MANAGE,
         ActionOwner.ARCH_CP01A,
     ),
-    _planned(
+    _active(
         ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
         PermissionId.COMPENSATION_ADAPTER_BINDING_MANAGE,
         ActionOwner.ARCH_CP01A,
@@ -938,6 +938,10 @@ def _index_actions(
         ActionId.ARTIFACT_PENDING_WORK_SCAN,
         ActionId.ARTIFACT_PUT_ATTEMPT_RESOLVE,
         ActionId.ARTIFACT_PRE_SUBMIT_CHECKER_INPUT_MATERIALIZE,
+        ActionId.COMPENSATION_ADAPTER_BINDING_READ,
+        ActionId.COMPENSATION_ADAPTER_BINDING_CREATE,
+        ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND,
+        ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
     }
     if {
         definition.action_id

--- a/backend/app/modules/authorization/domain/adapter_bindings.py
+++ b/backend/app/modules/authorization/domain/adapter_bindings.py
@@ -1,0 +1,78 @@
+"""Internal resource contexts for compensation adapter-binding authority."""
+
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.modules.authorization.catalogue import ActionId
+
+_STRICT_FROZEN = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class AdapterBindingReadResourceContext(BaseModel):
+    """Exact project-scoped binding disclosure target."""
+
+    model_config = _STRICT_FROZEN
+    resource_type: Literal["compensation_adapter_binding"]
+    resource_id: UUID
+    scope_project_id: UUID
+    resource_facts_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+
+
+class AdapterBindingMutationResourceContext(BaseModel):
+    """Exact immutable facts for one adapter-binding mutation."""
+
+    model_config = _STRICT_FROZEN
+    resource_type: Literal["compensation_adapter_binding"]
+    resource_id: UUID
+    scope_project_id: UUID
+    operation_id: UUID
+    request_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+    instrument_type: Literal["money", "project_points"]
+    adapter_actor_id: UUID
+    route_key: str
+    expected_status: Literal["active", "suspended"] | None
+    expected_lifecycle_version: int | None = Field(default=None, ge=1)
+    resource_facts_digest: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
+
+    @model_validator(mode="after")
+    def require_transition_pair(self):
+        """Require status and lifecycle version together for transitions only."""
+        if (self.expected_status is None) != (self.expected_lifecycle_version is None):
+            raise ValueError("adapter-binding transition facts must be complete")
+        return self
+
+
+AdapterBindingResourceContext = (
+    AdapterBindingReadResourceContext | AdapterBindingMutationResourceContext
+)
+
+ADAPTER_BINDING_RESOURCE_BY_ACTION = {
+    ActionId.COMPENSATION_ADAPTER_BINDING_READ: AdapterBindingReadResourceContext,
+    ActionId.COMPENSATION_ADAPTER_BINDING_CREATE: AdapterBindingMutationResourceContext,
+    ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND: AdapterBindingMutationResourceContext,
+    ActionId.COMPENSATION_ADAPTER_BINDING_RESUME: AdapterBindingMutationResourceContext,
+}
+ADAPTER_BINDING_READ_ACTIONS = frozenset(
+    {ActionId.COMPENSATION_ADAPTER_BINDING_READ}
+)
+ADAPTER_BINDING_MUTATION_ACTIONS = frozenset(
+    {
+        ActionId.COMPENSATION_ADAPTER_BINDING_CREATE,
+        ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND,
+        ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
+    }
+)
+ADAPTER_BINDING_ACTIONS = ADAPTER_BINDING_READ_ACTIONS | ADAPTER_BINDING_MUTATION_ACTIONS
+
+
+def finance_authority_grant_filters(action_id: ActionId) -> dict[str, object]:
+    """Confine binding actions to the exact Finance Authority role."""
+    if action_id not in ADAPTER_BINDING_ACTIONS:
+        return {}
+    from app.modules.authorization.schemas import AdminRole
+
+    return {"allowed_roles": frozenset({AdminRole.FINANCE_AUTHORITY})}

--- a/backend/app/modules/authorization/domain/prepared_adapter_bindings.py
+++ b/backend/app/modules/authorization/domain/prepared_adapter_bindings.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from app.modules.authorization.catalogue import ActionId
 from app.modules.authorization.domain.adapter_bindings import (
+    ADAPTER_BINDING_MUTATION_ACTIONS,
     AdapterBindingMutationResourceContext,
 )
 from app.modules.authorization.runtime import (
@@ -14,20 +15,11 @@ from app.modules.authorization.runtime import (
     authorization_resource_digest,
 )
 
-_MUTATIONS = frozenset(
-    {
-        ActionId.COMPENSATION_ADAPTER_BINDING_CREATE,
-        ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND,
-        ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
-    }
-)
-
-
 def parse_prepared_adapter_binding(
     action_id: ActionId, request_value: Mapping[str, object]
 ) -> dict[str, object]:
     """Parse exact adapter-binding facts for the three mutation actions."""
-    if action_id not in _MUTATIONS:
+    if action_id not in ADAPTER_BINDING_MUTATION_ACTIONS:
         return {}
     try:
         value = dict(request_value)

--- a/backend/app/modules/authorization/domain/prepared_adapter_bindings.py
+++ b/backend/app/modules/authorization/domain/prepared_adapter_bindings.py
@@ -1,0 +1,59 @@
+"""Prepared-capability parsing for adapter-binding mutations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from uuid import UUID
+
+from app.modules.authorization.catalogue import ActionId
+from app.modules.authorization.domain.adapter_bindings import (
+    AdapterBindingMutationResourceContext,
+)
+from app.modules.authorization.runtime import (
+    PreparedAuthorizationHandleInvalid,
+    authorization_resource_digest,
+)
+
+_MUTATIONS = frozenset(
+    {
+        ActionId.COMPENSATION_ADAPTER_BINDING_CREATE,
+        ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND,
+        ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
+    }
+)
+
+
+def parse_prepared_adapter_binding(
+    action_id: ActionId, request_value: Mapping[str, object]
+) -> dict[str, object]:
+    """Parse exact adapter-binding facts for the three mutation actions."""
+    if action_id not in _MUTATIONS:
+        return {}
+    try:
+        value = dict(request_value)
+        for field in (
+            "resource_id",
+            "scope_project_id",
+            "operation_id",
+            "adapter_actor_id",
+        ):
+            value[field] = UUID(str(value[field]))
+        resource = AdapterBindingMutationResourceContext.model_validate(value)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise PreparedAuthorizationHandleInvalid("invalid prepared authorization handle") from exc
+    return {
+        "adapter_binding_context": resource.model_dump(mode="json"),
+        "adapter_binding_resource_digest": authorization_resource_digest(resource),
+    }
+
+
+def prepared_adapter_binding_matches(
+    context: dict | None,
+    digest: str | None,
+    resource: object,
+) -> bool:
+    """Require exact resource facts and digest equality."""
+    return isinstance(resource, AdapterBindingMutationResourceContext) and (
+        context == resource.model_dump(mode="json")
+        and digest == authorization_resource_digest(resource)
+    )

--- a/backend/app/modules/authorization/kernel.py
+++ b/backend/app/modules/authorization/kernel.py
@@ -23,7 +23,7 @@ from app.modules.authorization.catalogue import (
     ActionId,
     PermissionId,
 )
-from app.modules.authorization.domain import guide_compilation as compilation
+from app.modules.authorization.domain import adapter_bindings, guide_compilation as compilation
 from app.modules.authorization.domain.audit import CONTEXT_DIGEST_RESOURCE_TYPES
 from app.modules.authorization.domain.prepared_service import (
     is_project_setup_scope,
@@ -163,7 +163,7 @@ _ADMIN_ACTIONS = frozenset(
         ActionId.PROJECT_PRE_SUBMIT_CHECKER_POLICY_READ,
         ActionId.PROJECT_ACTIVE_GUIDE_READ,
     }
-)
+) | adapter_bindings.ADAPTER_BINDING_READ_ACTIONS
 _SERIALIZED_ADMIN_READS = frozenset(
     {
         ActionId.ACTOR_PROFILE_READ,
@@ -178,7 +178,7 @@ _SERIALIZED_ADMIN_READS = frozenset(
         ActionId.PROJECT_PRE_SUBMIT_CHECKER_POLICY_READ,
         ActionId.PROJECT_ACTIVE_GUIDE_READ,
     }
-)
+) | adapter_bindings.ADAPTER_BINDING_READ_ACTIONS
 _ADMIN_MUTATIONS = frozenset(
     {
         ActionId.ADMIN_ROLE_GRANT_ISSUE,
@@ -192,7 +192,7 @@ _ADMIN_MUTATIONS = frozenset(
         ActionId.PROJECT_ROLE_GRANT_ISSUE,
         ActionId.PROJECT_ROLE_GRANT_REVOKE,
     }
-)
+) | adapter_bindings.ADAPTER_BINDING_MUTATION_ACTIONS
 
 _ARTIFACT_INTERNAL_RESOURCES = {
     ActionId.ARTIFACT_GUIDE_SOURCE_BINDING_CREATE: (
@@ -258,10 +258,10 @@ _ADMIN_EXPECTED_RESOURCES = MappingProxyType(
         ),
         ActionId.PROJECT_PRE_SUBMIT_CHECKER_POLICY_READ: ProjectPolicyReadResourceContext,
         ActionId.PROJECT_ACTIVE_GUIDE_READ: ProjectActiveGuideReadResourceContext,
+        **adapter_bindings.ADAPTER_BINDING_RESOURCE_BY_ACTION,
         **PROJECT_MUTATION_RESOURCE_BY_ACTION,
     }
 )
-
 
 def project_action_available_for_status(action_id: ActionId, project_status: str) -> bool:
     """Apply project-only lifecycle guards shared by decisions and projections."""
@@ -277,7 +277,6 @@ def project_action_available_for_status(action_id: ActionId, project_status: str
     }:
         return project_status == "active"
     return True
-
 
 class _PrelockedAuthority:
     """AUTH-private authority facts locked by the prepared protocol."""
@@ -334,9 +333,7 @@ class _PrelockedAuthority:
     def __setattr__(self, _name: str, _value: object) -> None:
         raise AttributeError("prelocked authority is immutable")
 
-
 _PRELOCKED_CONSTRUCTOR_TOKEN = object()
-
 
 class AuthorizationService:
     """Evaluate one request against closed action definitions and stage evidence."""
@@ -465,15 +462,13 @@ class AuthorizationService:
                 raise PreparedAuthorizationUnsupported(
                     AuthorizationDenialCode.PERMISSION_NOT_GRANTED
                 )
-            if scope.kind not in {
-                PreparedAuthorityScopeKind.SYSTEM,
-                PreparedAuthorityScopeKind.PROJECT,
-            }:
+            if scope.kind not in {PreparedAuthorityScopeKind.SYSTEM, PreparedAuthorityScopeKind.PROJECT}:
                 raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED)
             if scope.kind is PreparedAuthorityScopeKind.PROJECT and action_id not in {
                 ActionId.ADMIN_ROLE_GRANT_ISSUE,
                 ActionId.PROJECT_ROLE_GRANT_ISSUE,
                 ActionId.PROJECT_ROLE_GRANT_REVOKE,
+                *adapter_bindings.ADAPTER_BINDING_MUTATION_ACTIONS,
             }:
                 raise PreparedAuthorizationUnsupported(AuthorizationDenialCode.SCOPE_NOT_AUTHORIZED)
             await self._admin.lock_control()
@@ -502,6 +497,7 @@ class AuthorizationService:
                 scope_project_id=scope.project_id,
                 system_scope_only=scope.project_id is None,
                 for_update=True,
+                **adapter_bindings.finance_authority_grant_filters(action_id),
             )
             if grant is None:
                 raise PreparedAuthorizationUnsupported(
@@ -1226,6 +1222,10 @@ class AuthorizationService:
         grant_filters: dict[str, object] = {}
         if action.action_id is ActionId.PROJECT_ACTIVE_GUIDE_READ:
             grant_filters["allowed_roles"] = ACTIVE_GUIDE_ADMIN_ROLES
+        else:
+            grant_filters.update(
+                adapter_bindings.finance_authority_grant_filters(action.action_id)
+            )
         matched = await self._admin.find_effective_grant(
             context.actor_profile_id,
             action.permission_id,
@@ -1504,13 +1504,11 @@ class AuthorizationService:
             resource_context,
             (
                 PreSubmitCheckerInputResourceContext,
-                compilation.ProjectGuideCompilationRequestResourceContext,
-                compilation.ProjectGuideCompilationExecuteResourceContext,
+                compilation.ProjectGuideCompilationRequestResourceContext, compilation.ProjectGuideCompilationExecuteResourceContext,
+                adapter_bindings.AdapterBindingReadResourceContext, adapter_bindings.AdapterBindingMutationResourceContext,
             ),
         ):
-            project_id = getattr(resource_context, "project_id", None) or getattr(
-                resource_context, "scope_project_id"
-            )
+            project_id = getattr(resource_context, "project_id", None) or getattr(resource_context, "scope_project_id")
             audit_project_id = str(project_id)
             audit_resource_type = resource_context.resource_type
             audit_resource_id = str(resource_context.resource_id)
@@ -1530,6 +1528,7 @@ class AuthorizationService:
             ActionId.PROJECT_CREATE,
             *_GUIDE_BOUND_PROJECT_MANAGER_MUTATIONS,
             *_SUBMISSION_POLICY_MUTATIONS,
+            *adapter_bindings.ADAPTER_BINDING_ACTIONS,
         }:
             after_facts["resource_context_digest"] = decision.resource_context_digest
         try:

--- a/backend/app/modules/authorization/prepared.py
+++ b/backend/app/modules/authorization/prepared.py
@@ -36,6 +36,13 @@ from app.modules.authorization.domain.prepared_compilation import (
     parse_prepared_compilation,
     prepared_compilation_matches,
 )
+from app.modules.authorization.domain.adapter_bindings import (
+    AdapterBindingMutationResourceContext,
+)
+from app.modules.authorization.domain.prepared_adapter_bindings import (
+    parse_prepared_adapter_binding,
+    prepared_adapter_binding_matches,
+)
 from app.modules.authorization.domain.prepared_service import project_setup_resource_matches
 from app.modules.authorization.runtime import (
     ActorSelfResourceContext,
@@ -195,6 +202,8 @@ class _PreparedAuthorizationBinding:
     submission_preparation_final_digest: str | None = None
     guide_compilation_context: dict | None = None
     guide_compilation_resource_digest: str | None = None
+    adapter_binding_context: dict | None = None
+    adapter_binding_resource_digest: str | None = None
 
 
 @dataclass(slots=True)
@@ -466,6 +475,14 @@ class PreparedAuthorizationService:
         ) and not _guide_mutation_binding_matches(issuance.binding, final_resource_context):
             raise PreparedAuthorizationHandleInvalid("invalid prepared authorization handle")
         if isinstance(
+            final_resource_context, AdapterBindingMutationResourceContext
+        ) and not prepared_adapter_binding_matches(
+            issuance.binding.adapter_binding_context,
+            issuance.binding.adapter_binding_resource_digest,
+            final_resource_context,
+        ):
+            raise PreparedAuthorizationHandleInvalid("invalid prepared authorization handle")
+        if isinstance(
             final_resource_context,
             (
                 ProjectReviewPolicyMutationResourceContext,
@@ -561,6 +578,16 @@ class PreparedAuthorizationService:
         self._closed = True
         self._issued.clear()
 
+    def close_handle(self, handle: PreparedAuthorizationHandle) -> None:
+        """Invalidate one exact capability without closing the request service."""
+        if self._closed or type(handle) is not PreparedAuthorizationHandle:
+            raise PreparedAuthorizationHandleInvalid("invalid prepared authorization handle")
+        issuance = self._issued.pop(handle, None)
+        if issuance is None:
+            raise PreparedAuthorizationHandleInvalid("invalid prepared authorization handle")
+        if isinstance(issuance, _Issuance):
+            self._authorization._discard_prelocked(issuance.authority)
+
     def _root_transaction(self) -> object:
         if self._closed or self._session.in_nested_transaction():
             raise PreparedAuthorizationHandleInvalid("invalid prepared authorization handle")
@@ -576,7 +603,7 @@ class PreparedAuthorizationService:
             issuance = self._issued[handle]
             if isinstance(issuance, _Issuance):
                 self._authorization._discard_prelocked(issuance.authority)
-            del self._issued[handle]
+            self._issued[handle] = _CONSUMED
         return transaction
 
     def _binding(
@@ -585,10 +612,8 @@ class PreparedAuthorizationService:
         caller_input: PreparedAuthorizationInput,
         scope: PreparedAuthorityScope,
     ) -> _PreparedAuthorizationBinding:
-        operation_id = project_id = None
-        operation_generation = None
-        guide_mutation_project_id = guide_mutation_guide_id = None
-        guide_mutation_target_resource_id = guide_mutation_operation_id = None
+        operation_id = project_id = operation_generation = None
+        guide_mutation_project_id = guide_mutation_guide_id = guide_mutation_target_resource_id = guide_mutation_operation_id = None
         policy_mutation_project_id = policy_mutation_guide_id = None
         policy_mutation_policy_id = policy_mutation_operation_id = None
         policy_mutation_request_digest = None
@@ -856,6 +881,7 @@ class PreparedAuthorizationService:
                 )
             ),
             **compilation_binding,
+            **parse_prepared_adapter_binding(action_id, caller_input.request_value),
         )
 
     @staticmethod
@@ -882,6 +908,11 @@ class PreparedAuthorizationService:
         expected_project_mutation = PROJECT_MUTATION_RESOURCE_BY_ACTION.get(
             action_id
         ) or COMPILATION_RESOURCE_BY_ACTION.get(action_id)
+        if isinstance(resource, AdapterBindingMutationResourceContext):
+            return PreparedAuthorityScope(
+                kind=PreparedAuthorityScopeKind.PROJECT,
+                project_id=resource.scope_project_id,
+            )
         if action_id in {
             ActionId.PROJECT_GUIDE_CREATE,
             ActionId.PROJECT_GUIDE_UPDATE,

--- a/backend/app/modules/authorization/prepared.py
+++ b/backend/app/modules/authorization/prepared.py
@@ -37,6 +37,7 @@ from app.modules.authorization.domain.prepared_compilation import (
     prepared_compilation_matches,
 )
 from app.modules.authorization.domain.adapter_bindings import (
+    ADAPTER_BINDING_MUTATION_ACTIONS,
     AdapterBindingMutationResourceContext,
 )
 from app.modules.authorization.domain.prepared_adapter_bindings import (
@@ -908,7 +909,9 @@ class PreparedAuthorizationService:
         expected_project_mutation = PROJECT_MUTATION_RESOURCE_BY_ACTION.get(
             action_id
         ) or COMPILATION_RESOURCE_BY_ACTION.get(action_id)
-        if isinstance(resource, AdapterBindingMutationResourceContext):
+        if action_id in ADAPTER_BINDING_MUTATION_ACTIONS and isinstance(
+            resource, AdapterBindingMutationResourceContext
+        ):
             return PreparedAuthorityScope(
                 kind=PreparedAuthorityScopeKind.PROJECT,
                 project_id=resource.scope_project_id,

--- a/backend/app/modules/authorization/runtime.py
+++ b/backend/app/modules/authorization/runtime.py
@@ -15,6 +15,7 @@ from app.modules.authorization.domain.guide_compilation import (
     ProjectGuideCompilationRequestResourceContext,
     persisted_result_digest,
 )
+from app.modules.authorization.domain.adapter_bindings import AdapterBindingMutationResourceContext, AdapterBindingReadResourceContext
 from app.modules.authorization.domain.project_create import ProjectCreateResourceContext
 from app.modules.actors.service_identities import ServiceIdentity
 from app.modules.authorization.catalogue import ActionId, PermissionId
@@ -30,13 +31,10 @@ PROJECT_DIAGNOSTIC_TARGET_KIND_BY_ACTION = {
     ActionId.PROJECT_SUBMISSION_ARTIFACT_POLICY_READ: "submission_artifact_policy",
     ActionId.PROJECT_POST_SUBMIT_CHECKER_POLICY_SETUP_READ: ("post_submit_checker_policy_setup"),
 }
-
 PROJECT_POLICY_READ_TARGET_KIND_BY_ACTION = {
     ActionId.PROJECT_EFFECTIVE_SUBMISSION_ARTIFACT_POLICY_READ: "effective_policy",
     ActionId.PROJECT_PRE_SUBMIT_CHECKER_POLICY_READ: "pre_submit_checker_policy",
 }
-
-
 class ActorKind(StrEnum):
     """Canonical actor kinds visible to authorization."""
 
@@ -1520,6 +1518,7 @@ AuthorizationResourceContext = (
     | PreSubmitCheckerInputResourceContext
     | SubmissionBundlePreparationPreflightResourceContext
     | SubmissionBundlePreparationResourceContext
+    | AdapterBindingReadResourceContext | AdapterBindingMutationResourceContext
 )
 
 
@@ -1610,7 +1609,7 @@ class AuthorizationDecision(BaseModel):
         "pre_submit_checker_input",
         "submission_bundle_preparation_preflight",
         "submission_bundle_preparation",
-        "submission_creation", "submission_binding",
+        "submission_creation", "submission_binding", "compensation_adapter_binding",
     ]
     resource_id: (
         UUID

--- a/backend/scripts/authorization_boundary.py
+++ b/backend/scripts/authorization_boundary.py
@@ -25,6 +25,7 @@ DYNAMIC_LOADING_MODULES = {
 }
 INBOUND_HEADING = "## Inbound private-import debt"
 OUTBOUND_HEADING = "## AUTH outbound private-import debt"
+AUTH_ADAPTER_ROOT = "backend/app/adapters/auth/__init__.py"
 
 
 class AuthorizationBoundaryError(RuntimeError):
@@ -259,7 +260,11 @@ def scan_edges(root: Path) -> tuple[set[ImportEdge], set[ImportEdge]]:
         source = _repository_path(path, root)
         module = _module_name(path, root)
         imports = source_imports(path, root)
-        inside_auth = module == AUTH_PACKAGE or module.startswith(f"{AUTH_PACKAGE}.")
+        inside_auth = (
+            module == AUTH_PACKAGE
+            or module.startswith(f"{AUTH_PACKAGE}.")
+            or source == AUTH_ADAPTER_ROOT
+        )
         if inside_auth:
             outbound.update(
                 ImportEdge(source, target) for target in imports if _private_product_target(target)

--- a/backend/scripts/behavior_ownership.py
+++ b/backend/scripts/behavior_ownership.py
@@ -130,6 +130,14 @@ ARCH_CP03A_OWNER_ELIGIBILITY_TARGETS = frozenset(
         "backend/app/modules/projects/compensation_binding.py",
     }
 )
+ARCH_CP03B_ADAPTER_BINDING_AUTH_TARGETS = frozenset(
+    {
+        "backend/app/adapters/auth/adapter_bindings.py",
+        "backend/app/modules/authorization/adapter_binding_authorization.py",
+        "backend/app/modules/authorization/domain/adapter_bindings.py",
+        "backend/app/modules/authorization/domain/prepared_adapter_bindings.py",
+    }
+)
 POL_03A_CALLABLE_TARGETS = frozenset(
     {
         "backend/app/modules/authorization/api/project_guide_compilation.py",
@@ -323,6 +331,7 @@ def _validate_additive_partition_transition(
         | ARCH_02H_AUTH_CONSUMPTION_TARGETS
         | ARCH_CP02_ADAPTER_BINDING_TARGETS
         | ARCH_CP03A_OWNER_ELIGIBILITY_TARGETS
+        | ARCH_CP03B_ADAPTER_BINDING_AUTH_TARGETS
         | V01_BASELINE_ADDED_TARGETS
     )
     expected_additions = (approved_additions & additions) - set(trusted_targets)

--- a/backend/scripts/module_boundaries.py
+++ b/backend/scripts/module_boundaries.py
@@ -130,7 +130,7 @@ def _source_owner_adapter(source: str) -> str | None:
     parts = source.removeprefix(prefix).split("/")
     if len(parts) != 2 or parts[1] != "__init__.py":
         return None
-    return parts[0]
+    return "authorization" if parts[0] == "auth" else parts[0]
 
 
 def _is_public_target(target: str, module: str) -> bool:
@@ -199,6 +199,10 @@ def scan(root: Path, registry: Registry) -> tuple[set[PrivateEdge], dict[str, se
         source = path.relative_to(root).as_posix()
         source_module = _source_module(source)
         source_owner_adapter = _source_owner_adapter(source)
+        source_is_auth = (
+            source_module == "authorization"
+            or source == authorization_boundary.AUTH_ADAPTER_ROOT
+        )
         canonical_imports = authorization_boundary.source_imports(path, root)
         exact_imports = exact_source_imports(path, root, source_validated=True)
         for target in canonical_imports:
@@ -210,22 +214,22 @@ def scan(root: Path, registry: Registry) -> tuple[set[PrivateEdge], dict[str, se
             if source_module == target_module:
                 continue
             edge = authorization_boundary.ImportEdge(source, target)
-            if source_module == "authorization" or target_module == "authorization":
+            if source_module == target_module or (
+                source_is_auth and source_owner_adapter == target_module
+            ):
+                continue
+            if source_is_auth or target_module == "authorization":
                 if not _is_public_target(target, target_module):
                     auth_edges.add(edge)
-            if source_owner_adapter == target_module:
-                continue
         for target in exact_imports:
             target_module = _module_from_target(target)
             if target_module is None:
                 continue
             if target_module not in registry.names:
                 raise ModuleBoundaryError("unknown_module")
-            if source_module == target_module:
+            if source_module == target_module or source_owner_adapter == target_module:
                 continue
-            if source_owner_adapter == target_module:
-                continue
-            if source_module == "authorization" or target_module == "authorization":
+            if source_is_auth or target_module == "authorization":
                 continue
             if _is_public_target(target, target_module):
                 if source_module is not None:

--- a/backend/scripts/run_test_lanes.py
+++ b/backend/scripts/run_test_lanes.py
@@ -151,6 +151,7 @@ SHARED_FOUNDATION_MODULES = (
     "tests/authorization/guide_compilation/test_domain_contract.py",
     "tests/authorization/guide_compilation/test_migration_contract.py",
     "tests/authorization/test_fixed_service_action_context.py",
+    "tests/authorization/test_adapter_binding_authorization.py",
     "tests/authorization/test_adapter_binding_registration.py",
     "tests/authorization/test_contribution_policy_registration.py",
     "tests/test_behavior_ownership.py",

--- a/backend/tests/architecture/test_authorization_boundary.py
+++ b/backend/tests/architecture/test_authorization_boundary.py
@@ -44,6 +44,29 @@ def test_repository_private_import_edges_equal_the_frozen_ledger() -> None:
     boundary.validate(ROOT, LEDGER)
 
 
+def test_only_exact_auth_adapter_root_has_same_owner_private_access(
+    tmp_path: Path,
+) -> None:
+    """Nested adapters remain public consumers while the exact root may compose AUTH."""
+    root = _minimal_root(tmp_path)
+    _write_module(
+        root,
+        "backend/app/adapters/auth/__init__.py",
+        "from app.modules.authorization.kernel import AuthorizationService\n",
+    )
+    nested = "backend/app/adapters/auth/adapter_bindings.py"
+    _write_module(
+        root,
+        nested,
+        "from app.modules.authorization.kernel import AuthorizationService\n",
+    )
+    inbound, outbound = boundary.scan_edges(root)
+    assert inbound == {
+        boundary.ImportEdge(nested, "app.modules.authorization.kernel")
+    }
+    assert outbound == set()
+
+
 def test_public_api_reachability_contains_no_private_runtime_module() -> None:
     """Every public value is defined by the API package or the standard library."""
     forbidden = (

--- a/backend/tests/architecture/test_module_boundaries.py
+++ b/backend/tests/architecture/test_module_boundaries.py
@@ -549,6 +549,38 @@ def test_authorization_adapter_root_is_present_in_canonical_auth_view(
     }
 
 
+def test_exact_auth_adapter_root_uses_owner_parity_without_nested_exception(
+    tmp_path: Path,
+) -> None:
+    """Root wiring is AUTH-owned while nested/private product edges stay visible."""
+    _registry(tmp_path / "registry.json")
+    _write(
+        tmp_path / "backend/app/adapters/auth/__init__.py",
+        "import app.modules.authorization.runtime\n"
+        "import app.modules.tasks.repository\n",
+    )
+    nested = "backend/app/adapters/auth/adapter_bindings.py"
+    _write(
+        tmp_path / nested,
+        "import app.modules.authorization.kernel\n",
+    )
+    registry = boundary.load_registry(tmp_path / "registry.json")
+
+    private, _, actual_auth = boundary.scan(tmp_path, registry)
+
+    assert private == set()
+    assert actual_auth == {
+        boundary.authorization_boundary.ImportEdge(
+            "backend/app/adapters/auth/__init__.py",
+            "app.modules.tasks.repository",
+        ),
+        boundary.authorization_boundary.ImportEdge(
+            nested,
+            "app.modules.authorization.kernel",
+        ),
+    }
+
+
 @pytest.mark.parametrize(
     "source",
     (

--- a/backend/tests/authorization/test_adapter_binding_authorization.py
+++ b/backend/tests/authorization/test_adapter_binding_authorization.py
@@ -49,9 +49,19 @@ class _Session:
 
 
 class _FinanceRepository:
-    def __init__(self, grant_project_id: UUID | None) -> None:
+    def __init__(
+        self,
+        grant_project_id: UUID | None,
+        *,
+        grant_available: bool = True,
+        actor_status: ActorStatus = ActorStatus.ACTIVE,
+        link_status: IdentityLinkStatus = IdentityLinkStatus.ACTIVE,
+    ) -> None:
         self.grant_id = uuid4()
         self.grant_project_id = grant_project_id
+        self.grant_available = grant_available
+        self.actor_status = actor_status
+        self.link_status = link_status
 
     async def lock_control(self) -> None:
         return None
@@ -61,13 +71,17 @@ class _FinanceRepository:
             SimpleNamespace(
                 id=str(identity_link_id),
                 actor_profile_id=str(actor_profile_id),
-                status="active",
+                status=self.link_status.value,
             ),
-            SimpleNamespace(id=str(actor_profile_id), actor_kind="human", status="active"),
+            SimpleNamespace(
+                id=str(actor_profile_id), actor_kind="human", status=self.actor_status.value
+            ),
         )
 
     async def find_effective_grant(self, *_args, **kwargs):
         assert {role.value for role in kwargs["allowed_roles"]} == {"finance_authority"}
+        if not self.grant_available:
+            return None
         requested = kwargs["scope_project_id"]
         if self.grant_project_id is not None and requested != self.grant_project_id:
             return None
@@ -92,18 +106,29 @@ class _Evidence:
         self.events.append(event)
 
 
-def _adapter(project_id: UUID | None):
+def _adapter(
+    project_id: UUID | None,
+    *,
+    actor_status: ActorStatus = ActorStatus.ACTIVE,
+    link_status: IdentityLinkStatus = IdentityLinkStatus.ACTIVE,
+    grant_available: bool = True,
+):
     context = HumanAuthorizationContext(
         actor_profile_id=uuid4(),
         actor_kind=ActorKind.HUMAN,
-        actor_status=ActorStatus.ACTIVE,
+        actor_status=actor_status,
         identity_link_id=uuid4(),
-        identity_link_status=IdentityLinkStatus.ACTIVE,
+        identity_link_status=link_status,
         request_id=uuid4(),
         correlation_id=uuid4(),
     )
     session = _Session()
-    repository = _FinanceRepository(project_id)
+    repository = _FinanceRepository(
+        project_id,
+        grant_available=grant_available,
+        actor_status=actor_status,
+        link_status=link_status,
+    )
     kernel = AuthorizationService(
         session,
         context,
@@ -152,6 +177,102 @@ def _transition_facts(
         expected_status=("active" if action.endswith("suspend") else "suspended"),
         expected_lifecycle_version=4,
     )
+
+
+def _facts_for_action(
+    actor_id: UUID, project_id: UUID, action: str
+) -> AdapterBindingMutationAuthorityFacts:
+    return (
+        _create_facts(actor_id, project_id)
+        if action.endswith("create")
+        else _transition_facts(actor_id, project_id, action)
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("project_scoped", (False, True))
+async def test_system_and_project_finance_authority_can_read_exact_binding(
+    project_scoped: bool,
+) -> None:
+    project_id = uuid4()
+    adapter, context, _session, evidence = _adapter(project_id if project_scoped else None)
+    await adapter.authorize_read(
+        actor_profile_id=context.actor_profile_id,
+        facts=AdapterBindingReadFacts(project_id=project_id, adapter_binding_id=uuid4()),
+    )
+    assert len(evidence.events) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("project_scoped", (False, True))
+@pytest.mark.parametrize(
+    "action",
+    (
+        "compensation.adapter_binding.create",
+        "compensation.adapter_binding.suspend",
+        "compensation.adapter_binding.resume",
+    ),
+)
+async def test_system_and_project_finance_authority_can_consume_every_mutation(
+    project_scoped: bool,
+    action: str,
+) -> None:
+    project_id = uuid4()
+    adapter, context, _session, evidence = _adapter(project_id if project_scoped else None)
+    facts = _facts_for_action(context.actor_profile_id, project_id, action)
+    prepared = await adapter.prepare_mutation(facts)
+    assert await adapter.consume_mutation(prepared, facts) == context.actor_profile_id
+    adapter.close_mutation(prepared)
+    assert len(evidence.events) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("actor_status", "link_status"),
+    (
+        (ActorStatus.SUSPENDED, IdentityLinkStatus.ACTIVE),
+        (ActorStatus.DEACTIVATED, IdentityLinkStatus.ACTIVE),
+        (ActorStatus.ACTIVE, IdentityLinkStatus.REVOKED),
+    ),
+)
+async def test_inactive_actor_or_identity_link_denies_before_authority_issuance(
+    actor_status: ActorStatus,
+    link_status: IdentityLinkStatus,
+) -> None:
+    project_id = uuid4()
+    adapter, context, _session, evidence = _adapter(
+        project_id, actor_status=actor_status, link_status=link_status
+    )
+    with pytest.raises(AuthorizationDenied):
+        await adapter.prepare_mutation(_create_facts(context.actor_profile_id, project_id))
+    assert evidence.events == []
+
+
+@pytest.mark.asyncio
+async def test_missing_or_stale_finance_grant_denies_every_binding_operation() -> None:
+    project_id = uuid4()
+    adapter, context, _session, evidence = _adapter(project_id, grant_available=False)
+    with pytest.raises(AuthorizationDenied):
+        await adapter.authorize_read(
+            actor_profile_id=context.actor_profile_id,
+            facts=AdapterBindingReadFacts(project_id=project_id, adapter_binding_id=uuid4()),
+        )
+    with pytest.raises(AuthorizationDenied):
+        await adapter.prepare_mutation(_create_facts(context.actor_profile_id, project_id))
+    assert len(evidence.events) == 1 and not evidence.events[0].after_facts["allowed"]
+
+
+@pytest.mark.asyncio
+async def test_non_human_context_cannot_receive_finance_authority() -> None:
+    project_id = uuid4()
+    adapter, context, _session, evidence = _adapter(project_id)
+    adapter._authorization._context = SimpleNamespace(
+        actor_profile_id=context.actor_profile_id,
+        actor_kind=ActorKind.SERVICE,
+    )
+    with pytest.raises(AuthorizationDenied):
+        await adapter.prepare_mutation(_create_facts(context.actor_profile_id, project_id))
+    assert evidence.events == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/authorization/test_adapter_binding_authorization.py
+++ b/backend/tests/authorization/test_adapter_binding_authorization.py
@@ -1,0 +1,226 @@
+"""Focused AUTH proof for Finance Authority adapter-binding activation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.modules.audit.schemas import AuthorityAuditEventInput
+from app.modules.authorization.adapter_binding_authorization import (
+    AdapterBindingAuthorizationAdapter,
+)
+from app.modules.authorization.api import (
+    AdapterBindingMutationAuthorityFacts,
+    AdapterBindingReadFacts,
+    AuthorizationDenied,
+    PreparedAuthorizationInvalid,
+    action_id,
+)
+from app.modules.authorization.kernel import AuthorizationService
+from app.modules.authorization.catalogue import ActionId
+from app.modules.authorization.domain.adapter_bindings import (
+    AdapterBindingMutationResourceContext,
+)
+from app.modules.authorization.prepared import PreparedAuthorizationService
+from app.modules.authorization.runtime import (
+    ActorKind,
+    ActorStatus,
+    HumanAuthorizationContext,
+    IdentityLinkStatus,
+    AuthorizationDenied as KernelAuthorizationDenied,
+)
+
+
+class _Session:
+    def __init__(self) -> None:
+        self.root = SimpleNamespace(is_active=True)
+        self.sync_session = self
+
+    def get_transaction(self):
+        return self.root
+
+    def in_transaction(self) -> bool:
+        return True
+
+    def in_nested_transaction(self) -> bool:
+        return False
+
+
+class _FinanceRepository:
+    def __init__(self, grant_project_id: UUID | None) -> None:
+        self.grant_id = uuid4()
+        self.grant_project_id = grant_project_id
+
+    async def lock_control(self) -> None:
+        return None
+
+    async def lock_request_actor(self, identity_link_id, actor_profile_id):
+        return (
+            SimpleNamespace(
+                id=str(identity_link_id),
+                actor_profile_id=str(actor_profile_id),
+                status="active",
+            ),
+            SimpleNamespace(id=str(actor_profile_id), actor_kind="human", status="active"),
+        )
+
+    async def find_effective_grant(self, *_args, **kwargs):
+        assert {role.value for role in kwargs["allowed_roles"]} == {"finance_authority"}
+        requested = kwargs["scope_project_id"]
+        if self.grant_project_id is not None and requested != self.grant_project_id:
+            return None
+        return SimpleNamespace(
+            id=self.grant_id,
+            status="active",
+            scope_type="system" if self.grant_project_id is None else "project",
+            scope_project_id=(
+                None if self.grant_project_id is None else str(self.grant_project_id)
+            ),
+        )
+
+    async def has_effective_permission_any_scope(self, *_args, **_kwargs) -> bool:
+        return True
+
+
+class _Evidence:
+    def __init__(self) -> None:
+        self.events: list[AuthorityAuditEventInput] = []
+
+    async def add_authority_event(self, event: AuthorityAuditEventInput) -> None:
+        self.events.append(event)
+
+
+def _adapter(project_id: UUID | None):
+    context = HumanAuthorizationContext(
+        actor_profile_id=uuid4(),
+        actor_kind=ActorKind.HUMAN,
+        actor_status=ActorStatus.ACTIVE,
+        identity_link_id=uuid4(),
+        identity_link_status=IdentityLinkStatus.ACTIVE,
+        request_id=uuid4(),
+        correlation_id=uuid4(),
+    )
+    session = _Session()
+    repository = _FinanceRepository(project_id)
+    kernel = AuthorizationService(
+        session,
+        context,
+        admin_repository=repository,  # type: ignore[arg-type]
+    )
+    evidence = _Evidence()
+    kernel._audit = evidence  # type: ignore[assignment]
+    prepared = PreparedAuthorizationService(
+        session,
+        context,
+        kernel,
+        repository,  # type: ignore[arg-type]
+    )
+    return AdapterBindingAuthorizationAdapter(kernel, prepared), context, session, evidence
+
+
+def _create_facts(actor_id: UUID, project_id: UUID) -> AdapterBindingMutationAuthorityFacts:
+    return AdapterBindingMutationAuthorityFacts(
+        action_id=action_id("compensation.adapter_binding.create"),
+        actor_profile_id=actor_id,
+        operation_id=uuid4(),
+        request_digest="sha256:" + "a" * 64,
+        project_id=project_id,
+        adapter_binding_id=uuid4(),
+        instrument_type="money",
+        adapter_actor_id=uuid4(),
+        route_key="stripe.primary",
+        expected_status=None,
+        expected_lifecycle_version=None,
+    )
+
+
+def _transition_facts(
+    actor_id: UUID, project_id: UUID, action: str
+) -> AdapterBindingMutationAuthorityFacts:
+    return AdapterBindingMutationAuthorityFacts(
+        action_id=action_id(action),
+        actor_profile_id=actor_id,
+        operation_id=uuid4(),
+        request_digest="sha256:" + "c" * 64,
+        project_id=project_id,
+        adapter_binding_id=uuid4(),
+        instrument_type="project_points",
+        adapter_actor_id=uuid4(),
+        route_key="points.primary",
+        expected_status=("active" if action.endswith("suspend") else "suspended"),
+        expected_lifecycle_version=4,
+    )
+
+
+@pytest.mark.asyncio
+async def test_project_finance_authority_reads_and_consumes_exact_create_once() -> None:
+    project_id = uuid4()
+    adapter, context, _session, evidence = _adapter(project_id)
+    await adapter.authorize_read(
+        actor_profile_id=context.actor_profile_id,
+        facts=AdapterBindingReadFacts(project_id=project_id, adapter_binding_id=uuid4()),
+    )
+    facts = _create_facts(context.actor_profile_id, project_id)
+    prepared = await adapter.prepare_mutation(facts)
+    assert await adapter.consume_mutation(prepared, facts) == context.actor_profile_id
+    adapter.close_mutation(prepared)
+    assert len(evidence.events) == 2
+    with pytest.raises(PreparedAuthorizationInvalid):
+        await adapter.consume_mutation(prepared, facts)
+
+
+@pytest.mark.asyncio
+async def test_wrong_actor_and_cross_project_deny_before_authority_issuance() -> None:
+    project_id = uuid4()
+    adapter, context, _session, evidence = _adapter(project_id)
+    with pytest.raises(AuthorizationDenied):
+        await adapter.prepare_mutation(_create_facts(uuid4(), project_id))
+    cross_project = _create_facts(context.actor_profile_id, uuid4())
+    with pytest.raises(AuthorizationDenied):
+        await adapter.prepare_mutation(cross_project)
+    assert evidence.events == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action",
+    (
+        "compensation.adapter_binding.suspend",
+        "compensation.adapter_binding.resume",
+    ),
+)
+async def test_system_finance_authority_consumes_exact_transition(
+    action: str,
+) -> None:
+    project_id = uuid4()
+    adapter, context, _session, evidence = _adapter(None)
+    facts = _transition_facts(context.actor_profile_id, project_id, action)
+    prepared = await adapter.prepare_mutation(facts)
+    assert await adapter.consume_mutation(prepared, facts) == context.actor_profile_id
+    adapter.close_mutation(prepared)
+    assert len(evidence.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_replaced_transaction_invalidates_prepared_authority() -> None:
+    project_id = uuid4()
+    adapter, context, session, _evidence = _adapter(project_id)
+    facts = _create_facts(context.actor_profile_id, project_id)
+    prepared = await adapter.prepare_mutation(facts)
+    session.root = SimpleNamespace(is_active=True)
+    with pytest.raises(PreparedAuthorizationInvalid):
+        await adapter.consume_mutation(prepared, facts)
+    adapter.close_mutation(prepared)
+
+
+@pytest.mark.asyncio
+async def test_mutation_action_cannot_bypass_prep_through_direct_kernel_require() -> None:
+    project_id = uuid4()
+    adapter, context, _session, _evidence = _adapter(project_id)
+    facts = _create_facts(context.actor_profile_id, project_id)
+    _, resource = adapter._mutation_context(facts)
+    assert isinstance(resource, AdapterBindingMutationResourceContext)
+    with pytest.raises(KernelAuthorizationDenied):
+        await adapter._authorization.require(ActionId.COMPENSATION_ADAPTER_BINDING_CREATE, resource)

--- a/backend/tests/authorization/test_adapter_binding_authorization.py
+++ b/backend/tests/authorization/test_adapter_binding_authorization.py
@@ -15,9 +15,11 @@ from app.modules.authorization.api import (
     AdapterBindingMutationAuthorityFacts,
     AdapterBindingReadFacts,
     AuthorizationDenied,
+    AuthorizationUnavailable,
     PreparedAuthorizationInvalid,
     action_id,
 )
+from sqlalchemy.exc import SQLAlchemyError
 from app.modules.authorization.kernel import AuthorizationService
 from app.modules.authorization.catalogue import ActionId
 from app.modules.authorization.domain.adapter_bindings import (
@@ -104,6 +106,13 @@ class _Evidence:
 
     async def add_authority_event(self, event: AuthorityAuditEventInput) -> None:
         self.events.append(event)
+
+
+class _UnavailableEvidence(_Evidence):
+    async def add_authority_event(self, event: AuthorityAuditEventInput) -> None:
+        """Simulate failure to persist mandatory authorization evidence."""
+        del event
+        raise SQLAlchemyError("evidence unavailable")
 
 
 def _adapter(
@@ -249,7 +258,17 @@ async def test_inactive_actor_or_identity_link_denies_before_authority_issuance(
 
 
 @pytest.mark.asyncio
-async def test_missing_or_stale_finance_grant_denies_every_binding_operation() -> None:
+@pytest.mark.parametrize(
+    "action",
+    (
+        "compensation.adapter_binding.create",
+        "compensation.adapter_binding.suspend",
+        "compensation.adapter_binding.resume",
+    ),
+)
+async def test_missing_or_stale_finance_grant_denies_every_binding_operation(
+    action: str,
+) -> None:
     project_id = uuid4()
     adapter, context, _session, evidence = _adapter(project_id, grant_available=False)
     with pytest.raises(AuthorizationDenied):
@@ -258,8 +277,33 @@ async def test_missing_or_stale_finance_grant_denies_every_binding_operation() -
             facts=AdapterBindingReadFacts(project_id=project_id, adapter_binding_id=uuid4()),
         )
     with pytest.raises(AuthorizationDenied):
-        await adapter.prepare_mutation(_create_facts(context.actor_profile_id, project_id))
+        await adapter.prepare_mutation(
+            _facts_for_action(context.actor_profile_id, project_id, action)
+        )
     assert len(evidence.events) == 1 and not evidence.events[0].after_facts["allowed"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ("read", "consume"))
+async def test_evidence_failure_is_a_stable_unavailable_boundary(operation: str) -> None:
+    project_id = uuid4()
+    adapter, context, _session, _evidence = _adapter(project_id)
+    facts = _create_facts(context.actor_profile_id, project_id)
+    prepared = await adapter.prepare_mutation(facts) if operation == "consume" else None
+    adapter._authorization._audit = _UnavailableEvidence()  # type: ignore[assignment]
+
+    with pytest.raises(AuthorizationUnavailable, match="unavailable"):
+        if operation == "read":
+            await adapter.authorize_read(
+                actor_profile_id=context.actor_profile_id,
+                facts=AdapterBindingReadFacts(
+                    project_id=project_id,
+                    adapter_binding_id=uuid4(),
+                ),
+            )
+        else:
+            assert prepared is not None
+            await adapter.consume_mutation(prepared, facts)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/authorization/test_adapter_binding_registration.py
+++ b/backend/tests/authorization/test_adapter_binding_registration.py
@@ -46,14 +46,13 @@ _ACTIONS = {
 }
 
 
-def test_cp01a_registers_only_exact_planned_binding_actions() -> None:
+def test_cp03b_activates_only_exact_binding_actions() -> None:
     for action in _ACTIONS:
         definition = ACTION_BY_ID[action]
         assert definition.permission_id is PermissionId.COMPENSATION_ADAPTER_BINDING_MANAGE
         assert definition.owner is ActionOwner.ARCH_CP01A
-        assert definition.availability is ActionAvailability.PLANNED
-        with pytest.raises(ValueError, match="authorization action is not active"):
-            resolve_executable_action(action)
+        assert definition.availability is ActionAvailability.ACTIVE
+        assert resolve_executable_action(action) is definition
 
     assert "compensation.adapter_binding.retire" not in {item.value for item in ActionId}
     assert all(_ACTIONS.isdisjoint(actions) for actions in SERVICE_ACTIONS_BY_IDENTITY.values())

--- a/backend/tests/compensation/test_adapter_binding_authorization_integration.py
+++ b/backend/tests/compensation/test_adapter_binding_authorization_integration.py
@@ -159,8 +159,19 @@ async def test_public_adapter_preserves_exact_read_and_mutation_facts() -> None:
     adapter.close_adapter_binding_mutation(prepared)
     translated = authorization.calls[1][1]
     assert authorization.calls[0][1]["actor_profile_id"] == read.actor_profile_id
+    assert authorization.calls[0][1]["facts"].project_id == read.project_id
+    assert authorization.calls[0][1]["facts"].adapter_binding_id == read.adapter_binding_id
+    assert translated.action_id == facts.action
+    assert translated.actor_profile_id == facts.actor_profile_id
+    assert translated.operation_id == facts.operation_id
+    assert translated.request_digest == facts.request_digest
+    assert translated.project_id == facts.project_id
+    assert translated.adapter_binding_id == facts.adapter_binding_id
     assert translated.instrument_type == facts.instrument_type
-    assert translated.expected_lifecycle_version == 3
+    assert translated.adapter_actor_id == facts.adapter_actor_id
+    assert translated.route_key == facts.route_key
+    assert translated.expected_status == facts.expected_status
+    assert translated.expected_lifecycle_version == facts.expected_lifecycle_version
     assert actor == facts.actor_profile_id
     assert authorization.calls[-1] == ("close", authorization.handle)
 

--- a/backend/tests/compensation/test_adapter_binding_authorization_integration.py
+++ b/backend/tests/compensation/test_adapter_binding_authorization_integration.py
@@ -1,4 +1,6 @@
-"""CP03A composition proof while adapter-binding AUTH remains unavailable."""
+"""Public-port composition proof for CON-to-AUTH adapter binding."""
+
+from __future__ import annotations
 
 from datetime import UTC, datetime
 from uuid import uuid4
@@ -7,16 +9,60 @@ import pytest
 from sqlalchemy import func, select
 
 from app.db import session as db_session
+from app.adapters.auth.adapter_bindings import CompensationAdapterBindingAuthorization
 from app.modules.actors.api import ServiceIdentity
 from app.modules.actors.compensation_adapter import CompensationAdapterActorEligibility
 from app.modules.actors.models import ActorIdentityLink, ActorProfile
-from app.modules.compensation.api import AdapterBindingCreateRequest, AdapterBindingUnavailable
+from app.modules.authorization.api import AuthorizationDenied
+from app.modules.compensation.api import (
+    AdapterBindingCreateRequest,
+    AdapterBindingMutationAuthorizationFacts,
+    AdapterBindingReadRequest,
+    AdapterBindingUnavailable,
+)
 from app.modules.compensation.models import ProjectCompensationAdapterBinding
 from app.modules.compensation.service import AdapterBindingService
 from app.modules.projects.compensation_binding import ProjectCompensationBindingEligibility
 from project_create_fixtures import insert_historical_project
 
+
 pytest_plugins = ("adapter_binding_fixtures",)
+
+
+class _Authorization:
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+        self.handle = object()
+
+    async def authorize_read(self, **kwargs) -> None:
+        self.calls.append(("read", kwargs))
+
+    async def prepare_mutation(self, facts):
+        self.calls.append(("prepare", facts))
+        return self.handle
+
+    async def consume_mutation(self, prepared, facts):
+        self.calls.append(("consume", prepared, facts))
+        return facts.actor_profile_id
+
+    def close_mutation(self, prepared) -> None:
+        self.calls.append(("close", prepared))
+
+
+def _facts() -> AdapterBindingMutationAuthorizationFacts:
+    return AdapterBindingMutationAuthorizationFacts(
+        action="compensation.adapter_binding.suspend",
+        actor_profile_id=uuid4(),
+        operation_id=uuid4(),
+        request_digest="sha256:" + "b" * 64,
+        project_id=uuid4(),
+        adapter_binding_id=uuid4(),
+        instrument_type="project_points",
+        adapter_actor_id=uuid4(),
+        route_key="points.primary",
+        expected_status="active",
+        expected_lifecycle_version=3,
+    )
 
 
 @pytest.mark.asyncio
@@ -97,3 +143,41 @@ async def test_real_owner_eligibility_does_not_activate_binding_authority(
             select(func.count()).select_from(ProjectCompensationAdapterBinding)
         )
         assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_public_adapter_preserves_exact_read_and_mutation_facts() -> None:
+    authorization = _Authorization()
+    adapter = CompensationAdapterBindingAuthorization(authorization)
+    read = AdapterBindingReadRequest(
+        actor_profile_id=uuid4(), project_id=uuid4(), adapter_binding_id=uuid4()
+    )
+    await adapter.authorize_adapter_binding_read(read)
+    facts = _facts()
+    prepared = await adapter.prepare_adapter_binding_mutation(facts)
+    actor = await adapter.consume_adapter_binding_mutation(prepared, facts)
+    adapter.close_adapter_binding_mutation(prepared)
+    translated = authorization.calls[1][1]
+    assert authorization.calls[0][1]["actor_profile_id"] == read.actor_profile_id
+    assert translated.instrument_type == facts.instrument_type
+    assert translated.expected_lifecycle_version == 3
+    assert actor == facts.actor_profile_id
+    assert authorization.calls[-1] == ("close", authorization.handle)
+
+
+@pytest.mark.asyncio
+async def test_public_adapter_conceals_auth_boundary_denial() -> None:
+    class _Denied(_Authorization):
+        async def authorize_read(self, **kwargs) -> None:
+            del kwargs
+            raise AuthorizationDenied("denied")
+
+    adapter = CompensationAdapterBindingAuthorization(_Denied())
+    with pytest.raises(AdapterBindingUnavailable, match="unavailable"):
+        await adapter.authorize_adapter_binding_read(
+            AdapterBindingReadRequest(
+                actor_profile_id=uuid4(),
+                project_id=uuid4(),
+                adapter_binding_id=uuid4(),
+            )
+        )

--- a/backend/tests/compensation/test_adapter_binding_authorization_integration.py
+++ b/backend/tests/compensation/test_adapter_binding_authorization_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from uuid import uuid4
 
@@ -158,6 +159,7 @@ async def test_public_adapter_preserves_exact_read_and_mutation_facts() -> None:
     actor = await adapter.consume_adapter_binding_mutation(prepared, facts)
     adapter.close_adapter_binding_mutation(prepared)
     translated = authorization.calls[1][1]
+    consumed = authorization.calls[2][2]
     assert authorization.calls[0][1]["actor_profile_id"] == read.actor_profile_id
     assert authorization.calls[0][1]["facts"].project_id == read.project_id
     assert authorization.calls[0][1]["facts"].adapter_binding_id == read.adapter_binding_id
@@ -172,6 +174,7 @@ async def test_public_adapter_preserves_exact_read_and_mutation_facts() -> None:
     assert translated.route_key == facts.route_key
     assert translated.expected_status == facts.expected_status
     assert translated.expected_lifecycle_version == facts.expected_lifecycle_version
+    assert consumed == translated
     assert actor == facts.actor_profile_id
     assert authorization.calls[-1] == ("close", authorization.handle)
 
@@ -192,3 +195,44 @@ async def test_public_adapter_conceals_auth_boundary_denial() -> None:
                 adapter_binding_id=uuid4(),
             )
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ("prepare", "consume", "close"))
+async def test_public_adapter_conceals_each_mutation_boundary_denial(
+    operation: str,
+) -> None:
+    class _Denied(_Authorization):
+        async def prepare_mutation(self, facts):
+            del facts
+            raise AuthorizationDenied("denied")
+
+        async def consume_mutation(self, prepared, facts):
+            del prepared, facts
+            raise AuthorizationDenied("denied")
+
+        def close_mutation(self, prepared) -> None:
+            del prepared
+            raise AuthorizationDenied("denied")
+
+    adapter = CompensationAdapterBindingAuthorization(_Denied())
+    facts = _facts()
+    with pytest.raises(AdapterBindingUnavailable, match="unavailable"):
+        if operation == "prepare":
+            await adapter.prepare_adapter_binding_mutation(facts)
+        elif operation == "consume":
+            await adapter.consume_adapter_binding_mutation(object(), facts)
+        else:
+            adapter.close_adapter_binding_mutation(object())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ("prepare", "consume"))
+async def test_public_adapter_conceals_invalid_fact_translation(operation: str) -> None:
+    adapter = CompensationAdapterBindingAuthorization(_Authorization())
+    invalid = replace(_facts(), action="invalid.action")  # type: ignore[arg-type]
+    with pytest.raises(AdapterBindingUnavailable, match="unavailable"):
+        if operation == "prepare":
+            await adapter.prepare_adapter_binding_mutation(invalid)
+        else:
+            await adapter.consume_adapter_binding_mutation(object(), invalid)

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -213,6 +213,10 @@ def test_action_aware_audit_input_enforces_mapping_and_action_availability() -> 
         ActionId.ARTIFACT_GUIDE_SOURCE_READ,
         ActionId.ARTIFACT_PRE_SUBMIT_CHECKER_INPUT_MATERIALIZE, ActionId.ARTIFACT_SUBMISSION_BUNDLE_PREPARE,
         ActionId.SUBMISSION_CREATE, ActionId.ARTIFACT_SUBMISSION_BINDING_CREATE,
+        ActionId.COMPENSATION_ADAPTER_BINDING_READ,
+        ActionId.COMPENSATION_ADAPTER_BINDING_CREATE,
+        ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND,
+        ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
     }
     artifact_allowed = _authority_input(
         AuthorityEventType.SENSITIVE_AUTHORIZATION_ALLOWED,

--- a/backend/tests/test_audit.py
+++ b/backend/tests/test_audit.py
@@ -162,16 +162,11 @@ def test_action_aware_audit_input_enforces_mapping_and_action_availability() -> 
             assert allowed.action_id is not None
             allowed_action_ids.add(allowed.action_id)
     assert allowed_action_ids == {
-        ActionId.ACTOR_PROFILE_READ_SELF,
-        ActionId.ACTOR_PROFILE_UPDATE_SELF,
-        ActionId.AUTHORIZATION_PERMISSION_CATALOGUE_READ,
-        ActionId.AUTHORIZATION_ADMIN_ROLE_DEFINITIONS_READ,
-        ActionId.ADMIN_ROLE_GRANT_LIST,
-        ActionId.ACTOR_ADMIN_ROLE_GRANT_HISTORY_READ,
-        ActionId.ADMIN_ROLE_GRANT_ISSUE,
-        ActionId.ADMIN_ROLE_GRANT_REVOKE,
-        ActionId.ADMIN_ROLE_GRANT_BOOTSTRAP,
-        ActionId.ACTOR_PROFILE_READ,
+        ActionId.ACTOR_PROFILE_READ_SELF, ActionId.ACTOR_PROFILE_UPDATE_SELF,
+        ActionId.AUTHORIZATION_PERMISSION_CATALOGUE_READ, ActionId.AUTHORIZATION_ADMIN_ROLE_DEFINITIONS_READ,
+        ActionId.ADMIN_ROLE_GRANT_LIST, ActionId.ACTOR_ADMIN_ROLE_GRANT_HISTORY_READ,
+        ActionId.ADMIN_ROLE_GRANT_ISSUE, ActionId.ADMIN_ROLE_GRANT_REVOKE,
+        ActionId.ADMIN_ROLE_GRANT_BOOTSTRAP, ActionId.ACTOR_PROFILE_READ,
         ActionId.ACTOR_IDENTITY_LINK_READ,
         ActionId.ACTOR_SERVICE_PROVISION,
         ActionId.ACTOR_PROFILE_SUSPEND,

--- a/backend/tests/test_authorization.py
+++ b/backend/tests/test_authorization.py
@@ -2149,6 +2149,7 @@ def test_closed_permission_and_action_catalogue_is_exact_and_non_executable() ->
         ActionId.ARTIFACT_PENDING_WORK_SCAN,
         ActionId.ARTIFACT_PUT_ATTEMPT_RESOLVE,
         ActionId.ARTIFACT_PRE_SUBMIT_CHECKER_INPUT_MATERIALIZE, ActionId.ARTIFACT_SUBMISSION_BUNDLE_PREPARE, ActionId.SUBMISSION_CREATE, ActionId.ARTIFACT_SUBMISSION_BINDING_CREATE,
+        ActionId.COMPENSATION_ADAPTER_BINDING_READ, ActionId.COMPENSATION_ADAPTER_BINDING_CREATE, ActionId.COMPENSATION_ADAPTER_BINDING_SUSPEND, ActionId.COMPENSATION_ADAPTER_BINDING_RESUME,
     }
     assert {
         definition.action_id.value: (
@@ -2225,12 +2226,10 @@ def test_closed_permission_and_action_catalogue_is_exact_and_non_executable() ->
         ActionOwner.XINT_003_08B: 1,
     }
     assert all(not owner.value.startswith("WS-REV-") for owner in ActionOwner)
-    availability_counts = Counter(
-        definition.availability for definition in ACTION_DEFINITIONS
-    )
+    availability_counts = Counter(definition.availability for definition in ACTION_DEFINITIONS)
     assert availability_counts == {
-        ActionAvailability.ACTIVE: 57,
-        ActionAvailability.PLANNED: 54,
+        ActionAvailability.ACTIVE: 61,
+        ActionAvailability.PLANNED: 50,
     }
     assert resolve_executable_action(ActionId.ACTOR_PROFILE_READ_SELF).permission_id is PermissionId.ACTOR_PROFILE_READ_SELF
     with pytest.raises(ValueError, match="not active"):
@@ -2894,7 +2893,7 @@ def test_art_custody_documentation_matches_the_independent_activation_fixture() 
     assert "does not grant Operator" in operations
     assert "verification retry remains independently gated" in operations
     assert (
-            "73 PermissionIds, 111 ActionIds, 57 active actions, and\n54 planned actions" in operations
+            "73 PermissionIds, 111 ActionIds, 61 active actions, and\n50 planned actions" in operations
     )
 
 def test_rev_custody_documentation_matches_the_independent_catalogue_fixture() -> None:

--- a/docs/operations_authorization_service.md
+++ b/docs/operations_authorization_service.md
@@ -494,8 +494,8 @@ v0.1 baseline.
 The REV transfer adds no migration. The ART transfer does not grant Operator
 authority; its `OPERATOR` suffix denotes only future activation custody, and
 verification retry remains independently gated from read/status actions.
-Catalogue totals are 73 PermissionIds, 111 ActionIds, 57 active actions, and
-54 planned actions. CP01A adds four unavailable adapter-binding actions under
+Catalogue totals are 73 PermissionIds, 111 ActionIds, 61 active actions, and
+50 planned actions. CP01A added four initially unavailable adapter-binding actions under
 `WS-ARCH-001-CP01A` custody; it adds no evaluator, identity, grant, service
 matrix row, route, or activation. CP01B adds five unavailable
 `contribution.policy.*` actions with the same non-activation guarantees. CP01C
@@ -756,8 +756,9 @@ assignment, or service-action-matrix data.
 Controlled provisioning may create the target-only
 `workstream.compensation.adapter` profile and service identity link. Operators
 must not add a service-action matrix row for it: it is a binding target, not an
-action-bearing service principal. CP03A leaves all adapter-binding actions unavailable; CP03B
-is the separate Finance Authority activation boundary.
+action-bearing service principal. CP03A left all adapter-binding actions
+unavailable; CP03B is the separate completed Finance Authority activation
+boundary.
 
 The kernel locks and revalidates the human caller profile, exact link, and
 matched system grant before target lookup and holds those locks through

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -135,10 +135,10 @@ review. Their presence does not change the implemented-on-`main` list above.
    merged through WS-ARCH-001-02H.
 2. CP01A and CP01B have registered exact adapter-binding and ContributionPolicy
    authority while keeping all nine actions unavailable. CP01C corrects the
-   unavailable binding facts before CP02. CP02 is complete on merge with hidden,
+   unavailable binding facts before CP02. CP02 is complete with hidden,
    route-unreachable adapter-binding behavior and immutable lifecycle history.
-   CP03A is complete on merge with the target identity and owner eligibility.
-   CP03B is complete on merge with exact hidden Finance Authority read/PREP
+   CP03A is complete with the target identity and owner eligibility.
+   CP03B is complete with exact hidden Finance Authority read/PREP
    activation for those four actions. The remaining order is CP04 hidden ContributionPolicy behavior,
    then CP05 ContributionPolicy activation;
    expose CON validation; then bind one exact published,

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -137,10 +137,9 @@ review. Their presence does not change the implemented-on-`main` list above.
    authority while keeping all nine actions unavailable. CP01C corrects the
    unavailable binding facts before CP02. CP02 is complete on merge with hidden,
    route-unreachable adapter-binding behavior and immutable lifecycle history.
-   CP03A is complete on merge with the target identity and owner eligibility
-   while all four actions remain unavailable. The remaining order is CP03B activation
-   for an authenticated human Finance Authority covering the exact project,
-   CP04 hidden ContributionPolicy behavior,
+   CP03A is complete on merge with the target identity and owner eligibility.
+   CP03B is complete on merge with exact hidden Finance Authority read/PREP
+   activation for those four actions. The remaining order is CP04 hidden ContributionPolicy behavior,
    then CP05 ContributionPolicy activation;
    expose CON validation; then bind one exact published,
    complete, binding-valid ContributionPolicyVersion at guide activation, and

--- a/docs/spec_authorization_service.md
+++ b/docs/spec_authorization_service.md
@@ -278,9 +278,10 @@ counts, mappings, owners, and availability remain unchanged.
 WS-ARCH-001-CP03 is split after merged CP02 hidden behavior. CP03A adds only
 the closed target identity `workstream.compensation.adapter` and real
 PROJECTS/ACTORS eligibility adapters; it adds no service-matrix membership and
-is complete on merge while keeping all four binding actions unavailable. CP03B then installs the exact
-read/PREP adapter for an authenticated human Finance Authority covering the
-exact project and activates only those four actions.
+is complete on merge while keeping all four binding actions unavailable. CP03B
+then installs the exact read/PREP adapter for an authenticated human Finance
+Authority covering the exact project and activates only those four actions,
+producing the current 111-row catalogue with 61 active and 50 planned actions.
 AUTH-10A added five project-role read/manage rows;
 AUTH-10B owns and activates the three reads, while AUTH-10C owns and activates
 the two reason-bound, idempotent project-role mutations. AUTH-11A adds eleven

--- a/docs/spec_authorization_service.md
+++ b/docs/spec_authorization_service.md
@@ -278,7 +278,7 @@ counts, mappings, owners, and availability remain unchanged.
 WS-ARCH-001-CP03 is split after merged CP02 hidden behavior. CP03A adds only
 the closed target identity `workstream.compensation.adapter` and real
 PROJECTS/ACTORS eligibility adapters; it adds no service-matrix membership and
-is complete on merge while keeping all four binding actions unavailable. CP03B
+is complete while keeping all four binding actions unavailable. CP03B
 then installs the exact read/PREP adapter for an authenticated human Finance
 Authority covering the exact project and activates only those four actions,
 producing the current 111-row catalogue with 61 active and 50 planned actions.

--- a/docs/spec_contribution_compensation.md
+++ b/docs/spec_contribution_compensation.md
@@ -805,10 +805,10 @@ behavior, or ContributionPolicy authority.
 | ActionId | PermissionId | Principal / target | Protocol | Feature owner |
 |---|---|---|---:|---|
 | `outbox.dispatch` | proposed `outbox.dispatch` | fixed dispatcher / claimed event | T | CON-02B |
-| `compensation.adapter_binding.read` | `compensation.adapter_binding.manage` | Finance / binding | Q | WS-ARCH-001-CP01A (registered, unavailable) |
-| `compensation.adapter_binding.create` | `compensation.adapter_binding.manage` | Finance / binding collection | T | WS-ARCH-001-CP01A (registered, unavailable) |
-| `compensation.adapter_binding.suspend` | `compensation.adapter_binding.manage` | Finance / active binding | T | WS-ARCH-001-CP01A (registered, unavailable) |
-| `compensation.adapter_binding.resume` | `compensation.adapter_binding.manage` | Finance / suspended binding | T | WS-ARCH-001-CP01A (registered, unavailable) |
+| `compensation.adapter_binding.read` | `compensation.adapter_binding.manage` | covered human Finance Authority / binding | Q | WS-ARCH-001-CP03B (active; CP01A registration custody) |
+| `compensation.adapter_binding.create` | `compensation.adapter_binding.manage` | covered human Finance Authority / binding collection | T | WS-ARCH-001-CP03B (active; CP01A registration custody) |
+| `compensation.adapter_binding.suspend` | `compensation.adapter_binding.manage` | covered human Finance Authority / active binding | T | WS-ARCH-001-CP03B (active; CP01A registration custody) |
+| `compensation.adapter_binding.resume` | `compensation.adapter_binding.manage` | covered human Finance Authority / suspended binding | T | WS-ARCH-001-CP03B (active; CP01A registration custody) |
 | `compensation.adapter_binding.retire` | `compensation.adapter_binding.manage` | Finance / dependency-free binding | T | CON-10B |
 | `contribution.policy.read` | `compensation.policy.manage` | Finance / policy version | Q | WS-ARCH-001-CP01B (registered, unavailable) |
 | `contribution.policy.create_draft` | `compensation.policy.manage` | Finance / policy collection | T | WS-ARCH-001-CP01B (registered, unavailable) |

--- a/docs/spec_contribution_compensation.md
+++ b/docs/spec_contribution_compensation.md
@@ -771,9 +771,11 @@ activation. Target-only identity registration never satisfies that path.
 
 The table contains both registered-unavailable and future proposed mappings.
 CP01A registers the four adapter-binding read/create/suspend/resume ActionIds,
-and CP01B registers the five ContributionPolicy ActionIds. All nine remain
-unavailable and have no evaluator, identity, service-matrix row, route, or
-activation. CP01C corrects the unavailable binding facts before behavior:
+and CP01B registers the five ContributionPolicy ActionIds. CP03B now activates
+only the four adapter-binding actions for covered human Finance Authority
+through the hidden AUTH factory; it adds no public route, fixed-service
+identity, or service-matrix row. The five ContributionPolicy actions remain
+unavailable with no evaluator or activation. CP01C corrected the binding facts before behavior:
 create binds project, server-selected binding identity, `instrument_type`, adapter
 actor, and non-secret route key; suspend/resume additionally bind the exact
 positive lifecycle version. A binding is project/instrument scoped, so its


### PR DESCRIPTION
## Chunk

`WS-ARCH-001-CP03B` — adapter-binding AUTH activation.

## Goal and approved intent

Activate exactly four hidden adapter-binding actions for covered authenticated human Finance Authority:

- `compensation.adapter_binding.read`
- `compensation.adapter_binding.create`
- `compensation.adapter_binding.suspend`
- `compensation.adapter_binding.resume`

The target-only compensation adapter service receives no caller authority. ContributionPolicy, retirement, awards, fulfillment, delivery, callbacks, reconciliation, routes, and reputation remain outside this chunk.

## What changed

- Added strict AUTH-owned read and mutation resource facts and reused the existing opaque transaction-bound PREP protocol.
- Added the public CON-to-AUTH adapter and exact AUTH adapter-root factory.
- Activated only the four catalogue actions and restricted grants to system or exact-project Finance Authority.
- Added exact actor, identity-link, action, permission, project, binding, operation, request digest, resource digest, session, transaction, lifecycle status/version, instrument, adapter actor, and route binding.
- Added atomic authorization evidence using the registered `compensation_adapter_binding` audit resource.
- Preserved the deny-default CON constructor and intentionally added no public route or reachable internal command caller; future callers must explicitly inject the AUTH factory.
- Reconciled exact AUTH adapter-root boundary scanning, semantic ownership custody, structural-debt parity, state ledgers, and canonical documentation.

## Scope control

No migration, frontend, route, fixed-service matrix grant, provider behavior, ContributionPolicy behavior, ContributionRecord, CompensationAward, fulfillment, delivery, callback, reconciliation, or reputation behavior was added. Nested adapters consume public module APIs; private AUTH wiring is confined to `backend/app/adapters/auth/__init__.py`.

## Proof

- Final focused non-database AUTH/public-adapter replay: 36 passed; PostgreSQL-backed proof remained assigned to hosted CI because the local database URL is intentionally unavailable.
- Focused changed-module coverage: 91.82%, above the 90% subsystem requirement.
- Architecture scanner suite: 101 passed during implementation; final reviewer replay also passed both boundary validators.
- Full system/project Finance Authority read and create/suspend/resume matrix is covered.
- Denial coverage includes wrong actor, non-human context, suspended/deactivated actor, revoked link, missing/stale grant, cross-project use, replaced transaction, replay, and direct-kernel mutation bypass.
- Public adapter tests assert every immutable translated fact.
- Ruff, structural-debt validation, module-boundary validation, behavior-ownership validation, stale wording, stale authorization docs, chunk-state sync, Markdown links, and `git diff --check` pass.
- Hosted CI assigned all 3,889 canonical tests exactly once across seven semantic lanes; every lane and the aggregate coverage job passed.
- The final audit parity correction shrinks the frozen oversized audit test file and function by one line each; no structural-debt exception or new debt was accepted.
- No tests, assertions, coverage thresholds, workflows, or CI lanes were weakened.

The full PostgreSQL matrix and repository-wide coverage run in GitHub Actions, not on the local machine.

## Internal review

All nine required specialties replayed against exact clean head `621ee7ce106c581e95382e3dc01e750945ed9992` after merging current `main` and resolving every durable-state conflict:

- Architecture: pass.
- Security/auth: pass with low risks.
- Product/operations: pass with low risks.
- QA: pass with low risks.
- Test delta: pass with low risks.
- CI integrity: pass.
- Senior engineering: pass with low risks.
- Reuse/dedup: pass.
- Documentation: pass.

Valid review findings fixed included semantic ownership custody, the full authorization test matrix, exact public fact assertions, stale activation wording, factory-versus-command composition clarity, and duplicated action sets.

## External review

GitHub Actions pass on the exact pushed head: Agent Gates, AUTH preflight,
all seven semantic backend lanes, and the aggregate test/coverage job are green.
CodeRabbit's earlier substantive findings were individually replayed, fixed,
and all threads resolved. Its final-head check passes but explicitly skipped a
new substantive review pending a manual trigger; this is not represented as
fresh CodeRabbit review evidence.

## Remaining risk

No production command caller or public route exists in this chunk. The AUTH factory is ready for explicit injection by a future approved caller; uncomposed CON usage continues to deny by default.

## Human review focus

Confirm that only covered human Finance Authority receives the four actions, mutations cannot bypass PREP, the target service remains target-only, and no adjacent compensation lifecycle was activated.

Only an authorized human may approve and merge this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled four Finance Authority adapter-binding actions: read, create, suspend, and resume.
  * Added authorization checks for human Finance Authority, project scope, actor identity, and resource access.
  * Added secure one-time authorization handling and audit coverage for adapter-binding operations.
* **Documentation**
  * Updated authorization catalogue totals and roadmap/specification status.
  * Clarified that ContributionPolicy actions, compensation delivery, and fulfillment remain unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->