### PR TITLE
docs(eng): plan atomic Commitrail cutover

### DIFF
--- a/.agent-loop/CURRENT_STATE.md
+++ b/.agent-loop/CURRENT_STATE.md
@@ -56,6 +56,9 @@ authority; these records do not grant or withhold it.
 | [FN-ART-002](initiatives/FN-ART-002-deferred-flow-node-artifact-store/STATUS.md) | Deferred and outside the Workstream v0.1 delivery path | Reconsider only through a new explicit initiative |
 | [WS-ENG-001 through WS-ENG-008](initiatives/README.md#historical-eng-initiatives) | Historical and closed or superseded | Do not use signed-start, loop-memory, recovery, or archive proposals as current instructions |
 
+`WS-ENG-009-01` is Planned as the atomic Commitrail cutover.
+`WS-ENG-009-02` is Planned as the subsequent blind Workstream stress test.
+
 ## How To Start Contributing
 
 1. Pull current `main` and read `CONTRIBUTING.md`, the capability ledger, and

--- a/.agent-loop/CURRENT_STATE.md
+++ b/.agent-loop/CURRENT_STATE.md
@@ -28,6 +28,7 @@ authority; these records do not grant or withhold it.
 
 | Initiative | Durable state on `main` | Remaining boundary |
 |---|---|---|
+| [WS-ENG-009](initiatives/WS-ENG-009-commitrail-cutover/STATUS.md) | Commitrail cutover is planned; no implementation has started | Human approval of the atomic cutover, followed by one real Workstream blind stress test |
 | [WS-ARCH-001](initiatives/WS-ARCH-001-modular-monolith-boundaries/STATUS.md) | Complete through `WS-ARCH-001-02H`; CP01A-CP03B establish adapter-binding behavior/activation; CP04A-CP04B complete hidden policy behavior with durable custody | Prepare CP05 to activate only the proven policy actions; PLAN2 still targets durable `allow_review` |
 | [WS-ART-001](initiatives/WS-ART-001-immutable-artifact-storage/STATUS.md) | Active delivery initiative; verified ready-admission publication, hidden preparation, consumption and binding are merged through ARCH-02H | Implement exact post-submit materialization only after the unified guide/checker and PLAN2 public contracts are executable; live cutover remains later |
 | [WS-AUTH-001](initiatives/WS-AUTH-001-workstream-authorization-service/STATUS.md) | Active delivery initiative; AUTH-12J has an executable contract after complete hidden POL-04A3 projections | Implement AUTH-12J; AUTH-12B2 waits for both 12J and hidden POL-04A2 finalization |

--- a/.agent-loop/REVIEW_LOG.md
+++ b/.agent-loop/REVIEW_LOG.md
@@ -3012,3 +3012,13 @@ then identified two final gaps: source inspection could appear to replace
 required database/session custody, and future outcomes used present-tense
 completion wording. Both are corrected; final-head review and hosted checks
 remain required before human merge.
+
+## 2026-09-03 - WS-ENG-009 Commitrail Cutover Planning
+
+PR #359 records the proposed atomic replacement of `.agent-loop` with
+Commitrail. CodeRabbit identified eight valid planning gaps covering complete
+current-ledger and internal-record custody, exact Agent Gates preservation,
+permanent legacy-path rejection, scope wording, public-release prerequisites,
+and positive/negative validator coverage. All eight were incorporated into the
+plan and cutover contract. No implementation or product behavior changes in
+this planning PR; fresh exact-head checks and human approval remain required.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/CHUNK_MAP.md
@@ -3,7 +3,7 @@
 | Chunk | Purpose | Durable disposition | Dependency |
 |---|---|---|---|
 | `WS-ENG-009-01` | Atomically commission Commitrail and remove `.agent-loop` from the working tree | Planned | Human approval of this plan |
-| `WS-ENG-009-02` | Run one real Workstream bounded change as a blind Commitrail stress test and correct demonstrated method defects | Planned | `WS-ENG-009-01` merged |
+| `WS-ENG-009-02` | Run one real Workstream bounded change as a blind Commitrail stress test and record demonstrated method defects | Planned | Atomic Commitrail cutover merged |
 
 One chunk equals one pull request. No additional migration chunk should be
 invented unless discovery proves the atomic cutover is not independently

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/CHUNK_MAP.md
@@ -1,0 +1,10 @@
+# WS-ENG-009 Chunk Map
+
+| Chunk | Purpose | Durable disposition | Dependency |
+|---|---|---|---|
+| `WS-ENG-009-01` | Atomically commission Commitrail and remove `.agent-loop` from the working tree | Planned | Human approval of this plan |
+| `WS-ENG-009-02` | Run one real Workstream bounded change as a blind Commitrail stress test and correct demonstrated method defects | Planned | `WS-ENG-009-01` merged |
+
+One chunk equals one pull request. No additional migration chunk should be
+invented unless discovery proves the atomic cutover is not independently
+reviewable.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/DECISIONS.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/DECISIONS.md
@@ -1,0 +1,29 @@
+# WS-ENG-009 Decisions
+
+## D1 — Atomic active-method cutover
+
+Workstream will not operate `.agent-loop` and Commitrail as simultaneous active
+methods. The implementation PR establishes Commitrail and removes the old
+method together.
+
+## D2 — Git history is the archive
+
+Historical review bundles, merge intents, queues, recovery records, and closed
+planning detail will not be copied into a new in-tree archive. Still-normative
+facts are relocated; everything else remains recoverable from Git.
+
+## D3 — One-record default
+
+A meaningful single-PR change uses one combined change record. Additional
+records must be justified by multi-PR coordination or material risk.
+
+## D4 — No process authority
+
+Commitrail records explain and evidence work. GitHub permissions, branch
+protection, required checks, eligible human approval, and human merge decisions
+remain authoritative.
+
+## D5 — Workstream is the first blind evaluation
+
+The first post-cutover bounded Workstream change will evaluate the method using
+the documented entry path without legacy compatibility or private procedure.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/DISCOVERY.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/DISCOVERY.md
@@ -1,0 +1,92 @@
+# WS-ENG-009 Discovery — Commitrail Cutover
+
+## Observed repository state
+
+- `.agent-loop` occupies approximately 9.4 MB and contains 1,246 initiative
+  files across 33 initiative directories, 76 merge-intent files, 16 template
+  files, and 12 policy files.
+- `.agent-loop/CURRENT_STATE.md` is the current durable initiative ledger.
+  GitHub open pull requests are already defined as the transient-work view.
+- `.agent-loop/README.md` already rejects the directory as an authorization
+  database and recommends the smallest useful artifact.
+- Git history preserves every removed record after cutover.
+
+## Direct dependencies outside `.agent-loop`
+
+### Contributor and architecture guidance
+
+- `AGENTS.md`, `CONTRIBUTING.md`, and `README.md`
+- `docs/architecture_lockdown.md`
+- `docs/operations_post_merge_memory.md`
+- `docs/operations_subagent_review_protocol.md`
+
+### Skills and reviewer configuration
+
+- `.agents/skills/initiative-planning/SKILL.md`
+- `.agents/skills/task-chunk-loop/SKILL.md`
+- `.agents/skills/plan-to-chunks/SKILL.md`
+- `.agents/skills/memory-update/SKILL.md`
+- `.agents/skills/external-review-response/SKILL.md`
+- `.agents/skills/reviewer-evidence-protocol/SKILL.md`
+- `.codex/agents/product-ops-reviewer.toml`
+- `.codex/config.toml`
+
+### Automation and tests
+
+- `.github/workflows/agent-gates.yml` runs atomic chunk-state and active-state
+  projection validators tied to `.agent-loop`.
+- `scripts/check_chunk_state_sync.py` requires one changed chunk contract and
+  synchronized `CHUNK_MAP.md`, `STATUS.md`, and `CURRENT_STATE.md` projections.
+- `scripts/check_active_state_projections.py` scans the current-state file.
+- `scripts/reviewer_contracts.py` binds reviewer adoption wording to it.
+- Regression tests under `scripts/` encode those paths and behaviors.
+- `.github/pull_request_template.md` mirrors an `.agent-loop` template.
+
+### Product and operational references
+
+Current documents cite selected handoffs, action custody, conformance, and
+historical contracts under `.agent-loop`, including:
+
+- `docs/spec_authorization_service.md`
+- `docs/spec_review_lifecycle.md`
+- `docs/spec_contribution_compensation.md`
+- `docs/operations_roles_permissions.md`
+- `docs/operations_authorization_service.md`
+
+These references must be classified as normative, current navigation, or
+historical evidence. Normative facts must move to the owning specification or a
+current Commitrail decision record; historical-only links must be labelled or
+removed rather than copied wholesale.
+
+## Existing checks to preserve
+
+- Markdown link checking
+- Workstream and authorization stale-wording checks
+- Artifact-contract stale checks
+- Reviewer contract and exact-target review tests
+- Backend test and coverage workflows
+- Human approval and conversation-resolution protections on GitHub
+
+## Worktree integration risk
+
+At discovery time, separate worktrees exist for ARCH, AUTH, and CON branches.
+They may contain `.agent-loop` changes based on the old method. The cutover must
+not edit those worktrees. Their owners must rebase after cutover and translate
+their still-current intent into one Commitrail change record rather than
+restoring `.agent-loop`.
+
+## Gaps
+
+- The generated Commitrail v0.1 source currently exists outside the repository
+  and has no repository-owned canonical location or assigned public license.
+- There is no automated negative assertion that legacy engineering-method
+  paths cannot return.
+- Current initiative truth is spread across verbose status files and must be
+  distilled against `docs/roadmap_status.md` and current specifications.
+
+## Assumptions
+
+- The user intends removal from the current working tree, not destruction of
+  Git history.
+- Commitrail will initially be a Workstream-owned repository method; public
+  licensing and an independent upstream repository may follow separately.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/INTENT.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/INTENT.md
@@ -1,0 +1,82 @@
+# WS-ENG-009 Intent — Commitrail Cutover
+
+## Problem being solved
+
+Workstream's repository-native engineering method has accumulated a large
+`.agent-loop` implementation whose duplicated state, historical queues,
+merge-intent records, and mandatory projections can confuse contributors and
+create process work unrelated to the change being delivered. Commitrail v0.1
+captures the useful controls in a smaller portable method.
+
+## Why this work matters
+
+Workstream must be the first complete real-world proving ground for Commitrail.
+The repository should preserve intent, boundaries, evidence, exact-target
+review, and human merge authority without maintaining a second authorization
+system or a stale shadow of GitHub.
+
+## Current behavior
+
+`.agent-loop` contains current navigation, policies, templates, initiative
+plans, reviews, and retired automation records. Repository instructions,
+skills, reviewer definitions, CI, scripts, tests, and some canonical product
+documents refer to it directly.
+
+## Target behavior
+
+`.commitrail` is the only active engineering-record location. A meaningful
+single-PR change normally uses one combined change record. Multi-PR work uses
+one initiative overview and one change record per PR. GitHub owns transient
+work, checks, approvals, and merge state. Historical `.agent-loop` content is
+removed from the working tree after current truth and still-normative material
+are deliberately migrated; Git history remains the archive.
+
+## Design chosen
+
+Use one atomic cutover PR, followed by one blind stress-test PR on real
+Workstream work. The cutover updates the records, contributor guidance,
+skills, reviewers, automation, tests, and every live reference together. It
+does not run two active methods in parallel.
+
+## Alternatives considered
+
+- A directory rename was rejected because it would preserve the accumulated
+  complexity under a new name.
+- A prolonged dual-read period was rejected because it would create two
+  apparent sources of engineering truth.
+- Deleting all records without classification was rejected because a small
+  number of current handoffs, decisions, and constraints are cited by current
+  specifications.
+
+## Boundaries preserved
+
+- GitHub permissions and branch protection remain authoritative.
+- Human maintainers retain merge and material-risk decisions.
+- Product lifecycle terminology and behavior do not change.
+- Existing test and coverage protections may not be weakened.
+- Other worktrees are not edited by this initiative.
+
+## Expected risks
+
+- A hidden `.agent-loop` dependency may break CI or contributor tooling.
+- Removing a cited record may erase context still needed by a canonical spec.
+- Active branches may carry old paths and require rebase reconciliation.
+- Commitrail could accidentally reproduce the same ceremonial complexity.
+
+## What must not change
+
+No backend, frontend, database, API, authorization, artifact, review,
+contribution, compensation, or product behavior may change during cutover.
+
+## How this will be proven
+
+The cutover must pass reference scans, Markdown links, focused script tests,
+all Agent Gates, applicable reviewer tracks, and a repository-wide assertion
+that `.agent-loop` is absent and no active instruction references it. The next
+real bounded Workstream change must then complete entirely through Commitrail
+without compatibility files or manual state repair.
+
+## Human decisions required
+
+Approve the atomic-cutover boundary and selection of the first real stress-test
+change. Human approval is also required before either PR is merged.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/INTENT.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/INTENT.md
@@ -65,8 +65,12 @@ does not run two active methods in parallel.
 
 ## What must not change
 
-No backend, frontend, database, API, authorization, artifact, review,
-contribution, compensation, or product behavior may change during cutover.
+No Workstream product, runtime, database, API, authorization, artifact,
+product-review, contribution, or compensation behavior may change during
+cutover. Engineering-process implementation—including contributor guidance,
+reviewer configuration, validation scripts, tests, and CI enforcement—may
+change only as defined by this plan. Existing quality protections, GitHub
+authority, and human merge authority must remain effective throughout.
 
 ## How this will be proven
 

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/PLAN.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/PLAN.md
@@ -1,0 +1,114 @@
+# WS-ENG-009 Plan — Commission Commitrail in Workstream
+
+## Outcome
+
+Replace `.agent-loop` atomically with the reduced Commitrail method, then use a
+real Workstream change as a blind end-to-end stress test. The cutover changes
+engineering process only and does not touch product behavior.
+
+## Cutover design
+
+### 1. Establish the canonical Commitrail package
+
+Add `.commitrail/README.md`, `INDEX.md`, `CHANGE_TEMPLATE.md`, and
+`initiatives/`. Include a repository-owned Workstream operating guide derived
+from Commitrail v0.1. Do not describe that copy as Commitrail's canonical public
+distribution until the author assigns publication terms and a canonical
+location. The Workstream installation may add only the records earned by its
+risk; it must not recreate every generic appendix as a required file.
+
+### 2. Distil current truth
+
+Build `.commitrail/INDEX.md` from current `main`, `docs/roadmap_status.md`, open
+GitHub work, and the active initiative ledger. Record only durable initiative
+disposition and the next usable boundary. Open PRs remain GitHub data.
+
+For active multi-PR initiatives, create one short overview containing intent,
+current boundary, governing specifications, material decisions, and remaining
+risks. Do not copy old review bundles, merge intents, queues, or redundant
+status prose.
+
+### 3. Preserve only normative material
+
+Classify references into:
+
+1. product truth that belongs in an owning specification or ADR;
+2. current engineering navigation that belongs in `.commitrail`;
+3. historical evidence recoverable from Git history.
+
+Before deletion, produce a machine-readable or reviewable relocation inventory
+for every tracked reference from outside `.agent-loop`, naming the destination
+or recording that the reference was historical-only. Move categories 1 and 2
+deliberately. Delete category 3 from the working tree. No canonical product rule
+may depend solely on a deleted historical plan.
+
+### 4. Cut every active integration point
+
+Update `AGENTS.md`, `CONTRIBUTING.md`, `README.md`, relevant docs, PR template,
+skills, reviewer definitions, scripts, CI, and tests in the same PR. Replace
+mandatory triple state projection with validation of one change record and,
+only for multi-PR work, its initiative overview/index entry.
+
+The validator must enforce useful invariants without treating records as
+permission:
+
+- non-trivial implementation changes have one bounded change record;
+- allowed and prohibited scope, acceptance criteria, verification, risk,
+  reviewers, and intended merge outcome are explicit;
+- durable dispositions use `Planned`, `Complete`, `Stopped`, or `Superseded`;
+- transient review/CI/approval state is not committed as current truth;
+- no `.agent-loop` path or retired signed-loop mechanism can be reintroduced.
+
+### 5. Remove `.agent-loop`
+
+Delete the directory atomically after all live references and needed facts have
+been migrated. Git history is the historical archive; no repository copy of
+the entire old tree will be created.
+
+### 6. Reconcile other worktrees
+
+After cutover merges, each active worktree rebases on current `main`, removes
+old-method changes, and translates only its current bounded work into the
+Commitrail record. Unaffected test evidence remains valid only if the rebase
+does not change its impact cone.
+
+### 7. Blind stress test
+
+Select the next already-needed Workstream bounded change. Its owner uses only
+the published Commitrail entry path without private coaching or compatibility
+files. Measure record count, preparation effort, reviewer routing, stale-state
+failures, rebase handling, and whether a new contributor can identify current
+and remaining work. The stress-test PR records findings but does not mix
+Commitrail implementation corrections into the product change. A demonstrated
+method defect earns a later bounded correction only if needed.
+
+## Verification strategy
+
+- Assert `.agent-loop` does not exist at the candidate head.
+- Verify the relocation inventory has no unclassified external reference.
+- Scan tracked files for legacy names and paths, with narrowly documented
+  historical exceptions only if essential.
+- Validate all Markdown links.
+- Run updated Commitrail validator and its negative regression suite.
+- Run reviewer-contract and exact-target review tests.
+- Run Agent Gates and all workflow/schema validation affected by path changes.
+- Run architecture, CI-integrity, docs, QA, reuse, and senior-engineering
+  review for the cutover; security review applies to trusted-base and evidence
+  handling changes.
+- Complete the live stress-test PR and capture measured findings in its one
+  change record.
+
+## Rejected approaches
+
+- No compatibility symlink, alias, or permanent `.agent-loop` reader.
+- No automatic migration of all 1,246 initiative files.
+- No signed local authority, start token, merge-intent queue, or second
+  permission system.
+- No mandatory fixed reviewer count.
+- No second post-merge reconciliation PR.
+
+## Rollback
+
+Before merge, revert the candidate branch. After merge, restore only through a
+new human-approved PR. Git history retains the former records, but the old
+runtime process must not silently reactivate.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/PLAN.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/PLAN.md
@@ -3,8 +3,11 @@
 ## Outcome
 
 Replace `.agent-loop` atomically with the reduced Commitrail method, then use a
-real Workstream change as a blind end-to-end stress test. The cutover changes
-engineering process only and does not touch product behavior.
+real Workstream change as a blind end-to-end stress test. Workstream product,
+runtime, database, and API behavior remain unchanged. Engineering-process and
+CI enforcement intentionally change from the legacy projection model to the
+Commitrail record model while preserving existing quality and human-authority
+protections.
 
 ## Cutover design
 
@@ -14,8 +17,9 @@ Add `.commitrail/README.md`, `INDEX.md`, `CHANGE_TEMPLATE.md`, and
 `initiatives/`. Include a repository-owned Workstream operating guide derived
 from Commitrail v0.1. Do not describe that copy as Commitrail's canonical public
 distribution until the author assigns publication terms and a canonical
-location. The Workstream installation may add only the records earned by its
-risk; it must not recreate every generic appendix as a required file.
+location and the blind stress test produces evaluation evidence. The Workstream
+installation may add only the records earned by its risk; it must not recreate
+every generic appendix as a required file.
 
 ### 2. Distil current truth
 
@@ -36,11 +40,20 @@ Classify references into:
 2. current engineering navigation that belongs in `.commitrail`;
 3. historical evidence recoverable from Git history.
 
-Before deletion, produce a machine-readable or reviewable relocation inventory
-for every tracked reference from outside `.agent-loop`, naming the destination
-or recording that the reference was historical-only. Move categories 1 and 2
-deliberately. Delete category 3 from the working tree. No canonical product rule
-may depend solely on a deleted historical plan.
+Before deletion, produce a reviewable relocation inventory that:
+
+- classifies every tracked reference originating outside `.agent-loop`;
+- gives every non-historical row in `.agent-loop/CURRENT_STATE.md` an explicit
+  `.commitrail` or owning-specification destination;
+- enumerates every tracked `.agent-loop` record containing normative or durable
+  material—including initiative status and chunk records—regardless of whether
+  another file links to it; and
+- names the destination or an explicit historical-only disposition for every
+  inventory entry.
+
+The inventory must have no unclassified entry before removal. Move categories
+1 and 2 deliberately. Delete category 3 from the working tree. No canonical
+product rule may depend solely on a deleted historical plan.
 
 ### 4. Cut every active integration point
 
@@ -58,6 +71,32 @@ permission:
 - durable dispositions use `Planned`, `Complete`, `Stopped`, or `Superseded`;
 - transient review/CI/approval state is not committed as current truth;
 - no `.agent-loop` path or retired signed-loop mechanism can be reintroduced.
+
+The repository-owned validator must include executable positive cases for a
+valid single-record change and a valid multi-PR initiative. Together those
+cases cover `Planned`, `Complete`, `Stopped`, and `Superseded`. Negative cases
+must reject missing required fields, unknown dispositions, committed transient
+review/CI/approval state, inconsistent overview/index entries, and every
+attempt to restore `.agent-loop` or retired signed-loop paths.
+
+### Agent Gates preservation map
+
+| Existing protection | Post-cutover disposition |
+|---|---|
+| Markdown links | Preserve `check_markdown_links.py` |
+| Workstream stale wording | Preserve `check_stale_workstream_wording.py` |
+| Authorization documentation | Preserve `check_stale_authorization_docs.py` |
+| Artifact contracts | Preserve `check_stale_artifact_contracts.py` |
+| Guide-extractor dependencies | Preserve `backend/scripts/check_guide_extractor_dependencies.py` |
+| Atomic chunk-state projections | Replace with the Commitrail record/index validator |
+| Active-state projections | Replace with durable-disposition and transient-state Commitrail validation |
+| Reviewer contracts | Preserve and update `reviewer_contracts.py` for Commitrail terminology |
+| Stale review contracts | Preserve `check_stale_review_contracts.py` |
+| Reviewer and exact-target tests | Preserve `test_reviewer_contracts` and `test_review_target` |
+| Lightweight workflow regression | Update it to assert the complete post-cutover command set |
+
+The implementation may consolidate commands, but each row requires an
+executable successor in Agent Gates; no protection disappears implicitly.
 
 ### 5. Remove `.agent-loop`
 
@@ -85,11 +124,13 @@ method defect earns a later bounded correction only if needed.
 ## Verification strategy
 
 - Assert `.agent-loop` does not exist at the candidate head.
-- Verify the relocation inventory has no unclassified external reference.
+- Verify the relocation inventory has no unclassified external reference,
+  current-ledger row, or internal normative/durable record.
 - Scan tracked files for legacy names and paths, with narrowly documented
   historical exceptions only if essential.
 - Validate all Markdown links.
-- Run updated Commitrail validator and its negative regression suite.
+- Run updated Commitrail validator and its positive and negative regression
+  suite across every supported durable disposition.
 - Run reviewer-contract and exact-target review tests.
 - Run Agent Gates and all workflow/schema validation affected by path changes.
 - Run architecture, CI-integrity, docs, QA, reuse, and senior-engineering

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/RISKS.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/RISKS.md
@@ -1,0 +1,12 @@
+# WS-ENG-009 Risks
+
+| Risk | Severity | Control |
+|---|---|---|
+| Hidden legacy path breaks CI or tools | High | Exhaustive tracked-reference scan plus focused negative tests |
+| Normative product fact is deleted with history | High | Classify every external reference and relocate product truth before deletion |
+| Active worktree restores old machinery during rebase | High | Rebase only after cutover; validator rejects legacy paths |
+| Commitrail recreates ceremonial file fanout | High | One-record default and measured blind stress test |
+| Current initiative summary becomes another stale queue | Medium | GitHub owns transient work; index stores durable disposition only |
+| Review protections are weakened during simplification | High | Preserve exact-target, impact-routed, evidence-adequacy, and human-merge controls |
+| Cutover PR becomes unreviewably broad | Medium | Restrict it to process paths and mechanical reference migrations; circuit-break on product diffs |
+| Public Commitrail status is overstated | Medium | Keep release-candidate wording until license, canonical publication, and evaluation evidence exist |

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/STATUS.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/STATUS.md
@@ -7,6 +7,11 @@
 - Next boundary: Human approval of `WS-ENG-009-01`
 - Product behavior changed: No
 
+## Planned boundaries
+
+- `WS-ENG-009-01`: Planned; atomic Commitrail cutover after human approval.
+- `WS-ENG-009-02`: Planned; blind Workstream stress test after the cutover.
+
 This is the final initiative created under `.agent-loop`. The approved cutover
 will remove this transitional record together with the retired method after its
 intent is represented in the canonical Commitrail initiative overview.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/STATUS.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/STATUS.md
@@ -1,0 +1,12 @@
+# WS-ENG-009 Status
+
+- Initiative: `WS-ENG-009-commitrail-cutover`
+- Durable disposition: Planned
+- Planning state: Complete
+- Implementation state: Not started
+- Next boundary: Human approval of `WS-ENG-009-01`
+- Product behavior changed: No
+
+This is the final initiative created under `.agent-loop`. The approved cutover
+will remove this transitional record together with the retired method after its
+intent is represented in the canonical Commitrail initiative overview.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/chunks/WS-ENG-009-01-atomic-commitrail-cutover.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/chunks/WS-ENG-009-01-atomic-commitrail-cutover.md
@@ -41,13 +41,25 @@ facts.
 - A relocation inventory classifies every pre-cutover reference originating
   outside `.agent-loop` and identifies its destination or historical-only
   disposition.
+- The inventory gives every non-historical `CURRENT_STATE.md` row and every
+  internal normative/durable record an explicit destination or historical-only
+  disposition; no entry remains unclassified.
 - `.agent-loop` is absent from the final candidate.
 - No active tracked file instructs a contributor to use retired signed-loop,
   merge-intent, queue, recovery-certificate, or projection machinery.
+- A repository-owned negative regression check runs in Agent Gates and rejects
+  any later restoration of `.agent-loop` paths or retired engineering-method
+  machinery.
 - Commitrail validation preserves bounded scope, evidence adequacy,
   exact-target review, proportional routing, durable dispositions, and human
   merge authority without creating contribution permission.
 - Other worktrees receive explicit rebase/translation guidance.
+- Every protection in the plan's Agent Gates preservation map has an
+  executable post-cutover check, and the lightweight workflow regression test
+  asserts the complete command set.
+- Commitrail validator tests cover valid single-record and multi-PR examples,
+  all four durable dispositions, missing fields, invalid dispositions,
+  transient state, inconsistent index/overview state, and legacy restoration.
 
 ## Risk class
 
@@ -61,6 +73,12 @@ test ! -e .agent-loop
 git grep -n -E '\.agent-loop|signed loop|loop memory|merge-intent|recovery certificate'
 python3 scripts/check_markdown_links.py
 python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_stale_artifact_contracts.py
+python3 backend/scripts/check_guide_extractor_dependencies.py
+python3 scripts/check_commitrail_records.py --base-ref origin/main
+python3 scripts/reviewer_contracts.py
+python3 scripts/check_stale_review_contracts.py
 python3 -m unittest -v scripts.test_commitrail_contracts scripts.test_reviewer_contracts scripts.test_review_target scripts.test_lightweight_agent_gates
 ```
 

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/chunks/WS-ENG-009-01-atomic-commitrail-cutover.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/chunks/WS-ENG-009-01-atomic-commitrail-cutover.md
@@ -1,0 +1,99 @@
+# WS-ENG-009-01 — Atomic Commitrail Cutover
+
+## Goal
+
+Commission Commitrail as Workstream's only active engineering method and remove
+`.agent-loop` without changing product behavior or losing current normative
+facts.
+
+## Allowed files
+
+- `.commitrail/**`
+- `.agent-loop/**` for removal and this chunk's final projection
+- `.agents/skills/**`
+- `.codex/**`
+- `.github/pull_request_template.md`
+- `.github/workflows/agent-gates.yml`
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+- `README.md`
+- `docs/**` where engineering-method or relocated normative references require it
+- `scripts/**` for Commitrail validation and regression tests
+- Existing architecture/test files only where they assert the retired path
+
+## Not allowed
+
+- Backend or frontend product behavior
+- Database models or migrations
+- API, authorization, artifact, review, contribution, or compensation behavior
+- Coverage-floor reduction, test deselection, or check bypass
+- Compatibility aliases or dual active engineering methods
+- Copying the full `.agent-loop` tree into another archive directory
+
+## Acceptance criteria
+
+- `.commitrail` provides the canonical entry point, index, combined change
+  template, and concise overviews for current multi-PR initiatives.
+- Repository guidance, skills, reviewer agents, PR template, checks, and tests
+  consistently use Commitrail.
+- Still-normative facts formerly cited from `.agent-loop` are owned by current
+  specifications, ADRs, or concise Commitrail decisions.
+- A relocation inventory classifies every pre-cutover reference originating
+  outside `.agent-loop` and identifies its destination or historical-only
+  disposition.
+- `.agent-loop` is absent from the final candidate.
+- No active tracked file instructs a contributor to use retired signed-loop,
+  merge-intent, queue, recovery-certificate, or projection machinery.
+- Commitrail validation preserves bounded scope, evidence adequacy,
+  exact-target review, proportional routing, durable dispositions, and human
+  merge authority without creating contribution permission.
+- Other worktrees receive explicit rebase/translation guidance.
+
+## Risk class
+
+L1 engineering-process, CI-integrity, and repository-navigation change. No
+product behavior is in scope.
+
+## Verification commands
+
+```bash
+test ! -e .agent-loop
+git grep -n -E '\.agent-loop|signed loop|loop memory|merge-intent|recovery certificate'
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 -m unittest -v scripts.test_commitrail_contracts scripts.test_reviewer_contracts scripts.test_review_target scripts.test_lightweight_agent_gates
+```
+
+The legacy-wording scan must return no active dependency; any intentional
+historical quotation requires explicit reviewer acceptance.
+
+## Required reviewers
+
+- Architecture
+- CI integrity
+- Documentation
+- QA
+- Reuse/deduplication
+- Security
+- Senior engineering
+
+Product-operations review is not required unless the diff touches Workstream
+product lifecycle language beyond link relocation. Test-delta review is
+required only if existing assertions are removed or materially rewritten.
+
+## Human review focus
+
+- Does the cutover preserve useful controls while materially reducing burden?
+- Is any product truth lost or silently moved into process ownership?
+- Can an unfamiliar contributor start without private instructions?
+- Does any hidden dual system remain?
+- Is the Workstream operating copy clearly distinguished from a future
+  canonically licensed public Commitrail distribution?
+
+## Merge state
+
+- Outcome on merge: `planned`
+
+The implementation contract becomes executable only after explicit human
+approval. Its implementation PR must express its final disposition using the
+current method until that same PR atomically replaces it.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/chunks/WS-ENG-009-02-live-workstream-stress-test.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/chunks/WS-ENG-009-02-live-workstream-stress-test.md
@@ -1,0 +1,58 @@
+# WS-ENG-009-02 — Live Workstream Commitrail Stress Test
+
+## Goal
+
+Use one necessary bounded Workstream change to test Commitrail end to end and
+record any method defects demonstrated by that use.
+
+## Allowed files
+
+- The one Commitrail change record and applicable initiative index/overview
+- The product and test files explicitly selected in the future change record
+- Related current documentation
+
+## Not allowed
+
+- `.agent-loop` restoration or compatibility
+- Unrelated product work
+- New process records not justified by observed risk
+- Reviewer fanout unrelated to the change's impact cone
+
+## Acceptance criteria
+
+- A contributor identifies the work from current repository entry points.
+- The change uses one combined record unless multi-PR scope is independently
+  justified.
+- Scope, tests, review, exact candidate, PR, rebase, and human merge work
+  without stale state repair or a second reconciliation PR.
+- Measured friction and escaped ambiguity are recorded.
+- No Commitrail method implementation is changed in the product PR. A proven
+  defect may become a separate bounded correction after this evaluation.
+
+## Risk class
+
+To be assigned from the selected real change. Any later Commitrail method
+correction is a separate L1 process change.
+
+## Verification commands
+
+Defined in the selected change record after the human selects the product
+boundary. Repository-standard CI remains blocking.
+
+## Required reviewers
+
+Impact-routed from the real change. Architecture, CI, docs, security, payment,
+or product-operations review runs only where that surface is affected.
+
+## Human review focus
+
+- Did Commitrail make the change easier to understand and govern?
+- Did it omit a control that would have caught a real risk?
+- Did it require any file, check, or reviewer that added no decision value?
+
+## Merge state
+
+- Outcome on merge: `planned`
+
+This chunk cannot start until `WS-ENG-009-01` is merged and the human selects
+the real Workstream boundary.

--- a/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/reviews/WS-ENG-009-PLAN-external-review-response.md
+++ b/.agent-loop/initiatives/WS-ENG-009-commitrail-cutover/reviews/WS-ENG-009-PLAN-external-review-response.md
@@ -1,0 +1,57 @@
+# WS-ENG-009 Planning External Review Response
+
+## Target
+
+- Pull request: `#359`
+- Reviewed head: `5f9bf82aed646baec31523abd4b9f7c8945b9227`
+- Reviewer: CodeRabbit
+
+## Comments addressed
+
+1. **Current initiative ledger custody — addressed.** The cutover inventory now
+   requires a row-by-row disposition for every non-historical
+   `CURRENT_STATE.md` entry.
+2. **Complete Agent Gates equivalence — addressed.** `PLAN.md` maps every
+   existing gate to its preserved or explicit Commitrail successor, and the
+   cutover contract lists the complete post-cutover command set.
+3. **Permanent legacy-path prevention — addressed.** A repository-owned
+   negative regression check in Agent Gates must reject restoration of
+   `.agent-loop` and retired signed-loop machinery.
+4. **Intent scope contradiction — addressed.** Product/runtime/API behavior is
+   immutable; engineering-process and CI enforcement are explicitly allowed to
+   change while protections and human authority remain effective.
+5. **Public-status gate — addressed.** Publication terms, canonical location,
+   and blind stress-test evaluation evidence are all required.
+6. **Internal record custody — addressed.** The inventory covers every tracked
+   internal record containing normative or durable material, not only files
+   referenced from outside the directory.
+7. **Plan scope contradiction — addressed.** The outcome now distinguishes
+   unchanged product behavior from intentional process/CI enforcement change.
+8. **Validator coverage — addressed.** Positive single-record and multi-PR
+   cases cover all durable dispositions; negative cases cover missing fields,
+   invalid dispositions, transient state, inconsistent projections, and legacy
+   restoration.
+
+## Comments deferred
+
+None.
+
+## Human decisions needed
+
+Human approval of the planning PR remains required. Public Commitrail release
+terms and canonical distribution remain a later human decision and cannot be
+inferred from this Workstream adoption.
+
+## Commands rerun
+
+- `python3 scripts/check_chunk_state_sync.py --base-ref edacdfdbb485f6959cb5d5f4f4def82bb713e1dd`
+- `python3 scripts/check_active_state_projections.py`
+- `python3 scripts/check_markdown_links.py`
+- `python3 scripts/check_stale_workstream_wording.py`
+- `git diff --check`
+
+## Remaining risks
+
+The implementation must prove the relocation inventory is complete and that
+the replacement validator preserves every mapped gate. This response approves
+no implementation and is not merge authority.


### PR DESCRIPTION
## Intent

Plan the complete replacement of Workstream's accumulated `.agent-loop` machinery with the reduced Commitrail v0.1 method.

## Scope

- records the current dependency inventory and migration risks;
- defines one atomic cutover PR with no prolonged dual-system period;
- preserves normative product facts while leaving historical bulk in Git history;
- defines one later real Workstream change as a blind end-to-end stress test;
- changes no product, CI, runtime, database, or API behavior.

## Design

The cutover will commission `.commitrail`, update every active instruction/tool/check/reference, and remove `.agent-loop` in the same implementation PR. Active worktrees will rebase afterward and translate only their current bounded work. There will be no compatibility alias, signed local authority, merge-intent queue, fixed reviewer count, or second post-merge reconciliation PR.

## Evidence

- `python3 scripts/check_chunk_state_sync.py --base-ref origin/main`
- `python3 scripts/check_active_state_projections.py`
- `python3 scripts/check_markdown_links.py`
- `python3 scripts/check_stale_workstream_wording.py`
- `git diff --check`

All passed locally.

## Human review focus

- Is one atomic cutover preferable to a temporary dual system?
- Does the relocation inventory prevent loss of normative product facts?
- Is the one-record default materially simpler for contributors?
- Is Git history sufficient for retired planning and review evidence?

Planning only. No implementation begins until explicit human approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning documentation for the planned Commitrail cutover.
  * Documented the intended transition to Commitrail as the sole active engineering-record method.
  * Added discovery findings, implementation boundaries, decisions, risks, verification criteria, and rollback guidance.
  * Defined a follow-up blind Workstream stress test to validate the cutover.
* **Status**
  * Recorded the initiative as planned, with implementation not yet started and human approval required before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->