### PR TITLE
docs: distinguish checker stages and same-PR roadmap updates

### DIFF
--- a/.commitrail/changes/roadmap-checker-stages.md
+++ b/.commitrail/changes/roadmap-checker-stages.md
@@ -1,0 +1,41 @@
+# Roadmap checker stages and same-PR maintenance
+
+- Initiative: None
+- Durable disposition: Complete
+- Intended merge outcome: distinguish intake checks from post-submit evaluation and require same-PR roadmap impact assessment.
+
+## Intent
+
+Make both checker stages visible in the existing v0.1 roadmap and prevent stale
+capability claims without a separate post-merge update cycle.
+
+## Bounded change
+
+- Allowed: `docs/roadmap_status.md`, `AGENTS.md`, `CONTRIBUTING.md`, this record;
+  synchronize ignored roadmap exports if present.
+- Not allowed: runtime behavior, checker dispatch, canonical specifications,
+  CI gates, approval authority, historical archives, new release scope.
+
+## Acceptance criteria
+
+- Show pre-submission checks before Submission creation and durable post-submit
+  evaluation after it; neither replaces authorized review.
+- Distinguish unified setup proposals from runtime execution and supported
+  current behavior from future integration.
+- Reconcile the selected AUTH audit delivered in PR #379; do not mark open
+  product implementation complete.
+- Each PR assesses roadmap impact before readiness. Update changed capabilities
+  and next boundaries in that PR; explain no impact in the PR when applicable.
+  No mandatory no-op file edits, second permission system, or post-merge PR.
+
+## Risk and review routing
+
+- Risk class: L2, documentation of existing lifecycle and contribution rules.
+- Reviewers: documentation and product/operations, one bounded review assignment.
+- Human focus: stage separation and proportionate same-PR maintenance.
+
+## Evidence
+
+- Proof: canonical checker specifications and current initiative records;
+  Markdown links, stale wording, Commitrail validation, diff checks. Hosted
+  CI remains unchanged. No local roadmap spreadsheet exports are present.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,14 @@ Before reporting completion:
 
 - run a stale wording scan
 - check markdown links
+- assess `docs/roadmap_status.md` in every PR before marking it ready. If the
+  change affects a capability, its exposure, completed work, remaining scope,
+  or next dependency, update the affected roadmap sections in that same PR to
+  reflect its intended merged outcome. Reconcile again after incorporating
+  relevant changes from `main`. If there is no roadmap impact, state why in
+  the PR; do not make a no-op roadmap edit. Do not defer an affected roadmap
+  update to a separate post-merge PR. Do not treat planned/open work as already
+  delivered on `main`.
 - verify the local XLSX has one sheet only when local sheet exports are present
 - verify the current Workstream definition appears in README and local sheet exports when local sheet exports are present
 - update related docs/templates and local sheet exports together when the roadmap changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,12 @@ active queue or approval gate.
 - Preserve security defaults and existing coverage floors.
 - Record important reviewer findings and how they were resolved.
 - Reconcile with current `main` and rerun affected checks.
+- Before marking the PR ready, assess its impact on
+  [`docs/roadmap_status.md`](docs/roadmap_status.md). Update affected capability,
+  exposure, completed/remaining work, and next-dependency sections in this same
+  PR to reflect its intended merged outcome, including relevant changes from
+  `main`. If there is no impact, explain why in the PR instead of making a
+  no-op edit. Do not defer this to a separate post-merge roadmap PR.
 - In the change record, declare the intended merge outcome and durable
   disposition (`Planned`, `Complete`, `Stopped`, or `Superseded`). Update an
   initiative overview or index row only when its durable meaning changes.

--- a/docs/roadmap_status.md
+++ b/docs/roadmap_status.md
@@ -22,8 +22,9 @@ Workstream turns governed work into trusted `ContributionRecord` facts:
 ```text
 Project Guide
 -> governed Task
+-> artifact preparation and pre-submission intake checks
 -> immutable Submission
--> deterministic Checks
+-> post-submission evaluation against locked requirements
 -> authorized Review
 -> controlled Revision when required
 -> Contribution Records
@@ -70,6 +71,29 @@ with `routing_recommendation = allow_review`. That fact unlocks the live
 review/revision path. Review decisions must then create contribution and
 conditional compensation facts atomically before v0.1 can be released.
 
+## Pre-Submission And Post-Submission Checking
+
+Both stages enforce quality, but answer different questions and produce
+different outcomes. They are not one combined checker phase.
+
+| Stage | Purpose and examples | Policy and execution boundary | Outcome |
+| --- | --- | --- | --- |
+| Pre-submission intake checks | Is this package acceptable to submit? Check completeness, required/forbidden files, evidence integrity, and configured intake-quality rules. | The locked `PreSubmitCheckerPolicy` and effective artifact policy drive the pre-submission catalogue during continuous artifact preparation, before a Submission exists. | Blocking failures return correction feedback and prevent Submission creation. Passing intake does not prove the task is accepted or ready for review. |
+| Post-submission evaluation | Does the submitted work meet the configured task/project checks? Evaluate the exact stored work and evidence under the locked requirements. | The Submission-stamped `PostSubmitCheckerPolicy` drives the durable checker registry after immutable Submission creation. Only supported, registered checks execute. | Persist a durable current result; blocking failures prevent review admission. Eligible results produce `allow_review`, not final acceptance. |
+
+The unified guide agent proposes both sets of policy bindings in one setup
+result. Trusted compilation, validation, and the governing approval path turn
+those proposals into separate locked policies; setup inference is not a second
+agent run judging a contributor's submission. An agent-based evaluator or quality
+judge would require its own supported checker implementation and policy binding;
+it is not implied to be live by the unified setup agent or the roadmap.
+
+Authorized reviewers still own `accept`, `needs_revision`, and `reject`.
+Neither checker stage can substitute for that decision. Pre-submission feedback
+cannot be reused as post-submission review-gate evidence. See the
+[checker architecture](architecture_checker_framework.md) and
+[pre-submit versus durable contract](spec_chunk_8_submission_artifact_policy_checkers.md#pre-submit-versus-durable-runs).
+
 ## End-To-End Lifecycle Scoreboard
 
 | Lifecycle stage | Status on `main` | What is already proven | What remains before v0.1 |
@@ -81,8 +105,9 @@ conditional compensation facts atomically before v0.1 can be released.
 | Contribution policy administration | **Hidden and proven** | Finance Authority adapter-binding lifecycle; ContributionPolicy read/create/update/publish/retire behavior; immutable operation and event history | Activate the five policy actions, expose validation, bind one published complete version to the active guide generation |
 | Task readiness and claim | **Foundation plus planned replacement** | Task records, lifecycle guards, assignments, locked work context, public owner facts | A task must inherit the guide-bound ContributionPolicyVersion before `READY`; claim copies the prepared task context into TaskAssignment without a current-policy lookup; activate exact task authority |
 | Contributor artifact preparation | **Hidden and proven** | One outer ZIP; bounded scratch inspection; canonical manifest; platform and project prechecks; unchanged-work rejection; durable put intent; verification; capacity-charged ready admission | Connect only the active unified guide/checker lineage and complete the later public admission-only cutover |
+| Pre-submission intake checking | **Hidden and proven; unified-guide integration remains** | Separate versioned pre-submission catalogue, locked effective-plan compilation, platform/project checks during continuous preparation, and blocking feedback before Submission creation | Connect approved unified-guide pre-submit policy lineage through task/assignment preparation and complete the canonical public cutover; passing intake must never substitute for post-submit evaluation |
 | Immutable Submission creation | **Hidden and proven** | Contributor preparation authority; atomic admission consumption; TASK-owned Submission creation; fixed-service artifact binding; replay/concurrency/rollback proof | Stamp the assignment's exact ContributionPolicyVersion and unified policy lineage; remove the legacy Submission path only after remediation and review prerequisites are ready |
-| Post-submit checking and `allow_review` | **Planned; immediate integration milestone** | Checker contracts, registry/runner foundations, existing pre-review behavior, artifact materialization foundations | Publish one CHECKER post-submit API; materialize the exact Submission; persist one durable current superseding result; activate fixed services; automatically dispatch it and publish the canonical `allow_review` manifest |
+| Post-submission evaluation and `allow_review` | **Planned; immediate integration milestone** | Separate durable checker contracts and registry/runner foundations, existing pre-review behavior, artifact materialization foundations | Publish one CHECKER post-submit API; evaluate the exact Submission against its locked policy; persist one durable current superseding result; activate fixed services; automatically dispatch it and publish the canonical `allow_review` manifest |
 | Review queue and lease | **Hidden persistence foundation** | Queue/admission idempotency and ReviewLease/preference persistence; complete unavailable REV action/principal catalogue and typed AUTH contracts | Packet-membership contract and manifest; Review schema; canonical admission from `allow_review`; claim/lease/packet authority; lease copies the Submission-stamped policy version with no CON lookup |
 | Review decision and revision | **Planned** | Review/revision policy identities and mutation authority; approved same-task revision-rebase semantics | Immutable findings and decisions; `accept`, `needs_revision`, and `reject`; complete-context revision preparation; finding responses; replacement contributor rules; replay and recovery |
 | Contribution and compensation truth | **Schema foundations plus hidden policy behavior** | ContributionPolicyVersion persistence; lifecycle-audit participant; adapter bindings; hidden policy administration | Persist ContributionRecord and CompensationAward; atomically create one reviewer record for every final review and, on accept only, FinalAcceptance plus the submitter record; evaluate frozen rules into zero, one, or two awards |
@@ -182,6 +207,11 @@ The next dependency-safe product sequence is:
    and policy context before `READY`. Claim copies it to TaskAssignment; it
    performs no ContributionPolicy selection. Submission later copies the
    assignment's attempt version.
+   **Complete pre-submission intake integration before creating the Submission:**
+   continuous artifact preparation executes the locked intake plan, returns
+   correction feedback on blocking failures, and publishes ready admission only
+   after the required preparation/custody checks. TASK then consumes that
+   admission to create the immutable Submission with the same assignment lineage.
 6. **Produce canonical `allow_review`.** Materialize the exact immutable
    Submission, execute the locked post-submit plan, persist one current result,
    activate only its fixed services, and automatically publish an exact
@@ -210,8 +240,10 @@ the seven hosted CI lanes. The audit also corrected concrete sufficiency and
 submission-policy validation defects. These are delivered bounded repairs,
 not a claim that every test or subsystem is fully audited.
 
-Remaining work includes AUTH historical-evidence and actor-resolution proof,
-oversized AUTH/test-module decomposition, and the remaining TASK, CHECKER,
+The selected AUTH projection replay, actor-resolution, and authentication audit
+and decomposition are also delivered, including stronger first-access race
+proof. That does not complete the remaining AUTH lifecycle families or the full
+suite audit. Remaining work includes those AUTH families and the TASK, CHECKER,
 ART, CON, REV, and tooling audit. The audit requires behavioral proof, not only
 file splitting or coverage percentages. Real PostgreSQL, concurrency, storage,
 and full hosted coverage checks remain required. Product implementation is
@@ -239,6 +271,8 @@ Hidden ContributionPolicy behavior (complete)
 Both chains
   -> terminal Project Guide activation
   -> Task readiness and assignment lineage
+  -> artifact preparation + locked pre-submission intake checks
+  -> ready admission after intake and custody checks
   -> immutable admitted Submission
   -> durable current post-submit result
   -> canonical allow_review
@@ -261,8 +295,12 @@ v0.1 is not ready until all of the following are true:
 - One active Project Guide generation contains a complete approved compilation
   and every required policy identity/hash, including ContributionPolicyVersion.
 - A task cannot enter `READY` without that complete locked context.
-- A contributor can claim, submit one immutable ZIP, pass both checker phases,
-  and receive a durable ready admission without a parallel legacy path.
+- A contributor can claim and prepare one ZIP under the locked pre-submit
+  policy. Blocking intake failures return feedback and create no Submission;
+  successful preparation produces ready admission after the required custody
+  checks, without a parallel legacy path.
+- TASK consumes that admission to create the immutable Submission with exact
+  assignment/policy lineage. Pre-submit feedback is not post-submit proof.
 - The immutable Submission automatically reaches exactly one current
   post-submit result and an exact `allow_review` manifest when eligible.
 - A reviewer can claim only that admitted version, access only its bounded


### PR DESCRIPTION
## Change

Distinguish pre-submission intake checks from post-submission work evaluation
in the existing roadmap, and make same-PR roadmap maintenance explicit.

## Goal

Readers can see both checker stages and their separate outcomes; contributors
keep capability status current without a second post-merge update cycle.

## Intent And Planning Context

User-requested roadmap correction and agent guidance. The small
[change record](.commitrail/changes/roadmap-checker-stages.md) covers the
contribution-instruction changes. No new initiative or workflow gate.

## What Changed / Why It Changed

- Dedicated pre-submission scoreboard row, before immutable Submission creation.
- Separate post-submission evaluation and durable review-admission outcome.
- Lifecycle, dependency map, and release gates now show the distinct stages.
- Reconciled selected AUTH audit work merged in #379; open #377 remains unmerged.
- AGENTS and CONTRIBUTING require roadmap-impact assessment before PR readiness,
  same-PR updates when relevant, and no-impact explanation without no-op edits.

## Design Chosen / Alternatives Rejected

Reuse the current roadmap and existing rules. No new status file, automatic
permission gate, copied PR queue, unconditional roadmap edit, or post-merge PR.
Setup-agent policy proposals do not imply a live runtime agent evaluator.

## Scope Control

Only roadmap, AGENTS, CONTRIBUTING, and one required standalone instruction-change
record. No files outside scope. No local roadmap spreadsheets exist to update;
no remote spreadsheet was changed.

## Product Behavior

- [x] No runtime behavior, canonical specification, or release scope changes.

## Evidence

Passed local Markdown links, stale wording, stale authorization documentation,
stale artifact contracts, Commitrail validation, and diff checks. Source
comparison uses checker architecture, the pre-submit/durable contract, and the
merged selected AUTH audit record. Hosted checks will run after publication.

## Acceptance Criteria Proof

- [x] Intake failures prevent Submission creation; passing intake is not review proof.
- [x] Post-submit checks operate on the immutable Submission and persist durable results.
- [x] Authorized reviewers retain final `accept`, `needs_revision`, and `reject` decisions.
- [x] Same-PR maintenance distinguishes changed roadmap facts from no-impact work.

## Test Delta

No tests added, changed, removed, skipped, or deselected.

## Impact-Routed Reviewer Results

Documentation: PASS. Product/operations: PASS. One paired assignment.

Exact reviewed head: `e21c39ed51a1e703c95947f0d8d9ce446a067312`.
Run: `/root/checker_roadmap_review/docs-product-ops-e21c39ed`.
`DOCS-PRODOPS-001` fixed: prohibit deferring an affected update, not legitimate
later repairs. Source-consistency inspection verifies checker ordering,
policy boundaries, and unchanged reviewer decision authority. An overbroad-ban
counterexample was rejected after correction. These are documentation/process
proofs, not new runtime or PostgreSQL execution evidence. No open findings.

## External Review

Unavailable before publication. Skipped/rate-limited checks are not substantive review.

## CI And Gate Integrity

No workflow, test selection, coverage floor, lint, package script, dependency,
action, or credential configuration changed.

## Remaining Risks / Follow-Up Work

No implementation or live checker activation is claimed. Existing product PRs
retain their owners and must reconcile shared roadmap lines at integration.

## Human Review Focus

Clear intake-versus-work-evaluation distinction and proportionate roadmap upkeep.

## Human Merge Ownership

- [x] The human accepts the change and explicitly approves this PR for merge.
