### PR TITLE
docs: publish complete v0.1 roadmap

### DIFF
--- a/.agent-loop/CURRENT_STATE.md
+++ b/.agent-loop/CURRENT_STATE.md
@@ -9,7 +9,8 @@ plans and reviews cannot be mistaken for work that is still active.
 Use these sources in order:
 
 1. [`docs/roadmap_status.md`](../docs/roadmap_status.md) states the capabilities
-   implemented on `main` and the remaining v0.1 milestones.
+   implemented on `main`, hidden integrations, the current critical path, and
+   the complete remaining v0.1 release gates in human-readable form.
 2. [Open pull requests](https://github.com/Flow-Research/workstream/pulls)
    show work currently under review. An open PR is not implemented behavior.
 3. The initiative table below records durable disposition and the next usable
@@ -49,7 +50,7 @@ authority; these records do not grant or withhold it.
 | [WS-CI-005](initiatives/WS-CI-005-semantic-proof-quality/STATUS.md) | Complete through `WS-CI-005-03`; shared proof foundations and reviewer contracts are behaviorally adopted through blind evaluation | Preserve the proof corpus and add only reusable escaped-failure classes |
 | [WS-DB-001](initiatives/WS-DB-001-v01-schema-baseline/STATUS.md) | v0.1 schema baseline complete through PRs #316 and #317 | Extend `0001_v01_baseline` only through future bounded migrations |
 | [WS-SEC-001](initiatives/WS-SEC-001-dependency-alert-remediation/STATUS.md) | `WS-SEC-001-01` is complete with patched runtime and tooling dependencies | Handle future security alerts through fresh bounded dependency changes |
-| [WS-DOCS-001](initiatives/WS-DOCS-001-current-v01-documentation/STATUS.md) | Current v0.1 entry documentation complete | Keep current pages synchronized with merged capability changes |
+| [WS-DOCS-001](initiatives/WS-DOCS-001-current-v01-documentation/STATUS.md) | Public v0.1 lifecycle scoreboard and engineering-state navigation complete through `WS-DOCS-001-04` | Keep the public roadmap synchronized with merged capability changes |
 | [WS-DOCS-002](initiatives/WS-DOCS-002-workstream-definition/STATUS.md) | Canonical Workstream definition complete | Preserve terminology across current documentation and generated artifacts |
 | [WS-XINT-001](initiatives/WS-XINT-001-lifecycle-boundary-reconciliation/STATUS.md) | Planning reconciliation complete and closed | Owner initiatives implement the resulting boundaries |
 | [WS-AUTH-002](initiatives/WS-AUTH-002-authorization-docstring-lint-correction/STATUS.md) | Bounded correction complete | Future lint work is a new bounded change |

--- a/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/CHUNK_MAP.md
+++ b/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/CHUNK_MAP.md
@@ -4,8 +4,9 @@
 | --- | --- | --- |
 | `WS-DOCS-001-01` | Modernize the current v0.1 documentation entry path and archive expired calendar framing | Merged through PR #246 |
 | `WS-DOCS-001-02` | Reconcile remaining current-facing timeline wording, historical classification, and documentation initiative state | Merged through PR #250 |
-| `WS-DOCS-001-03` | Establish one current engineering-state ledger and reconcile stale initiative and review-log navigation | Candidate; GitHub is authoritative for review and merge state |
+| `WS-DOCS-001-03` | Establish one current engineering-state ledger and reconcile stale initiative and review-log navigation | Complete |
+| `WS-DOCS-001-04` | Make the public v0.1 roadmap a complete human-readable lifecycle scoreboard and dependency map | Complete |
 
-All three chunks are documentation-only. Chunk 02 preserved historical records
+All four chunks are documentation-only. Chunk 02 preserved historical records
 where old wording is itself evidence; chunk 03 makes that archive/current-state
 boundary explicit and repairs current-facing initiative navigation.

--- a/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/STATUS.md
+++ b/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/STATUS.md
@@ -13,3 +13,9 @@ Ongoing documentation maintenance follows the ordinary bounded-change loop.
 initiative dispositions. Its durable outcome is the repository-wide
 `.agent-loop/CURRENT_STATE.md`; GitHub remains authoritative for the chunk's
 transient review and merge state.
+
+`WS-DOCS-001-04` makes `docs/roadmap_status.md` the complete public lifecycle
+scoreboard. It explains merged foundations, hidden integrations, the immediate
+dependency order, and every remaining v0.1 release gate without requiring a
+reader to inspect `.agent-loop`. Open pull requests remain the only transient
+work view.

--- a/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/chunks/WS-DOCS-001-04-public-v01-roadmap.md
+++ b/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/chunks/WS-DOCS-001-04-public-v01-roadmap.md
@@ -12,9 +12,11 @@ remaining v0.1 release gates without reading `.agent-loop`.
 
 - `docs/roadmap_status.md`
 - `README.md`
+- `CONTRIBUTING.md`
 - `.agent-loop/CURRENT_STATE.md`
 - `.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/CHUNK_MAP.md`
 - `.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/STATUS.md`
+- `.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/reviews/WS-DOCS-001-04-external-review-response.md`
 - this contract
 
 ## Not allowed

--- a/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/chunks/WS-DOCS-001-04-public-v01-roadmap.md
+++ b/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/chunks/WS-DOCS-001-04-public-v01-roadmap.md
@@ -1,0 +1,53 @@
+# Chunk Contract: WS-DOCS-001-04 Public v0.1 Roadmap
+
+Status: Complete. Risk: L2. Outcome on merge: complete.
+
+## Intent
+
+Make `docs/roadmap_status.md` sufficient for a human reader to understand the
+implemented product, hidden integrations, current critical path, and complete
+remaining v0.1 release gates without reading `.agent-loop`.
+
+## Allowed files
+
+- `docs/roadmap_status.md`
+- `README.md`
+- `.agent-loop/CURRENT_STATE.md`
+- `.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/CHUNK_MAP.md`
+- `.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/STATUS.md`
+- this contract
+
+## Not allowed
+
+- Runtime, schema, migration, CI, dependency, or authorization changes.
+- Claims that planned or hidden behavior is live.
+- Calendar promises or a second transient-work tracker.
+- Rewriting historical review or contract evidence.
+
+## Acceptance criteria
+
+- The public roadmap distinguishes live, hidden, next, planned, and deferred.
+- Every v0.1 lifecycle stage states implemented behavior and its remaining gate.
+- The immediate dependency order through guide activation, task readiness,
+  canonical `allow_review`, REV/CON, fulfillment, frontend, and pilot is clear.
+- ContributionPolicy inheritance and human-revision rebase semantics match the
+  canonical current plans.
+- Open pull requests remain the sole transient-work view.
+- README and current engineering state point readers to the public roadmap.
+
+## Verification
+
+```bash
+git diff --check
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_chunk_state_sync.py --base-ref origin/main --head-ref HEAD
+python3 scripts/check_active_state_projections.py --base-ref origin/main --head-ref HEAD
+```
+
+## Review
+
+Documentation and product/operations review are required. Architecture review
+is required only to verify that the roadmap preserves subsystem ownership and
+dependency order. No runtime or security claim changes.

--- a/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/chunks/WS-DOCS-001-04-public-v01-roadmap.md
+++ b/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/chunks/WS-DOCS-001-04-public-v01-roadmap.md
@@ -1,6 +1,6 @@
 # Chunk Contract: WS-DOCS-001-04 Public v0.1 Roadmap
 
-Status: Complete. Risk: L2. Outcome on merge: complete.
+Status: Complete. Risk: L2.
 
 ## Intent
 
@@ -51,3 +51,7 @@ python3 scripts/check_active_state_projections.py --base-ref origin/main --head-
 Documentation and product/operations review are required. Architecture review
 is required only to verify that the roadmap preserves subsystem ownership and
 dependency order. No runtime or security claim changes.
+
+## Merge state
+
+- Outcome on merge: `complete`

--- a/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/reviews/WS-DOCS-001-04-external-review-response.md
+++ b/.agent-loop/initiatives/WS-DOCS-001-current-v01-documentation/reviews/WS-DOCS-001-04-external-review-response.md
@@ -1,0 +1,36 @@
+# WS-DOCS-001-04 External Review Response
+
+## Comments Addressed
+
+1. CodeRabbit reported that README used two display names for the canonical
+   roadmap. The remaining navigation label now uses `v0.1 Roadmap And
+   Capability Status`.
+2. The same stale display name was present in the current contributor entry
+   path. `CONTRIBUTING.md` now uses the canonical label and explicitly includes
+   hidden capabilities in the roadmap description.
+
+## Comments Deferred
+
+None. Historical planning documents retain their original link prose because
+they are historical evidence rather than current navigation.
+
+## Human Decisions Needed
+
+None. The correction changes link labels only and does not change product,
+architecture, authorization, or release semantics.
+
+## Commands Rerun
+
+```text
+git diff --check
+python3 scripts/check_markdown_links.py
+python3 scripts/check_stale_workstream_wording.py
+python3 scripts/check_stale_authorization_docs.py
+python3 scripts/check_chunk_state_sync.py --base-ref origin/main --head-ref HEAD
+python3 scripts/check_active_state_projections.py --base-ref origin/main --head-ref HEAD
+```
+
+## Remaining Risks
+
+None identified. Runtime, schema, migrations, dependencies, CI, tests, and
+capability availability are unchanged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,8 @@ locks.
 Before implementation, update from current `main` and read:
 
 1. [README.md](README.md) for the product boundary and current v0.1 summary.
-2. [Current v0.1 Status](docs/roadmap_status.md) for implemented, in-progress, and
-   remaining capabilities.
+2. [v0.1 Roadmap And Capability Status](docs/roadmap_status.md) for implemented,
+   hidden, in-progress, and remaining capabilities.
 3. [Current Engineering State](.agent-loop/CURRENT_STATE.md) for durable
    initiative dispositions, remaining boundaries, and the live pull-request
    view of transient work.

--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ reputation projection. Frontend product work follows stable and tested backend
 contracts for the surface it consumes.
 
 The release bar is a verified end-to-end v0.1 lifecycle, not the completion of
-an old timeboxed plan. See [Current v0.1 Status](docs/roadmap_status.md) for the
-capability ledger and explicit remaining work.
+an old timeboxed plan. See the [v0.1 Roadmap And Capability Status](docs/roadmap_status.md)
+for the lifecycle scoreboard, current critical path, and complete release gates;
+reading internal agent-loop records is not required to understand product progress.
 
 ## Start Here
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ reading internal agent-loop records is not required to understand product progre
 
 - [Developer Quickstart](#developer-quickstart)
 - [Contribution Guide](CONTRIBUTING.md)
-- [Current v0.1 Status](docs/roadmap_status.md)
+- [v0.1 Roadmap And Capability Status](docs/roadmap_status.md)
 - [Product Principles](docs/product_principles.md)
 - [Product Brief](docs/product_brief.md)
 - [Architecture Lockdown](docs/architecture_lockdown.md)

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -1,196 +1,262 @@
-# Current Workstream v0.1 Status
+# Workstream v0.1 Roadmap And Capability Status
 
-This is the capability ledger for current v0.1 development. It records what is
-implemented on `main`, what is being integrated, and what remains before the
-v0.1 lifecycle is proven. It intentionally contains no delivery calendar.
+This is the public, human-readable source for what Workstream can do on
+`main`, what is implemented but intentionally hidden, what we are building
+next, and what remains before v0.1 is ready. It uses capability milestones,
+not calendar promises.
 
-The complete product is source-agnostic governed contribution infrastructure.
-This ledger deliberately tracks the narrower v0.1 proof: one secured path from
-project rules and a task through exact artifact custody, checks, authorized
-review, revision when needed, and immutable contribution facts. Flow-token
-verification is the current identity adapter, not the product definition.
+Implementation claims require merged code, migrations, tests, and review
+evidence. A plan or open pull request is not implemented behavior. Open pull
+requests are the transient view of work currently under review.
 
-Implementation claims must be supported by code, migrations, tests, and merged
-history. A plan, contract, draft pull request, or historical specification is
-not evidence that behavior is live.
+## Product Goal
 
-## v0.1 Release Boundary
-
-The target remains:
+Workstream turns governed work into trusted `ContributionRecord` facts:
 
 ```text
 Project Guide
--> Task
--> Submission Packet
--> Automated Checks
--> Human Review
--> Revision when required
+-> governed Task
+-> immutable Submission
+-> deterministic Checks
+-> authorized Review
+-> controlled Revision when required
 -> Contribution Records
--> Conditional Compensation Award / Fulfillment
--> Contribution Evidence For Future Reputation Projection
+-> conditional Compensation Awards and Fulfillment
+-> evidence for a future Reputation projection
 ```
 
-The release bar is one secured, observable, end-to-end lifecycle using the
-locked backend and storage architecture. Marketplace expansion, blockchain
-settlement, external source adapters, automated routing, and agent workspaces
-remain outside v0.1.
+The v0.1 release bar is one secured, observable, recoverable end-to-end path.
+Marketplace expansion, blockchain settlement, external source adapters,
+automated routing, agent workspaces, and runtime reputation projection remain
+outside v0.1.
 
-## Implemented On `main`
+## Status Vocabulary
 
-### Platform foundation
+| Status | Meaning |
+| --- | --- |
+| **Live foundation** | Merged behavior is available to its intended caller. It may still be only one part of a larger product flow. |
+| **Hidden and proven** | Merged behavior exists and is tested, but no public production route exposes the complete flow yet. |
+| **Next** | The next dependency-safe implementation boundary after current `main`. |
+| **Planned** | The design direction is accepted, but its current skeleton must be refreshed into a bounded executable contract before coding. |
+| **Deferred** | Deliberately outside the v0.1 runtime. |
 
-- FastAPI backend, SQLAlchemy async persistence, Alembic migrations, and
-  PostgreSQL record storage.
-- Async checker and project-setup execution with Celery and Redis where durable
-  retries and isolation are required.
-- Provider-neutral immutable artifact storage with MinIO protocol proof for
-  local development and CI, plus bounded private processing scratch.
-- External integrations composed through the typed ADR 0014 adapter boundary.
+## Executive Snapshot
+
+Workstream already has strong backend foundations for identity, authorization,
+projects, guide ingestion, immutable artifact storage, tasks, submissions, and
+checker execution. The new unified Project Guide compiler and its two
+deterministic projections are implemented behind hidden boundaries. The
+contributor artifact path can prepare verified bytes, publish a ready
+admission, create the immutable Submission, and bind it atomically, but its
+public legacy cutover is intentionally deferred.
+
+The current critical path is to finish one complete governed Project Guide
+generation, lock its ContributionPolicyVersion into claimable work, and carry
+one admitted Submission through a durable current post-submit checker result
+with `routing_recommendation = allow_review`. That fact unlocks the live
+review/revision path. Review decisions must then create contribution and
+conditional compensation facts atomically before v0.1 can be released.
+
+## End-To-End Lifecycle Scoreboard
+
+| Lifecycle stage | Status on `main` | What is already proven | What remains before v0.1 |
+| --- | --- | --- | --- |
+| Identity and actor resolution | **Live foundation** | Flow-token verification; canonical ActorProfile and ActorIdentityLink; human/service separation; lifecycle controls | Final end-to-end operational and conformance proof |
+| Authorization kernel | **Live foundation** | Closed action/permission catalogues; deny-by-default evaluation; grants; fixed services; rate controls; opaque transaction-bound PREP; atomic decision evidence | Activate only the remaining owner-proven TASK, checker, REV, and CON boundaries; remove obsolete authority after replacement paths are live |
+| Project Guide source custody | **Live foundation** | Project Manager ingestion; immutable snapshots; verified binding and reads; PDF, DOCX, PPTX, XLSX and image handling; bounded extraction | Complete the unified-generation cutover and later remove remaining legacy inference paths |
+| Unified Project Guide compilation | **Hidden and proven** | One immutable model attempt; persisted complete result; crash/recovery custody; deterministic sufficiency and submission-artifact-policy projections; exact AUTH request/execute/projection adapters | Finalize the setup ledger, activate finalization authority, cut live execution over, add approval and deterministic post-submit projection, expose one checker-service port |
+| Contribution policy administration | **Hidden and proven** | Finance Authority adapter-binding lifecycle; ContributionPolicy read/create/update/publish/retire behavior; immutable operation and event history | Activate the five policy actions, expose validation, bind one published complete version to the active guide generation |
+| Task readiness and claim | **Foundation plus planned replacement** | Task records, lifecycle guards, assignments, locked work context, public owner facts | A task must inherit the guide-bound ContributionPolicyVersion before `READY`; claim copies the prepared task context into TaskAssignment without a current-policy lookup; activate exact task authority |
+| Contributor artifact preparation | **Hidden and proven** | One outer ZIP; bounded scratch inspection; canonical manifest; platform and project prechecks; unchanged-work rejection; durable put intent; verification; capacity-charged ready admission | Connect only the active unified guide/checker lineage and complete the later public admission-only cutover |
+| Immutable Submission creation | **Hidden and proven** | Contributor preparation authority; atomic admission consumption; TASK-owned Submission creation; fixed-service artifact binding; replay/concurrency/rollback proof | Stamp the assignment's exact ContributionPolicyVersion and unified policy lineage; remove the legacy Submission path only after remediation and review prerequisites are ready |
+| Post-submit checking and `allow_review` | **Planned; immediate integration milestone** | Checker contracts, registry/runner foundations, existing pre-review behavior, artifact materialization foundations | Publish one CHECKER post-submit API; materialize the exact Submission; persist one durable current superseding result; activate fixed services; automatically dispatch it and publish the canonical `allow_review` manifest |
+| Review queue and lease | **Hidden persistence foundation** | Queue/admission idempotency and ReviewLease/preference persistence; complete unavailable REV action/principal catalogue and typed AUTH contracts | Packet-membership contract and manifest; Review schema; canonical admission from `allow_review`; claim/lease/packet authority; lease copies the Submission-stamped policy version with no CON lookup |
+| Review decision and revision | **Planned** | Review/revision policy identities and mutation authority; approved same-task revision-rebase semantics | Immutable findings and decisions; `accept`, `needs_revision`, and `reject`; complete-context revision preparation; finding responses; replacement contributor rules; replay and recovery |
+| Contribution and compensation truth | **Schema foundations plus hidden policy behavior** | ContributionPolicyVersion persistence; lifecycle-audit participant; adapter bindings; hidden policy administration | Persist ContributionRecord and CompensationAward; atomically create one reviewer record for every final review and, on accept only, FinalAcceptance plus the submitter record; evaluate frozen rules into zero, one, or two awards |
+| Fulfillment, reconciliation, and audit | **Planned** | Shared audit foundations and provider-neutral adapter convention | Outbox/dispatcher authority, conditional award fulfillment, callbacks, idempotent recovery, reconciliation, bounded operational reads, and release controls |
+| Frontend and pilot | **Planned after stable backend contracts** | React + Vite + TypeScript stack decision | Implement only stable backed surfaces, run the real internal pilot, repair findings, and complete release drills |
+
+## What Has Been Completed
+
+### Security and platform foundations
+
+- FastAPI, SQLAlchemy 2.x async, PostgreSQL, Alembic, Celery, and Redis form the
+  locked backend execution stack.
+- The schema has one clean v0.1 Alembic baseline; later bounded migrations
+  extend it without compatibility bridges for discarded pre-v0.1 history.
+- AWS S3 is the hosted artifact target, MinIO proves the storage protocol in
+  development and CI, and all storage access stays behind `ArtifactStore`.
+- Private extraction scratch is bounded by `ArtifactScratchManager`; it is not
+  durable artifact storage.
+- Cross-module behavior is moving through explicit public ports under the
+  modular-monolith boundary. New private edges are prohibited and touched debt
+  is reduced incrementally.
+- GitHub CI distributes the backend suite across semantic lanes, rejects
+  skipped/deselected tests, preserves global coverage, and requires at least
+  90 percent coverage for new or materially changed backend subsystems.
 
 ### Identity and authorization
 
-- External Flow-token verification with issuer boundaries and request context.
-- Canonical actors, identity links, actor lifecycle controls, and human lineage.
-- Closed permission/action catalogues, deny-by-default authorization, bootstrap
-  administrator grants, fixed-service identities, and runtime admission.
-- Project-role grants, administrative APIs, authority evidence, idempotency,
-  and PostgreSQL-backed rate controls.
-- Project setup plus project create, guide mutation, binding, and read
-  authorization foundations.
-- Immutable review/revision policy identities, AUTH-owned policy mutation,
-  complete planned REV action and fixed-service catalogues, and the typed
-  fail-closed PREP/read handoff required for hidden REV implementation. These
-  foundations merged through PRs #242, #248, #255, and #257 respectively.
-  Contributor bundle preparation now uses the exact assigned-contributor AUTH
-  PREP boundary from WS-ARCH-001-02G. Hidden TASK-owned Submission creation,
-  admission consumption, and fixed-service binding are active through
-  WS-ARCH-001-02H; only the later public clean cut remains gated.
-  These readiness contracts do not make the review lifecycle available.
-- Project Manager-authorized guide-sufficiency creation, asynchronous agent-run
-  requests, and warning acknowledgement with UUID replay custody; automatic
-  readiness and manual recovery converge on one deterministic setup task, and
-  only the fixed project-setup service executes sufficiency and creates its
-  authoritative report.
-
-### Project, task, submission, and checker foundations
-
-- Project guides, task queue records, task lifecycle guards, work context, and
-  contributor submission requirements.
-- Versioned submission packets with evidence references, locked context,
-  finalization, and contributor privacy boundaries.
-- Typed checker contracts, registry and runner behavior, durable checker
-  records, pre-submit checks, and the automatic pre-review gate.
-- Trusted retry, supersession, audit evidence, and real API contract drills for
-  the implemented lifecycle.
-
-### Guide-source and artifact processing
-
-- Immutable source snapshots, source-media classification, typed extraction
-  boundaries, and persisted extraction results.
-- PDF, DOCX, and XLSX extraction with bounded input handling and OOXML security
-  controls.
-- Image metadata handling and persisted guide-sufficiency evidence.
-- Guide materialization from persisted artifact-processing evidence.
-- Fixed-service guide-source reads and binding creation with authorization,
-  custody, lineage, rate-control, and stale-generation enforcement.
-- Hidden unified Project Guide compilation custody with immutable attempt and
-  result lineage, crash-safe reservation/recovery states, append-only
-  supersession, merged AUTH-12I request/execute authority, and complete
-  AUTH-12J request-local authority for both deterministic POL-04A3 component
-  projections. The flow remains hidden and not live until POL-04A2
-  finalization, AUTH-12B2 finalization authority, and POL-04B live cutover are
+- Workstream verifies external Flow identity tokens but owns no login,
+  password, or primary authentication session.
+- External subject identity resolves through ActorIdentityLink into a stable
+  internal ActorProfile.
+- Human roles and fixed-service authority remain separate and fail closed.
+- Project and administrative grants, resource guards, lifecycle revalidation,
+  idempotency, rate controls, audit evidence, and opaque prepared authority are
   implemented.
-## Integration In Progress
+- Guide ingestion, guide binding/read, artifact verification/recovery,
+  contributor preparation, Submission consumption/binding, unified compilation
+  request/execute, and deterministic projection authority are implemented at
+  their current hidden or live boundaries.
 
-The following areas have merged planning, contracts, or partial foundations,
-but are not all complete as one production path:
+### Project Guide and artifact pipeline
 
-- Hidden contributor-ZIP pre-submit execution: fixed-service authority precedes
-  byte access; one manifest-verified callback-scoped scratch tree runs the
-  platform/default and project-policy phases; cleanup precedes one immutable
-  combined evidence set. Evidence-linked durable put intent, verification, and
-  capacity-charged ready-admission publication are merged. Contributor
-  preparation authority is active through WS-ARCH-001-02G; hidden admission
-  consumption, TASK-owned Submission creation, and final binding are active
-  through 02H; the later public clean cut remains gated.
+- Project Managers can authorize guide-source ingestion for projects they are
+  permitted to manage.
+- Original bytes are immutable and verified before binding. Classification and
+  extraction occur asynchronously from stored bytes; extracted content never
+  replaces the original artifact.
+- The unified compiler produces sufficiency, submission artifact, pre-submit,
+  and post-submit proposals in one accepted result. The sufficiency and
+  submission-artifact-policy components now project deterministically without
+  another model call.
+- Contributor ZIP preparation uses one verified byte lineage from scratch
+  inspection through durable admission and eventual Submission binding.
 
-- integration of the merged review/revision policy and authorization readiness
-  contracts into hidden REV lifecycle behavior;
-- hidden review queue, reviewer assignment/claim, immutable decisions, and revision
-  replay on the canonical authorization boundary;
-- atomic review-to-contribution and conditional compensation integration.
+### Contribution and review foundations
 
-The immediate upstream integration milestone is narrower and precedes live REV
-work: one admission-backed immutable Submission must produce one durable final
-current post-submit checker result with `routing_recommendation = allow_review`
-through PROJECTS, TASKS, ART, CHECKERS, and AUTH public APIs. The existing
-legacy pre-review result does not satisfy that milestone.
+- Finance Authority can manage compensation adapter bindings through the
+  hidden, authorized boundary.
+- Complete hidden ContributionPolicy draft/publication/retirement behavior is
+  persisted with immutable lifecycle history; its AUTH actions intentionally
+  remain unavailable until the activation gate.
+- REV queue/admission and lease/preference persistence foundations are merged.
+- The governing rule is fixed: one ContributionPolicyVersion contains both the
+  `accepted_submission` and `completed_review` rules. It is bound before task
+  readiness and carried as immutable attempt lineage.
 
-Open pull requests are the authoritative view of the exact code currently under
-review. Their presence does not change the implemented-on-`main` list above.
+## Current Work And Immediate Order
 
-## Remaining v0.1 Capability Milestones
+Only open pull requests describe transient work. Use the repository's
+[open pull-request view](https://github.com/Flow-Research/workstream/pulls) to
+see whether any item below is already under review.
 
-1. Complete the remaining artifact custody chain: contributor intake cleanup,
-   archive safety, semantic change gating, post-submit checker materialization,
-   recovery, provider proof, and the later public cutover.
-   Hidden durable admission, Submission creation, and final binding are already
-   merged through WS-ARCH-001-02H.
-2. CP01A and CP01B have registered exact adapter-binding and ContributionPolicy
-   authority while keeping all nine actions unavailable. CP01C corrects the
-   unavailable binding facts before CP02. CP02 is complete with hidden,
-   route-unreachable adapter-binding behavior and immutable lifecycle history.
-   CP03A is complete with the target identity and owner eligibility.
-   CP03B is complete with exact hidden Finance Authority read/PREP
-   activation for those four actions. CP04 is a non-executable split parent.
-   CP04A is complete with hidden read/create/update-draft behavior and immutable
-   operation/event custody. CP04B adds hidden publish/retire behavior with
-   immutable transition custody. The remaining order begins with CP05
-   ContributionPolicy activation;
-   expose CON validation; then bind one exact published,
-   complete, binding-valid ContributionPolicyVersion at guide activation, and
-   lock it on each task before that task becomes claimable. TaskAssignment
-   inherits the task lock without a claim-time lookup, and each immutable
-   Submission stamps the exact version governing that attempt.
-   Complete `WS-ARCH-001-03A` through `WS-ARCH-001-03C` to activate the sole
-   replacement task/assignment path, then run `WS-ARCH-001-CP09` to remove the
-   retired guide-bound economic path only after that replacement is live.
-3. Continue independent REV schema and packet-contract foundations. After
-   canonical `allow_review`, activate admission and claim only when ReviewLease
-   copies the exact ContributionPolicyVersion stamped on the admitted
-   Submission, without a claim-time lookup.
-4. Persist ContributionRecord and CompensationAward before live Review
-   decisions. Every final decision atomically creates the reviewer record and
-   evaluates its frozen rule; accept additionally creates FinalAcceptance and
-   the submitter record and evaluates the assignment-frozen rule.
-   `needs_revision` and `reject` create neither FinalAcceptance nor a submitter
-   record.
-5. Complete review/revision findings, replay, recovery, contribution-award
-   fulfillment, idempotency, reconciliation, product reads, and audit behavior
-   without making settlement a prerequisite.
-6. Preserve authoritative contribution evidence for future reputation
-   projections; reputation projection remains deferred from the v0.1 runtime.
-7. Prove the complete v0.1 lifecycle through real API, database, durable-job,
-   storage, security, and operational recovery tests.
-8. Add the React/Vite/TypeScript product surfaces only against stable and tested
-   backend contracts.
-9. Run a real internal pilot and close findings without weakening lifecycle,
-   authorization, storage, or evidence guarantees.
+The next dependency-safe product sequence is:
 
-These are dependency-ordered capability milestones, not a schedule. Distinct
-initiatives may proceed concurrently when their contracts and integration
-boundaries do not conflict.
+1. **Finish the hidden unified-guide generation.** Implement POL finalization,
+   then its exact AUTH finalization gate, followed by the live unified
+   compilation cutover. This completes one stored setup result without
+   reviving the three legacy inference calls.
+2. **Complete guide policy approval.** Project Manager approval consumes the
+   already-produced unified result; it does not run another agent. Persist the
+   effective pre-submit policy and deterministic post-submit policy, activate
+   their narrow AUTH gates, and expose one typed checker-service port.
+3. **Activate and bind ContributionPolicy.** Activate only the five proven
+   hidden policy actions, expose CON validation, and bind one exact published,
+   complete, binding-valid ContributionPolicyVersion to the Project Guide.
+4. **Activate the complete guide generation.** AUTH may permit terminal guide
+   activation only when compilation, sufficiency, pre-submit policy,
+   post-submit policy, review policy, revision policy, and ContributionPolicy
+   all belong to the same approved current generation.
+5. **Make tasks claimable from that generation.** TASK locks the complete guide
+   and policy context before `READY`. Claim copies it to TaskAssignment; it
+   performs no ContributionPolicy selection. Submission later copies the
+   assignment's attempt version.
+6. **Produce canonical `allow_review`.** Materialize the exact immutable
+   Submission, execute the locked post-submit plan, persist one current result,
+   activate only its fixed services, and automatically publish an exact
+   `allow_review` manifest when no blocking failure exists.
+7. **Start the live REV path.** Complete packet, Review, and FinalAcceptance
+   persistence; admit only canonical `allow_review`; claim a bounded lease and
+   exact packet using the Submission-stamped ContributionPolicyVersion.
+8. **Make review decisions economically complete.** Before the first live
+   Review commit, persist ContributionRecord/CompensationAward and install the
+   atomic CON participant. Every final decision records reviewer work; accept
+   additionally records accepted submitter work.
+9. **Complete revision and operations.** Preserve old attempts immutably;
+   rebase a continuing TaskAssignment only at the controlled human-revision
+   boundary when the complete governed context changed. Finish recovery,
+   fulfillment, reconciliation, audit, release controls, and legacy cleanup.
+10. **Release proof.** Expose stable APIs and frontend surfaces, exercise the
+    complete path through real database, durable-job, storage, security, failure,
+    and recovery tests, then run the internal pilot.
 
-## How To Read Repository Status
+## Critical Dependency Map
 
-- **Implemented:** code and required evidence are merged on `main`.
-- **In progress:** a bounded branch or pull request exists; behavior is not yet
-  part of `main`.
-- **Planned:** an accepted specification or initiative describes future work;
-  behavior is unavailable until implemented and merged.
-- **Historical:** the document records prior intent or evidence and does not
-  control current work.
+```text
+Hidden unified compilation and projections (complete)
+  -> setup finalization
+  -> AUTH finalization gate
+  -> live unified compilation cutover
+  -> Project Manager approval + effective pre-submit policy
+  -> deterministic post-submit policy + single checker port
 
-Use [CONTRIBUTING.md](../CONTRIBUTING.md) to start work and the
-[Historical Planning Index](historical_planning.md) when investigating earlier
-decisions.
+Hidden ContributionPolicy behavior (complete)
+  -> AUTH policy activation
+  -> CON validation
+  -> Project Guide policy-version binding
+
+Both chains
+  -> terminal Project Guide activation
+  -> Task readiness and assignment lineage
+  -> immutable admitted Submission
+  -> durable current post-submit result
+  -> canonical allow_review
+  -> REV admission, lease, packet, decision and revision
+  -> atomic ContributionRecord / CompensationAward effects
+  -> fulfillment, reconciliation and release proof
+```
+
+No claim-time policy selection exists. A normal task claim copies the version
+already locked on the ready task. Review claim copies the version stamped on
+the admitted Submission. During `needs_revision`, the continuing assignment
+may rebase only after comparing and atomically preparing the complete newer
+governed context; earlier Submission, ReviewLease, Review, ContributionRecord,
+and award history never changes.
+
+## Remaining Release Gates
+
+v0.1 is not ready until all of the following are true:
+
+- One active Project Guide generation contains a complete approved compilation
+  and every required policy identity/hash, including ContributionPolicyVersion.
+- A task cannot enter `READY` without that complete locked context.
+- A contributor can claim, submit one immutable ZIP, pass both checker phases,
+  and receive a durable ready admission without a parallel legacy path.
+- The immutable Submission automatically reaches exactly one current
+  post-submit result and an exact `allow_review` manifest when eligible.
+- A reviewer can claim only that admitted version, access only its bounded
+  packet, and record one immutable final decision.
+- `needs_revision` safely continues or rebases the same assignment while
+  preserving every earlier attempt; `reject` and `accept` have their exact
+  distinct effects.
+- Every final review atomically creates the reviewer ContributionRecord;
+  `accept` additionally creates FinalAcceptance and the submitter record.
+- Frozen policy rules produce zero, one, or two CompensationAwards without
+  controlling Workstream lifecycle truth.
+- Fulfillment and recovery are idempotent, observable, reconcilable, and safe
+  under durable-job, provider, transaction, and unknown-commit failures.
+- Public APIs and frontend surfaces expose only the canonical paths, obsolete
+  authority and legacy routes are removed, and the full security/operations
+  drill plus internal pilot passes without weakening safeguards.
+
+## Trace References
+
+Internal chunk identifiers are useful for implementation traceability, but a
+reader does not need `.agent-loop` to understand the roadmap above. The main
+remaining trace sequence is:
+
+- Unified guide: `POL-04A2 -> AUTH-12B2 -> POL-04B -> POL-05A -> AUTH-12F4
+  -> POL-05B -> POL-06A -> AUTH-12G -> POL-06B -> POL-07 -> AUTH-12H`.
+- Contribution lineage: `CP05 -> CP06 -> CP07 -> CP08 -> ARCH-03A -> ARCH-03B
+  -> ARCH-03C -> CP09`.
+- Post-submit admission: `ARCH-04A -> 04B -> 04C -> 04D -> 04E`; `04F` is the
+  contributor-remediation prerequisite for the later public Submission cutover.
+- Review/revision: REV packet/schema foundations may proceed independently,
+  but live admission starts after `ARCH-04E`; the first live Review commit also
+  requires CON contribution/award persistence and its atomic decision participant.
+
+For implementation ownership and exact contracts, contributors can follow
+[Current Engineering State](../.agent-loop/CURRENT_STATE.md). For historical
+decisions, use the [Historical Planning Index](historical_planning.md).


### PR DESCRIPTION
## Intent

Make the public v0.1 roadmap sufficient for humans to understand what is complete, what is hidden, the current critical path, and every remaining release gate without reading internal agent-loop records.

## Scope

- lifecycle scoreboard from identity through pilot
- completed capability summary
- exact dependency order through guide activation, task readiness, canonical allow_review, REV/CON, fulfillment, and release
- ContributionPolicy inheritance and controlled revision-rebase rule
- README and engineering-state navigation updates
- documentation only; no runtime, schema, CI, migration, action, or availability change

## Evidence

- reconciled against current ARCH, ART, AUTH, POL, CON, REV, and XINT status and chunk maps
- documentation and product reviewers agreed with the lifecycle direction
- their only concrete stale-state finding was fixed before commit
- diff, Markdown links, stale wording, stale AUTH documentation, chunk-state, and active-state checks pass locally

## Human review focus

- whether the lifecycle scoreboard is understandable without internal planning context
- whether hidden behavior is clearly distinguished from live behavior
- whether the critical path and v0.1 release gates match product intent

Human approval is required. This PR does not authorize merge itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a public v0.1 roadmap and capability status guide covering completed capabilities, hidden integrations, current priorities, dependencies, and remaining release gates.
  * Added an end-to-end lifecycle scoreboard and clarified status terminology for live, hidden, upcoming, planned, and deferred work.
  * Updated the README to link to the roadmap and explain its role as the primary product progress reference.
  * Expanded documentation tracking to reflect completion of the public roadmap work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->